### PR TITLE
Add `Approximation::for_face`

### DIFF
--- a/src/kernel/approximation.rs
+++ b/src/kernel/approximation.rs
@@ -114,7 +114,6 @@ impl Approximation {
     ///
     /// `tolerance` defines how far the approximation is allowed to deviate from
     /// the actual edges.
-    #[allow(unused)]
     pub fn for_face(face: &Face, tolerance: Scalar) -> Self {
         // Curved faces whose curvature is not fully defined by their edges
         // are not supported yet. For that reason, we can fully ignore `face`'s

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -102,8 +102,8 @@ impl Face {
         debug_info: &mut DebugInfo,
     ) {
         match self {
-            Self::Face { edges, surface } => {
-                let approx = Approximation::for_edges(edges, tolerance);
+            Self::Face { surface, .. } => {
+                let approx = Approximation::for_face(self, tolerance);
 
                 let points: Vec<_> = approx
                     .points


### PR DESCRIPTION
These commits come from an aborted attempt to support continuous faces in the approximation code, which would be required to fully address #97. As it turns out, the solution would require a lot of changes, more than I want to make right now. All that's left from that branch is the new `Approximation::for_face`, which doesn't add a whole lot, but at least has some comments that could serve as useful guide posts for future extensions.

As for the reasons I aborted my attempt to approximate continuous faces, I'll open an issue soon. That will require some explaining though, and I haven't found the time yet to write all of it down.