### PR TITLE
Simplify creation of `Line` and `Edge`

### DIFF
--- a/src/kernel/geometry/curves/line.rs
+++ b/src/kernel/geometry/curves/line.rs
@@ -15,6 +15,14 @@ pub struct Line {
 }
 
 impl Line {
+    /// Create a line from two points
+    pub fn from_points([a, b]: [Point<3>; 2]) -> Self {
+        Line {
+            origin: a,
+            direction: b - a,
+        }
+    }
+
     /// Access the origin of the curve's coordinate system
     pub fn origin(&self) -> Point<3> {
         self.origin

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -1,7 +1,7 @@
 use crate::{
     debug::DebugInfo,
     kernel::{
-        geometry::{Curve, Line, Surface},
+        geometry::Surface,
         topology::{
             edges::{Edge, Edges},
             faces::{Face, Faces},
@@ -40,11 +40,7 @@ impl ToShape for fj::Sketch {
                 let a = window[0];
                 let b = window[1];
 
-                let line = Curve::Line(Line::from_points(
-                    [a, b].map(|vertex| vertex.point().canonical()),
-                ));
-                let edge = Edge::new(line, Some([a, b]));
-
+                let edge = Edge::line_segment([a, b]);
                 edges.push(edge);
             }
 

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -40,10 +40,9 @@ impl ToShape for fj::Sketch {
                 let a = window[0];
                 let b = window[1];
 
-                let line = Curve::Line(Line {
-                    origin: a.point().native(),
-                    direction: b.point() - a.point(),
-                });
+                let line = Curve::Line(Line::from_points(
+                    [a, b].map(|vertex| vertex.point().canonical()),
+                ));
                 let edge = Edge::new(line, Some([a, b]));
 
                 edges.push(edge);

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -1,5 +1,5 @@
 use crate::{
-    kernel::geometry::{Circle, Curve},
+    kernel::geometry::{Circle, Curve, Line},
     math::{Point, Vector},
 };
 
@@ -68,6 +68,16 @@ impl Edge {
             .map(|vertices| vertices.map(|vertex| vertex.to_1d(&curve)));
 
         Self { curve, vertices }
+    }
+
+    /// Construct an edge that is a line segment
+    pub fn line_segment(vertices: [Vertex<3>; 2]) -> Self {
+        Self::new(
+            Curve::Line(Line::from_points(
+                vertices.map(|vertex| vertex.point().canonical()),
+            )),
+            Some(vertices),
+        )
     }
 
     /// Create a circle


### PR DESCRIPTION
These new constructors are useful in unit tests. I'm working on some changes that make use of `Edge::line_segment`.