### PR TITLE
Model recompile on windows and MacOS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'fj-host'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=fj-host",
+                    "--package=fj-host"
+                ],
+                "filter": {
+                    "name": "fj-host",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'fj-host'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=fj-host",
+                    "--package=fj-host"
+                ],
+                "filter": {
+                    "name": "fj-host",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'fj-host'",
+            "name": "Debug executable 'fj'",
             "cargo": {
                 "args": [
                     "build",
@@ -25,7 +25,7 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in executable 'fj-host'",
+            "name": "Debug unit tests in executable 'fj'",
             "cargo": {
                 "args": [
                     "test",

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ fn main() -> anyhow::Result<()> {
             //       handle it.
             let event = event.expect("Error handling watch event");
 
+            //Various acceptable ModifyKind kinds. Varies across platforms (e.g. MacOs vs. Windows10)
             if let notify::EventKind::Modify(notify::event::ModifyKind::Any)
             | notify::EventKind::Modify(notify::event::ModifyKind::Data(
                 notify::event::DataChange::Any,

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,11 +65,8 @@ fn main() -> anyhow::Result<()> {
             //       handle it.
             let event = event.expect("Error handling watch event");
 
-            if let notify::EventKind::Access(
-                notify::event::AccessKind::Close(
-                    notify::event::AccessMode::Write,
-                ),
-            ) = event.kind
+            if let notify::EventKind::Modify(notify::event::ModifyKind::Any) =
+                event.kind
             {
                 let shape = match model.load(&parameters) {
                     Ok(shape) => shape,

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,8 +65,13 @@ fn main() -> anyhow::Result<()> {
             //       handle it.
             let event = event.expect("Error handling watch event");
 
-            if let notify::EventKind::Modify(notify::event::ModifyKind::Any) =
-                event.kind
+            if let notify::EventKind::Modify(notify::event::ModifyKind::Any)
+            | notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Any,
+            ))
+            | notify::EventKind::Modify(notify::event::ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )) = event.kind
             {
                 let shape = match model.load(&parameters) {
                     Ok(shape) => shape,


### PR DESCRIPTION
Changes recompile to 'save file event'. 

Solves some of the issues related to #12, as the model recompiles and reloades on Win10 but only recompiles on MacOS.
The issue of reloading model on MacOS does not appear to be related monitoring of/watching for changes to model files.