### PR TITLE
Make sweep operation slightly more correct

### DIFF
--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -30,6 +30,10 @@ impl Shape for fj::Sweep {
 
         let original_faces = self.shape.faces(tolerance, debug_info);
 
+        // This only works for faces that are symmetric to the x-axis.
+        //
+        // See issue:
+        // https://github.com/hannobraun/Fornjot/issues/230
         let bottom_faces = original_faces.clone().transform(&rotation);
 
         let top_faces = original_faces.transform(&translation);

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -34,36 +34,39 @@ impl Shape for fj::Sweep {
         let top_faces = original_faces
             .transform(&Isometry::translation(0.0, 0.0, self.length).into());
 
-        // This will only work correctly, if the original shape consists of one
-        // edge. If there are more, this will create some kind of weird face
-        // chimera, a single face to represent all the side faces.
-        //
-        // It'll be even worse, if the original shape consists of multiple
-        // faces.
-        let approx = Approximation::for_edges(&self.shape.edges(), tolerance);
+        let mut side_faces = Vec::new();
+        for cycle in self.shape.edges().cycles {
+            let approx = Approximation::for_cycle(&cycle, tolerance);
 
-        let mut quads = Vec::new();
-        for segment in approx.segments {
-            let [v0, v1] = segment.points();
-            let [v3, v2] = {
-                let segment = Transform::translation(0., 0., self.length)
-                    .transform_segment(&segment);
-                segment.points()
-            };
+            // This will only work correctly, if the cycle consists of one edge.
+            // If there are more, this will create some kind of weird face
+            // chimera, a single face to represent all the side faces.
 
-            quads.push([v0, v1, v2, v3]);
-        }
+            let mut quads = Vec::new();
+            for segment in approx.segments {
+                let [v0, v1] = segment.points();
+                let [v3, v2] = {
+                    let segment = Transform::translation(0., 0., self.length)
+                        .transform_segment(&segment);
+                    segment.points()
+                };
 
-        let mut side_face = Vec::new();
-        for [v0, v1, v2, v3] in quads {
-            side_face.push([v0, v1, v2].into());
-            side_face.push([v0, v2, v3].into());
+                quads.push([v0, v1, v2, v3]);
+            }
+
+            let mut side_face = Vec::new();
+            for [v0, v1, v2, v3] in quads {
+                side_face.push([v0, v1, v2].into());
+                side_face.push([v0, v2, v3].into());
+            }
+
+            side_faces.push(Face::Triangles(side_face));
         }
 
         let mut faces = Vec::new();
         faces.extend(bottom_faces.0);
         faces.extend(top_faces.0);
-        faces.push(Face::Triangles(side_face));
+        faces.extend(side_faces);
 
         Faces(faces)
     }

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -30,6 +30,7 @@ impl Shape for fj::Sweep {
 
         let mut bottom_faces = Vec::new();
         let mut top_faces = Vec::new();
+        let mut side_faces = Vec::new();
 
         let original_faces = self.shape.faces(tolerance, debug_info);
         for face in original_faces.0 {
@@ -42,7 +43,6 @@ impl Shape for fj::Sweep {
             top_faces.push(face.transform(&translation));
         }
 
-        let mut side_faces = Vec::new();
         for cycle in self.shape.edges().cycles {
             let approx = Approximation::for_cycle(&cycle, tolerance);
 

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -25,14 +25,14 @@ impl Shape for fj::Sweep {
     }
 
     fn faces(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Faces {
+        let rotation = Isometry::rotation(vector![PI, 0., 0.]).into();
+        let translation = Isometry::translation(0.0, 0.0, self.length).into();
+
         let original_faces = self.shape.faces(tolerance, debug_info);
 
-        let bottom_faces = original_faces
-            .clone()
-            .transform(&Isometry::rotation(vector![PI, 0., 0.]).into());
+        let bottom_faces = original_faces.clone().transform(&rotation);
 
-        let top_faces = original_faces
-            .transform(&Isometry::translation(0.0, 0.0, self.length).into());
+        let top_faces = original_faces.transform(&translation);
 
         let mut side_faces = Vec::new();
         for cycle in self.shape.edges().cycles {


### PR DESCRIPTION
This came out of my work on #178. It makes the topological information generated by the sweep operation (the side walls, specifically) more correct. I don't think this causes any user-visible changes, but it's good none the less, and prepares for further work here.