### PR TITLE
Fix coordinate systems of `Line` and `Plane`

### DIFF
--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -102,9 +102,16 @@ mod tests {
             direction: vector![1., 0., 0.],
         };
 
-        assert_eq!(line.point_model_to_curve(&point![0., 0., 0.]), point![-1.]);
-        assert_eq!(line.point_model_to_curve(&point![1., 0., 0.]), point![0.]);
-        assert_eq!(line.point_model_to_curve(&point![2., 0., 0.]), point![1.]);
-        assert_eq!(line.point_model_to_curve(&point![3., 0., 0.]), point![2.]);
+        verify(line, -1.);
+        verify(line, 0.);
+        verify(line, 1.);
+        verify(line, 2.);
+
+        fn verify(line: Line, t: f64) {
+            let point = line.origin + line.direction * t;
+            let t_result = line.point_model_to_curve(&point);
+
+            assert_eq!(point![t], t_result);
+        }
     }
 }

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -42,7 +42,7 @@ impl Line {
         let p = point - self.origin;
 
         // scalar projection
-        let t = p.dot(&self.direction.normalize());
+        let t = p.dot(&self.direction.normalize()) / self.direction.magnitude();
 
         point![t]
     }
@@ -99,7 +99,7 @@ mod tests {
     fn test_point_model_to_curve() {
         let line = Line {
             origin: point![1., 0., 0.],
-            direction: vector![1., 0., 0.],
+            direction: vector![2., 0., 0.],
         };
 
         verify(line, -1.);

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -52,7 +52,7 @@ impl Surface {
     }
 
     /// Convert a vector in surface coordinates to model coordinates
-    pub fn vector_surface_to_model(&self, vector: Vector<2>) -> Vector<3> {
+    pub fn vector_surface_to_model(&self, vector: &Vector<2>) -> Vector<3> {
         match self {
             Self::Plane(plane) => plane.vector_surface_to_model(vector),
         }
@@ -136,11 +136,11 @@ impl Plane {
 
     /// Convert a point in surface coordinates to model coordinates
     pub fn point_surface_to_model(&self, point: Point<2>) -> Point<3> {
-        self.origin + self.vector_surface_to_model(point.coords)
+        self.origin + self.vector_surface_to_model(&point.coords)
     }
 
     /// Convert a vector in surface coordinates to model coordinates
-    pub fn vector_surface_to_model(&self, vector: Vector<2>) -> Vector<3> {
+    pub fn vector_surface_to_model(&self, vector: &Vector<2>) -> Vector<3> {
         vector.x * self.u + vector.y * self.v
     }
 }
@@ -263,7 +263,7 @@ mod tests {
         };
 
         assert_eq!(
-            plane.vector_surface_to_model(vector![2., 4.]),
+            plane.vector_surface_to_model(&vector![2., 4.]),
             vector![0., 2., 4.],
         );
     }

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -197,7 +197,7 @@ mod tests {
     use nalgebra::{point, vector, UnitQuaternion};
     use parry3d_f64::math::{Isometry, Translation};
 
-    use crate::math::Vector;
+    use crate::math::{Point, Vector};
 
     use super::Plane;
 
@@ -232,12 +232,14 @@ mod tests {
             v: vector![0., 0., 1.],
         };
 
-        let valid_model_point = point![1., 4., 6.];
+        verify(&plane, point![2., 3.]);
 
-        assert_eq!(
-            plane.point_model_to_surface(valid_model_point),
-            point![2., 3.],
-        );
+        fn verify(plane: &Plane, surface_point: Point<2>) {
+            let point = plane.point_surface_to_model(&surface_point);
+            let result = plane.point_model_to_surface(point);
+
+            assert_eq!(result, surface_point);
+        }
     }
 
     #[test]

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -128,8 +128,8 @@ impl Plane {
         let p = point - self.origin;
 
         // scalar projection
-        let u = p.dot(&self.u.normalize());
-        let v = p.dot(&self.v.normalize());
+        let u = p.dot(&self.u.normalize()) / self.u.magnitude();
+        let v = p.dot(&self.v.normalize()) / self.v.magnitude();
 
         point![u, v]
     }
@@ -228,8 +228,8 @@ mod tests {
     fn test_model_to_surface_point_conversion() {
         let plane = Plane {
             origin: point![1., 2., 3.],
-            u: vector![0., 1., 0.],
-            v: vector![0., 0., 1.],
+            u: vector![0., 2., 0.],
+            v: vector![0., 0., 3.],
         };
 
         verify(&plane, point![-1., -1.]);

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -232,6 +232,9 @@ mod tests {
             v: vector![0., 0., 1.],
         };
 
+        verify(&plane, point![-1., -1.]);
+        verify(&plane, point![0., 0.]);
+        verify(&plane, point![1., 1.]);
         verify(&plane, point![2., 3.]);
 
         fn verify(plane: &Plane, surface_point: Point<2>) {

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -33,18 +33,15 @@ impl Surface {
     /// Convert a point in model coordinates to surface coordinates
     ///
     /// Returns an error, if the provided point is not in the surface.
-    pub fn point_model_to_surface(
-        &self,
-        point_3d: Point<3>,
-    ) -> Result<SurfacePoint, ()> {
+    pub fn point_model_to_surface(&self, point_3d: Point<3>) -> SurfacePoint {
         let point_2d = match self {
             Self::Plane(plane) => plane.point_model_to_surface(point_3d),
         };
 
-        Ok(SurfacePoint {
+        SurfacePoint {
             value: point_2d,
             from: point_3d,
-        })
+        }
     }
 
     /// Convert a point in surface coordinates to model coordinates

--- a/src/kernel/geometry/surfaces.rs
+++ b/src/kernel/geometry/surfaces.rs
@@ -45,7 +45,7 @@ impl Surface {
     }
 
     /// Convert a point in surface coordinates to model coordinates
-    pub fn point_surface_to_model(&self, point: Point<2>) -> Point<3> {
+    pub fn point_surface_to_model(&self, point: &Point<2>) -> Point<3> {
         match self {
             Self::Plane(plane) => plane.point_surface_to_model(point),
         }
@@ -135,7 +135,7 @@ impl Plane {
     }
 
     /// Convert a point in surface coordinates to model coordinates
-    pub fn point_surface_to_model(&self, point: Point<2>) -> Point<3> {
+    pub fn point_surface_to_model(&self, point: &Point<2>) -> Point<3> {
         self.origin + self.vector_surface_to_model(&point.coords)
     }
 
@@ -249,7 +249,7 @@ mod tests {
         };
 
         assert_eq!(
-            plane.point_surface_to_model(point![2., 4.]),
+            plane.point_surface_to_model(&point![2., 4.]),
             point![1., 4., 7.],
         );
     }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -120,7 +120,7 @@ impl Face {
                     .map(|vertex| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
-                        surface.point_model_to_surface(vertex).unwrap()
+                        surface.point_model_to_surface(vertex)
                     })
                     .collect();
 
@@ -130,8 +130,8 @@ impl Face {
                     .map(|Segment3 { a, b }| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
-                        let a = surface.point_model_to_surface(a).unwrap();
-                        let b = surface.point_model_to_surface(b).unwrap();
+                        let a = surface.point_model_to_surface(a);
+                        let b = surface.point_model_to_surface(b);
 
                         [a, b]
                     })

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -175,7 +175,7 @@ impl Face {
                         };
                         let mut check = TriangleEdgeCheck::new(Ray3 {
                             origin: surface.point_surface_to_model(ray.origin),
-                            dir: surface.vector_surface_to_model(ray.dir),
+                            dir: surface.vector_surface_to_model(&ray.dir),
                         });
 
                         // We need to keep track of where our ray hits the

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -174,7 +174,7 @@ impl Face {
                             dir: outside - center,
                         };
                         let mut check = TriangleEdgeCheck::new(Ray3 {
-                            origin: surface.point_surface_to_model(ray.origin),
+                            origin: surface.point_surface_to_model(&ray.origin),
                             dir: surface.vector_surface_to_model(&ray.dir),
                         });
 


### PR DESCRIPTION
The conversion from model points to curve/surface points didn't use the correct coordinate system, not taking the lengths of the direction vectors in account.

Also includes some cleanups of related code.