### PR TITLE
Simplify approximation test suite

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -155,7 +155,7 @@ mod tests {
 
     use crate::{
         kernel::{
-            geometry::{Curve, Surface},
+            geometry::{self, Curve, Surface},
             topology::{
                 edges::{Cycle, Edge, Edges},
                 faces::Face,
@@ -165,28 +165,26 @@ mod tests {
         math::{Point, Scalar, Segment},
     };
 
-    use super::Approximation;
+    use super::{approximate_edge, Approximation};
 
     #[test]
     fn for_edge() {
-        let tolerance = Scalar::ONE;
+        // Doesn't test `Approximation::for_edge` directly, but that method only
+        // contains a bit of additional glue code that is not critical.
 
         let a = Point::from([1., 2., 3.]);
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = Vertex::new(a);
-        let v2 = Vertex::new(d);
+        let v1 = Vertex::new(geometry::Point::new(Point::from([0.]), a));
+        let v2 = Vertex::new(geometry::Point::new(Point::from([1.]), d));
 
-        let curve = Curve::Mock {
-            approx: vec![b, c],
-            coords: RefCell::new(vec![Point::from([0.]), Point::from([1.])]),
-        };
+        let points = vec![b, c];
 
-        let edge_regular = Edge::new(curve.clone(), Some([v1, v2]));
+        // Regular edge
         assert_eq!(
-            Approximation::for_edge(&edge_regular, tolerance),
+            approximate_edge(points.clone(), Some([v1, v2])),
             Approximation {
                 points: set![a, b, c, d],
                 segments: set![
@@ -197,9 +195,9 @@ mod tests {
             }
         );
 
-        let edge_self_connected = Edge::new(curve, None);
+        // Continuous edge
         assert_eq!(
-            Approximation::for_edge(&edge_self_connected, tolerance),
+            approximate_edge(points, None),
             Approximation {
                 points: set![b, c],
                 segments: set![Segment::from([b, c]), Segment::from([c, b])],

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -149,13 +149,11 @@ fn approximate_edge(
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use map_macro::set;
 
     use crate::{
         kernel::{
-            geometry::{self, Curve, Surface},
+            geometry::{self, Surface},
             topology::{
                 edges::{Cycle, Edge, Edges},
                 faces::Face,
@@ -217,14 +215,9 @@ mod tests {
         let v2 = Vertex::new(b);
         let v3 = Vertex::new(c);
 
-        let curve = Curve::Mock {
-            approx: Vec::new(),
-            coords: RefCell::new(vec![Point::from([0.]), Point::from([1.])]),
-        };
-
-        let ab = Edge::new(curve.clone(), Some([v1, v2]));
-        let bc = Edge::new(curve.clone(), Some([v2, v3]));
-        let ca = Edge::new(curve, Some([v3, v1]));
+        let ab = Edge::line_segment([v1, v2]);
+        let bc = Edge::line_segment([v2, v3]);
+        let ca = Edge::line_segment([v3, v1]);
 
         let cycle = Cycle {
             edges: vec![ab, bc, ca],
@@ -257,15 +250,10 @@ mod tests {
         let v3 = Vertex::new(c);
         let v4 = Vertex::new(d);
 
-        let curve = Curve::Mock {
-            approx: Vec::new(),
-            coords: RefCell::new(vec![Point::from([0.]), Point::from([1.])]),
-        };
-
-        let ab = Edge::new(curve.clone(), Some([v1, v2]));
-        let ba = Edge::new(curve.clone(), Some([v2, v1]));
-        let cd = Edge::new(curve.clone(), Some([v3, v4]));
-        let dc = Edge::new(curve, Some([v4, v3]));
+        let ab = Edge::line_segment([v1, v2]);
+        let ba = Edge::line_segment([v2, v1]);
+        let cd = Edge::line_segment([v3, v4]);
+        let dc = Edge::line_segment([v4, v3]);
 
         let ab_ba = Cycle {
             edges: vec![ab, ba],
@@ -308,15 +296,10 @@ mod tests {
         let v3 = Vertex::new(c);
         let v4 = Vertex::new(d);
 
-        let curve = Curve::Mock {
-            approx: Vec::new(),
-            coords: RefCell::new(vec![Point::from([0.]), Point::from([1.])]),
-        };
-
-        let ab = Edge::new(curve.clone(), Some([v1, v2]));
-        let bc = Edge::new(curve.clone(), Some([v2, v3]));
-        let cd = Edge::new(curve.clone(), Some([v3, v4]));
-        let da = Edge::new(curve, Some([v4, v1]));
+        let ab = Edge::line_segment([v1, v2]);
+        let bc = Edge::line_segment([v2, v3]);
+        let cd = Edge::line_segment([v3, v4]);
+        let da = Edge::line_segment([v4, v1]);
 
         let abcd = Cycle {
             edges: vec![ab, bc, cd, da],

--- a/src/kernel/geometry/curves/mod.rs
+++ b/src/kernel/geometry/curves/mod.rs
@@ -21,13 +21,6 @@ pub enum Curve {
 
     /// A line
     Line(Line),
-
-    /// A mock curve used for testing
-    #[cfg(test)]
-    Mock {
-        approx: Vec<Point<3>>,
-        coords: std::cell::RefCell<Vec<Point<1>>>,
-    },
 }
 
 impl Curve {
@@ -36,9 +29,6 @@ impl Curve {
         match self {
             Self::Circle(curve) => curve.origin(),
             Self::Line(curve) => curve.origin(),
-
-            #[cfg(test)]
-            Self::Mock { .. } => todo!(),
         }
     }
 
@@ -47,9 +37,6 @@ impl Curve {
         match self {
             Self::Circle(curve) => Self::Circle(curve.transform(transform)),
             Self::Line(curve) => Self::Line(curve.transform(transform)),
-
-            #[cfg(test)]
-            Self::Mock { .. } => todo!(),
         }
     }
 
@@ -66,9 +53,6 @@ impl Curve {
         match self {
             Self::Circle(curve) => curve.point_model_to_curve(point),
             Self::Line(curve) => curve.point_model_to_curve(point),
-
-            #[cfg(test)]
-            Self::Mock { coords, .. } => coords.borrow_mut().remove(0),
         }
     }
 
@@ -77,9 +61,6 @@ impl Curve {
         match self {
             Self::Circle(curve) => curve.point_curve_to_model(point),
             Self::Line(curve) => curve.point_curve_to_model(point),
-
-            #[cfg(test)]
-            Self::Mock { .. } => todo!(),
         }
     }
 
@@ -88,9 +69,6 @@ impl Curve {
         match self {
             Self::Circle(curve) => curve.vector_curve_to_model(point),
             Self::Line(curve) => curve.vector_curve_to_model(point),
-
-            #[cfg(test)]
-            Self::Mock { .. } => todo!(),
         }
     }
 
@@ -113,9 +91,6 @@ impl Curve {
         match self {
             Self::Circle(circle) => circle.approx(tolerance, out),
             Self::Line(_) => {}
-
-            #[cfg(test)]
-            Self::Mock { approx, .. } => out.extend(approx),
         }
     }
 }


### PR DESCRIPTION
The main advantage here is the removal of `Curve::Mock` in the last commit. It was kind of ugly, and was getting in the way of some changes I'm working on.