### PR TITLE
Add `math::Segment`

### DIFF
--- a/src/kernel/approximation.rs
+++ b/src/kernel/approximation.rs
@@ -1,10 +1,9 @@
 use std::{cmp::Ordering, collections::HashSet};
 
 use decorum::R64;
-use parry3d_f64::shape::Segment;
 
 use super::{
-    math::Point,
+    math::{Point, Segment},
     topology::edges::{Cycle, Edge, Edges},
 };
 
@@ -224,10 +223,10 @@ mod tests {
     use std::cell::RefCell;
 
     use nalgebra::point;
-    use parry3d_f64::shape::Segment;
 
     use crate::kernel::{
         geometry::Curve,
+        math::Segment,
         topology::{
             edges::{Cycle, Edge, Edges},
             vertices::Vertex,

--- a/src/kernel/approximation.rs
+++ b/src/kernel/approximation.rs
@@ -69,7 +69,7 @@ impl Approximation {
             let p0 = segment[0];
             let p1 = segment[1];
 
-            segments.push([p0, p1].into());
+            segments.push(Segment::from([p0, p1]));
         }
 
         Self { points, segments }

--- a/src/kernel/math/mod.rs
+++ b/src/kernel/math/mod.rs
@@ -1,5 +1,8 @@
 pub mod point;
+pub mod segment;
 pub mod transform;
 pub mod vector;
 
-pub use self::{point::Point, transform::Transform, vector::Vector};
+pub use self::{
+    point::Point, segment::Segment, transform::Transform, vector::Vector,
+};

--- a/src/kernel/math/segment.rs
+++ b/src/kernel/math/segment.rs
@@ -1,0 +1,24 @@
+use super::Point;
+
+/// A line segment, defined by its two end points
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Segment {
+    pub a: Point<3>,
+    pub b: Point<3>,
+}
+
+impl Segment {
+    /// Convert the segment into a Parry segment
+    pub fn to_parry(&self) -> parry3d_f64::shape::Segment {
+        [self.a, self.b].into()
+    }
+}
+
+impl From<[Point<3>; 2]> for Segment {
+    fn from(points: [Point<3>; 2]) -> Self {
+        Self {
+            a: points[0],
+            b: points[1],
+        }
+    }
+}

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -45,11 +45,9 @@ impl Shape for fj::Sweep {
         for segment in approx.segments {
             let [v0, v1] = [segment.a, segment.b];
             let [v3, v2] = {
-                let segment = segment.transformed(&Isometry::translation(
-                    0.0,
-                    0.0,
-                    self.length,
-                ));
+                let segment = segment
+                    .to_parry()
+                    .transformed(&Isometry::translation(0.0, 0.0, self.length));
                 [segment.a, segment.b]
             };
 

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -6,15 +6,14 @@ use parry2d_f64::{
     query::{Ray as Ray2, RayCast as _},
     shape::Segment as Segment2,
 };
-use parry3d_f64::{
-    query::Ray as Ray3,
-    shape::{Segment as Segment3, Triangle},
-};
+use parry3d_f64::{query::Ray as Ray3, shape::Triangle};
 
 use crate::{
     debug::{DebugInfo, TriangleEdgeCheck},
     kernel::{
-        approximation::Approximation, geometry::Surface, math::Transform,
+        approximation::Approximation,
+        geometry::Surface,
+        math::{Segment, Transform},
         triangulation::triangulate,
     },
 };
@@ -126,7 +125,7 @@ impl Face {
                 let segments: Vec<_> = approx
                     .segments
                     .into_iter()
-                    .map(|Segment3 { a, b }| {
+                    .map(|Segment { a, b }| {
                         // Can't panic, unless the approximation wrongfully
                         // generates points that are not in the surface.
                         let a = surface.point_model_to_surface(a);


### PR DESCRIPTION
This is a further step towards #193. Specifically, it will make the conversion of `Point` much easier.