### PR TITLE
Make edge approximation more robust

### DIFF
--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -82,7 +82,7 @@ impl Curve {
     pub fn approx(&self, tolerance: f64, out: &mut Vec<Point<3>>) {
         match self {
             Self::Circle(circle) => circle.approx(tolerance, out),
-            Self::Line(Line { a, b }) => out.extend([*a, *b]),
+            Self::Line(_) => {}
 
             #[cfg(test)]
             Self::Mock { approx, .. } => out.extend(approx),

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -75,7 +75,6 @@ impl<const D: usize> Vertex<D> {
     }
 
     /// Convert the vertex to its canonical form
-    #[allow(unused)]
     pub fn to_canonical(&self) -> Vertex<3> {
         Vertex {
             location: self.canonical,

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -74,6 +74,15 @@ impl<const D: usize> Vertex<D> {
         &self.location
     }
 
+    /// Convert the vertex to its canonical form
+    #[allow(unused)]
+    pub fn to_canonical(&self) -> Vertex<3> {
+        Vertex {
+            location: self.canonical,
+            canonical: self.canonical,
+        }
+    }
+
     /// Create a transformed vertex
     ///
     /// The transformed vertex has its canonical form transformed by the


### PR DESCRIPTION
This is a pure refactoring, meaning it doesn't actually fix any robustness issues. But it does make the edge approximation code more robust, meaning some requirements on the neighboring curve approximation code are lifted. This will enable adding more interesting curves, which is required for a follow-up refactoring I'm going to tackle next, which is needed to address #97.