### PR TITLE
Add `math::Transform`

### DIFF
--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -1,9 +1,8 @@
 use std::f64::consts::PI;
 
 use nalgebra::{point, vector};
-use parry3d_f64::math::Isometry;
 
-use crate::kernel::math::{Point, Vector};
+use crate::kernel::math::{Point, Transform, Vector};
 
 /// A circle
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -26,7 +25,7 @@ impl Circle {
     }
 
     #[must_use]
-    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(self, transform: &Transform) -> Self {
         let radius = vector![self.radius.x, self.radius.y, 0.];
 
         Self {

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -94,10 +94,13 @@ mod tests {
             direction: vector![0., 1., 0.],
         };
 
-        let line = line.transform(&Isometry::from_parts(
-            Translation::from([1., 2., 3.]),
-            UnitQuaternion::from_axis_angle(&Vector::z_axis(), FRAC_PI_2),
-        ));
+        let line = line.transform(
+            &Isometry::from_parts(
+                Translation::from([1., 2., 3.]),
+                UnitQuaternion::from_axis_angle(&Vector::z_axis(), FRAC_PI_2),
+            )
+            .into(),
+        );
 
         assert_abs_diff_eq!(
             line,

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -1,8 +1,7 @@
 use approx::AbsDiffEq;
 use nalgebra::point;
-use parry3d_f64::math::Isometry;
 
-use crate::kernel::math::{Point, Vector};
+use crate::kernel::math::{Point, Transform, Vector};
 
 /// A line, defined by a point and a vector
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -26,7 +25,7 @@ impl Line {
 
     /// Transform the line
     #[must_use]
-    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(self, transform: &Transform) -> Self {
         Self {
             origin: transform.transform_point(&self.origin),
             direction: transform.transform_vector(&self.direction),

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -1,11 +1,9 @@
 mod circle;
 mod line;
 
-use crate::kernel::math::{Point, Vector};
+use crate::kernel::math::{Point, Transform, Vector};
 
 pub use self::{circle::Circle, line::Line};
-
-use parry3d_f64::math::Isometry;
 
 /// A one-dimensional shape
 ///
@@ -45,7 +43,7 @@ impl Curve {
     }
 
     #[must_use]
-    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(self, transform: &Transform) -> Self {
         match self {
             Self::Circle(curve) => Self::Circle(curve.transform(transform)),
             Self::Line(curve) => Self::Line(curve.transform(transform)),

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -3,9 +3,8 @@ pub mod swept;
 pub use self::swept::Swept;
 
 use nalgebra::vector;
-use parry3d_f64::math::Isometry;
 
-use crate::kernel::math::{Point, Vector};
+use crate::kernel::math::{Point, Transform, Vector};
 
 use super::{points::SurfacePoint, Curve, Line};
 
@@ -30,7 +29,7 @@ impl Surface {
 
     /// Transform the surface
     #[must_use]
-    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(self, transform: &Transform) -> Self {
         match self {
             Self::Swept(surface) => Self::Swept(surface.transform(transform)),
         }

--- a/src/kernel/geometry/surfaces/swept.rs
+++ b/src/kernel/geometry/surfaces/swept.rs
@@ -1,9 +1,8 @@
 use nalgebra::{point, vector};
-use parry3d_f64::math::Isometry;
 
 use crate::kernel::{
     geometry::Curve,
-    math::{Point, Vector},
+    math::{Point, Transform, Vector},
 };
 
 /// A surface that was swept from a curve
@@ -19,7 +18,7 @@ pub struct Swept {
 impl Swept {
     /// Transform the surface
     #[must_use]
-    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(mut self, transform: &Transform) -> Self {
         self.curve = self.curve.transform(transform);
         self.path = transform.transform_vector(&self.path);
         self

--- a/src/kernel/math.rs
+++ b/src/kernel/math.rs
@@ -1,2 +1,3 @@
 pub type Point<const D: usize> = nalgebra::Point<f64, D>;
 pub type Vector<const D: usize> = nalgebra::SVector<f64, D>;
+pub type Transform = parry3d_f64::math::Isometry<f64>;

--- a/src/kernel/math.rs
+++ b/src/kernel/math.rs
@@ -1,3 +1,35 @@
 pub type Point<const D: usize> = nalgebra::Point<f64, D>;
 pub type Vector<const D: usize> = nalgebra::SVector<f64, D>;
-pub type Transform = parry3d_f64::math::Isometry<f64>;
+
+/// A transform
+pub struct Transform(parry3d_f64::math::Isometry<f64>);
+
+impl Transform {
+    /// Transform the given point
+    pub fn transform_point(&self, point: &Point<3>) -> Point<3> {
+        self.0.transform_point(point)
+    }
+
+    /// Transform the given vector
+    pub fn transform_vector(&self, vector: &Vector<3>) -> Vector<3> {
+        self.0.transform_vector(vector)
+    }
+}
+
+impl From<parry3d_f64::math::Isometry<f64>> for Transform {
+    fn from(isometry: parry3d_f64::math::Isometry<f64>) -> Self {
+        Self(isometry)
+    }
+}
+
+impl From<Transform> for parry3d_f64::math::Isometry<f64> {
+    fn from(transform: Transform) -> Self {
+        transform.0
+    }
+}
+
+impl<'r> From<&'r Transform> for parry3d_f64::math::Isometry<f64> {
+    fn from(transform: &Transform) -> Self {
+        transform.0
+    }
+}

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -28,13 +28,10 @@ impl Shape for fj::Sweep {
 
         let bottom_faces = original_faces
             .clone()
-            .transform(&Isometry::rotation(vector![PI, 0., 0.]));
+            .transform(&Isometry::rotation(vector![PI, 0., 0.]).into());
 
-        let top_faces = original_faces.transform(&Isometry::translation(
-            0.0,
-            0.0,
-            self.length,
-        ));
+        let top_faces = original_faces
+            .transform(&Isometry::translation(0.0, 0.0, self.length).into());
 
         // This will only work correctly, if the original shape consists of one
         // edge. If there are more, this will create some kind of weird face

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -11,7 +11,9 @@ use crate::{
 
 impl Shape for fj::Transform {
     fn bounding_volume(&self) -> AABB {
-        self.shape.bounding_volume().transform_by(&isometry(self))
+        self.shape
+            .bounding_volume()
+            .transform_by(&isometry(self).into())
     }
 
     fn faces(&self, tolerance: f64, debug_info: &mut DebugInfo) -> Faces {
@@ -31,5 +33,5 @@ impl Shape for fj::Transform {
 
 fn isometry(transform: &fj::Transform) -> Transform {
     let axis = Vector::from(transform.axis).normalize();
-    Isometry::new(Vector::from(transform.offset), axis * transform.angle)
+    Isometry::new(Vector::from(transform.offset), axis * transform.angle).into()
 }

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -13,13 +13,13 @@ impl Shape for fj::Transform {
     fn bounding_volume(&self) -> AABB {
         self.shape
             .bounding_volume()
-            .transform_by(&isometry(self).into())
+            .transform_by(&transform(self).into())
     }
 
     fn faces(&self, tolerance: f64, debug_info: &mut DebugInfo) -> Faces {
         self.shape
             .faces(tolerance, debug_info)
-            .transform(&isometry(self))
+            .transform(&transform(self))
     }
 
     fn edges(&self) -> Edges {
@@ -31,7 +31,7 @@ impl Shape for fj::Transform {
     }
 }
 
-fn isometry(transform: &fj::Transform) -> Transform {
+fn transform(transform: &fj::Transform) -> Transform {
     let axis = Vector::from(transform.axis).normalize();
     Isometry::new(Vector::from(transform.offset), axis * transform.angle).into()
 }

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -3,7 +3,7 @@ use parry3d_f64::{bounding_volume::AABB, math::Isometry};
 use crate::{
     debug::DebugInfo,
     kernel::{
-        math::Vector,
+        math::{Transform, Vector},
         topology::{edges::Edges, faces::Faces, vertices::Vertices},
         Shape,
     },
@@ -29,7 +29,7 @@ impl Shape for fj::Transform {
     }
 }
 
-fn isometry(transform: &fj::Transform) -> Isometry<f64> {
+fn isometry(transform: &fj::Transform) -> Transform {
     let axis = Vector::from(transform.axis).normalize();
     Isometry::new(Vector::from(transform.offset), axis * transform.angle)
 }

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -1,9 +1,8 @@
 use nalgebra::vector;
-use parry3d_f64::math::Isometry;
 
 use crate::kernel::{
     geometry::{Circle, Curve},
-    math::Point,
+    math::{Point, Transform},
 };
 
 use super::vertices::Vertex;
@@ -33,7 +32,7 @@ impl Edges {
 
     /// Transform the edges
     #[must_use]
-    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(mut self, transform: &Transform) -> Self {
         for cycle in &mut self.cycles {
             for edge in &mut cycle.edges {
                 *edge = edge.clone().transform(transform);
@@ -115,7 +114,7 @@ impl Edge {
 
     /// Transform the edge
     #[must_use]
-    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(mut self, transform: &Transform) -> Self {
         self.curve = self.curve.transform(transform);
         self.vertices = self
             .vertices

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -94,7 +94,7 @@ impl Face {
             },
             Self::Triangles(mut triangles) => {
                 for triangle in &mut triangles {
-                    *triangle = triangle.transformed(transform);
+                    *triangle = triangle.transformed(&transform.into());
                 }
 
                 Self::Triangles(triangles)

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -7,7 +7,6 @@ use parry2d_f64::{
     shape::Segment as Segment2,
 };
 use parry3d_f64::{
-    math::Isometry,
     query::Ray as Ray3,
     shape::{Segment as Segment3, Triangle},
 };
@@ -15,7 +14,7 @@ use parry3d_f64::{
 use crate::{
     debug::{DebugInfo, TriangleEdgeCheck},
     kernel::{
-        approximation::Approximation, geometry::Surface,
+        approximation::Approximation, geometry::Surface, math::Transform,
         triangulation::triangulate,
     },
 };
@@ -29,7 +28,7 @@ pub struct Faces(pub Vec<Face>);
 impl Faces {
     /// Transform all the faces
     #[must_use]
-    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(self, transform: &Transform) -> Self {
         let faces = self
             .0
             .into_iter()
@@ -87,7 +86,7 @@ pub enum Face {
 impl Face {
     /// Transform the face
     #[must_use]
-    pub fn transform(self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(self, transform: &Transform) -> Self {
         match self {
             Self::Face { edges, surface } => Self::Face {
                 edges: edges.transform(transform),

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,6 +1,7 @@
-use parry3d_f64::math::Isometry;
-
-use crate::kernel::{geometry::Curve, math::Point};
+use crate::kernel::{
+    geometry::Curve,
+    math::{Point, Transform},
+};
 
 /// The vertices of a shape
 pub struct Vertices(pub Vec<Vertex<3>>);
@@ -87,7 +88,7 @@ impl<const D: usize> Vertex<D> {
     /// The transformed vertex has its canonical form transformed by the
     /// transformation provided, but is otherwise identical.
     #[must_use]
-    pub fn transform(mut self, transform: &Isometry<f64>) -> Self {
+    pub fn transform(mut self, transform: &Transform) -> Self {
         self.canonical = transform.transform_point(&self.canonical);
         self
     }


### PR DESCRIPTION
This adds a new struct to `crate::kernel::math`, `Transform`, which wraps the transform type we've previously been using. It will make further changes to the transform code easier, and is thus relevant for #101.

Depending on how my further experimentation with #193 goes, a full struct might turn out not to be necessary. This isn't much of a problem, as `Transform` can be converted back into a type definition quite easily, without changes required to the code using it.