### PR TITLE
Clean up vertices aspect of the `Shape` API

### DIFF
--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -58,7 +58,7 @@ pub fn transform_face(
                                 transform.transform_point(&point.canonical());
 
                             shape
-                                .vertices
+                                .vertices()
                                 .create(geometry::Point::new(native, canonical))
                         })
                     });

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -18,11 +18,11 @@ impl ToShape for fj::Sketch {
         let mut shape = Shape::new();
 
         for [x, y] in self.to_points() {
-            shape.vertices.create(Point::from([x, y, 0.]));
+            shape.vertices().create(Point::from([x, y, 0.]));
         }
 
         shape.edges = {
-            let mut vertices: Vec<_> = shape.vertices.iter().collect();
+            let mut vertices: Vec<_> = shape.vertices().iter().collect();
 
             if !vertices.is_empty() {
                 // Add the first vertex at the end again, to close the loop.

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -6,7 +6,8 @@ use self::{edges::Edges, faces::Faces, vertices::Vertices};
 
 /// The boundary representation of a shape
 pub struct Shape {
-    pub vertices: Vertices,
+    vertices: Vertices,
+
     pub edges: Edges,
     pub faces: Faces,
 }

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -7,6 +7,12 @@ use crate::math::Point;
 use self::{edges::Edges, faces::Faces, vertices::Vertices};
 
 /// The boundary representation of a shape
+///
+/// # Implementation note
+///
+/// The goal for `Shape` is to enforce full self-consistency, through the API it
+/// provides. Steps have been made in that direction, but right now, the API is
+/// still full of holes, forcing callers to just be careful for the time being.
 pub struct Shape {
     vertices: Vec<Point<3>>,
 

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -2,11 +2,13 @@ pub mod edges;
 pub mod faces;
 pub mod vertices;
 
+use crate::math::Point;
+
 use self::{edges::Edges, faces::Faces, vertices::Vertices};
 
 /// The boundary representation of a shape
 pub struct Shape {
-    vertices: Vertices,
+    vertices: Vec<Point<3>>,
 
     pub edges: Edges,
     pub faces: Faces,
@@ -16,14 +18,16 @@ impl Shape {
     /// Construct a new shape
     pub fn new() -> Self {
         Self {
-            vertices: Vertices::new(),
+            vertices: Vec::new(),
             edges: Edges { cycles: Vec::new() },
             faces: Faces(Vec::new()),
         }
     }
 
     /// Access and modify the shape's vertices
-    pub fn vertices(&mut self) -> &mut Vertices {
-        &mut self.vertices
+    pub fn vertices(&mut self) -> Vertices {
+        Vertices {
+            vertices: &mut self.vertices,
+        }
     }
 }

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -20,4 +20,9 @@ impl Shape {
             faces: Faces(Vec::new()),
         }
     }
+
+    /// Access and modify the shape's vertices
+    pub fn vertices(&mut self) -> &mut Vertices {
+        &mut self.vertices
+    }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -4,18 +4,11 @@ use crate::{
 };
 
 /// The vertices of a shape
-pub struct Vertices {
-    vertices: Vec<Point<3>>,
+pub struct Vertices<'r> {
+    pub(super) vertices: &'r mut Vec<Point<3>>,
 }
 
-impl Vertices {
-    /// Construct a new instance of `Vertices`
-    pub fn new() -> Self {
-        Self {
-            vertices: Vec::new(),
-        }
-    }
-
+impl Vertices<'_> {
     /// Create a vertex
     ///
     /// The caller must make sure to uphold all rules regarding vertex

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -5,12 +5,16 @@ use crate::{
 
 /// The vertices of a shape
 #[derive(Clone)]
-pub struct Vertices(Vec<Point<3>>);
+pub struct Vertices {
+    vertices: Vec<Point<3>>,
+}
 
 impl Vertices {
     /// Construct a new instance of `Vertices`
     pub fn new() -> Self {
-        Self(Vec::new())
+        Self {
+            vertices: Vec::new(),
+        }
     }
 
     /// Create a vertex
@@ -28,13 +32,13 @@ impl Vertices {
         point: impl Into<geometry::Point<D>>,
     ) -> Vertex<D> {
         let point = point.into();
-        self.0.push(point.canonical());
+        self.vertices.push(point.canonical());
         Vertex(point)
     }
 
     /// Access an iterator over all vertices
     pub fn iter(&self) -> impl Iterator<Item = Vertex<3>> + '_ {
-        self.0
+        self.vertices
             .iter()
             .copied()
             .map(|point| Vertex(geometry::Point::new(point, point)))

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 
 /// The vertices of a shape
-#[derive(Clone)]
 pub struct Vertices {
     vertices: Vec<Point<3>>,
 }


### PR DESCRIPTION
This takes steps into the direction of making `Shape` a robust API that enforces internal consistency. I intend to make similar changes for edges and faces at some point, but the work on vertex validation (#242) has provided an opportunity to make those changes for vertices already.