### PR TITLE
Consolidate `Vertex` and the former `SurfacePoint`

### DIFF
--- a/src/kernel/geometry/mod.rs
+++ b/src/kernel/geometry/mod.rs
@@ -4,5 +4,6 @@ pub mod surfaces;
 
 pub use self::{
     curves::{Circle, Curve, Line},
+    points::SurfacePoint,
     surfaces::Surface,
 };

--- a/src/kernel/geometry/mod.rs
+++ b/src/kernel/geometry/mod.rs
@@ -4,6 +4,6 @@ pub mod surfaces;
 
 pub use self::{
     curves::{Circle, Curve, Line},
-    points::SurfacePoint,
+    points::Point,
     surfaces::Surface,
 };

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -7,7 +7,7 @@ use crate::math::{self, Vector};
 /// The canonical form is always the 3D representation. It needs to be provided
 /// when constructing the point, along with the point's native form.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct SurfacePoint {
+pub struct Point {
     /// This point's native form
     ///
     /// The native form of the point is its representation in its native
@@ -24,7 +24,7 @@ pub struct SurfacePoint {
     pub from: math::Point<3>,
 }
 
-impl Deref for SurfacePoint {
+impl Deref for Point {
     type Target = math::Point<2>;
 
     fn deref(&self) -> &Self::Target {
@@ -32,16 +32,16 @@ impl Deref for SurfacePoint {
     }
 }
 
-impl DerefMut for SurfacePoint {
+impl DerefMut for Point {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
     }
 }
 
 // Some math operations for convenience. Obviously those can never return a new
-// `SurfacePoint`, or the conversion back to 3D would be broken.
+// `Point`, or the conversion back to 3D would be broken.
 
-impl Add<Vector<2>> for SurfacePoint {
+impl Add<Vector<2>> for Point {
     type Output = math::Point<2>;
 
     fn add(self, rhs: Vector<2>) -> Self::Output {
@@ -49,7 +49,7 @@ impl Add<Vector<2>> for SurfacePoint {
     }
 }
 
-impl Sub<Self> for SurfacePoint {
+impl Sub<Self> for Point {
     type Output = Vector<2>;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -57,7 +57,7 @@ impl Sub<Self> for SurfacePoint {
     }
 }
 
-impl Sub<math::Point<2>> for SurfacePoint {
+impl Sub<math::Point<2>> for Point {
     type Output = Vector<2>;
 
     fn sub(self, rhs: math::Point<2>) -> Self::Output {

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -37,6 +37,11 @@ impl<const D: usize> Point<D> {
     pub fn native(&self) -> math::Point<D> {
         self.native
     }
+
+    /// Access the point's canonical form
+    pub fn canonical(&self) -> math::Point<3> {
+        self.canonical
+    }
 }
 
 impl<const D: usize> Deref for Point<D> {

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -24,6 +24,16 @@ pub struct Point<const D: usize> {
     pub canonical: math::Point<3>,
 }
 
+impl<const D: usize> Point<D> {
+    /// Construct a new instance
+    ///
+    /// Both the native and the canonical form must be provide. The caller must
+    /// guarantee that both of them match.
+    pub fn new(native: math::Point<D>, canonical: math::Point<3>) -> Self {
+        Self { native, canonical }
+    }
+}
+
 impl<const D: usize> Deref for Point<D> {
     type Target = math::Point<D>;
 

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -21,7 +21,7 @@ pub struct Point {
     /// kept here, unchanged, as the point is converted into other coordinate
     /// systems, it allows for a lossless conversion back into 3D coordinates,
     /// unaffected by floating point accuracy issues.
-    pub from: math::Point<3>,
+    pub canonical: math::Point<3>,
 }
 
 impl Deref for Point {

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -13,7 +13,7 @@ pub struct Point<const D: usize> {
     /// The native form of the point is its representation in its native
     /// coordinate system. This could be a 1-dimensional curve, 2-dimensional
     /// surface, or 3-dimensional model coordinate system.
-    pub native: math::Point<D>,
+    native: math::Point<D>,
 
     /// The canonical form of the point
     ///
@@ -21,7 +21,7 @@ pub struct Point<const D: usize> {
     /// kept here, unchanged, as the point is converted into other coordinate
     /// systems, it allows for a lossless conversion back into 3D coordinates,
     /// unaffected by floating point accuracy issues.
-    pub canonical: math::Point<3>,
+    canonical: math::Point<3>,
 }
 
 impl<const D: usize> Point<D> {

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -7,13 +7,13 @@ use crate::math::{self, Vector};
 /// The canonical form is always the 3D representation. It needs to be provided
 /// when constructing the point, along with the point's native form.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Point {
+pub struct Point<const D: usize> {
     /// This point's native form
     ///
     /// The native form of the point is its representation in its native
     /// coordinate system. This could be a 1-dimensional curve, 2-dimensional
     /// surface, or 3-dimensional model coordinate system.
-    pub native: math::Point<2>,
+    pub native: math::Point<D>,
 
     /// The canonical form of the point
     ///
@@ -24,15 +24,15 @@ pub struct Point {
     pub canonical: math::Point<3>,
 }
 
-impl Deref for Point {
-    type Target = math::Point<2>;
+impl<const D: usize> Deref for Point<D> {
+    type Target = math::Point<D>;
 
     fn deref(&self) -> &Self::Target {
         &self.native
     }
 }
 
-impl DerefMut for Point {
+impl<const D: usize> DerefMut for Point<D> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.native
     }
@@ -41,26 +41,26 @@ impl DerefMut for Point {
 // Some math operations for convenience. Obviously those can never return a new
 // `Point`, or the conversion back to 3D would be broken.
 
-impl Add<Vector<2>> for Point {
-    type Output = math::Point<2>;
+impl<const D: usize> Add<Vector<D>> for Point<D> {
+    type Output = math::Point<D>;
 
-    fn add(self, rhs: Vector<2>) -> Self::Output {
+    fn add(self, rhs: Vector<D>) -> Self::Output {
         self.native.add(rhs)
     }
 }
 
-impl Sub<Self> for Point {
-    type Output = Vector<2>;
+impl<const D: usize> Sub<Self> for Point<D> {
+    type Output = Vector<D>;
 
     fn sub(self, rhs: Self) -> Self::Output {
         Vector::from(self.native.sub(rhs.native))
     }
 }
 
-impl Sub<math::Point<2>> for Point {
-    type Output = Vector<2>;
+impl<const D: usize> Sub<math::Point<D>> for Point<D> {
+    type Output = Vector<D>;
 
-    fn sub(self, rhs: math::Point<2>) -> Self::Output {
+    fn sub(self, rhs: math::Point<D>) -> Self::Output {
         Vector::from(self.native.sub(rhs))
     }
 }

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -7,7 +7,7 @@ use crate::math::{Point, Vector};
 /// This type is used for algorithms that need to deal with 2D points in surface
 /// coordinates. It can be converted back to the 3D point it originates from
 /// without loss from floating point accuracy issues.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfacePoint {
     /// The surface coordinates of this point
     pub value: Point<2>,

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -32,6 +32,11 @@ impl<const D: usize> Point<D> {
     pub fn new(native: math::Point<D>, canonical: math::Point<3>) -> Self {
         Self { native, canonical }
     }
+
+    /// Access the point's native form
+    pub fn native(&self) -> math::Point<D> {
+        self.native
+    }
 }
 
 impl<const D: usize> Deref for Point<D> {

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Deref, DerefMut, Sub};
 
-use crate::math::{Point, Vector};
+use crate::math::{self, Vector};
 
 /// A point that can be losslessly converted into its canonical form
 ///
@@ -13,7 +13,7 @@ pub struct SurfacePoint {
     /// The native form of the point is its representation in its native
     /// coordinate system. This could be a 1-dimensional curve, 2-dimensional
     /// surface, or 3-dimensional model coordinate system.
-    pub value: Point<2>,
+    pub value: math::Point<2>,
 
     /// The canonical form of the point
     ///
@@ -21,11 +21,11 @@ pub struct SurfacePoint {
     /// kept here, unchanged, as the point is converted into other coordinate
     /// systems, it allows for a lossless conversion back into 3D coordinates,
     /// unaffected by floating point accuracy issues.
-    pub from: Point<3>,
+    pub from: math::Point<3>,
 }
 
 impl Deref for SurfacePoint {
-    type Target = Point<2>;
+    type Target = math::Point<2>;
 
     fn deref(&self) -> &Self::Target {
         &self.value
@@ -42,7 +42,7 @@ impl DerefMut for SurfacePoint {
 // `SurfacePoint`, or the conversion back to 3D would be broken.
 
 impl Add<Vector<2>> for SurfacePoint {
-    type Output = Point<2>;
+    type Output = math::Point<2>;
 
     fn add(self, rhs: Vector<2>) -> Self::Output {
         self.value.add(rhs)
@@ -57,10 +57,10 @@ impl Sub<Self> for SurfacePoint {
     }
 }
 
-impl Sub<Point<2>> for SurfacePoint {
+impl Sub<math::Point<2>> for SurfacePoint {
     type Output = Vector<2>;
 
-    fn sub(self, rhs: Point<2>) -> Self::Output {
+    fn sub(self, rhs: math::Point<2>) -> Self::Output {
         Vector::from(self.value.sub(rhs))
     }
 }

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -13,7 +13,7 @@ pub struct Point {
     /// The native form of the point is its representation in its native
     /// coordinate system. This could be a 1-dimensional curve, 2-dimensional
     /// surface, or 3-dimensional model coordinate system.
-    pub value: math::Point<2>,
+    pub native: math::Point<2>,
 
     /// The canonical form of the point
     ///
@@ -28,13 +28,13 @@ impl Deref for Point {
     type Target = math::Point<2>;
 
     fn deref(&self) -> &Self::Target {
-        &self.value
+        &self.native
     }
 }
 
 impl DerefMut for Point {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
+        &mut self.native
     }
 }
 
@@ -45,7 +45,7 @@ impl Add<Vector<2>> for Point {
     type Output = math::Point<2>;
 
     fn add(self, rhs: Vector<2>) -> Self::Output {
-        self.value.add(rhs)
+        self.native.add(rhs)
     }
 }
 
@@ -53,7 +53,7 @@ impl Sub<Self> for Point {
     type Output = Vector<2>;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Vector::from(self.value.sub(rhs.value))
+        Vector::from(self.native.sub(rhs.native))
     }
 }
 
@@ -61,6 +61,6 @@ impl Sub<math::Point<2>> for Point {
     type Output = Vector<2>;
 
     fn sub(self, rhs: math::Point<2>) -> Self::Output {
-        Vector::from(self.value.sub(rhs))
+        Vector::from(self.native.sub(rhs))
     }
 }

--- a/src/kernel/geometry/points.rs
+++ b/src/kernel/geometry/points.rs
@@ -2,21 +2,25 @@ use std::ops::{Add, Deref, DerefMut, Sub};
 
 use crate::math::{Point, Vector};
 
-/// A point on a surface
+/// A point that can be losslessly converted into its canonical form
 ///
-/// This type is used for algorithms that need to deal with 2D points in surface
-/// coordinates. It can be converted back to the 3D point it originates from
-/// without loss from floating point accuracy issues.
+/// The canonical form is always the 3D representation. It needs to be provided
+/// when constructing the point, along with the point's native form.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfacePoint {
-    /// The surface coordinates of this point
+    /// This point's native form
+    ///
+    /// The native form of the point is its representation in its native
+    /// coordinate system. This could be a 1-dimensional curve, 2-dimensional
+    /// surface, or 3-dimensional model coordinate system.
     pub value: Point<2>,
 
-    /// The 3D point this surface point was converted from
+    /// The canonical form of the point
     ///
-    /// Keeping this point around allows for the conversion back to a 3D point
-    /// to be unaffected by floating point accuracy issues, which avoids a whole
-    /// host of possible issues.
+    /// This is always the 3D representation of the point. Since this is always
+    /// kept here, unchanged, as the point is converted into other coordinate
+    /// systems, it allows for a lossless conversion back into 3D coordinates,
+    /// unaffected by floating point accuracy issues.
     pub from: Point<3>,
 }
 

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -48,7 +48,7 @@ impl Surface {
         };
 
         geometry::Point {
-            value: point_2d,
+            native: point_2d,
             from: point_3d,
         }
     }

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -4,9 +4,12 @@ pub use self::swept::Swept;
 
 use nalgebra::vector;
 
-use crate::math::{Point, Transform, Vector};
+use crate::{
+    kernel::geometry,
+    math::{Point, Transform, Vector},
+};
 
-use super::{points::SurfacePoint, Curve, Line};
+use super::{Curve, Line};
 
 /// A two-dimensional shape
 #[derive(Clone, Debug, PartialEq)]
@@ -36,12 +39,15 @@ impl Surface {
     }
 
     /// Convert a point in model coordinates to surface coordinates
-    pub fn point_model_to_surface(&self, point_3d: Point<3>) -> SurfacePoint {
+    pub fn point_model_to_surface(
+        &self,
+        point_3d: Point<3>,
+    ) -> geometry::SurfacePoint {
         let point_2d = match self {
             Self::Swept(surface) => surface.point_model_to_surface(&point_3d),
         };
 
-        SurfacePoint {
+        geometry::SurfacePoint {
             value: point_2d,
             from: point_3d,
         }

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -42,7 +42,7 @@ impl Surface {
     pub fn point_model_to_surface(
         &self,
         point_3d: Point<3>,
-    ) -> geometry::Point {
+    ) -> geometry::Point<2> {
         let point_2d = match self {
             Self::Swept(surface) => surface.point_model_to_surface(&point_3d),
         };

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -49,7 +49,7 @@ impl Surface {
 
         geometry::Point {
             native: point_2d,
-            from: point_3d,
+            canonical: point_3d,
         }
     }
 

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -47,10 +47,7 @@ impl Surface {
             Self::Swept(surface) => surface.point_model_to_surface(&point_3d),
         };
 
-        geometry::Point {
-            native: point_2d,
-            canonical: point_3d,
-        }
+        geometry::Point::new(point_2d, point_3d)
     }
 
     /// Convert a point in surface coordinates to model coordinates

--- a/src/kernel/geometry/surfaces/mod.rs
+++ b/src/kernel/geometry/surfaces/mod.rs
@@ -42,12 +42,12 @@ impl Surface {
     pub fn point_model_to_surface(
         &self,
         point_3d: Point<3>,
-    ) -> geometry::SurfacePoint {
+    ) -> geometry::Point {
         let point_2d = match self {
             Self::Swept(surface) => surface.point_model_to_surface(&point_3d),
         };
 
-        geometry::SurfacePoint {
+        geometry::Point {
             value: point_2d,
             from: point_3d,
         }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -133,7 +133,7 @@ impl Face {
                 // We're also going to need a point outside of the polygon, for
                 // the point-in-polygon tests.
                 let aabb = Aabb::<2>::from_points(
-                    points.iter().map(|vertex| vertex.native),
+                    points.iter().map(|vertex| vertex.native()),
                 );
                 let outside = aabb.max * 2.;
 
@@ -191,7 +191,7 @@ impl Face {
                             // cases that would arise from that case.
 
                             let edge =
-                                Segment::from(edge.map(|point| point.native));
+                                Segment::from(edge.map(|point| point.native()));
 
                             let intersection = edge
                                 .to_parry()

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -226,7 +226,7 @@ impl Face {
                 });
 
                 out.extend(triangles.into_iter().map(|triangle| {
-                    let [a, b, c] = triangle.map(|point| point.canonical);
+                    let [a, b, c] = triangle.map(|point| point.canonical());
                     Triangle::from([a, b, c])
                 }));
             }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -226,7 +226,7 @@ impl Face {
                 });
 
                 out.extend(triangles.into_iter().map(|triangle| {
-                    let [a, b, c] = triangle.map(|point| point.from);
+                    let [a, b, c] = triangle.map(|point| point.canonical);
                     Triangle::from([a, b, c])
                 }));
             }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -133,7 +133,7 @@ impl Face {
                 // We're also going to need a point outside of the polygon, for
                 // the point-in-polygon tests.
                 let aabb = Aabb::<2>::from_points(
-                    points.iter().map(|vertex| vertex.value),
+                    points.iter().map(|vertex| vertex.native),
                 );
                 let outside = aabb.max * 2.;
 
@@ -191,7 +191,7 @@ impl Face {
                             // cases that would arise from that case.
 
                             let edge =
-                                Segment::from(edge.map(|point| point.value));
+                                Segment::from(edge.map(|point| point.native));
 
                             let intersection = edge
                                 .to_parry()

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -32,9 +32,7 @@ pub struct Vertices(pub Vec<Vertex<3>>);
 /// This can be prevented outright by never creating a new `Vertex` instance
 /// for an existing vertex. Hence why this is strictly forbidden.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub struct Vertex<const D: usize> {
-    location: geometry::Point<D>,
-}
+pub struct Vertex<const D: usize>(geometry::Point<D>);
 
 impl Vertex<3> {
     /// Create a vertex at the given location
@@ -47,9 +45,7 @@ impl Vertex<3> {
     /// representation of a vertex. If you need a vertex of different
     /// dimensionality, use a conversion method.
     pub fn create_at(location: math::Point<3>) -> Self {
-        Self {
-            location: geometry::Point::new(location, location),
-        }
+        Self(geometry::Point::new(location, location))
     }
 
     /// Convert the vertex to a 1-dimensional vertex
@@ -57,11 +53,9 @@ impl Vertex<3> {
     /// Uses to provided curve to convert the vertex into a 1-dimensional vertex
     /// in the curve's coordinate system.
     pub fn to_1d(&self, curve: &Curve) -> Vertex<1> {
-        let location = curve.point_model_to_curve(&self.location);
+        let location = curve.point_model_to_curve(&self.0);
 
-        Vertex {
-            location: geometry::Point::new(location, self.location.canonical()),
-        }
+        Vertex(geometry::Point::new(location, self.0.canonical()))
     }
 }
 
@@ -81,9 +75,9 @@ impl Vertex<1> {
     /// sure this is the case, is the responsibility of the caller.
     #[must_use]
     pub fn transform(mut self, transform: &Transform) -> Self {
-        self.location = geometry::Point::new(
-            self.location.native(),
-            transform.transform_point(&self.location.canonical()),
+        self.0 = geometry::Point::new(
+            self.0.native(),
+            transform.transform_point(&self.0.canonical()),
         );
         self
     }
@@ -92,16 +86,11 @@ impl Vertex<1> {
 impl<const D: usize> Vertex<D> {
     /// Access the location of this vertex
     pub fn location(&self) -> &math::Point<D> {
-        &self.location
+        &self.0
     }
 
     /// Convert the vertex to its canonical form
     pub fn to_canonical(&self) -> Vertex<3> {
-        Vertex {
-            location: geometry::Point::new(
-                self.location.canonical(),
-                self.location.canonical(),
-            ),
-        }
+        Vertex(geometry::Point::new(self.0.canonical(), self.0.canonical()))
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -31,7 +31,7 @@ pub struct Vertices(pub Vec<Vertex<3>>);
 ///
 /// This can be prevented outright by never creating a new `Vertex` instance
 /// for an existing vertex. Hence why this is strictly forbidden.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex<const D: usize>(geometry::Point<D>);
 
 impl Vertex<3> {

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::geometry::Curve,
-    math::{Point, Transform},
+    math::{self, Transform},
 };
 
 /// The vertices of a shape
@@ -33,7 +33,7 @@ pub struct Vertices(pub Vec<Vertex<3>>);
 /// for an existing vertex. Hence why this is strictly forbidden.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Vertex<const D: usize> {
-    location: Point<D>,
+    location: math::Point<D>,
 
     /// The canonical location of this vertex
     ///
@@ -41,7 +41,7 @@ pub struct Vertex<const D: usize> {
     /// `Vertex<3>`, this field is just redundant. If the vertex is of different
     /// dimensionality, this field allows for loss-free conversion back into the
     /// canonical representation.
-    canonical: Point<3>,
+    canonical: math::Point<3>,
 }
 
 impl Vertex<3> {
@@ -54,7 +54,7 @@ impl Vertex<3> {
     /// Only 3-dimensional vertices can be created, as that is the canonical
     /// representation of a vertex. If you need a vertex of different
     /// dimensionality, use a conversion method.
-    pub fn create_at(location: Point<3>) -> Self {
+    pub fn create_at(location: math::Point<3>) -> Self {
         Self {
             location,
             canonical: location,
@@ -98,7 +98,7 @@ impl Vertex<1> {
 
 impl<const D: usize> Vertex<D> {
     /// Access the location of this vertex
-    pub fn location(&self) -> &Point<D> {
+    pub fn location(&self) -> &math::Point<D> {
         &self.location
     }
 

--- a/src/kernel/triangulation.rs
+++ b/src/kernel/triangulation.rs
@@ -42,8 +42,8 @@ impl HasPosition for geometry::Point<2> {
 
     fn position(&self) -> spade::Point2<Self::Scalar> {
         spade::Point2 {
-            x: self.native.u,
-            y: self.native.v,
+            x: self.native().u,
+            y: self.native().v,
         }
     }
 }

--- a/src/kernel/triangulation.rs
+++ b/src/kernel/triangulation.rs
@@ -6,7 +6,9 @@ use crate::math::Scalar;
 use super::geometry;
 
 /// Create a Delaunay triangulation of all points
-pub fn triangulate(points: Vec<geometry::Point>) -> Vec<[geometry::Point; 3]> {
+pub fn triangulate(
+    points: Vec<geometry::Point<2>>,
+) -> Vec<[geometry::Point<2>; 3]> {
     use spade::Triangulation as _;
 
     let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
@@ -35,7 +37,7 @@ pub fn triangulate(points: Vec<geometry::Point>) -> Vec<[geometry::Point; 3]> {
 }
 
 // Enables the use of `SurfacePoint` in the triangulation.
-impl HasPosition for geometry::Point {
+impl HasPosition for geometry::Point<2> {
     type Scalar = Scalar;
 
     fn position(&self) -> spade::Point2<Self::Scalar> {

--- a/src/kernel/triangulation.rs
+++ b/src/kernel/triangulation.rs
@@ -6,9 +6,7 @@ use crate::math::Scalar;
 use super::geometry;
 
 /// Create a Delaunay triangulation of all points
-pub fn triangulate(
-    points: Vec<geometry::SurfacePoint>,
-) -> Vec<[geometry::SurfacePoint; 3]> {
+pub fn triangulate(points: Vec<geometry::Point>) -> Vec<[geometry::Point; 3]> {
     use spade::Triangulation as _;
 
     let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
@@ -37,7 +35,7 @@ pub fn triangulate(
 }
 
 // Enables the use of `SurfacePoint` in the triangulation.
-impl HasPosition for geometry::SurfacePoint {
+impl HasPosition for geometry::Point {
     type Scalar = Scalar;
 
     fn position(&self) -> spade::Point2<Self::Scalar> {

--- a/src/kernel/triangulation.rs
+++ b/src/kernel/triangulation.rs
@@ -40,8 +40,8 @@ impl HasPosition for geometry::Point {
 
     fn position(&self) -> spade::Point2<Self::Scalar> {
         spade::Point2 {
-            x: self.value.u,
-            y: self.value.v,
+            x: self.native.u,
+            y: self.native.v,
         }
     }
 }

--- a/src/kernel/triangulation.rs
+++ b/src/kernel/triangulation.rs
@@ -3,10 +3,12 @@ use spade::HasPosition;
 
 use crate::math::Scalar;
 
-use super::geometry::points::SurfacePoint;
+use super::geometry;
 
 /// Create a Delaunay triangulation of all points
-pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<[SurfacePoint; 3]> {
+pub fn triangulate(
+    points: Vec<geometry::SurfacePoint>,
+) -> Vec<[geometry::SurfacePoint; 3]> {
     use spade::Triangulation as _;
 
     let triangulation = spade::DelaunayTriangulation::<_>::bulk_load(points)
@@ -35,7 +37,7 @@ pub fn triangulate(points: Vec<SurfacePoint>) -> Vec<[SurfacePoint; 3]> {
 }
 
 // Enables the use of `SurfacePoint` in the triangulation.
-impl HasPosition for SurfacePoint {
+impl HasPosition for geometry::SurfacePoint {
     type Scalar = Scalar;
 
     fn position(&self) -> spade::Point2<Self::Scalar> {


### PR DESCRIPTION
There were some parallels and duplication between those structs. This pull request renames `SurfacePoint` to `geometry::Point`, cleans it up and makes it more broadly useful, then employs it within `Vertex` to consolidate the duplication.

`Vertex` is still a bit funky in its use of `geometry::Point`. This pull request is mostly about cleaning up `geometry::Point`. On the `Vertex` side, it's basically the minimally invasive change, just making it use `geometry::Point` while completely preserving its external API.

`Vertex` is due for changes anyway (#242), so I think this is fine.