### PR TITLE
Add `Vertices::create`

### DIFF
--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -5,7 +5,6 @@ use crate::{
         topology::{
             edges::{Edge, Edges},
             faces::{Face, Faces},
-            vertices::Vertices,
             Shape,
         },
     },
@@ -16,21 +15,19 @@ use super::ToShape;
 
 impl ToShape for fj::Circle {
     fn to_shape(&self, _: Scalar, _: &mut DebugInfo) -> Shape {
-        // Circles have just a single round edge with no vertices.
-        let vertices = Vertices(Vec::new());
+        let mut shape = Shape::new();
 
-        let edges = Edges::single_cycle([Edge::circle(self.radius)]);
+        // Circles have just a single round edge with no vertices. So none need
+        // to be added here.
 
-        let faces = Faces(vec![Face::Face {
-            edges: edges.clone(),
+        shape.edges = Edges::single_cycle([Edge::circle(self.radius)]);
+
+        shape.faces = Faces(vec![Face::Face {
+            edges: shape.edges.clone(),
             surface: Surface::x_y_plane(),
         }]);
 
-        Shape {
-            vertices,
-            edges,
-            faces,
-        }
+        shape
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -3,7 +3,6 @@ use crate::{
     kernel::topology::{
         edges::Edges,
         faces::{Face, Faces},
-        vertices::Vertices,
         Shape,
     },
     math::{Aabb, Scalar},
@@ -16,10 +15,12 @@ impl ToShape for fj::Difference2d {
         // This method assumes that `b` is fully contained within `a`:
         // https://github.com/hannobraun/Fornjot/issues/92
 
+        let mut shape = Shape::new();
+
         let mut a = self.a.to_shape(tolerance, debug_info);
         let mut b = self.b.to_shape(tolerance, debug_info);
 
-        let edges = {
+        shape.edges = {
             let (a, b) = if a.edges.cycles.len() == 1
                 && b.edges.cycles.len() == 1
             {
@@ -36,7 +37,7 @@ impl ToShape for fj::Difference2d {
             Edges { cycles: vec![a, b] }
         };
 
-        let faces = {
+        shape.faces = {
             let (a, b) = if a.faces.0.len() == 1 && b.faces.0.len() == 1 {
                 // Can't panic. We just checked that length of `a` and `b` is 1.
                 (a.faces.0.pop().unwrap(), b.faces.0.pop().unwrap())
@@ -79,11 +80,7 @@ impl ToShape for fj::Difference2d {
             Faces(vec![Face::Face { edges, surface }])
         };
 
-        Shape {
-            vertices: Vertices(Vec::new()),
-            edges,
-            faces,
-        }
+        shape
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -5,7 +5,6 @@ use crate::{
         topology::{
             edges::{Edge, Edges},
             faces::{Face, Faces},
-            vertices::{Vertex, Vertices},
             Shape,
         },
     },
@@ -18,12 +17,9 @@ impl ToShape for fj::Sketch {
     fn to_shape(&self, _: Scalar, _: &mut DebugInfo) -> Shape {
         let mut shape = Shape::new();
 
-        shape.vertices = Vertices(
-            self.to_points()
-                .into_iter()
-                .map(|[x, y]| Vertex::new(Point::from([x, y, 0.])))
-                .collect(),
-        );
+        for [x, y] in self.to_points() {
+            shape.vertices.create(Point::from([x, y, 0.]));
+        }
 
         shape.edges = {
             let vertices = match shape.vertices.clone() {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -16,15 +16,17 @@ use super::ToShape;
 
 impl ToShape for fj::Sketch {
     fn to_shape(&self, _: Scalar, _: &mut DebugInfo) -> Shape {
-        let vertices = Vertices(
+        let mut shape = Shape::new();
+
+        shape.vertices = Vertices(
             self.to_points()
                 .into_iter()
                 .map(|[x, y]| Vertex::new(Point::from([x, y, 0.])))
                 .collect(),
         );
 
-        let edges = {
-            let vertices = match vertices.clone() {
+        shape.edges = {
+            let vertices = match shape.vertices.clone() {
                 vertices if vertices.0.is_empty() => vertices.0,
                 vertices => {
                     let mut vertices = vertices.0;
@@ -59,16 +61,12 @@ impl ToShape for fj::Sketch {
         };
 
         let face = Face::Face {
-            edges: edges.clone(),
+            edges: shape.edges.clone(),
             surface: Surface::x_y_plane(),
         };
-        let faces = Faces(vec![face]);
+        shape.faces = Faces(vec![face]);
 
-        Shape {
-            vertices,
-            edges,
-            faces,
-        }
+        shape
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -8,9 +8,7 @@ use crate::{
     kernel::{
         algorithms::approximation::Approximation,
         topology::{
-            edges::Edges,
             faces::{Face, Faces},
-            vertices::Vertices,
             Shape,
         },
     },
@@ -21,6 +19,8 @@ use super::ToShape;
 
 impl ToShape for fj::Sweep {
     fn to_shape(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Shape {
+        let mut shape = Shape::new();
+
         let original_shape = self.shape.to_shape(tolerance, debug_info);
 
         let rotation = Isometry::rotation(vector![PI, 0., 0.]).into();
@@ -73,13 +73,9 @@ impl ToShape for fj::Sweep {
         faces.extend(top_faces);
         faces.extend(side_faces);
 
-        let faces = Faces(faces);
+        shape.faces = Faces(faces);
 
-        Shape {
-            vertices: Vertices(Vec::new()),
-            edges: Edges { cycles: Vec::new() },
-            faces,
-        }
+        shape
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -2,7 +2,7 @@ use parry3d_f64::math::Isometry;
 
 use crate::{
     debug::DebugInfo,
-    kernel::topology::{edges::Edges, vertices::Vertices, Shape},
+    kernel::topology::Shape,
     math::{Aabb, Scalar, Transform},
 };
 
@@ -10,17 +10,15 @@ use super::ToShape;
 
 impl ToShape for fj::Transform {
     fn to_shape(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Shape {
-        let faces = self
+        let mut shape = Shape::new();
+
+        shape.faces = self
             .shape
             .to_shape(tolerance, debug_info)
             .faces
             .transform(&transform(self));
 
-        Shape {
-            vertices: Vertices(Vec::new()),
-            edges: Edges { cycles: Vec::new() },
-            faces,
-        }
+        shape
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -1,6 +1,6 @@
 use crate::{
     debug::DebugInfo,
-    kernel::topology::{edges::Edges, faces::Faces, vertices::Vertices, Shape},
+    kernel::topology::{faces::Faces, Shape},
     math::{Aabb, Scalar},
 };
 
@@ -8,6 +8,8 @@ use super::ToShape;
 
 impl ToShape for fj::Union {
     fn to_shape(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Shape {
+        let mut shape = Shape::new();
+
         let a = self.a.to_shape(tolerance, debug_info).faces;
         let b = self.b.to_shape(tolerance, debug_info).faces;
 
@@ -20,13 +22,9 @@ impl ToShape for fj::Union {
         faces.extend(a.0);
         faces.extend(b.0);
 
-        let faces = Faces(faces);
+        shape.faces = Faces(faces);
 
-        Shape {
-            vertices: Vertices(Vec::new()),
-            edges: Edges { cycles: Vec::new() },
-            faces,
-        }
+        shape
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -10,3 +10,14 @@ pub struct Shape {
     pub edges: Edges,
     pub faces: Faces,
 }
+
+impl Shape {
+    /// Construct a new shape
+    pub fn new() -> Self {
+        Self {
+            vertices: Vertices(Vec::new()),
+            edges: Edges { cycles: Vec::new() },
+            faces: Faces(Vec::new()),
+        }
+    }
+}

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -4,7 +4,7 @@ pub mod vertices;
 
 use self::{edges::Edges, faces::Faces, vertices::Vertices};
 
-/// A placeholder struct that will be filled with life later
+/// The boundary representation of a shape
 pub struct Shape {
     pub vertices: Vertices,
     pub edges: Edges,

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -7,6 +7,28 @@ use crate::{
 #[derive(Clone)]
 pub struct Vertices(pub Vec<Vertex<3>>);
 
+impl Vertices {
+    /// Create a vertex
+    ///
+    /// The caller must make sure to uphold all rules regarding vertex
+    /// uniqueness.
+    ///
+    /// # Implementation note
+    ///
+    /// This method is intended to be the only means to create `Vertex`
+    /// instances, outside of unit tests. We're not quite there yet, but once we
+    /// are, this method is in a great position to enforce vertex uniqueness
+    /// rules, instead of requiring the user to uphold those.
+    pub fn create(
+        &mut self,
+        point: impl Into<geometry::Point<3>>,
+    ) -> Vertex<3> {
+        let vertex = Vertex(point.into());
+        self.0.push(vertex);
+        vertex
+    }
+}
+
 /// A vertex
 ///
 /// This struct exists to distinguish between vertices and points at the type
@@ -40,6 +62,7 @@ impl<const D: usize> Vertex<D> {
     /// You **MUST NOT** use this method to construct a new instance of `Vertex`
     /// that represents an already existing vertex. See documentation of
     /// [`Vertex`] for more information.
+    #[cfg(test)]
     pub fn new(point: impl Into<geometry::Point<D>>) -> Self {
         Self(point.into())
     }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -59,9 +59,8 @@ pub struct Vertex<const D: usize>(geometry::Point<D>);
 impl<const D: usize> Vertex<D> {
     /// Construct a new vertex
     ///
-    /// You **MUST NOT** use this method to construct a new instance of `Vertex`
-    /// that represents an already existing vertex. See documentation of
-    /// [`Vertex`] for more information.
+    /// This method is only intended for unit tests. All other code should call
+    /// [`Vertices::create`].
     #[cfg(test)]
     pub fn new(point: impl Into<geometry::Point<D>>) -> Self {
         Self(point.into())


### PR DESCRIPTION
This pull request adds `Vertices::create`, in addition to making some cleanups leading up to that. It came out of my work towrads #242.

As the implementation note states, `Vertices::create` will be in a good position to enforce the vertex uniqueness rules. Right now, there's still one other method that creates `Vertex` instances (`Vertex::transform`). That hole needs to be plugged before vertex uniqueness rules can be enforced.