### PR TITLE
Iterate on workflow to compile binaries for all major OS<>arch combinations

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -59,13 +59,17 @@ jobs:
         shell: bash
         run: |
           # Include compile target in binary name
-          
-          mv -v \
-            "target/${{ matrix.target }}/release/${PROJ_NAME}" \
-            "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
-          
-          chmod -v +x \
-            "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
+
+          src="target/${{ matrix.target }}/release/${PROJ_NAME}"
+          dst="${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
+
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            src="${src}.exe"
+            dst="${dst}.exe"
+          fi
+
+          mv -v "${src}" "${dst}"
+          chmod -v +x "${dst}"
 
       - name: Upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
   # Name of the crate from Cargo.toml
-  # used to package up the binaries on disk
+  # used to rename and upload the binaries
   PROJ_NAME: fj-host
 
 jobs:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -71,8 +71,16 @@ jobs:
           mv -v "${src}" "${dst}"
           chmod -v +x "${dst}"
 
-      - name: Upload
+      - name: Upload Unix
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.PROJ_NAME }}-${{ matrix.target }}
           path: ${{ env.PROJ_NAME }}-${{ matrix.target }}
+
+      - name: Upload Windows
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PROJ_NAME }}-${{ matrix.target }}.exe
+          path: ${{ env.PROJ_NAME }}-${{ matrix.target }}.exe

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,7 +2,7 @@ name: Compile Binaries
 
 on:
   push:
-    branches: [ main, '#57_do-not-compress-binaries' ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -29,7 +29,7 @@ jobs:
           - { target: x86_64-apple-darwin, os: macOS-latest, cross: false }
           - { target: aarch64-apple-darwin, os: macOS-latest, cross: false }
 
-          # Windows works
+          # Windows targets
           - { target: x86_64-pc-windows-msvc, os: windows-latest, cross: false }
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,4 +1,4 @@
-name: Binaries
+name: Compile Binaries
 
 on:
   push:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -60,11 +60,11 @@ jobs:
         run: |
           # Include compile target in binary name
           
-          mv --verbose \
+          mv -v \
             "target/${{ matrix.target }}/release/${PROJ_NAME}" \
             "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
           
-          chmod --changes +x \
+          chmod -c +x \
             "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
 
       - name: Upload

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -58,8 +58,13 @@ jobs:
       - name: Prepare Upload
         shell: bash
         run: |
-          mv \
+          # Include compile target in binary name
+          
+          mv --verbose \
             "target/${{ matrix.target }}/release/${PROJ_NAME}" \
+            "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
+          
+          chmod --changes +x \
             "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
 
       - name: Upload

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -64,7 +64,7 @@ jobs:
             "target/${{ matrix.target }}/release/${PROJ_NAME}" \
             "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
           
-          chmod -c +x \
+          chmod -v +x \
             "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
 
       - name: Upload

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -55,37 +55,15 @@ jobs:
           command: build
           use-cross: ${{ matrix.cross }}
 
-      - name: Compress
+      - name: Prepare Upload
         shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          case "${RUNNER_OS}" in
-            Linux)
-              tar czvf "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}.tar.gz" "${PROJ_NAME}"
-              ;;
-            macOS)
-              # gh docs say gtar is aliased to tar, but it failed
-              gtar czvf "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}.tar.gz" "${PROJ_NAME}"
-              ;;
-            Windows)
-              7z a "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}.zip" "${PROJ_NAME}.exe"
-              ;;
-            *)
-              echo "[ERROR] unsupported OS: ${RUNNER_OS}"
-              exit 1
-          esac
-          cd -
+          mv \
+            "target/${{ matrix.target }}/release/${PROJ_NAME}" \
+            "${GITHUB_WORKSPACE}/${PROJ_NAME}-${{ matrix.target }}"
 
-      - name: Upload Unix
-        if: runner.os != 'Windows'
+      - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.PROJ_NAME }}-${{ matrix.target }}.tar.gz
-          path: ${{ env.PROJ_NAME }}-${{ matrix.target }}.tar.gz
-
-      - name: Upload Windows
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PROJ_NAME }}-${{ matrix.target }}.zip
-          path: ${{ env.PROJ_NAME }}-${{ matrix.target }}.zip
+          name: ${{ env.PROJ_NAME }}-${{ matrix.target }}
+          path: ${{ env.PROJ_NAME }}-${{ matrix.target }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -2,7 +2,7 @@ name: Binaries
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '#57_do-not-compress-binaries' ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This change-set iterates on the initial version of the workflow https://github.com/hannobraun/Fornjot/issues/57 and fixes the behavior observed and described in https://github.com/hannobraun/Fornjot/pull/175#pullrequestreview-880472207.

Instead of compressing the compiled binaries before they are uploaded to GitHub, they are renamed to `fj-host-<target>`:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/188284/153719358-c79c7f0d-cd9c-4472-9d2e-294b4a9b254a.png">

Furthermore, I adjusted the name of the workflow and some comments in the file.
