### PR TITLE
Consolidate all transformation code in a single module

### DIFF
--- a/src/kernel/algorithms/mod.rs
+++ b/src/kernel/algorithms/mod.rs
@@ -1,2 +1,3 @@
 pub mod approximation;
+pub mod transform;
 pub mod triangulation;

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -1,4 +1,7 @@
-use crate::{kernel::topology::Shape, math::Transform};
+use crate::{
+    kernel::topology::{faces::Face, Shape},
+    math::Transform,
+};
 
 /// Create a new shape that is a transformed version of an existing one
 ///
@@ -14,9 +17,26 @@ pub fn transform_shape(original: &Shape, transform: &Transform) -> Shape {
     let mut transformed = Shape::new();
 
     for face in &original.faces.0 {
-        let face = face.clone().transform(transform);
+        let face = transform_face(face, transform);
         transformed.faces.0.push(face);
     }
 
     transformed
+}
+
+/// Create a new face that is a transformed version of an existing one
+pub fn transform_face(original: &Face, transform: &Transform) -> Face {
+    match original.clone() {
+        Face::Face { edges, surface } => Face::Face {
+            edges: edges.transform(transform),
+            surface: surface.transform(transform),
+        },
+        Face::Triangles(mut triangles) => {
+            for triangle in &mut triangles {
+                *triangle = transform.transform_triangle(triangle);
+            }
+
+            Face::Triangles(triangles)
+        }
+    }
 }

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -1,0 +1,17 @@
+use crate::{kernel::topology::Shape, math::Transform};
+
+/// Create a new shape that is a transformed version of an existing one
+///
+/// # Implementation note
+///
+/// This code isn't really correct, only transforming the faces of the original
+/// shape and not taking care of anything else, but this is more a reflection of
+/// the state of `Shape`, with its redundant data.
+///
+/// Addressing the shortcomings in this method probably doesn't make sense,
+/// except as a side effect of addressing the shortcomings of `Shape`.
+pub fn transform_shape(original: &Shape, transform: &Transform) -> Shape {
+    let mut transformed = Shape::new();
+    transformed.faces = original.faces.clone().transform(transform);
+    transformed
+}

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -12,6 +12,11 @@ use crate::{kernel::topology::Shape, math::Transform};
 /// except as a side effect of addressing the shortcomings of `Shape`.
 pub fn transform_shape(original: &Shape, transform: &Transform) -> Shape {
     let mut transformed = Shape::new();
-    transformed.faces = original.faces.clone().transform(transform);
+
+    for face in &original.faces.0 {
+        let face = face.clone().transform(transform);
+        transformed.faces.0.push(face);
+    }
+
     transformed
 }

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -1,5 +1,9 @@
 use crate::{
-    kernel::topology::{faces::Face, Shape},
+    kernel::topology::{
+        edges::{Cycle, Edges},
+        faces::Face,
+        Shape,
+    },
     math::Transform,
 };
 
