### PR TITLE
Change order of fields in `Face`

### DIFF
--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -51,6 +51,9 @@ pub enum Face {
     /// A face is defined by a surface, and is bounded by edges that lie in that
     /// surface.
     Face {
+        /// The surface that defines this face
+        surface: Surface,
+
         /// The edges that bound the face
         ///
         /// # Implementation Note
@@ -62,9 +65,6 @@ pub enum Face {
         /// more specialized data structure here, that specifies the edges in
         /// surface coordinates.
         edges: Edges,
-
-        /// The surface that defines this face
-        surface: Surface,
     },
 
     /// The triangles of the face


### PR DESCRIPTION
I think this makes more sense, since the surface is the defining element
of the face, and the edges only make sense in reference to the surface.
This way, it's also consistent with the order of fields in `Edge`.