### PR TITLE
Derive `Hash` for most math types

### DIFF
--- a/src/math/aabb.rs
+++ b/src/math/aabb.rs
@@ -3,7 +3,7 @@ use parry3d_f64::bounding_volume::BoundingVolume as _;
 use super::{Point, Vector};
 
 /// An axis-aligned bounding box (AABB)
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Aabb<const D: usize> {
     /// The minimum coordinates of the AABB
     pub min: Point<D>,

--- a/src/math/point.rs
+++ b/src/math/point.rs
@@ -12,7 +12,7 @@ use super::{Scalar, Vector};
 ///
 /// The goal of this type is to eventually implement `Eq` and `Hash`, making it
 /// easier to work with vectors. This is a work in progress.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Point<const D: usize>([Scalar; D]);
 
 impl<const D: usize> Point<D> {

--- a/src/math/segment.rs
+++ b/src/math/segment.rs
@@ -1,7 +1,7 @@
 use super::Point;
 
 /// A line segment, defined by its two end points
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Segment<const D: usize> {
     pub a: Point<D>,
     pub b: Point<D>,

--- a/src/math/triangle.rs
+++ b/src/math/triangle.rs
@@ -1,7 +1,7 @@
 use super::Point;
 
 /// A triangle
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Triangle {
     pub a: Point<3>,
     pub b: Point<3>,

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -12,7 +12,7 @@ use super::Scalar;
 ///
 /// The goal of this type is to eventually implement `Eq` and `Hash`, making it
 /// easier to work with vectors. This is a work in progress.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Vector<const D: usize>([Scalar; D]);
 
 impl<const D: usize> Vector<D> {


### PR DESCRIPTION
In #214, I already declared that I did this, and closed #193 for good
measure. Here I'm actually doing it.