### PR TITLE
Prevent potential floating-point accuracy issues in triangulation

### DIFF
--- a/src/kernel/geometry/mod.rs
+++ b/src/kernel/geometry/mod.rs
@@ -1,4 +1,5 @@
 pub mod curves;
+pub mod points;
 pub mod surfaces;
 
 pub use self::{

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -1,0 +1,62 @@
+use std::ops::{Add, Deref, DerefMut, Sub};
+
+use crate::math::{Point, Vector};
+
+/// A point on a surface
+///
+/// This type is used for algorithms that need to deal with 2D points in surface
+/// coordinates. It can be converted back to the 3D point it originates from
+/// without loss from floating point accuracy issues.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SurfacePoint {
+    /// The surface coordinates of this point
+    pub value: Point<2>,
+
+    /// The 3D point this surface point was converted from
+    ///
+    /// Keeping this point around allows for the conversion back to a 3D point
+    /// to be unaffected by floating point accuracy issues, which avoids a whole
+    /// host of possible issues.
+    pub from: Point<3>,
+}
+
+impl Deref for SurfacePoint {
+    type Target = Point<2>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl DerefMut for SurfacePoint {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+// Some math operations for convenience. Obviously those can never return a new
+// `SurfacePoint`, or the conversion back to 3D would be broken.
+
+impl Add<Vector<2>> for SurfacePoint {
+    type Output = Point<2>;
+
+    fn add(self, rhs: Vector<2>) -> Self::Output {
+        self.value.add(rhs)
+    }
+}
+
+impl Sub<Self> for SurfacePoint {
+    type Output = Vector<2>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.value.sub(rhs.value)
+    }
+}
+
+impl Sub<Point<2>> for SurfacePoint {
+    type Output = Vector<2>;
+
+    fn sub(self, rhs: Point<2>) -> Self::Output {
+        self.value.sub(rhs)
+    }
+}

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -3,6 +3,8 @@ use parry3d_f64::math::Isometry;
 
 use crate::math::{Point, Vector};
 
+use super::points::SurfacePoint;
+
 /// A two-dimensional shape
 #[derive(Clone, Debug, PartialEq)]
 pub enum Surface {
@@ -34,10 +36,15 @@ impl Surface {
     pub fn point_model_to_surface(
         &self,
         point_3d: Point<3>,
-    ) -> Result<Point<2>, ()> {
-        match self {
-            Self::Plane(plane) => plane.point_model_to_surface(point_3d),
-        }
+    ) -> Result<SurfacePoint, ()> {
+        let point_2d = match self {
+            Self::Plane(plane) => plane.point_model_to_surface(point_3d)?,
+        };
+
+        Ok(SurfacePoint {
+            value: point_2d,
+            from: point_3d,
+        })
     }
 
     /// Convert a point in surface coordinates to model coordinates

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -33,10 +33,10 @@ impl Surface {
     /// Returns an error, if the provided point is not in the surface.
     pub fn point_model_to_surface(
         &self,
-        point: Point<3>,
+        point_3d: Point<3>,
     ) -> Result<Point<2>, ()> {
         match self {
-            Self::Plane(plane) => plane.point_model_to_surface(point),
+            Self::Plane(plane) => plane.point_model_to_surface(point_3d),
         }
     }
 

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,6 +1,7 @@
 pub mod geometry;
 pub mod shapes;
 pub mod topology;
+pub mod util;
 
 use parry3d_f64::bounding_volume::AABB;
 

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -119,7 +119,7 @@ impl Face {
                     .map(|vertex| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
-                        surface.point_model_to_surface(vertex).unwrap()
+                        surface.point_model_to_surface(vertex).unwrap().value
                     })
                     .collect();
 
@@ -129,8 +129,10 @@ impl Face {
                     .map(|Segment3 { a, b }| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
-                        let a = surface.point_model_to_surface(a).unwrap();
-                        let b = surface.point_model_to_surface(b).unwrap();
+                        let a =
+                            surface.point_model_to_surface(a).unwrap().value;
+                        let b =
+                            surface.point_model_to_surface(b).unwrap().value;
 
                         Segment2 { a, b }
                     })

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -222,11 +222,8 @@ impl Face {
                     true
                 });
 
-                out.extend(triangles.into_iter().map(|[a, b, c]| {
-                    let a = a.from;
-                    let b = b.from;
-                    let c = c.from;
-
+                out.extend(triangles.into_iter().map(|triangle| {
+                    let [a, b, c] = triangle.map(|point| point.from);
                     Triangle { a, b, c }
                 }));
             }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -1,12 +1,10 @@
 use std::collections::BTreeSet;
 
 use decorum::R64;
-use nalgebra::point;
 use parry2d_f64::{
     bounding_volume::AABB,
     query::{Ray as Ray2, RayCast as _},
     shape::{Segment as Segment2, Triangle as Triangle2},
-    utils::point_in_triangle::{corner_direction, Orientation},
 };
 use parry3d_f64::{
     math::Isometry,
@@ -16,8 +14,7 @@ use parry3d_f64::{
 
 use crate::{
     debug::{DebugInfo, TriangleEdgeCheck},
-    kernel::geometry::Surface,
-    math::Point,
+    kernel::{geometry::Surface, util::triangulate},
 };
 
 use super::edges::Edges;
@@ -229,43 +226,4 @@ impl Face {
             Self::Triangles(triangles) => out.extend(triangles),
         }
     }
-}
-
-/// Create a Delaunay triangulation of all vertices
-pub fn triangulate(vertices: &[Point<2>]) -> Vec<Triangle2> {
-    use spade::Triangulation as _;
-
-    let points: Vec<_> = vertices
-        .iter()
-        .map(|vertex| spade::Point2 {
-            x: vertex.x,
-            y: vertex.y,
-        })
-        .collect();
-
-    let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
-        .expect("Inserted invalid values into triangulation");
-
-    let mut triangles = Vec::new();
-    for triangle in triangulation.inner_faces() {
-        let [v0, v1, v2] = triangle.vertices().map(|vertex| {
-            let pos = vertex.position();
-            point![pos.x, pos.y]
-        });
-
-        let triangle = match corner_direction(&v0, &v1, &v2) {
-            Orientation::Ccw => [v0, v1, v2].into(),
-            Orientation::Cw => [v0, v2, v1].into(),
-            Orientation::None => {
-                panic!(
-                    "Triangle returned from triangulation isn't actually a\
-                    triangle"
-                );
-            }
-        };
-
-        triangles.push(triangle);
-    }
-
-    triangles
 }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -152,11 +152,11 @@ impl Face {
 
                         // If the segment is an edge of the face, we don't need
                         // to take a closer look.
-                        if face_as_polygon.contains(&[segment.a, segment.b])
-                            || face_as_polygon.contains(&[
-                                inverted_segment.a,
-                                inverted_segment.b,
-                            ])
+                        if face_as_polygon.contains(&[segment.a, segment.b]) {
+                            continue;
+                        }
+                        if face_as_polygon
+                            .contains(&[inverted_segment.a, inverted_segment.b])
                         {
                             continue;
                         }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -116,7 +116,7 @@ impl Face {
                     .map(|vertex| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
-                        surface.point_model_to_surface(vertex).unwrap().value
+                        surface.point_model_to_surface(vertex).unwrap()
                     })
                     .collect();
 
@@ -136,10 +136,12 @@ impl Face {
                     .collect();
 
                 // We're also going to need a point outside of the polygon.
-                let aabb = AABB::from_points(&vertices);
+                let aabb = AABB::from_points(
+                    vertices.iter().map(|vertex| &vertex.value),
+                );
                 let outside = aabb.maxs * 2.;
 
-                let mut triangles = triangulate(&vertices);
+                let mut triangles = triangulate(vertices);
                 let face_as_polygon = segments;
 
                 triangles.retain(|triangle| {

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -135,7 +135,8 @@ impl Face {
                     })
                     .collect();
 
-                // We're also going to need a point outside of the polygon.
+                // We're also going to need a point outside of the polygon, for
+                // the point-in-polygon tests.
                 let aabb = AABB::from_points(
                     vertices.iter().map(|vertex| &vertex.value),
                 );

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -135,12 +135,12 @@ impl Face {
                     })
                     .collect();
 
-                let mut triangles = triangulate(&vertices);
-                let face_as_polygon = segments;
-
                 // We're also going to need a point outside of the polygon.
                 let aabb = AABB::from_points(&vertices);
                 let outside = aabb.maxs * 2.;
+
+                let mut triangles = triangulate(&vertices);
+                let face_as_polygon = segments;
 
                 triangles.retain(|triangle| {
                     for segment in triangle.edges() {

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -9,7 +9,7 @@ use parry2d_f64::{
 use parry3d_f64::{
     math::Isometry,
     query::Ray as Ray3,
-    shape::{Segment as Segment3, Triangle as Triangle3},
+    shape::{Segment as Segment3, Triangle},
 };
 
 use crate::{
@@ -39,7 +39,7 @@ impl Faces {
     pub fn triangles(
         &self,
         tolerance: f64,
-        out: &mut Vec<Triangle3>,
+        out: &mut Vec<Triangle>,
         debug_info: &mut DebugInfo,
     ) {
         for face in &self.0 {
@@ -78,7 +78,7 @@ pub enum Face {
     /// The plan is to eventually represent faces as a geometric surface,
     /// bounded by edges. While the transition is being made, this variant is
     /// still required.
-    Triangles(Vec<Triangle3>),
+    Triangles(Vec<Triangle>),
 }
 
 impl Face {
@@ -103,7 +103,7 @@ impl Face {
     pub fn triangles(
         &self,
         tolerance: f64,
-        out: &mut Vec<Triangle3>,
+        out: &mut Vec<Triangle>,
         debug_info: &mut DebugInfo,
     ) {
         match self {
@@ -232,7 +232,7 @@ impl Face {
                     let b = surface.point_surface_to_model(b.value);
                     let c = surface.point_surface_to_model(c.value);
 
-                    Triangle3 { a, b, c }
+                    Triangle { a, b, c }
                 }));
             }
             Self::Triangles(triangles) => out.extend(triangles),

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -126,10 +126,8 @@ impl Face {
                     .map(|Segment3 { a, b }| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
-                        let a =
-                            surface.point_model_to_surface(a).unwrap().value;
-                        let b =
-                            surface.point_model_to_surface(b).unwrap().value;
+                        let a = surface.point_model_to_surface(a).unwrap();
+                        let b = surface.point_model_to_surface(b).unwrap();
 
                         [a, b]
                     })
@@ -155,14 +153,10 @@ impl Face {
 
                         // If the segment is an edge of the face, we don't need
                         // to take a closer look.
-                        if face_as_polygon
-                            .contains(&segment.map(|point| point.value))
-                        {
+                        if face_as_polygon.contains(&segment) {
                             continue;
                         }
-                        if face_as_polygon.contains(
-                            &inverted_segment.map(|point| point.value),
-                        ) {
+                        if face_as_polygon.contains(&inverted_segment) {
                             continue;
                         }
 
@@ -194,7 +188,8 @@ impl Face {
                             // check above. We don't need to handle any edge
                             // cases that would arise from that case.
 
-                            let edge = Segment2::from_array(edge);
+                            let edge =
+                                Segment2::from(edge.map(|point| point.value));
 
                             let intersection =
                                 edge.cast_local_ray(&ray, f64::INFINITY, true);

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -223,9 +223,9 @@ impl Face {
                 });
 
                 out.extend(triangles.into_iter().map(|[a, b, c]| {
-                    let a = surface.point_surface_to_model(a.value);
-                    let b = surface.point_surface_to_model(b.value);
-                    let c = surface.point_surface_to_model(c.value);
+                    let a = a.from;
+                    let b = b.from;
+                    let c = c.from;
 
                     Triangle { a, b, c }
                 }));

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -131,7 +131,7 @@ impl Face {
                         let b =
                             surface.point_model_to_surface(b).unwrap().value;
 
-                        Segment2 { a, b }
+                        [a, b]
                     })
                     .collect();
 
@@ -152,8 +152,11 @@ impl Face {
 
                         // If the segment is an edge of the face, we don't need
                         // to take a closer look.
-                        if face_as_polygon.contains(&segment)
-                            || face_as_polygon.contains(&inverted_segment)
+                        if face_as_polygon.contains(&[segment.a, segment.b])
+                            || face_as_polygon.contains(&[
+                                inverted_segment.a,
+                                inverted_segment.b,
+                            ])
                         {
                             continue;
                         }
@@ -184,6 +187,8 @@ impl Face {
                             // the point is not on a polygon edge, due to the
                             // check above. We don't need to handle any edge
                             // cases that would arise from that case.
+
+                            let edge = Segment2::from_array(edge);
 
                             let intersection =
                                 edge.cast_local_ray(&ray, f64::INFINITY, true);

--- a/src/kernel/util.rs
+++ b/src/kernel/util.rs
@@ -1,13 +1,10 @@
-use parry2d_f64::{
-    shape::Triangle,
-    utils::point_in_triangle::{corner_direction, Orientation},
-};
+use parry2d_f64::utils::point_in_triangle::{corner_direction, Orientation};
 use spade::HasPosition;
 
 use super::geometry::points::SurfacePoint;
 
 /// Create a Delaunay triangulation of all points
-pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<Triangle> {
+pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<[SurfacePoint; 3]> {
     use spade::Triangulation as _;
 
     let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
@@ -15,12 +12,11 @@ pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<Triangle> {
 
     let mut triangles = Vec::new();
     for triangle in triangulation.inner_faces() {
-        let [v0, v1, v2] =
-            triangle.vertices().map(|vertex| vertex.data().value);
+        let [v0, v1, v2] = triangle.vertices().map(|vertex| *vertex.data());
 
         let triangle = match corner_direction(&v0, &v1, &v2) {
-            Orientation::Ccw => [v0, v1, v2].into(),
-            Orientation::Cw => [v0, v2, v1].into(),
+            Orientation::Ccw => [v0, v1, v2],
+            Orientation::Cw => [v0, v2, v1],
             Orientation::None => {
                 panic!(
                     "Triangle returned from triangulation isn't actually a\

--- a/src/kernel/util.rs
+++ b/src/kernel/util.rs
@@ -7,7 +7,7 @@ use spade::HasPosition;
 
 use super::geometry::points::SurfacePoint;
 
-/// Create a Delaunay triangulation of all vertices
+/// Create a Delaunay triangulation of all points
 pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<Triangle> {
     use spade::Triangulation as _;
 

--- a/src/kernel/util.rs
+++ b/src/kernel/util.rs
@@ -1,0 +1,46 @@
+use nalgebra::point;
+use parry2d_f64::{
+    shape::Triangle,
+    utils::point_in_triangle::{corner_direction, Orientation},
+};
+
+use crate::math::Point;
+
+/// Create a Delaunay triangulation of all vertices
+pub fn triangulate(vertices: &[Point<2>]) -> Vec<Triangle> {
+    use spade::Triangulation as _;
+
+    let points: Vec<_> = vertices
+        .iter()
+        .map(|vertex| spade::Point2 {
+            x: vertex.x,
+            y: vertex.y,
+        })
+        .collect();
+
+    let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
+        .expect("Inserted invalid values into triangulation");
+
+    let mut triangles = Vec::new();
+    for triangle in triangulation.inner_faces() {
+        let [v0, v1, v2] = triangle.vertices().map(|vertex| {
+            let pos = vertex.position();
+            point![pos.x, pos.y]
+        });
+
+        let triangle = match corner_direction(&v0, &v1, &v2) {
+            Orientation::Ccw => [v0, v1, v2].into(),
+            Orientation::Cw => [v0, v2, v1].into(),
+            Orientation::None => {
+                panic!(
+                    "Triangle returned from triangulation isn't actually a\
+                    triangle"
+                );
+            }
+        };
+
+        triangles.push(triangle);
+    }
+
+    triangles
+}

--- a/src/kernel/util.rs
+++ b/src/kernel/util.rs
@@ -1,4 +1,3 @@
-use nalgebra::point;
 use parry2d_f64::{
     shape::Triangle,
     utils::point_in_triangle::{corner_direction, Orientation},
@@ -16,10 +15,8 @@ pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<Triangle> {
 
     let mut triangles = Vec::new();
     for triangle in triangulation.inner_faces() {
-        let [v0, v1, v2] = triangle.vertices().map(|vertex| {
-            let pos = vertex.position();
-            point![pos.x, pos.y]
-        });
+        let [v0, v1, v2] =
+            triangle.vertices().map(|vertex| vertex.data().value);
 
         let triangle = match corner_direction(&v0, &v1, &v2) {
             Orientation::Ccw => [v0, v1, v2].into(),

--- a/src/kernel/util.rs
+++ b/src/kernel/util.rs
@@ -3,8 +3,11 @@ use parry2d_f64::{
     shape::Triangle,
     utils::point_in_triangle::{corner_direction, Orientation},
 };
+use spade::HasPosition;
 
 use crate::math::Point;
+
+use super::geometry::points::SurfacePoint;
 
 /// Create a Delaunay triangulation of all vertices
 pub fn triangulate(vertices: &[Point<2>]) -> Vec<Triangle> {
@@ -43,4 +46,16 @@ pub fn triangulate(vertices: &[Point<2>]) -> Vec<Triangle> {
     }
 
     triangles
+}
+
+// Enables the use of `SurfacePoint` in the triangulation.
+impl HasPosition for SurfacePoint {
+    type Scalar = f64;
+
+    fn position(&self) -> spade::Point2<Self::Scalar> {
+        spade::Point2 {
+            x: self.value.x,
+            y: self.value.y,
+        }
+    }
 }

--- a/src/kernel/util.rs
+++ b/src/kernel/util.rs
@@ -5,21 +5,11 @@ use parry2d_f64::{
 };
 use spade::HasPosition;
 
-use crate::math::Point;
-
 use super::geometry::points::SurfacePoint;
 
 /// Create a Delaunay triangulation of all vertices
-pub fn triangulate(vertices: &[Point<2>]) -> Vec<Triangle> {
+pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<Triangle> {
     use spade::Triangulation as _;
-
-    let points: Vec<_> = vertices
-        .iter()
-        .map(|vertex| spade::Point2 {
-            x: vertex.x,
-            y: vertex.y,
-        })
-        .collect();
 
     let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
         .expect("Inserted invalid values into triangulation");


### PR DESCRIPTION
This PR adds infrastructure to track the origin 3D points that surface points are converted from, making it possible to remove any conversions that could potentially introduce accuracy problems. See #78 for a wider context and discussion of the issue.

This infrastructure is added in the first few commits. Then follows a whole lot of refactoring, with the pay-off in the second-to-last commit, when the potentially problematic conversions are removed.