### PR TITLE
Add new `algorithms` module

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -1,10 +1,11 @@
 use std::collections::HashSet;
 
-use crate::math::{Point, Scalar, Segment};
-
-use super::topology::{
-    edges::{Cycle, Edge, Edges},
-    faces::Face,
+use crate::{
+    kernel::topology::{
+        edges::{Cycle, Edge, Edges},
+        faces::Face,
+    },
+    math::{Point, Scalar, Segment},
 };
 
 /// An approximation of an edge, multiple edges, or a face

--- a/src/kernel/algorithms/mod.rs
+++ b/src/kernel/algorithms/mod.rs
@@ -1,0 +1,2 @@
+pub mod approximation;
+pub mod triangulation;

--- a/src/kernel/algorithms/triangulation.rs
+++ b/src/kernel/algorithms/triangulation.rs
@@ -1,9 +1,7 @@
 use parry2d_f64::utils::point_in_triangle::{corner_direction, Orientation};
 use spade::HasPosition;
 
-use crate::math::Scalar;
-
-use super::geometry;
+use crate::{kernel::geometry, math::Scalar};
 
 /// Create a Delaunay triangulation of all points
 pub fn triangulate(

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1,5 +1,4 @@
-pub mod approximation;
+pub mod algorithms;
 pub mod geometry;
 pub mod shapes;
 pub mod topology;
-pub mod triangulation;

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -6,7 +6,7 @@ use parry3d_f64::math::Isometry;
 use crate::{
     debug::DebugInfo,
     kernel::{
-        approximation::Approximation,
+        algorithms::approximation::Approximation,
         topology::{
             edges::Edges,
             faces::{Face, Faces},

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -6,8 +6,10 @@ use parry3d_f64::query::Ray as Ray3;
 use crate::{
     debug::{DebugInfo, TriangleEdgeCheck},
     kernel::{
-        approximation::Approximation, geometry::Surface,
-        triangulation::triangulate,
+        algorithms::{
+            approximation::Approximation, triangulation::triangulate,
+        },
+        geometry::Surface,
     },
     math::{Aabb, Scalar, Segment, Transform, Triangle},
 };


### PR DESCRIPTION
This commit moves `approximation` and `triangulation` into a new
`kernel::algorithms` module.

Approximation and triangulation are examples of relatively self-
contained functionality, that uses the structures defined in `geometry`
and `topology` to do stuff, without those structures really needing to
know about it. This vision isn't fully realized, as especially
triangulation is entangled with `topology`, but this will be cleaned up
in due time.

It makes sense to have each of these algorithms in a central place,
where they can be understood and unit-tested, instead of spread over
lots of small methods in the `geometry` and `topology` modules. I think
we'll need to consolidate more functionality in this way:
transformations and sweep are candidates for this. Adding all of this to
the top-level namespace in the `kernel` module would become confusing.