### PR TITLE
Add workflow to compile binaries for all major OS<>arch combinations

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,7 +2,7 @@ name: Binaries
 
 on:
   push:
-    branches: [ main, '#57_provide-major-os-binaries-for-every-commit-to-main' ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -56,6 +56,7 @@ jobs:
           use-cross: ${{ matrix.cross }}
 
       - name: Compress
+        shell: bash
         run: |
           cd target/${{ matrix.target }}/release
           case "${RUNNER_OS}" in

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,90 @@
+name: Binaries
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+  # Name of the crate from Cargo.toml
+  # used to package up the binaries on disk
+  PROJ_NAME: fj-host
+
+jobs:
+  binaries:
+    name: Binaries
+    strategy:
+      matrix:
+        include:
+          # Supported `cross` targets:
+          #   https://github.com/rust-embedded/cross#supported-targets
+
+          # Linux targets
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, cross: true }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-latest, cross: true }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-latest, cross: true }
+
+          # macOS targets
+          - { target: x86_64-apple-darwin, os: macOS-latest, cross: false }
+          - { target: aarch64-apple-darwin, os: macOS-latest, cross: false }
+
+          # Windows works
+          - { target: x86_64-pc-windows-msvc, os: windows-latest, cross: false }
+
+    runs-on: ${{matrix.os}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+          toolchain: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Compile
+        uses: actions-rs/cargo@v1
+        with:
+          args: --release --target ${{ matrix.target }}
+          command: build
+          use-cross: ${{ matrix.cross }}
+
+      - name: Compress
+        run: |
+          cd target/${{ matrix.target }}/release
+          case "${RUNNER_OS}" in
+            Linux)
+              tar czvf "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}.tar.gz" "${PROJ_NAME}"
+              ;;
+            macOS)
+              # gh docs say gtar is aliased to tar, but it failed
+              gtar czvf "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}.tar.gz" "${PROJ_NAME}"
+              ;;
+            Windows)
+              7z a "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}.zip" "${PROJ_NAME}.exe"
+              ;;
+            *)
+              echo "[ERROR] unsupported OS: ${RUNNER_OS}"
+              exit 1
+          esac
+          cd -
+
+      - name: Upload Unix
+        if: runner.os != 'Windows'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PROJ_NAME }}-${{ matrix.target }}.tar.gz
+          path: ${{ env.PROJ_NAME }}-${{ matrix.target }}.tar.gz
+
+      - name: Upload Windows
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PROJ_NAME }}-${{ matrix.target }}.zip
+          path: ${{ env.PROJ_NAME }}-${{ matrix.target }}.zip

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,7 +2,7 @@ name: Binaries
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '#57_provide-major-os-binaries-for-every-commit-to-main' ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This change-set introduces a new workflow to compile Fornjot's host application binaries for all major operating system and architecture combinations.

As defined in #57, the workflow only runs on changes to the repository `main` branch. It does not run on or block pull-requests.

Each compiled binary is compressed (unix *.tar.gz, win *.zip) and uploaded as build artifact. The target OS and architecture are used to name the archive, while the binary inside is not renamed. These build artifacts can then be downloaded, expanded and tested as one sees fit. Please mind that the artifacts only show up once all branches of the matrix build have finished.

Currently, the workflow is untested. Testing GitHub Action workflows is best done by allowing the workflow to run on the current HEAD (e.g. on this pull-request). Once asserted, the run conditions can be changed back before merging.

~@hannobraun you'd need to allow the workflow to run, because fork workflows do not run without permission.~

~Another workaround is to submit a pull-request to my own fork, which I am doing here to test it https://github.com/hendrikmaus/Fornjot/pull/1~

Tested in https://github.com/hendrikmaus/Fornjot/actions/runs/1830515553 (follow the link to also see the list of build artifacts)

---

**Impressions:**

The matrix build running:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/188284/153631777-1fc73071-9051-46a3-a51e-af23cc3de6ff.png">

The list of artifacts appears once all matrix finished running: (Windows failed)
<img width="696" alt="image" src="https://user-images.githubusercontent.com/188284/153634581-9f09731b-a1ba-4428-a74d-6fa669291f57.png">

Cold compile times:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/188284/153634927-f4b4b27b-098a-496c-b50d-9252e8da96f2.png">

Warm compile times: (Windows also green now)
<img width="628" alt="image" src="https://user-images.githubusercontent.com/188284/153636526-e12e470b-895f-4407-ba67-b9626dfa746a.png">