### PR TITLE
Add `Vertex` and `Vertices`

### DIFF
--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -6,9 +6,9 @@ pub mod triangulation;
 
 use parry3d_f64::bounding_volume::AABB;
 
-use crate::{debug::DebugInfo, math::Point};
+use crate::debug::DebugInfo;
 
-use self::topology::{edges::Edges, faces::Faces};
+use self::topology::{edges::Edges, faces::Faces, vertices::Vertices};
 
 /// Implemented by all shapes
 pub trait Shape {
@@ -31,7 +31,7 @@ pub trait Shape {
     fn edges(&self) -> Edges;
 
     /// Return the shape's vertices
-    fn vertices(&self) -> Vec<Point<3>>;
+    fn vertices(&self) -> Vertices;
 }
 
 macro_rules! dispatch {
@@ -81,5 +81,5 @@ dispatch! {
         debug: &mut DebugInfo,
     ) -> Faces;
     edges() -> Edges;
-    vertices() -> Vec<Point<3>>;
+    vertices() -> Vertices;
 }

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -8,10 +8,10 @@ use crate::{
         topology::{
             edges::{Edge, Edges},
             faces::{Face, Faces},
+            vertices::Vertices,
         },
         Shape,
     },
-    math::Point,
 };
 
 impl Shape for fj::Circle {
@@ -34,8 +34,8 @@ impl Shape for fj::Circle {
         Edges::single_cycle([Edge::arc(self.radius)])
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
+    fn vertices(&self) -> Vertices {
         // Circles have just a single round edge with no vertices.
-        Vec::new()
+        Vertices(Vec::new())
     }
 }

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -6,10 +6,10 @@ use crate::{
         topology::{
             edges::Edges,
             faces::{Face, Faces},
+            vertices::Vertices,
         },
         Shape,
     },
-    math::Point,
 };
 
 impl Shape for fj::Difference2d {
@@ -94,7 +94,7 @@ impl Shape for fj::Difference2d {
         Edges { cycles: vec![a, b] }
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
+    fn vertices(&self) -> Vertices {
         todo!()
     }
 }

--- a/src/kernel/shapes/difference_3d.rs
+++ b/src/kernel/shapes/difference_3d.rs
@@ -3,10 +3,9 @@ use parry3d_f64::bounding_volume::AABB;
 use crate::{
     debug::DebugInfo,
     kernel::{
-        topology::{edges::Edges, faces::Faces},
+        topology::{edges::Edges, faces::Faces, vertices::Vertices},
         Shape,
     },
-    math::Point,
 };
 
 impl Shape for fj::Difference {
@@ -25,7 +24,7 @@ impl Shape for fj::Difference {
         todo!()
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
+    fn vertices(&self) -> Vertices {
         todo!()
     }
 }

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -28,7 +28,7 @@ impl Shape for fj::Sketch {
     }
 
     fn edges(&self) -> Edges {
-        let v = match self.vertices() {
+        let vertices = match self.vertices() {
             vertices if vertices.is_empty() => vertices,
             mut vertices => {
                 // Add the first vertex at the end again, to close the loop.
@@ -41,7 +41,7 @@ impl Shape for fj::Sketch {
         };
 
         let mut edges = Vec::new();
-        for window in v.windows(2) {
+        for window in vertices.windows(2) {
             // Can't panic, we passed `2` to `windows`.
             //
             // Can be cleaned up, once `array_windows` is stable.

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -7,6 +7,7 @@ use crate::{
         topology::{
             edges::{Edge, Edges},
             faces::{Face, Faces},
+            vertices::{Vertex, Vertices},
         },
         Shape,
     },
@@ -15,7 +16,8 @@ use crate::{
 
 impl Shape for fj::Sketch {
     fn bounding_volume(&self) -> AABB {
-        AABB::from_points(&self.vertices())
+        let vertices = self.vertices();
+        AABB::from_points(vertices.0.iter().map(|vertex| vertex.location()))
     }
 
     fn faces(&self, _: f64, _: &mut DebugInfo) -> Faces {
@@ -29,8 +31,10 @@ impl Shape for fj::Sketch {
 
     fn edges(&self) -> Edges {
         let vertices = match self.vertices() {
-            vertices if vertices.is_empty() => vertices,
-            mut vertices => {
+            vertices if vertices.0.is_empty() => vertices.0,
+            vertices => {
+                let mut vertices = vertices.0;
+
                 // Add the first vertex at the end again, to close the loop.
                 //
                 // This can't panic. This `match` expression makes sure that
@@ -48,7 +52,10 @@ impl Shape for fj::Sketch {
             let a = window[0];
             let b = window[1];
 
-            let line = Curve::Line(Line { a, b });
+            let line = Curve::Line(Line {
+                a: *a.location(),
+                b: *b.location(),
+            });
             let edge = Edge::new(line);
 
             edges.push(edge);
@@ -57,10 +64,15 @@ impl Shape for fj::Sketch {
         Edges::single_cycle(edges)
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
-        self.to_points()
+    fn vertices(&self) -> Vertices {
+        let vertices = self
+            .to_points()
             .into_iter()
-            .map(|[x, y]| Point::from([x, y, 0.]))
-            .collect()
+            // These calls to `create_at` are valid, since the points of this
+            // sketch come directly from the user and define new vertices of the
+            // shape.
+            .map(|[x, y]| Vertex::create_at(Point::from([x, y, 0.])))
+            .collect();
+        Vertices(vertices)
     }
 }

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -10,10 +10,10 @@ use crate::{
         topology::{
             edges::Edges,
             faces::{Face, Faces},
+            vertices::Vertices,
         },
         Shape,
     },
-    math::Point,
 };
 
 impl Shape for fj::Sweep {
@@ -77,7 +77,7 @@ impl Shape for fj::Sweep {
         todo!()
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
+    fn vertices(&self) -> Vertices {
         todo!()
     }
 }

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -3,10 +3,10 @@ use parry3d_f64::{bounding_volume::AABB, math::Isometry};
 use crate::{
     debug::DebugInfo,
     kernel::{
-        topology::{edges::Edges, faces::Faces},
+        topology::{edges::Edges, faces::Faces, vertices::Vertices},
         Shape,
     },
-    math::{Point, Vector},
+    math::Vector,
 };
 
 impl Shape for fj::Transform {
@@ -24,7 +24,7 @@ impl Shape for fj::Transform {
         todo!()
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
+    fn vertices(&self) -> Vertices {
         todo!()
     }
 }

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -3,10 +3,9 @@ use parry3d_f64::bounding_volume::{BoundingVolume as _, AABB};
 use crate::{
     debug::DebugInfo,
     kernel::{
-        topology::{edges::Edges, faces::Faces},
+        topology::{edges::Edges, faces::Faces, vertices::Vertices},
         Shape,
     },
-    math::Point,
 };
 
 impl Shape for fj::Union {
@@ -37,7 +36,7 @@ impl Shape for fj::Union {
         todo!()
     }
 
-    fn vertices(&self) -> Vec<Point<3>> {
+    fn vertices(&self) -> Vertices {
         todo!()
     }
 }

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -1,2 +1,3 @@
 pub mod edges;
 pub mod faces;
+pub mod vertices;

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use crate::math::Point;
 
 /// The vertices of a shape

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -2,6 +2,9 @@
 
 use crate::math::Point;
 
+/// The vertices of a shape
+pub struct Vertices(pub Vec<Vertex>);
+
 /// A vertex
 ///
 /// This struct exists to distinguish between vertices and points at the type

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,0 +1,43 @@
+#![allow(unused)]
+
+use crate::math::Point;
+
+/// A vertex
+///
+/// This struct exists to distinguish between vertices and points at the type
+/// level. This is a relevant distinction, as vertices are part of a shape that
+/// help define its topology.
+///
+/// Points, on the other hand, might be used to approximate a shape for various
+/// purposes, without presenting any deeper truth about the shape's structure.
+#[derive(Clone, Copy)]
+pub struct Vertex {
+    point: Point<3>,
+}
+
+impl Vertex {
+    /// Create a vertex at the given location
+    ///
+    /// This method **MUST NOT** be used to construct a new instance of `Vertex`
+    /// that represents an already existing vertex. If there already exists a
+    /// vertex and you need a `Vertex` instance to refer to it, acquire one by
+    /// copying the existing `Vertex` instance.
+    ///
+    /// Every time you create a `Vertex` instance, you might do so using a point
+    /// you have computed. When doing this for an existing vertex, you run the
+    /// risk of computing a slightly different point, due to floating point
+    /// accuracy issues. The resulting `Vertex` will then no longer be equal to
+    /// the existing `Vertex` instance that refers to the same vertex, which
+    /// will surely cause bugs.
+    ///
+    /// This can be prevented outright by never creating a new `Vertex` instance
+    /// for an existing vertex. Hence why this is strictly forbidden.
+    pub fn create_at(location: Point<3>) -> Self {
+        Self { point: location }
+    }
+
+    /// Access the location of this vertex
+    pub fn location(&self) -> &Point<3> {
+        &self.point
+    }
+}


### PR DESCRIPTION
`Vertex` is a new type to represent vertices of a shape. Its purpose is to make any code using it less error-prone (details in its documentation), and it will probably grow more functionality soon.

So far, there's not a whole lot to it, as it isn't used much. It will become more relevant as it is used in more places. The biggest advantage of this pull request is the documentation around `Vertex` and the constraints around its use that it adds.