### PR TITLE
Add bounding vertices to `Edge`

### DIFF
--- a/src/kernel/approximation.rs
+++ b/src/kernel/approximation.rs
@@ -213,7 +213,10 @@ mod tests {
 
     use crate::kernel::{
         geometry::Curve,
-        topology::edges::{Cycle, Edge, Edges},
+        topology::{
+            edges::{Cycle, Edge, Edges},
+            vertices::Vertex,
+        },
     };
 
     use super::Approximation;
@@ -225,12 +228,15 @@ mod tests {
         let a = point![1., 2., 3.];
         let b = point![3., 5., 8.];
 
+        let v1 = Vertex::create_at(a);
+        let v2 = Vertex::create_at(b);
+
         let curve = Curve::Mock {
             approx: vec![a, b],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
 
-        let edge_regular = Edge::new(curve.clone());
+        let edge_regular = Edge::new(curve.clone(), Some([v1, v2]));
         assert_eq!(
             Approximation::for_edge(&edge_regular, tolerance),
             Approximation {
@@ -239,8 +245,7 @@ mod tests {
             }
         );
 
-        let mut edge_self_connected = Edge::new(curve.clone());
-        edge_self_connected.vertices = None;
+        let edge_self_connected = Edge::new(curve.clone(), None);
         assert_eq!(
             Approximation::for_edge(&edge_self_connected, tolerance),
             Approximation {
@@ -249,7 +254,7 @@ mod tests {
             }
         );
 
-        let mut edge_reversed = Edge::new(curve.clone());
+        let mut edge_reversed = Edge::new(curve.clone(), Some([v1, v2]));
         edge_reversed.reverse();
         assert_eq!(
             Approximation::for_edge(&edge_reversed, tolerance),
@@ -268,22 +273,26 @@ mod tests {
         let b = point![2., 3., 5.];
         let c = point![3., 5., 8.];
 
+        let v1 = Vertex::create_at(a);
+        let v2 = Vertex::create_at(b);
+        let v3 = Vertex::create_at(c);
+
         let ab = Curve::Mock {
             approx: vec![a, b],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
         let bc = Curve::Mock {
             approx: vec![b, c],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
         let ca = Curve::Mock {
             approx: vec![c, a],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
 
-        let ab = Edge::new(ab);
-        let bc = Edge::new(bc);
-        let ca = Edge::new(ca);
+        let ab = Edge::new(ab, Some([v1, v2]));
+        let bc = Edge::new(bc, Some([v2, v3]));
+        let ca = Edge::new(ca, Some([v3, v1]));
 
         let cycle = Cycle {
             edges: vec![ab, bc, ca],
@@ -311,27 +320,32 @@ mod tests {
         let c = point![3., 5., 8.];
         let d = point![5., 8., 13.];
 
+        let v1 = Vertex::create_at(a);
+        let v2 = Vertex::create_at(b);
+        let v3 = Vertex::create_at(c);
+        let v4 = Vertex::create_at(d);
+
         let ab = Curve::Mock {
             approx: vec![a, b],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
         let ba = Curve::Mock {
             approx: vec![b, a],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
         let cd = Curve::Mock {
             approx: vec![c, d],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
         let dc = Curve::Mock {
             approx: vec![d, c],
-            coords: RefCell::new(Vec::new()),
+            coords: RefCell::new(vec![point![0.], point![1.]]),
         };
 
-        let ab = Edge::new(ab);
-        let ba = Edge::new(ba);
-        let cd = Edge::new(cd);
-        let dc = Edge::new(dc);
+        let ab = Edge::new(ab, Some([v1, v2]));
+        let ba = Edge::new(ba, Some([v2, v1]));
+        let cd = Edge::new(cd, Some([v3, v4]));
+        let dc = Edge::new(dc, Some([v4, v3]));
 
         let ab_ba = Cycle {
             edges: vec![ab, ba],

--- a/src/kernel/approximation.rs
+++ b/src/kernel/approximation.rs
@@ -206,6 +206,8 @@ fn point_to_r64(point: Point<3>) -> [R64; 3] {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use nalgebra::point;
     use parry3d_f64::shape::Segment;
 
@@ -223,7 +225,10 @@ mod tests {
         let a = point![1., 2., 3.];
         let b = point![3., 5., 8.];
 
-        let curve = Curve::Mock { approx: vec![a, b] };
+        let curve = Curve::Mock {
+            approx: vec![a, b],
+            coords: RefCell::new(Vec::new()),
+        };
 
         let edge_regular = Edge::new(curve.clone());
         assert_eq!(
@@ -263,9 +268,18 @@ mod tests {
         let b = point![2., 3., 5.];
         let c = point![3., 5., 8.];
 
-        let ab = Curve::Mock { approx: vec![a, b] };
-        let bc = Curve::Mock { approx: vec![b, c] };
-        let ca = Curve::Mock { approx: vec![c, a] };
+        let ab = Curve::Mock {
+            approx: vec![a, b],
+            coords: RefCell::new(Vec::new()),
+        };
+        let bc = Curve::Mock {
+            approx: vec![b, c],
+            coords: RefCell::new(Vec::new()),
+        };
+        let ca = Curve::Mock {
+            approx: vec![c, a],
+            coords: RefCell::new(Vec::new()),
+        };
 
         let ab = Edge::new(ab);
         let bc = Edge::new(bc);
@@ -297,10 +311,22 @@ mod tests {
         let c = point![3., 5., 8.];
         let d = point![5., 8., 13.];
 
-        let ab = Curve::Mock { approx: vec![a, b] };
-        let ba = Curve::Mock { approx: vec![b, a] };
-        let cd = Curve::Mock { approx: vec![c, d] };
-        let dc = Curve::Mock { approx: vec![d, c] };
+        let ab = Curve::Mock {
+            approx: vec![a, b],
+            coords: RefCell::new(Vec::new()),
+        };
+        let ba = Curve::Mock {
+            approx: vec![b, a],
+            coords: RefCell::new(Vec::new()),
+        };
+        let cd = Curve::Mock {
+            approx: vec![c, d],
+            coords: RefCell::new(Vec::new()),
+        };
+        let dc = Curve::Mock {
+            approx: vec![d, c],
+            coords: RefCell::new(Vec::new()),
+        };
 
         let ab = Edge::new(ab);
         let ba = Edge::new(ba);

--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -1,5 +1,7 @@
 use std::f64::consts::PI;
 
+#[cfg(test)]
+use nalgebra::point;
 use nalgebra::vector;
 use parry3d_f64::math::Isometry;
 
@@ -28,6 +30,26 @@ impl Circle {
             center: transform.transform_point(&self.center),
             radius: transform.transform_vector(&radius).xy(),
         }
+    }
+
+    /// Convert a point in model coordinates to curve coordinates
+    ///
+    /// Converts the provided point into curve coordinates between `0.`
+    /// (inclusive) and `PI * 2.` (exclusive).
+    ///
+    /// Ignores the radius, meaning points that are not on the circle will be
+    /// converted to the curve coordinate of their projection on the circle.
+    ///
+    /// This is done to make this method robust against floating point accuracy
+    /// issues. Callers are advised to be careful about the points they pass, as
+    /// the point not being on the circle, intended or not, will not result in
+    /// an error.
+    #[cfg(test)]
+    pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
+        let v = point - self.center;
+        let atan = f64::atan2(v.y, v.x);
+        let coord = if atan >= 0. { atan } else { atan + PI * 2. };
+        point![coord]
     }
 
     pub fn approx(&self, tolerance: f64, out: &mut Vec<Point<3>>) {
@@ -67,9 +89,36 @@ impl Circle {
 
 #[cfg(test)]
 mod tests {
-    use std::f64::consts::PI;
+    use std::f64::consts::{FRAC_PI_2, PI};
+
+    use nalgebra::{point, vector};
 
     use super::Circle;
+
+    #[test]
+    fn test_point_model_to_curve() {
+        let circle = Circle {
+            center: point![1., 2., 3.],
+            radius: vector![1., 0.],
+        };
+
+        assert_eq!(
+            circle.point_model_to_curve(&point![2., 2., 3.]),
+            point![0.],
+        );
+        assert_eq!(
+            circle.point_model_to_curve(&point![1., 3., 3.]),
+            point![FRAC_PI_2],
+        );
+        assert_eq!(
+            circle.point_model_to_curve(&point![0., 2., 3.]),
+            point![PI],
+        );
+        assert_eq!(
+            circle.point_model_to_curve(&point![1., 1., 3.]),
+            point![FRAC_PI_2 * 3.],
+        );
+    }
 
     #[test]
     fn test_number_of_vertices() {

--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -1,8 +1,6 @@
 use std::f64::consts::PI;
 
-#[cfg(test)]
-use nalgebra::point;
-use nalgebra::vector;
+use nalgebra::{point, vector};
 use parry3d_f64::math::Isometry;
 
 use crate::math::{Point, Vector};
@@ -44,7 +42,6 @@ impl Circle {
     /// issues. Callers are advised to be careful about the points they pass, as
     /// the point not being on the circle, intended or not, will not result in
     /// an error.
-    #[cfg(test)]
     pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
         let v = point - self.center;
         let atan = f64::atan2(v.y, v.x);

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -1,5 +1,4 @@
 use approx::AbsDiffEq;
-#[cfg(test)]
 use nalgebra::point;
 use parry3d_f64::math::Isometry;
 
@@ -39,7 +38,6 @@ impl Line {
     /// issues. Callers are advised to be careful about the points they pass, as
     /// the point not being on the line, intended or not, will not result in an
     /// error.
-    #[cfg(test)]
     pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
         let p = point - self.a;
         let d = self.b - self.a;

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -1,4 +1,6 @@
 use approx::AbsDiffEq;
+#[cfg(test)]
+use nalgebra::point;
 use parry3d_f64::math::Isometry;
 
 use crate::math::Point;
@@ -25,6 +27,27 @@ impl Line {
             a: transform.transform_point(&self.a),
             b: transform.transform_point(&self.b),
         }
+    }
+
+    /// Convert a point in model coordinates to curve coordinates
+    ///
+    /// Ignores the distance of the point to the line, meaning points on the
+    /// line will be converted to the curve coordinates of their projection on
+    /// the line.
+    ///
+    /// This is done to make this method robust against floating point accuracy
+    /// issues. Callers are advised to be careful about the points they pass, as
+    /// the point not being on the line, intended or not, will not result in an
+    /// error.
+    #[cfg(test)]
+    pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
+        let p = point - self.a;
+        let d = self.b - self.a;
+
+        // scalar projection
+        let t = p.dot(&d.normalize());
+
+        point![t]
     }
 }
 
@@ -73,5 +96,18 @@ mod tests {
             },
             epsilon = 1e-8,
         );
+    }
+
+    #[test]
+    fn test_point_model_to_curve() {
+        let line = Line {
+            a: point![1., 0., 0.],
+            b: point![2., 0., 0.],
+        };
+
+        assert_eq!(line.point_model_to_curve(&point![0., 0., 0.]), point![-1.]);
+        assert_eq!(line.point_model_to_curve(&point![1., 0., 0.]), point![0.]);
+        assert_eq!(line.point_model_to_curve(&point![2., 0., 0.]), point![1.]);
+        assert_eq!(line.point_model_to_curve(&point![3., 0., 0.]), point![2.]);
     }
 }

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -41,6 +41,28 @@ impl Curve {
         }
     }
 
+    /// Convert a point in model coordinates to curve coordinates
+    ///
+    /// Whether the point is actually on the curve or not will be ignored. The
+    /// curve coordinates of the projection of the point on the curve will be
+    /// returned.
+    ///
+    /// This is done to make this method robust against floating point accuracy
+    /// issues. Callers are advised to be careful about the points they pass, as
+    /// the point not being on the curve, intended or not, will not result in an
+    /// error.
+    #[allow(unused)]
+    #[cfg(test)]
+    pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
+        match self {
+            Self::Circle(circle) => circle.point_model_to_curve(point),
+            Self::Line(line) => line.point_model_to_curve(point),
+
+            #[cfg(test)]
+            Self::Mock { .. } => todo!(),
+        }
+    }
+
     /// Compute an approximation of the curve
     ///
     /// `tolerance` defines how far the approximation is allowed to deviate from

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -55,7 +55,6 @@ impl Curve {
     /// the point not being on the curve, intended or not, will not result in an
     /// error.
     #[allow(unused)]
-    #[cfg(test)]
     pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
         match self {
             Self::Circle(circle) => circle.point_model_to_curve(point),

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -26,7 +26,10 @@ pub enum Curve {
 
     /// A mock curve used for testing
     #[cfg(test)]
-    Mock { approx: Vec<Point<3>> },
+    Mock {
+        approx: Vec<Point<3>>,
+        coords: std::cell::RefCell<Vec<Point<1>>>,
+    },
 }
 
 impl Curve {
@@ -59,7 +62,7 @@ impl Curve {
             Self::Line(line) => line.point_model_to_curve(point),
 
             #[cfg(test)]
-            Self::Mock { .. } => todo!(),
+            Self::Mock { coords, .. } => coords.borrow_mut().remove(0),
         }
     }
 
@@ -85,7 +88,7 @@ impl Curve {
             Self::Line(Line { a, b }) => out.extend([*a, *b]),
 
             #[cfg(test)]
-            Self::Mock { approx } => out.extend(approx),
+            Self::Mock { approx, .. } => out.extend(approx),
         }
     }
 }

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -54,7 +54,6 @@ impl Curve {
     /// issues. Callers are advised to be careful about the points they pass, as
     /// the point not being on the curve, intended or not, will not result in an
     /// error.
-    #[allow(unused)]
     pub fn point_model_to_curve(&self, point: &Point<3>) -> Point<1> {
         match self {
             Self::Circle(circle) => circle.point_model_to_curve(point),

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -56,7 +56,7 @@ impl Shape for fj::Sketch {
                 a: *a.location(),
                 b: *b.location(),
             });
-            let edge = Edge::new(line);
+            let edge = Edge::new(line, Some([a, b]));
 
             edges.push(edge);
         }

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -36,7 +36,7 @@ impl Edges {
     pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
         for cycle in &mut self.cycles {
             for edge in &mut cycle.edges {
-                edge.curve = edge.curve.clone().transform(transform);
+                *edge = edge.clone().transform(transform);
             }
         }
 
@@ -149,5 +149,12 @@ impl Edge {
     /// Reverse the edge
     pub fn reverse(&mut self) {
         self.reverse = !self.reverse;
+    }
+
+    /// Transform the edge
+    #[must_use]
+    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
+        self.curve = self.curve.transform(transform);
+        self
     }
 }

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -113,6 +113,13 @@ pub struct Edge {
 
 impl Edge {
     /// Construct an edge
+    ///
+    /// If vertices are provided in `vertices`, they must be on `curve`.
+    ///
+    /// This constructor will convert the vertices into curve coordinates. If
+    /// they are not on the curve, this will result in their projection being
+    /// converted into curve coordinates, which is likely not the caller's
+    /// intention.
     pub fn new(curve: Curve, vertices: Option<[Vertex<3>; 2]>) -> Self {
         let vertices = vertices
             .map(|vertices| vertices.map(|vertex| vertex.to_1d(&curve)));

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -6,6 +6,8 @@ use crate::{
     math::Point,
 };
 
+use super::vertices::Vertex;
+
 /// The edges of a shape
 #[derive(Clone)]
 pub struct Edges {
@@ -99,7 +101,7 @@ pub struct Edge {
     /// The logical conclusion is that vertices here should be represented in 1D
     /// curve coordinates, only being converted into 3D points for the
     /// approximation.
-    pub vertices: Option<[(); 2]>,
+    pub vertices: Option<[Vertex<1>; 2]>,
 
     /// Indicates whether the curve's direction is reversed
     ///
@@ -111,10 +113,13 @@ pub struct Edge {
 
 impl Edge {
     /// Construct an edge
-    pub fn new(curve: Curve) -> Self {
+    pub fn new(curve: Curve, vertices: Option<[Vertex<3>; 2]>) -> Self {
+        let vertices = vertices
+            .map(|vertices| vertices.map(|vertex| vertex.to_1d(&curve)));
+
         Self {
             curve,
-            vertices: Some([(), ()]),
+            vertices,
             reverse: false,
         }
     }

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -155,6 +155,10 @@ impl Edge {
     #[must_use]
     pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
         self.curve = self.curve.transform(transform);
+        self.vertices = self
+            .vertices
+            .map(|vertices| vertices.map(|vertex| vertex.transform(transform)));
+
         self
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -56,7 +56,6 @@ impl Vertex<3> {
     ///
     /// Uses to provided curve to convert the vertex into a 1-dimensional vertex
     /// in the curve's coordinate system.
-    #[allow(unused)]
     pub fn to_1d(&self, curve: &Curve) -> Vertex<1> {
         let location = curve.point_model_to_curve(&self.location);
 

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,4 +1,4 @@
-use crate::math::Point;
+use crate::{kernel::geometry::Curve, math::Point};
 
 /// The vertices of a shape
 pub struct Vertices(pub Vec<Vertex<3>>);
@@ -14,6 +14,14 @@ pub struct Vertices(pub Vec<Vertex<3>>);
 #[derive(Clone, Copy, Debug)]
 pub struct Vertex<const D: usize> {
     location: Point<D>,
+
+    /// The canonical location of this vertex
+    ///
+    /// The canonical location is always a point in 3D space. If this is a
+    /// `Vertex<3>`, this field is just redundant. If the vertex is of different
+    /// dimensionality, this field allows for loss-free conversion back into the
+    /// canonical representation.
+    canonical: Point<3>,
 }
 
 impl Vertex<3> {
@@ -34,7 +42,24 @@ impl Vertex<3> {
     /// This can be prevented outright by never creating a new `Vertex` instance
     /// for an existing vertex. Hence why this is strictly forbidden.
     pub fn create_at(location: Point<3>) -> Self {
-        Self { location }
+        Self {
+            location,
+            canonical: location,
+        }
+    }
+
+    /// Convert the vertex to a 1-dimensional vertex
+    ///
+    /// Uses to provided curve to convert the vertex into a 1-dimensional vertex
+    /// in the curve's coordinate system.
+    #[allow(unused)]
+    pub fn to_1d(&self, curve: &Curve) -> Vertex<1> {
+        let location = curve.point_model_to_curve(&self.location);
+
+        Vertex {
+            location,
+            canonical: self.canonical,
+        }
     }
 }
 

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -27,10 +27,14 @@ pub struct Vertex<const D: usize> {
 impl Vertex<3> {
     /// Create a vertex at the given location
     ///
+    /// Only 3-dimensional vertices can be created, as that is the canonical
+    /// representation of a vertex. If you need a vertex of different
+    /// dimensionality, use a conversion method.
+    ///
     /// This method **MUST NOT** be used to construct a new instance of `Vertex`
     /// that represents an already existing vertex. If there already exists a
     /// vertex and you need a `Vertex` instance to refer to it, acquire one by
-    /// copying the existing `Vertex` instance.
+    /// copying or converting the existing `Vertex` instance.
     ///
     /// Every time you create a `Vertex` instance, you might do so using a point
     /// you have computed. When doing this for an existing vertex, you run the

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,3 +1,5 @@
+use parry3d_f64::math::Isometry;
+
 use crate::{kernel::geometry::Curve, math::Point};
 
 /// The vertices of a shape
@@ -70,5 +72,15 @@ impl<const D: usize> Vertex<D> {
     /// Access the location of this vertex
     pub fn location(&self) -> &Point<D> {
         &self.location
+    }
+
+    /// Create a transformed vertex
+    ///
+    /// The transformed vertex has its canonical form transformed by the
+    /// transformation provided, but is otherwise identical.
+    #[must_use]
+    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
+        self.canonical = transform.transform_point(&self.canonical);
+        self
     }
 }


### PR DESCRIPTION
This pull request adds bounding vertices to `Edge`, as well as the infrastructure required to support it. This doesn't provide any new capabilities, but it is a refactoring that enables more a robust edge approximation approach to be implemented.