### PR TITLE
Enforce correct use of vector coordinate nomemclature

### DIFF
--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -26,7 +26,7 @@ impl Circle {
 
     #[must_use]
     pub fn transform(self, transform: &Transform) -> Self {
-        let radius = self.radius.extend(0.);
+        let radius = self.radius.to_xyz(0.);
         let radius = transform.transform_vector(&radius);
         let radius = radius.xy();
 

--- a/src/kernel/geometry/curves/circle.rs
+++ b/src/kernel/geometry/curves/circle.rs
@@ -63,7 +63,7 @@ impl Circle {
     /// Convert a vector on the curve into model coordinates
     pub fn vector_curve_to_model(&self, point: &Vector<1>) -> Vector<3> {
         let radius = self.radius.magnitude();
-        let angle = point.x();
+        let angle = point.t();
 
         let (sin, cos) = angle.sin_cos();
 

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -57,8 +57,7 @@ impl Line {
 
     /// Convert a vector on the curve into model coordinates
     pub fn vector_curve_to_model(&self, point: &Vector<1>) -> Vector<3> {
-        let t = point.t();
-        self.direction * t
+        self.direction * point.t()
     }
 }
 

--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -57,7 +57,7 @@ impl Line {
 
     /// Convert a vector on the curve into model coordinates
     pub fn vector_curve_to_model(&self, point: &Vector<1>) -> Vector<3> {
-        let t = point.x();
+        let t = point.t();
         self.direction * t
     }
 }

--- a/src/kernel/geometry/surfaces/swept.rs
+++ b/src/kernel/geometry/surfaces/swept.rs
@@ -44,10 +44,9 @@ impl Swept {
 
     /// Convert a vector in surface coordinates to model coordinates
     pub fn vector_surface_to_model(&self, vector: &Vector<2>) -> Vector<3> {
-        let u = vector.u();
-        let v = vector.v();
-
-        self.curve.vector_curve_to_model(&Vector::from([u])) + self.path * v
+        self.curve
+            .vector_curve_to_model(&Vector::from([vector.u()]))
+            + self.path * vector.v()
     }
 }
 

--- a/src/kernel/geometry/surfaces/swept.rs
+++ b/src/kernel/geometry/surfaces/swept.rs
@@ -44,8 +44,8 @@ impl Swept {
 
     /// Convert a vector in surface coordinates to model coordinates
     pub fn vector_surface_to_model(&self, vector: &Vector<2>) -> Vector<3> {
-        let u = vector.x();
-        let v = vector.y();
+        let u = vector.u();
+        let v = vector.v();
 
         self.curve.vector_curve_to_model(&Vector::from([u])) + self.path * v
     }

--- a/src/kernel/math/vector.rs
+++ b/src/kernel/math/vector.rs
@@ -35,21 +35,6 @@ impl<const D: usize> Vector<D> {
         self.0.into()
     }
 
-    /// Access the vector's x coordinate
-    pub fn x(&self) -> f64 {
-        self.0[0]
-    }
-
-    /// Access the vector's y coordinate
-    pub fn y(&self) -> f64 {
-        self.0[1]
-    }
-
-    /// Construct a new vector from this vector's x and y components
-    pub fn xy(&self) -> Vector<2> {
-        Vector::from([self.x(), self.y()])
-    }
-
     /// Compute the magnitude of the vector
     pub fn magnitude(&self) -> f64 {
         self.to_na().magnitude()
@@ -87,6 +72,23 @@ impl Vector<2> {
     /// Extend a 2-dimensional vector into a 3-dimensional one
     pub fn extend(&self, scalar: f64) -> Vector<3> {
         Vector::from([self.u(), self.v(), scalar])
+    }
+}
+
+impl Vector<3> {
+    /// Access the vector's x coordinate
+    pub fn x(&self) -> f64 {
+        self.0[0]
+    }
+
+    /// Access the vector's y coordinate
+    pub fn y(&self) -> f64 {
+        self.0[1]
+    }
+
+    /// Construct a new vector from this vector's x and y components
+    pub fn xy(&self) -> Vector<2> {
+        Vector::from([self.x(), self.y()])
     }
 }
 

--- a/src/kernel/math/vector.rs
+++ b/src/kernel/math/vector.rs
@@ -67,9 +67,19 @@ impl<const D: usize> Vector<D> {
 }
 
 impl Vector<2> {
+    /// Access the surface vector's u coordinate
+    pub fn u(&self) -> f64 {
+        self.0[0]
+    }
+
+    /// Access the surface vector's v coordinate
+    pub fn v(&self) -> f64 {
+        self.0[1]
+    }
+
     /// Extend a 2-dimensional vector into a 3-dimensional one
     pub fn extend(&self, scalar: f64) -> Vector<3> {
-        Vector::from([self.x(), self.y(), scalar])
+        Vector::from([self.u(), self.v(), scalar])
     }
 }
 

--- a/src/kernel/math/vector.rs
+++ b/src/kernel/math/vector.rs
@@ -70,8 +70,8 @@ impl Vector<2> {
     }
 
     /// Extend a 2-dimensional vector into a 3-dimensional one
-    pub fn to_xyz(&self, scalar: f64) -> Vector<3> {
-        Vector::from([self.u(), self.v(), scalar])
+    pub fn to_xyz(&self, z: f64) -> Vector<3> {
+        Vector::from([self.u(), self.v(), z])
     }
 }
 

--- a/src/kernel/math/vector.rs
+++ b/src/kernel/math/vector.rs
@@ -70,7 +70,7 @@ impl Vector<2> {
     }
 
     /// Extend a 2-dimensional vector into a 3-dimensional one
-    pub fn extend(&self, scalar: f64) -> Vector<3> {
+    pub fn to_xyz(&self, scalar: f64) -> Vector<3> {
         Vector::from([self.u(), self.v(), scalar])
     }
 }

--- a/src/kernel/math/vector.rs
+++ b/src/kernel/math/vector.rs
@@ -66,6 +66,13 @@ impl<const D: usize> Vector<D> {
     }
 }
 
+impl Vector<1> {
+    /// Access the curve vector's t coordinate
+    pub fn t(&self) -> f64 {
+        self.0[0]
+    }
+}
+
 impl Vector<2> {
     /// Access the surface vector's u coordinate
     pub fn u(&self) -> f64 {


### PR DESCRIPTION
These are some further cleanups, based on the previous work in #197 and #198.