### PR TITLE
Make `transform` methods free of side effects

### DIFF
--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -20,9 +20,11 @@ pub struct Circle {
 }
 
 impl Circle {
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
-        self.center = transform.transform_point(&self.center);
-        self.radius = transform.transform_vector(&self.radius);
+    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+        Self {
+            center: transform.transform_point(&self.center),
+            radius: transform.transform_vector(&self.radius),
+        }
     }
 
     pub fn approx_vertices(&self, tolerance: f64, out: &mut Vec<Point<3>>) {

--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -6,7 +6,7 @@ use parry3d_f64::math::Isometry;
 use crate::math::{Point, Vector};
 
 /// A circle
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Circle {
     /// The center point of the circle
     pub center: Point<3>,

--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -20,6 +20,7 @@ pub struct Circle {
 }
 
 impl Circle {
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         Self {
             center: transform.transform_point(&self.center),

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -8,7 +8,7 @@ use crate::math::Point;
 /// The points that define the line also define the line's 1-dimensional curve
 /// coordinate system. `a` defines the origin (`0.0`), `b` defines coordinate
 /// `1.0`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Line {
     /// The first point that defines the line
     pub a: Point<3>,

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -19,9 +19,11 @@ pub struct Line {
 
 impl Line {
     /// Transform the line
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
-        self.a = transform.transform_point(&self.a);
-        self.b = transform.transform_point(&self.b);
+    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+        Self {
+            a: transform.transform_point(&self.a),
+            b: transform.transform_point(&self.b),
+        }
     }
 }
 
@@ -52,12 +54,12 @@ mod tests {
 
     #[test]
     fn test_transform() {
-        let mut line = Line {
+        let line = Line {
             a: point![1., 0., 0.],
             b: point![1., 1., 0.],
         };
 
-        line.transform(&Isometry::from_parts(
+        let line = line.transform(&Isometry::from_parts(
             Translation::from([1., 2., 3.]),
             UnitQuaternion::from_axis_angle(&Vector::z_axis(), FRAC_PI_2),
         ));

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -19,6 +19,7 @@ pub struct Line {
 
 impl Line {
     /// Transform the line
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         Self {
             a: transform.transform_point(&self.a),

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -29,10 +29,16 @@ pub enum Curve {
 }
 
 impl Curve {
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
+    pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Circle(circle) => circle.transform(transform),
-            Self::Line(line) => line.transform(transform),
+            Self::Circle(mut circle) => {
+                circle.transform(transform);
+                Self::Circle(circle)
+            }
+            Self::Line(mut line) => {
+                line.transform(transform);
+                Self::Line(line)
+            }
         }
     }
 

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -31,9 +31,8 @@ pub enum Curve {
 impl Curve {
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Circle(mut circle) => {
-                circle.transform(transform);
-                Self::Circle(circle)
+            Self::Circle(circle) => {
+                Self::Circle(circle.transform(transform))
             }
             Self::Line(mut line) => {
                 line.transform(transform);

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -31,13 +31,8 @@ pub enum Curve {
 impl Curve {
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Circle(circle) => {
-                Self::Circle(circle.transform(transform))
-            }
-            Self::Line(mut line) => {
-                line.transform(transform);
-                Self::Line(line)
-            }
+            Self::Circle(circle) => Self::Circle(circle.transform(transform)),
+            Self::Line(line) => Self::Line(line.transform(transform)),
         }
     }
 

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -19,7 +19,7 @@ use crate::math::Point;
 ///
 /// This distinction is not observed here, but moving things into that direction
 /// is the intention.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Curve {
     /// A circle
     Circle(Circle),

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -29,6 +29,7 @@ pub enum Curve {
 }
 
 impl Curve {
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
             Self::Circle(circle) => Self::Circle(circle.transform(transform)),

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -23,10 +23,7 @@ impl Surface {
     /// Transform the surface
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Plane(mut plane) => {
-                plane.transform(transform);
-                Self::Plane(plane)
-            }
+            Self::Plane(plane) => Self::Plane(plane.transform(transform)),
         }
     }
 
@@ -103,10 +100,12 @@ pub struct Plane {
 
 impl Plane {
     /// Transform the plane
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
-        self.origin = transform.transform_point(&self.origin);
-        self.u = transform.transform_vector(&self.u);
-        self.v = transform.transform_vector(&self.v);
+    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+        Self {
+            origin: transform.transform_point(&self.origin),
+            u: transform.transform_vector(&self.u),
+            v: transform.transform_vector(&self.v),
+        }
     }
 
     /// Convert a point in model coordinates to surface coordinates
@@ -211,13 +210,13 @@ mod tests {
 
     #[test]
     fn test_transform() {
-        let mut plane = Plane {
+        let plane = Plane {
             origin: point![1., 2., 3.],
             u: vector![1., 0., 0.],
             v: vector![0., 1., 0.],
         };
 
-        plane.transform(&Isometry::from_parts(
+        let plane = plane.transform(&Isometry::from_parts(
             Translation::from([2., 4., 6.]),
             UnitQuaternion::from_axis_angle(&Vector::z_axis(), FRAC_PI_2),
         ));

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -21,9 +21,12 @@ impl Surface {
     }
 
     /// Transform the surface
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
+    pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Plane(plane) => plane.transform(transform),
+            Self::Plane(mut plane) => {
+                plane.transform(transform);
+                Self::Plane(plane)
+            }
         }
     }
 

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -21,6 +21,7 @@ impl Surface {
     }
 
     /// Transform the surface
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
             Self::Plane(plane) => Self::Plane(plane.transform(transform)),
@@ -100,6 +101,7 @@ pub struct Plane {
 
 impl Plane {
     /// Transform the plane
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         Self {
             origin: transform.transform_point(&self.origin),

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -25,11 +25,15 @@ impl Shape for fj::Sweep {
     fn faces(&self, tolerance: f64, debug_info: &mut DebugInfo) -> Faces {
         let original_faces = self.shape.faces(tolerance, debug_info);
 
-        let mut bottom_faces = original_faces.clone();
-        bottom_faces.transform(&Isometry::rotation(vector![PI, 0., 0.]));
+        let bottom_faces = original_faces
+            .clone()
+            .transform(&Isometry::rotation(vector![PI, 0., 0.]));
 
-        let mut top_faces = original_faces.clone();
-        top_faces.transform(&Isometry::translation(0.0, 0.0, self.length));
+        let top_faces = original_faces.transform(&Isometry::translation(
+            0.0,
+            0.0,
+            self.length,
+        ));
 
         // This will only work correctly, if the original shape consists of one
         // edge. If there are more, this will create some kind of weird face

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -15,8 +15,9 @@ impl Shape for fj::Transform {
     }
 
     fn faces(&self, tolerance: f64, debug_info: &mut DebugInfo) -> Faces {
-        let isometry = isometry(self);
-        self.shape.faces(tolerance, debug_info).transform(&isometry)
+        self.shape
+            .faces(tolerance, debug_info)
+            .transform(&isometry(self))
     }
 
     fn edges(&self) -> Edges {

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -18,9 +18,7 @@ impl Shape for fj::Transform {
         let mut faces = self.shape.faces(tolerance, debug_info);
         let isometry = isometry(self);
 
-        for face in &mut faces.0 {
-            face.transform(&isometry);
-        }
+        faces.transform(&isometry);
 
         faces
     }

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -15,12 +15,10 @@ impl Shape for fj::Transform {
     }
 
     fn faces(&self, tolerance: f64, debug_info: &mut DebugInfo) -> Faces {
-        let mut faces = self.shape.faces(tolerance, debug_info);
+        let faces = self.shape.faces(tolerance, debug_info);
         let isometry = isometry(self);
 
-        faces.transform(&isometry);
-
-        faces
+        faces.transform(&isometry)
     }
 
     fn edges(&self) -> Edges {

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -15,10 +15,8 @@ impl Shape for fj::Transform {
     }
 
     fn faces(&self, tolerance: f64, debug_info: &mut DebugInfo) -> Faces {
-        let faces = self.shape.faces(tolerance, debug_info);
         let isometry = isometry(self);
-
-        faces.transform(&isometry)
+        self.shape.faces(tolerance, debug_info).transform(&isometry)
     }
 
     fn edges(&self) -> Edges {

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -31,12 +31,14 @@ impl Edges {
     }
 
     /// Transform the edges
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
+    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
         for cycle in &mut self.cycles {
             for edge in &mut cycle.edges {
                 edge.curve.transform(transform);
             }
         }
+
+        self
     }
 
     /// Compute an approximation of the edges

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -34,7 +34,7 @@ impl Edges {
     pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
         for cycle in &mut self.cycles {
             for edge in &mut cycle.edges {
-                edge.curve.transform(transform);
+                edge.curve = edge.curve.transform(transform);
             }
         }
 

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -31,6 +31,7 @@ impl Edges {
     }
 
     /// Transform the edges
+    #[must_use]
     pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
         for cycle in &mut self.cycles {
             for edge in &mut cycle.edges {

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -83,11 +83,8 @@ pub enum Face {
 impl Face {
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Face {
-                mut edges,
-                mut surface,
-            } => {
-                edges.transform(transform);
+            Self::Face { edges, mut surface } => {
+                let edges = edges.transform(transform);
                 surface.transform(transform);
 
                 Self::Face { edges, surface }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -83,9 +83,9 @@ pub enum Face {
 impl Face {
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Face { edges, mut surface } => {
+            Self::Face { edges, surface } => {
                 let edges = edges.transform(transform);
-                surface.transform(transform);
+                let surface = surface.transform(transform);
 
                 Self::Face { edges, surface }
             }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -83,12 +83,10 @@ pub enum Face {
 impl Face {
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
-            Self::Face { edges, surface } => {
-                let edges = edges.transform(transform);
-                let surface = surface.transform(transform);
-
-                Self::Face { edges, surface }
-            }
+            Self::Face { edges, surface } => Self::Face {
+                edges: edges.transform(transform),
+                surface: surface.transform(transform),
+            },
             Self::Triangles(mut triangles) => {
                 for triangle in &mut triangles {
                     *triangle = triangle.transformed(transform);

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -24,6 +24,7 @@ use super::edges::Edges;
 pub struct Faces(pub Vec<Face>);
 
 impl Faces {
+    /// Transform all the faces
     #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         let faces = self
@@ -82,6 +83,7 @@ pub enum Face {
 }
 
 impl Face {
+    /// Transform the face
     #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -24,10 +24,12 @@ use super::edges::Edges;
 pub struct Faces(pub Vec<Face>);
 
 impl Faces {
-    pub fn transform(&mut self, transform: &Isometry<f64>) {
+    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
         for face in &mut self.0 {
             face.transform(transform);
         }
+
+        self
     }
 
     pub fn triangles(

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -24,6 +24,7 @@ use super::edges::Edges;
 pub struct Faces(pub Vec<Face>);
 
 impl Faces {
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         let faces = self
             .0
@@ -81,6 +82,7 @@ pub enum Face {
 }
 
 impl Face {
+    #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
         match self {
             Self::Face { edges, surface } => Self::Face {


### PR DESCRIPTION
The way it worked previously was already a bit icky, and didn't match the method's use case in all cases. In addition, I'm working on further changes, that would have made these methods more confusing.

Just having them free of side effects is clearer, in my opinion, and less error-prone.