### PR TITLE
Define circle radius using 2D vector

### DIFF
--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -16,15 +16,17 @@ pub struct Circle {
     /// The radius is represented by a vector that points from the center to the
     /// circumference. The point on the circumference that it points to defines
     /// the origin of the circle's 1-dimensional curve coordinate system.
-    pub radius: Vector<3>,
+    pub radius: Vector<2>,
 }
 
 impl Circle {
     #[must_use]
     pub fn transform(self, transform: &Isometry<f64>) -> Self {
+        let radius = vector![self.radius.x, self.radius.y, 0.];
+
         Self {
             center: transform.transform_point(&self.center),
-            radius: transform.transform_vector(&self.radius),
+            radius: transform.transform_vector(&radius).xy(),
         }
     }
 

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -127,7 +127,7 @@ impl Edge {
         Self {
             curve: Curve::Circle(Circle {
                 center: Point::origin(),
-                radius: vector![radius, 0., 0.],
+                radius: vector![radius, 0.],
             }),
             vertices: None,
             reverse: false,


### PR DESCRIPTION
The 3D definition is kind of wrong. I think all code currently assumes
that circles are in the x-y place[1]. Even if that weren't the case, a
single 3D vector would not be enough to define the plane of the circle.

I think the best solution for now is to make this change, and
investigate how the circle representation needs to be improved later.

[1] This would mean that circles and shapes based on circles can't
    currently be rotated. There's no issue to track this, so if this is
    true, one should be opened. I've added investigating this to my task
    list.