### PR TITLE
Make `Vertices::create` more flexible

### DIFF
--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -22,7 +22,7 @@ impl ToShape for fj::Sketch {
         }
 
         shape.edges = {
-            let mut vertices = shape.vertices.0.clone();
+            let mut vertices: Vec<_> = shape.vertices.iter().collect();
 
             if !vertices.is_empty() {
                 // Add the first vertex at the end again, to close the loop.

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -22,19 +22,15 @@ impl ToShape for fj::Sketch {
         }
 
         shape.edges = {
-            let vertices = match shape.vertices.clone() {
-                vertices if vertices.0.is_empty() => vertices.0,
-                vertices => {
-                    let mut vertices = vertices.0;
+            let mut vertices = shape.vertices.0.clone();
 
-                    // Add the first vertex at the end again, to close the loop.
-                    //
-                    // This can't panic. This `match` expression makes sure that
-                    // there are vertices.
-                    vertices.push(vertices[0]);
-                    vertices
-                }
-            };
+            if !vertices.is_empty() {
+                // Add the first vertex at the end again, to close the loop.
+                //
+                // This can't panic. We just checked that `vertices` is not
+                // empty.
+                vertices.push(vertices[0]);
+            }
 
             let mut edges = Vec::new();
             for window in vertices.windows(2) {

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -15,7 +15,7 @@ impl Shape {
     /// Construct a new shape
     pub fn new() -> Self {
         Self {
-            vertices: Vertices(Vec::new()),
+            vertices: Vertices::new(),
             edges: Edges { cycles: Vec::new() },
             faces: Faces(Vec::new()),
         }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,11 +1,11 @@
 use crate::{
     kernel::geometry::{self, Curve},
-    math::Transform,
+    math::{Point, Transform},
 };
 
 /// The vertices of a shape
 #[derive(Clone)]
-pub struct Vertices(Vec<Vertex<3>>);
+pub struct Vertices(Vec<Point<3>>);
 
 impl Vertices {
     /// Construct a new instance of `Vertices`
@@ -28,14 +28,17 @@ impl Vertices {
         &mut self,
         point: impl Into<geometry::Point<3>>,
     ) -> Vertex<3> {
-        let vertex = Vertex(point.into());
-        self.0.push(vertex);
-        vertex
+        let point = point.into();
+        self.0.push(point.canonical());
+        Vertex(point)
     }
 
     /// Access an iterator over all vertices
     pub fn iter(&self) -> impl Iterator<Item = Vertex<3>> + '_ {
-        self.0.iter().copied()
+        self.0
+            .iter()
+            .copied()
+            .map(|point| Vertex(geometry::Point::new(point, point)))
     }
 }
 

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -32,6 +32,11 @@ impl Vertices {
         self.0.push(vertex);
         vertex
     }
+
+    /// Access an iterator over all vertices
+    pub fn iter(&self) -> impl Iterator<Item = Vertex<3>> + '_ {
+        self.0.iter().copied()
+    }
 }
 
 /// A vertex

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -8,6 +8,11 @@ use crate::{
 pub struct Vertices(pub Vec<Vertex<3>>);
 
 impl Vertices {
+    /// Construct a new instance of `Vertices`
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
     /// Create a vertex
     ///
     /// The caller must make sure to uphold all rules regarding vertex

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -24,10 +24,10 @@ impl Vertices {
     /// instances, outside of unit tests. We're not quite there yet, but once we
     /// are, this method is in a great position to enforce vertex uniqueness
     /// rules, instead of requiring the user to uphold those.
-    pub fn create(
+    pub fn create<const D: usize>(
         &mut self,
-        point: impl Into<geometry::Point<3>>,
-    ) -> Vertex<3> {
+        point: impl Into<geometry::Point<D>>,
+    ) -> Vertex<D> {
         let point = point.into();
         self.0.push(point.canonical());
         Vertex(point)

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -5,7 +5,7 @@ use crate::{
 
 /// The vertices of a shape
 #[derive(Clone)]
-pub struct Vertices(pub Vec<Vertex<3>>);
+pub struct Vertices(Vec<Vertex<3>>);
 
 impl Vertices {
     /// Construct a new instance of `Vertices`


### PR DESCRIPTION
Allow the creation of vertices of any dimension using `Vertices::create` this paves the way for replacing `Vertex::transform` and making `Vertices::create` the only way that vertex instances can be created.