### PR TITLE
Enable vertex validation

### DIFF
--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -1,7 +1,5 @@
 use std::collections::HashSet;
 
-use tracing::warn;
-
 use crate::{
     debug::DebugInfo,
     kernel::{
@@ -63,10 +61,7 @@ impl Topology<'_> {
                 (existing.get().point() - vertex.point()).magnitude();
 
             if distance < self.min_distance {
-                warn!(
-                    "Invalid vertex: {vertex:?}; \
-                    identical vertex at {existing:?}",
-                );
+                return Err(ValidationError::Uniqueness);
             }
         }
 
@@ -295,9 +290,9 @@ mod tests {
 
         // `point` is too close to the original point. `assert!` is commented,
         // because that only causes a warning to be logged right now.
-        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]));
-        let _result = shape.topology().add_vertex(Vertex { point });
-        // assert!(matches!(result, Err(ValidationError::Uniqueness)));
+        let point = shape.geometry().add_point(Point::from([5e-8, 0., 0.]));
+        let result = shape.topology().add_vertex(Vertex { point });
+        assert!(matches!(result, Err(ValidationError::Uniqueness)));
 
         // `point` is farther than `MIN_DISTANCE` away from original point.
         // Should work.


### PR DESCRIPTION
Vertex validation ensures that vertices are unique: Different vertices that don't have a specific minimum distance to each other are considered identical, which is not allowed. This is a user-visible change that can lead to errors in models that would have previously been accepted.

The immediate advantage of this is, that it is no longer possible to accidentally create distinct vertices that were supposed to be identical, which is a source of bugs. Due to floating point accuracy issues, this kind of thing can easily happen, both in models and in kernel code.

Longer-term, this is the start of a strategy of requiring geometrical relationships to be explicit, and immediately failing if they aren't. I've [started to document this](https://github.com/hannobraun/Fornjot/blob/9924a0b32b6680b3912c9908edaad78ae0a6e241/src/kernel/mod.rs#L8-L77).

Close #242