### PR TITLE
Remove dependency on Decorum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,15 +52,6 @@ checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -479,18 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "decorum"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281759d3c8a14f5c3f0c49363be56810fcd7f910422f97f2db850c2920fde5cf"
-dependencies = [
- "approx 0.3.2",
- "num-traits",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,10 +517,9 @@ name = "fj-host"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "approx 0.5.1",
+ "approx",
  "bytemuck",
  "clap",
- "decorum",
  "fj",
  "futures",
  "libloading",
@@ -758,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38"
 dependencies = [
  "ab_glyph",
- "approx 0.5.1",
+ "approx",
  "xi-unicode",
 ]
 
@@ -1113,7 +1091,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb2d0de08694bed883320212c18ee3008576bfe8c306f4c3c4a58b4876998be"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -1402,7 +1380,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96040e0f10b65df992e8367983b7c3ac779046cd6d9a4a7cd1496e8c6b6ef51"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "arrayvec",
  "bitflags",
  "downcast-rs",
@@ -1422,7 +1400,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "760c93194acb2bda0c4d0696b0350c143da072c8f8dbe01b38fe1d1aa3a154e0"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "bitflags",
  "downcast-rs",
  "either",
@@ -1669,17 +1647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 
 [[package]]
-name = "serde_derive"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,7 +1661,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a2609e876d4f77f6ab7ff5254fc39b4f1927ba8e6db3d18be7c32534d3725e"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ categories  = ["mathematics", "rendering"]
 anyhow      = "1.0.53"
 approx      = "0.5.1"
 bytemuck    = "1.7.3"
-decorum     = "0.3.1"
 futures     = "0.3.21"
 libloading  = "0.7.2"
 nalgebra    = "0.30.0"

--- a/src/graphics/vertices.rs
+++ b/src/graphics/vertices.rs
@@ -4,7 +4,7 @@ use nalgebra::{vector, Point};
 use crate::{
     debug::DebugInfo,
     math::Triangle,
-    mesh::{HashVector, Index, MeshMaker},
+    mesh::{Index, MeshMaker},
 };
 
 #[derive(Debug)]
@@ -56,12 +56,6 @@ impl From<&Vec<Triangle>> for Vertices {
             let [a, b, c] = triangle.vertices();
 
             let normal = (b - a).cross(&(c - a)).normalize();
-
-            let a = HashVector::from(&a.to_na());
-            let b = HashVector::from(&b.to_na());
-            let c = HashVector::from(&c.to_na());
-
-            let normal = HashVector::from(&normal.to_na());
 
             mesh.push((a, normal));
             mesh.push((b, normal));

--- a/src/kernel/approximation.rs
+++ b/src/kernel/approximation.rs
@@ -1,7 +1,5 @@
 use std::{cmp::Ordering, collections::HashSet};
 
-use decorum::R64;
-
 use crate::math::{Point, Scalar, Segment};
 
 use super::topology::edges::{Cycle, Edge, Edges};
@@ -149,20 +147,18 @@ impl Approximation {
         // Verify that there are no duplicate points
         let mut points = HashSet::new();
         for &point in &self.points {
-            let point_r64 = point_to_r64(point);
-
-            if points.contains(&point_r64) {
+            if points.contains(&point) {
                 duplicate_points.push(point);
             }
 
-            points.insert(point_r64);
+            points.insert(point);
         }
 
         let mut segments = HashSet::new();
         for &segment @ Segment { a, b } in &self.segments {
             // Verify that there are no duplicate segments
-            let ab = [point_to_r64(a), point_to_r64(b)];
-            let ba = [point_to_r64(b), point_to_r64(a)];
+            let ab = [a, b];
+            let ba = [b, a];
             if segments.contains(&ab) {
                 duplicate_segments.push(segment);
             }
@@ -211,14 +207,6 @@ pub struct ValidationError {
 
     /// Segments that do not refer to points from the approximation
     pub segments_with_invalid_points: Vec<Segment<3>>,
-}
-
-fn point_to_r64(point: Point<3>) -> [R64; 3] {
-    [
-        point.x().into_f64().into(),
-        point.y().into_f64().into(),
-        point.z().into_f64().into(),
-    ]
 }
 
 #[cfg(test)]

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeSet;
 
-use decorum::R64;
 use parry2d_f64::query::{Ray as Ray2, RayCast as _};
 use parry3d_f64::query::Ray as Ray3;
 
@@ -193,11 +192,10 @@ impl Face {
                             let edge =
                                 Segment::from(edge.map(|point| point.value));
 
-                            let intersection = edge.to_parry().cast_local_ray(
-                                &ray,
-                                f64::INFINITY,
-                                true,
-                            );
+                            let intersection = edge
+                                .to_parry()
+                                .cast_local_ray(&ray, f64::INFINITY, true)
+                                .map(|t| Scalar::from_f64(t));
 
                             if let Some(t) = intersection {
                                 // Due to slight inaccuracies, we might get
@@ -206,9 +204,8 @@ impl Face {
                                 let eps = 1_000_000.0;
                                 let t = (t * eps).round() / eps;
 
-                                let t_r64: R64 = t.into();
-                                if hits.insert(t_r64) {
-                                    check.hits.push(t);
+                                if hits.insert(t) {
+                                    check.hits.push(t.into_f64());
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use crate::{
     debug::DebugInfo,
     graphics::{DrawConfig, Renderer},
     kernel::Shape as _,
-    mesh::{HashVector, MeshMaker},
+    mesh::MeshMaker,
     model::Model,
     window::Window,
 };
@@ -97,7 +97,7 @@ fn main() -> anyhow::Result<()> {
 
         for triangle in triangles {
             for vertex in triangle.vertices() {
-                mesh_maker.push(HashVector::from(&vertex.to_na()));
+                mesh_maker.push(vertex);
             }
         }
 

--- a/src/math/point.rs
+++ b/src/math/point.rs
@@ -106,6 +106,18 @@ impl<const D: usize> From<nalgebra::Point<f64, D>> for Point<D> {
     }
 }
 
+impl<const D: usize> From<Point<D>> for [f32; D] {
+    fn from(point: Point<D>) -> Self {
+        point.0.map(|scalar| scalar.into_f32())
+    }
+}
+
+impl<const D: usize> From<Point<D>> for [f64; D] {
+    fn from(point: Point<D>) -> Self {
+        point.0.map(|scalar| scalar.into_f64())
+    }
+}
+
 impl<const D: usize> ops::Neg for Point<D> {
     type Output = Self;
 

--- a/src/math/scalar.rs
+++ b/src/math/scalar.rs
@@ -87,6 +87,11 @@ impl Scalar {
         self.0.ceil().into()
     }
 
+    /// Round the scalar
+    pub fn round(self) -> Self {
+        self.0.round().into()
+    }
+
     /// Compute the cosine
     pub fn cos(self) -> Self {
         self.0.cos().into()

--- a/src/math/scalar.rs
+++ b/src/math/scalar.rs
@@ -62,6 +62,11 @@ impl Scalar {
         Self::from_f64(scalar as f64)
     }
 
+    /// Convert the scalar into an `f32`
+    pub fn into_f32(self) -> f32 {
+        self.0 as f32
+    }
+
     /// Convert the scalar into a `f64`
     pub fn into_f64(self) -> f64 {
         self.0

--- a/src/math/scalar.rs
+++ b/src/math/scalar.rs
@@ -67,7 +67,7 @@ impl Scalar {
         self.0 as f32
     }
 
-    /// Convert the scalar into a `f64`
+    /// Convert the scalar into an `f64`
     pub fn into_f64(self) -> f64 {
         self.0
     }

--- a/src/math/vector.rs
+++ b/src/math/vector.rs
@@ -121,6 +121,12 @@ impl<const D: usize> From<nalgebra::SVector<f64, D>> for Vector<D> {
     }
 }
 
+impl<const D: usize> From<Vector<D>> for [f32; D] {
+    fn from(vector: Vector<D>) -> Self {
+        vector.0.map(|scalar| scalar.into_f32())
+    }
+}
+
 impl<const D: usize> ops::Add<Self> for Vector<D> {
     type Output = Self;
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,8 +1,5 @@
 use std::{collections::HashMap, hash::Hash};
 
-use decorum::R64;
-use nalgebra::{Point, SVector};
-
 /// API for creating a mesh
 pub struct MeshMaker<V> {
     vertices: Vec<V>,
@@ -44,38 +41,6 @@ where
     /// Access the indices of the mesh
     pub fn indices(&self) -> impl Iterator<Item = Index> + '_ {
         self.indices.iter().copied()
-    }
-}
-
-/// A point/vector type that can be used as a [`HashMap`] key
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-pub struct HashVector(pub [R64; 3]);
-
-impl From<&Point<f64, 3>> for HashVector {
-    fn from(point: &Point<f64, 3>) -> Self {
-        Self([R64::from(point.x), R64::from(point.y), R64::from(point.z)])
-    }
-}
-
-impl From<&SVector<f64, 3>> for HashVector {
-    fn from(vector: &SVector<f64, 3>) -> Self {
-        Self([
-            R64::from(vector.x),
-            R64::from(vector.y),
-            R64::from(vector.z),
-        ])
-    }
-}
-
-impl From<HashVector> for [f32; 3] {
-    fn from(hash_vector: HashVector) -> Self {
-        hash_vector.0.map(|coord| coord.into_inner() as f32)
-    }
-}
-
-impl From<HashVector> for [f64; 3] {
-    fn from(hash_vector: HashVector) -> Self {
-        hash_vector.0.map(|coord| coord.into_inner())
     }
 }
 


### PR DESCRIPTION
Removes the dependency on Decorum, along with the workarounds that required it. This is a bit of pay-off from #193.