### PR TITLE
Make `Aabb` generic over dimensionality

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -46,18 +46,14 @@ impl Camera {
             // To do that, first compute the model's highest point, as well as
             // the furthest point from the origin, in x and y.
             let highest_point = aabb.max.z;
-            let furthest_point = [
-                aabb.min.x.abs(),
-                aabb.max.x,
-                aabb.min.y.abs(),
-                aabb.max.y,
-            ]
-            .into_iter()
-            .reduce(|a, b| f64::max(a, b))
-            // `reduce` can only return `None`, if there are no items in
-            // the iterator. And since we're creating an array full of
-            // items above, we know this can't panic.
-            .unwrap();
+            let furthest_point =
+                [aabb.min.x.abs(), aabb.max.x, aabb.min.y.abs(), aabb.max.y]
+                    .into_iter()
+                    .reduce(|a, b| f64::max(a, b))
+                    // `reduce` can only return `None`, if there are no items in
+                    // the iterator. And since we're creating an array full of
+                    // items above, we know this can't panic.
+                    .unwrap();
 
             // The actual furthest point is not far enough. We don't want the
             // model to fill the whole screen.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -38,7 +38,7 @@ impl Camera {
 
     const INITIAL_FIELD_OF_VIEW_IN_X: f64 = FRAC_PI_2; // 90 degrees
 
-    pub fn new(aabb: &Aabb) -> Self {
+    pub fn new(aabb: &Aabb<3>) -> Self {
         let initial_distance = {
             // Let's make sure we choose a distance, so that the model fills
             // most of the screen.
@@ -176,7 +176,7 @@ impl Camera {
         transform
     }
 
-    pub fn update_planes(&mut self, aabb: &Aabb) {
+    pub fn update_planes(&mut self, aabb: &Aabb<3>) {
         let view_transform = self.camera_to_model();
         let view_direction = Vector::from([0., 0., -1.]);
 

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -14,7 +14,7 @@ pub trait Shape {
     ///
     /// If a shape is empty, its [`Aabb`]'s `min` and `max` points must be equal
     /// (but are otherwise not specified).
-    fn bounding_volume(&self) -> Aabb;
+    fn bounding_volume(&self) -> Aabb<3>;
 
     /// Compute triangles to approximate the shape's faces
     ///
@@ -73,7 +73,7 @@ macro_rules! dispatch {
 }
 
 dispatch! {
-    bounding_volume() -> Aabb;
+    bounding_volume() -> Aabb<3>;
     faces(
         tolerance: f64,
         debug: &mut DebugInfo,

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 impl Shape for fj::Circle {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         Aabb {
             min: point![-self.radius, -self.radius, 0.0],
             max: point![self.radius, self.radius, 0.0],

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 impl Shape for fj::Difference2d {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         // This is a conservative estimate of the bounding box: It's never going
         // to be bigger than the bounding box of the original shape that another
         // is being subtracted from.

--- a/src/kernel/shapes/difference_3d.rs
+++ b/src/kernel/shapes/difference_3d.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 impl Shape for fj::Difference {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         // This is a conservative estimate of the bounding box: It's never going
         // to be bigger than the bounding box of the original shape that another
         // is being subtracted from.

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 impl Shape for fj::Sketch {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         let vertices = self.vertices();
         Aabb::from_points(vertices.0.iter().map(|vertex| *vertex.location()))
     }

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -15,7 +15,9 @@ use crate::{
 impl Shape for fj::Sketch {
     fn bounding_volume(&self) -> Aabb<3> {
         let vertices = self.vertices();
-        Aabb::from_points(vertices.0.iter().map(|vertex| *vertex.location()))
+        Aabb::<3>::from_points(
+            vertices.0.iter().map(|vertex| *vertex.location()),
+        )
     }
 
     fn faces(&self, _: f64, _: &mut DebugInfo) -> Faces {

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 impl Shape for fj::Sweep {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         let mut aabb = self.shape.bounding_volume();
         aabb.max.z = self.length;
         aabb

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 impl Shape for fj::Transform {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         transform(self).transform_aabb(&self.shape.bounding_volume())
     }
 

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 impl Shape for fj::Union {
-    fn bounding_volume(&self) -> Aabb {
+    fn bounding_volume(&self) -> Aabb<3> {
         let a = self.a.bounding_volume();
         let b = self.b.bounding_volume();
 

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 
 use decorum::R64;
 use parry2d_f64::{
-    bounding_volume::AABB,
     query::{Ray as Ray2, RayCast as _},
     shape::Segment as Segment2,
 };
@@ -14,7 +13,7 @@ use crate::{
         approximation::Approximation, geometry::Surface,
         triangulation::triangulate,
     },
-    math::{Segment, Transform, Triangle},
+    math::{Aabb, Segment, Transform, Triangle},
 };
 
 use super::edges::Edges;
@@ -136,10 +135,10 @@ impl Face {
 
                 // We're also going to need a point outside of the polygon, for
                 // the point-in-polygon tests.
-                let aabb = AABB::from_points(
-                    points.iter().map(|vertex| &vertex.value),
+                let aabb = Aabb::<2>::from_points(
+                    points.iter().map(|vertex| vertex.value),
                 );
-                let outside = aabb.maxs * 2.;
+                let outside = aabb.max * 2.;
 
                 let mut triangles = triangulate(points);
                 let face_as_polygon = segments;

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -30,7 +30,7 @@ impl Aabb<2> {
 }
 
 impl Aabb<3> {
-    /// Construct an AABB from a list of points
+    /// Construct a 3-dimensional AABB from a list of points
     ///
     /// The resulting AABB will contain all the points.
     pub fn from_points(points: impl IntoIterator<Item = Point<3>>) -> Self {

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -12,6 +12,14 @@ pub struct Aabb<const D: usize> {
 }
 
 impl Aabb<2> {
+    /// Construct a 2-dimensional AABB from a list of points
+    ///
+    /// The resulting AABB will contain all the points.
+    pub fn from_points(points: impl IntoIterator<Item = Point<2>>) -> Self {
+        let points: Vec<_> = points.into_iter().collect();
+        parry2d_f64::bounding_volume::AABB::from_points(&points).into()
+    }
+
     /// Construct a 2-dimensional AABB from a Parry AABB
     pub fn from_parry(aabb: parry2d_f64::bounding_volume::AABB) -> Self {
         Self {

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -52,7 +52,7 @@ impl Aabb {
     }
 
     /// Merge this AABB with another
-    pub fn merged(&self, other: &Aabb) -> Aabb {
+    pub fn merged(&self, other: &Self) -> Self {
         self.to_parry().merged(&other.to_parry()).into()
     }
 }

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -3,15 +3,15 @@ use parry3d_f64::bounding_volume::BoundingVolume as _;
 use super::{Point, Vector};
 
 /// An axis-aligned bounding box (AABB)
-pub struct Aabb {
+pub struct Aabb<const D: usize> {
     /// The minimum coordinates of the AABB
-    pub min: Point<3>,
+    pub min: Point<D>,
 
     /// The maximum coordinates of the AABB
-    pub max: Point<3>,
+    pub max: Point<D>,
 }
 
-impl Aabb {
+impl Aabb<3> {
     /// Construct an AABB from a list of points
     ///
     /// The resulting AABB will contain all the points.
@@ -57,7 +57,7 @@ impl Aabb {
     }
 }
 
-impl From<parry3d_f64::bounding_volume::AABB> for Aabb {
+impl From<parry3d_f64::bounding_volume::AABB> for Aabb<3> {
     fn from(aabb: parry3d_f64::bounding_volume::AABB) -> Self {
         Self::from_parry(aabb)
     }

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -11,6 +11,16 @@ pub struct Aabb<const D: usize> {
     pub max: Point<D>,
 }
 
+impl Aabb<2> {
+    /// Construct a 2-dimensional AABB from a Parry AABB
+    pub fn from_parry(aabb: parry2d_f64::bounding_volume::AABB) -> Self {
+        Self {
+            min: aabb.mins.into(),
+            max: aabb.maxs.into(),
+        }
+    }
+}
+
 impl Aabb<3> {
     /// Construct an AABB from a list of points
     ///
@@ -54,6 +64,12 @@ impl Aabb<3> {
     /// Merge this AABB with another
     pub fn merged(&self, other: &Self) -> Self {
         self.to_parry().merged(&other.to_parry()).into()
+    }
+}
+
+impl From<parry2d_f64::bounding_volume::AABB> for Aabb<2> {
+    fn from(aabb: parry2d_f64::bounding_volume::AABB) -> Self {
+        Self::from_parry(aabb)
     }
 }
 

--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -30,7 +30,7 @@ impl Aabb<3> {
         parry3d_f64::bounding_volume::AABB::from_points(&points).into()
     }
 
-    /// Construct an AABB from a Parry AABB
+    /// Construct a 3-dimensional AABB from a Parry AABB
     pub fn from_parry(aabb: parry3d_f64::bounding_volume::AABB) -> Self {
         Self {
             min: aabb.mins.into(),

--- a/src/math/transform.rs
+++ b/src/math/transform.rs
@@ -24,7 +24,7 @@ impl Transform {
     }
 
     /// Transform the given axis-aligned bounding box
-    pub fn transform_aabb(&self, aabb: &Aabb) -> Aabb {
+    pub fn transform_aabb(&self, aabb: &Aabb<3>) -> Aabb<3> {
         Aabb {
             min: self.transform_point(&aabb.min),
             max: self.transform_point(&aabb.max),


### PR DESCRIPTION
Unfortunately, this requires some duplicated methods. I don't think there's a way to prevent this, due to the way the Parry types work underneath. Except to not use those Parry types, of course.

This is another step towards #193.