### PR TITLE
build: introduce bacon configuration file

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -42,7 +42,7 @@ need_stdout = false
 [jobs.doc-open]
 command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
 need_stdout = false
-on_success = "back"                                                    # so that we don't open the browser at each change
+on_success = "back" # so that we don't open the browser at each change
 
 # You can run your application and have the result displayed in bacon,
 # *if* it makes sense for this crate. You can run an example the same

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,66 @@
+# This is a configuration file for the bacon tool
+# More info at https://github.com/Canop/bacon
+
+default_job = "check"
+
+[jobs]
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.clippy]
+command = ["cargo", "clippy", "--color", "always"]
+need_stdout = false
+
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
+[jobs.test]
+command = ["cargo", "test", "--color", "always"]
+need_stdout = true
+watch = ["tests"]
+
+[jobs.nextest]
+command = ["cargo", "nextest", "run", "--color", "always"]
+need_stdout = true
+watch = ["tests"]
+
+[jobs.doc]
+command = ["cargo", "doc", "--color", "always", "--no-deps"]
+need_stdout = false
+
+# if the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--color", "always", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back"                                                    # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate. You can run an example the same
+# way. Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+[jobs.run]
+command = ["cargo", "run", "--color", "always"]
+need_stdout = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal prefs.toml file instead.
+[keybindings]
+a = "job:check-all"
+i = "job:initial"
+c = "job:clippy"
+d = "job:doc-open"
+t = "job:test"
+n = "job:nextest"
+r = "job:run"


### PR DESCRIPTION
_Aside: it is perfectly fine to reject this pull-request, if the root of the project gets too many tool-specific config files._

This change-set introduces a project-level configuration for the developer utility [`bacon`](https://dystroy.org/bacon/). Bacon allows for running various jobs, e.g. `cargo check` continuously. It functions similarly to `cargo watch` (also a 3rd party plugin to `cargo`) in that it monitors the filesystem and re-runs the given job at hand. One can run multiple instances of bacon in multiple terminal windows. There are no known side-effects on other tools that I know of.

I created the default configuration using `bacon --init`. Then I added a job called [`nextest`](https://nexte.st/) (short cut `n`) to use `nextest` (`cargo install nextest`; `cargo nextest run`), which is quite an interesting new test runner that I am starting to use across projects.

I tried to use bacon's global configuration to define jobs, but that is not supported. Jobs are project-level only. However, one can set certain defaults for oneself (see https://dystroy.org/bacon/#global-preferences) if desired.

I left the default job at `cargo check`, but we can change it to `clippy` later on.