@@ -28,10 +32,21 @@ pub fn transform_shape(original: &Shape, transform: &Transform) -> Shape {
 pub fn transform_face(original: &Face, transform: &Transform) -> Face {
     match original.clone() {
         Face::Face { edges, surface } => {
-            let edges = edges.transform(transform);
+            let mut cycles = Vec::new();
+
+            for cycle in edges.cycles {
+                let mut edges = Vec::new();
+
+                for edge in cycle.edges {
+                    let edge = edge.clone().transform(transform);
+                    edges.push(edge);
+                }
+
+                cycles.push(Cycle { edges });
+            }
 
             Face::Face {
-                edges,
+                edges: Edges { cycles },
                 surface: surface.transform(transform),
             }
         }

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -27,10 +27,14 @@ pub fn transform_shape(original: &Shape, transform: &Transform) -> Shape {
 /// Create a new face that is a transformed version of an existing one
 pub fn transform_face(original: &Face, transform: &Transform) -> Face {
     match original.clone() {
-        Face::Face { edges, surface } => Face::Face {
-            edges: edges.transform(transform),
-            surface: surface.transform(transform),
-        },
+        Face::Face { edges, surface } => {
+            let edges = edges.transform(transform);
+
+            Face::Face {
+                edges,
+                surface: surface.transform(transform),
+            }
+        }
         Face::Triangles(mut triangles) => {
             for triangle in &mut triangles {
                 *triangle = transform.transform_triangle(triangle);

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::topology::{
-        edges::{Cycle, Edges},
+        edges::{Cycle, Edge, Edges},
         faces::Face,
         Shape,
     },
@@ -38,8 +38,14 @@ pub fn transform_face(original: &Face, transform: &Transform) -> Face {
                 let mut edges = Vec::new();
 
                 for edge in cycle.edges {
-                    let edge = edge.clone().transform(transform);
-                    edges.push(edge);
+                    let vertices = edge.vertices.map(|vertices| {
+                        vertices.map(|vertex| vertex.transform(transform))
+                    });
+
+                    edges.push(Edge {
+                        curve: edge.curve.transform(transform),
+                        vertices,
+                    });
                 }
 
                 cycles.push(Cycle { edges });

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -35,9 +35,9 @@ impl ToShape for fj::Sweep {
             //
             // See issue:
             // https://github.com/hannobraun/Fornjot/issues/230
-            bottom_faces.push(transform_face(&face, &rotation));
+            bottom_faces.push(transform_face(&face, &rotation, &mut shape));
 
-            top_faces.push(transform_face(&face, &translation));
+            top_faces.push(transform_face(&face, &translation, &mut shape));
         }
 
         for cycle in original_shape.edges.cycles {

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -6,7 +6,7 @@ use parry3d_f64::math::Isometry;
 use crate::{
     debug::DebugInfo,
     kernel::{
-        algorithms::approximation::Approximation,
+        algorithms::{approximation::Approximation, transform::transform_face},
         topology::{
             faces::{Face, Faces},
             Shape,
@@ -35,9 +35,9 @@ impl ToShape for fj::Sweep {
             //
             // See issue:
             // https://github.com/hannobraun/Fornjot/issues/230
-            bottom_faces.push(face.clone().transform(&rotation));
+            bottom_faces.push(transform_face(&face, &rotation));
 
-            top_faces.push(face.transform(&translation));
+            top_faces.push(transform_face(&face, &translation));
         }
 
         for cycle in original_shape.edges.cycles {

--- a/src/kernel/shapes/transform.rs
+++ b/src/kernel/shapes/transform.rs
@@ -2,7 +2,7 @@ use parry3d_f64::math::Isometry;
 
 use crate::{
     debug::DebugInfo,
-    kernel::topology::Shape,
+    kernel::{algorithms::transform::transform_shape, topology::Shape},
     math::{Aabb, Scalar, Transform},
 };
 
@@ -10,15 +10,9 @@ use super::ToShape;
 
 impl ToShape for fj::Transform {
     fn to_shape(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Shape {
-        let mut shape = Shape::new();
-
-        shape.faces = self
-            .shape
-            .to_shape(tolerance, debug_info)
-            .faces
-            .transform(&transform(self));
-
-        shape
+        let shape = self.shape.to_shape(tolerance, debug_info);
+        let transform = transform(self);
+        transform_shape(&shape, &transform)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -27,18 +27,6 @@ impl Edges {
             cycles: vec![cycle],
         }
     }
-
-    /// Transform the edges
-    #[must_use]
-    pub fn transform(mut self, transform: &Transform) -> Self {
-        for cycle in &mut self.cycles {
-            for edge in &mut cycle.edges {
-                *edge = edge.clone().transform(transform);
-            }
-        }
-
-        self
-    }
 }
 
 /// A cycle of connected edges

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::geometry::{Circle, Curve},
-    math::{Point, Transform, Vector},
+    math::{Point, Vector},
 };
 
 use super::vertices::Vertex;
@@ -79,23 +79,5 @@ impl Edge {
             }),
             vertices: None,
         }
-    }
-
-    /// Create a transformed edge
-    ///
-    /// This method constructs new instances of [`Vertex`], by calling
-    /// [`Vertex::transform`].
-    ///
-    /// You **MUST NOT** use this method to construct a new instance of `Vertex`
-    /// that represents an already existing vertex. See documentation of
-    /// [`Vertex`] for more information.
-    #[must_use]
-    pub fn transform(mut self, transform: &Transform) -> Self {
-        self.curve = self.curve.transform(transform);
-        self.vertices = self
-            .vertices
-            .map(|vertices| vertices.map(|vertex| vertex.transform(transform)));
-
-        self
     }
 }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -21,18 +21,6 @@ use super::edges::Edges;
 pub struct Faces(pub Vec<Face>);
 
 impl Faces {
-    /// Transform all the faces
-    #[must_use]
-    pub fn transform(self, transform: &Transform) -> Self {
-        let faces = self
-            .0
-            .into_iter()
-            .map(|face| face.transform(transform))
-            .collect();
-
-        Self(faces)
-    }
-
     pub fn triangles(
         &self,
         tolerance: Scalar,

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         geometry::Surface,
     },
-    math::{Aabb, Scalar, Segment, Transform, Triangle},
+    math::{Aabb, Scalar, Segment, Triangle},
 };
 
 use super::edges::Edges;
@@ -67,24 +67,6 @@ pub enum Face {
 }
 
 impl Face {
-    /// Transform the face
-    #[must_use]
-    pub fn transform(self, transform: &Transform) -> Self {
-        match self {
-            Self::Face { edges, surface } => Self::Face {
-                edges: edges.transform(transform),
-                surface: surface.transform(transform),
-            },
-            Self::Triangles(mut triangles) => {
-                for triangle in &mut triangles {
-                    *triangle = transform.transform_triangle(triangle);
-                }
-
-                Self::Triangles(triangles)
-            }
-        }
-    }
-
     pub fn triangles(
         &self,
         tolerance: Scalar,

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -20,10 +20,9 @@ impl Vertices {
     ///
     /// # Implementation note
     ///
-    /// This method is intended to be the only means to create `Vertex`
-    /// instances, outside of unit tests. We're not quite there yet, but once we
-    /// are, this method is in a great position to enforce vertex uniqueness
-    /// rules, instead of requiring the user to uphold those.
+    /// This method is the only means to create `Vertex` instances, outside of
+    /// unit tests. That puts this method is in a great position to enforce
+    /// vertex uniqueness rules, instead of requiring the user to uphold those.
     pub fn create<const D: usize>(
         &mut self,
         point: impl Into<geometry::Point<D>>,

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,6 +1,6 @@
 use crate::{
     kernel::geometry::{self, Curve},
-    math::{Point, Transform},
+    math::Point,
 };
 
 /// The vertices of a shape
@@ -87,30 +87,6 @@ impl<const D: usize> Vertex<D> {
     /// Convert the vertex to its canonical form
     pub fn to_canonical(self) -> Vertex<3> {
         Vertex(geometry::Point::new(self.0.canonical(), self.0.canonical()))
-    }
-}
-
-impl Vertex<1> {
-    /// Create a transformed vertex
-    ///
-    /// You **MUST NOT** use this method to construct a new instance of `Vertex`
-    /// that represents an already existing vertex. See documentation of
-    /// [`Vertex`] for more information.
-    ///
-    /// This is a 3D transformation that transforms the canonical form of the
-    /// vertex, but leaves the native form untouched. Since `self` is a
-    /// 1-dimensional vertex, transforming the native form is not possible.
-    ///
-    /// And, presumably, also not necessary, as this is likely part of a larger
-    /// transformation that also transforms the curve the vertex is on. Making
-    /// sure this is the case, is the responsibility of the caller.
-    #[must_use]
-    pub fn transform(mut self, transform: &Transform) -> Self {
-        self.0 = geometry::Point::new(
-            self.0.native(),
-            transform.transform_point(&self.0.canonical()),
-        );
-        self
     }
 }
 


### PR DESCRIPTION
Adds the new module, `kernel::algorithms::transform` and consolidates all transformation code in there.

This has the following advantages:
1. All transformation code now lives in a single module, where it is easier to understand, modify, and test it.
2. `Vertex::transform` has been replaced, making `Vertices::create` the only way that `Vertex` instances can be created. This enables the implementation of vertex validation (#242).

To be clear, this doesn't make the transformation code any more beautiful, but this is not the priority right now. The transformation code is ugly because the data structures it operates on are not suited for their purpose. This is going to change, bit by bit, and as it changes, the transformation code will improve as a side effect.