### PR TITLE
Fix navigation links

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -10,14 +10,14 @@
     </head>
     <body>
         <header>
-            <a class="title" href="/">
+            <a class="title" href="/Fornjot">
                 <h1>Fornjot</h1>
                 <h2>The world needs another CAD program.</h2>
             </a>
             <nav>
                 <ul>
-                    <li><a href="/">About</a></li>
-                    <li><a href="/community">Community</a></li>
+                    <li><a href="/Fornjot">About</a></li>
+                    <li><a href="community">Community</a></li>
                 </ul>
             </nav>
         </header>


### PR DESCRIPTION
This is pretty annoying, as the links to "About" no longer works in
local preview mode now. But at least this should patch things up so they
work in production.

This could be fixed with a custom domain name, which I didn't want to
look into this early, but I guess the priority for that task just jumped
up.