### PR TITLE
Simplify topology types

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -119,8 +119,8 @@ fn approximate_edge(
     // the same vertex would be understood to refer to very close, but distinct
     // vertices.
     if let Some([a, b]) = vertices {
-        points.insert(0, a.point().canonical());
-        points.push(b.point().canonical());
+        points.insert(0, a.point());
+        points.push(b.point());
     }
 
     let mut segment_points = points.clone();

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -119,8 +119,8 @@ fn approximate_edge(
     // the same vertex would be understood to refer to very close, but distinct
     // vertices.
     if let Some([a, b]) = vertices {
-        points.insert(0, a.to_canonical().point().native());
-        points.push(b.to_canonical().point().native());
+        points.insert(0, a.point().canonical());
+        points.push(b.point().canonical());
     }
 
     let mut segment_points = points.clone();

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -215,8 +215,8 @@ mod tests {
         let v2 = Vertex::new(b);
         let v3 = Vertex::new(c);
 
-        let ab = Edge::line_segment([v1, v2]);
-        let bc = Edge::line_segment([v2, v3]);
+        let ab = Edge::line_segment([v1.clone(), v2.clone()]);
+        let bc = Edge::line_segment([v2, v3.clone()]);
         let ca = Edge::line_segment([v3, v1]);
 
         let cycle = Cycle {
@@ -250,9 +250,9 @@ mod tests {
         let v3 = Vertex::new(c);
         let v4 = Vertex::new(d);
 
-        let ab = Edge::line_segment([v1, v2]);
+        let ab = Edge::line_segment([v1.clone(), v2.clone()]);
         let ba = Edge::line_segment([v2, v1]);
-        let cd = Edge::line_segment([v3, v4]);
+        let cd = Edge::line_segment([v3.clone(), v4.clone()]);
         let dc = Edge::line_segment([v4, v3]);
 
         let ab_ba = Cycle {
@@ -296,9 +296,9 @@ mod tests {
         let v3 = Vertex::new(c);
         let v4 = Vertex::new(d);
 
-        let ab = Edge::line_segment([v1, v2]);
-        let bc = Edge::line_segment([v2, v3]);
-        let cd = Edge::line_segment([v3, v4]);
+        let ab = Edge::line_segment([v1.clone(), v2.clone()]);
+        let bc = Edge::line_segment([v2, v3.clone()]);
+        let cd = Edge::line_segment([v3, v4.clone()]);
         let da = Edge::line_segment([v4, v1]);
 
         let abcd = Cycle {

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -37,7 +37,7 @@ impl Approximation {
         let mut points = Vec::new();
         edge.curve.approx(tolerance, &mut points);
 
-        approximate_edge(points, edge.vertices)
+        approximate_edge(points, edge.vertices.as_ref())
     }
 
     /// Compute an approximation for a cycle
@@ -108,7 +108,7 @@ impl Approximation {
 
 fn approximate_edge(
     mut points: Vec<Point<3>>,
-    vertices: Option<[Vertex<1>; 2]>,
+    vertices: Option<&[Vertex<1>; 2]>,
 ) -> Approximation {
     // Insert the exact vertices of this edge into the approximation. This means
     // we don't rely on the curve approximation to deliver accurate
@@ -182,7 +182,7 @@ mod tests {
 
         // Regular edge
         assert_eq!(
-            approximate_edge(points.clone(), Some([v1, v2])),
+            approximate_edge(points.clone(), Some(&[v1, v2])),
             Approximation {
                 points: set![a, b, c, d],
                 segments: set![

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -157,7 +157,7 @@ mod tests {
             topology::{
                 edges::{Cycle, Edge, Edges},
                 faces::Face,
-                vertices::Vertex,
+                Shape,
             },
         },
         math::{Point, Scalar, Segment},
@@ -170,13 +170,19 @@ mod tests {
         // Doesn't test `Approximation::for_edge` directly, but that method only
         // contains a bit of additional glue code that is not critical.
 
+        let mut shape = Shape::new();
+
         let a = Point::from([1., 2., 3.]);
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = Vertex::new(geometry::Point::new(Point::from([0.]), a));
-        let v2 = Vertex::new(geometry::Point::new(Point::from([1.]), d));
+        let v1 = shape
+            .vertices()
+            .create(geometry::Point::new(Point::from([0.]), a));
+        let v2 = shape
+            .vertices()
+            .create(geometry::Point::new(Point::from([1.]), d));
 
         let points = vec![b, c];
 
@@ -207,13 +213,15 @@ mod tests {
     fn for_cycle() {
         let tolerance = Scalar::ONE;
 
+        let mut shape = Shape::new();
+
         let a = Point::from([1., 2., 3.]);
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
 
-        let v1 = Vertex::new(a);
-        let v2 = Vertex::new(b);
-        let v3 = Vertex::new(c);
+        let v1 = shape.vertices().create(a);
+        let v2 = shape.vertices().create(b);
+        let v3 = shape.vertices().create(c);
 
         let ab = Edge::line_segment([v1.clone(), v2.clone()]);
         let bc = Edge::line_segment([v2, v3.clone()]);
@@ -240,15 +248,17 @@ mod tests {
     fn for_edges() {
         let tolerance = Scalar::ONE;
 
+        let mut shape = Shape::new();
+
         let a = Point::from([1., 2., 3.]);
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = Vertex::new(a);
-        let v2 = Vertex::new(b);
-        let v3 = Vertex::new(c);
-        let v4 = Vertex::new(d);
+        let v1 = shape.vertices().create(a);
+        let v2 = shape.vertices().create(b);
+        let v3 = shape.vertices().create(c);
+        let v4 = shape.vertices().create(d);
 
         let ab = Edge::line_segment([v1.clone(), v2.clone()]);
         let ba = Edge::line_segment([v2, v1]);
@@ -286,15 +296,17 @@ mod tests {
 
         let tolerance = Scalar::ONE;
 
+        let mut shape = Shape::new();
+
         let a = Point::from([1., 2., 3.]);
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = Vertex::new(a);
-        let v2 = Vertex::new(b);
-        let v3 = Vertex::new(c);
-        let v4 = Vertex::new(d);
+        let v1 = shape.vertices().create(a);
+        let v2 = shape.vertices().create(b);
+        let v3 = shape.vertices().create(c);
+        let v4 = shape.vertices().create(d);
 
         let ab = Edge::line_segment([v1.clone(), v2.clone()]);
         let bc = Edge::line_segment([v2, v3.clone()]);

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -108,7 +108,7 @@ impl Approximation {
 
 fn approximate_edge(
     mut points: Vec<Point<3>>,
-    vertices: Option<&[Vertex<1>; 2]>,
+    vertices: Option<&[Vertex<3>; 2]>,
 ) -> Approximation {
     // Insert the exact vertices of this edge into the approximation. This means
     // we don't rely on the curve approximation to deliver accurate
@@ -153,7 +153,7 @@ mod tests {
 
     use crate::{
         kernel::{
-            geometry::{self, Surface},
+            geometry::Surface,
             topology::{
                 edges::{Cycle, Edge, Edges},
                 faces::Face,
@@ -177,12 +177,8 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape
-            .vertices()
-            .create(geometry::Point::new(Point::from([0.]), a));
-        let v2 = shape
-            .vertices()
-            .create(geometry::Point::new(Point::from([1.]), d));
+        let v1 = shape.vertices().create(a);
+        let v2 = shape.vertices().create(d);
 
         let points = vec![b, c];
 

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -108,7 +108,7 @@ impl Approximation {
 
 fn approximate_edge(
     mut points: Vec<Point<3>>,
-    vertices: Option<&[Vertex<3>; 2]>,
+    vertices: Option<&[Vertex; 2]>,
 ) -> Approximation {
     // Insert the exact vertices of this edge into the approximation. This means
     // we don't rely on the curve approximation to deliver accurate

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -121,7 +121,7 @@ mod tests {
 
             let abc = Face::Face {
                 surface: Surface::Swept(Swept::plane_from_points(
-                    [a, b, c].map(|vertex| vertex.point().canonical()),
+                    [a, b, c].map(|vertex| vertex.point()),
                 )),
                 edges: Edges::single_cycle([ab, bc, ca]),
             };

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -115,9 +115,9 @@ mod tests {
             let b = shape.vertices().create(b.into());
             let c = shape.vertices().create(c.into());
 
-            let ab = Edge::line_segment([a, b]);
-            let bc = Edge::line_segment([b, c]);
-            let ca = Edge::line_segment([c, a]);
+            let ab = Edge::line_segment([a.clone(), b.clone()]);
+            let bc = Edge::line_segment([b.clone(), c.clone()]);
+            let ca = Edge::line_segment([c.clone(), a.clone()]);
 
             let abc = Face::Face {
                 surface: Surface::Swept(Swept::plane_from_points(

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -1,11 +1,8 @@
 use crate::{
-    kernel::{
-        geometry,
-        topology::{
-            edges::{Cycle, Edge, Edges},
-            faces::Face,
-            Shape,
-        },
+    kernel::topology::{
+        edges::{Cycle, Edge, Edges},
+        faces::Face,
+        Shape,
     },
     math::Transform,
 };
@@ -49,14 +46,10 @@ pub fn transform_face(
                         vertices.map(|vertex| {
                             let point = vertex.point();
 
-                            let native =
-                                transform.transform_point(&point.native());
                             let canonical =
                                 transform.transform_point(&point.canonical());
 
-                            shape
-                                .vertices()
-                                .create(geometry::Point::new(native, canonical))
+                            shape.vertices().create(canonical)
                         })
                     });
 

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -49,11 +49,8 @@ pub fn transform_face(
                         vertices.map(|vertex| {
                             let point = vertex.point();
 
-                            // Transform the canonical form, but leave the
-                            // native form untouched. We're also transforming
-                            // the curve here, so the vertex doesn't move
-                            // relative to it.
-                            let native = point.native();
+                            let native =
+                                transform.transform_point(&point.native());
                             let canonical =
                                 transform.transform_point(&point.canonical());
 

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -44,12 +44,10 @@ pub fn transform_face(
                 for edge in cycle.edges {
                     let vertices = edge.vertices.map(|vertices| {
                         vertices.map(|vertex| {
-                            let point = vertex.point();
+                            let point =
+                                transform.transform_point(&vertex.point());
 
-                            let canonical =
-                                transform.transform_point(&point.canonical());
-
-                            shape.vertices().create(canonical)
+                            shape.vertices().create(point)
                         })
                     });
 

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -29,7 +29,7 @@ impl ToShape for fj::Sketch {
                 //
                 // This can't panic. We just checked that `vertices` is not
                 // empty.
-                vertices.push(vertices[0]);
+                vertices.push(vertices[0].clone());
             }
 
             let mut edges = Vec::new();
@@ -37,8 +37,8 @@ impl ToShape for fj::Sketch {
                 // Can't panic, we passed `2` to `windows`.
                 //
                 // Can be cleaned up, once `array_windows` is stable.
-                let a = window[0];
-                let b = window[1];
+                let a = window[0].clone();
+                let b = window[1].clone();
 
                 let edge = Edge::line_segment([a, b]);
                 edges.push(edge);

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -61,7 +61,7 @@ pub struct Edge {
     /// It got in the way of some work, however, so it made sense to simplify
     /// it by storing 3D vertices. It will probably make sense to revert this
     /// and store 1D vertices again, at some point.
-    pub vertices: Option<[Vertex<3>; 2]>,
+    pub vertices: Option<[Vertex; 2]>,
 }
 
 impl Edge {
@@ -73,12 +73,12 @@ impl Edge {
     /// they are not on the curve, this will result in their projection being
     /// converted into curve coordinates, which is likely not the caller's
     /// intention.
-    pub fn new(curve: Curve, vertices: Option<[Vertex<3>; 2]>) -> Self {
+    pub fn new(curve: Curve, vertices: Option<[Vertex; 2]>) -> Self {
         Self { curve, vertices }
     }
 
     /// Construct an edge that is a line segment
-    pub fn line_segment(vertices: [Vertex<3>; 2]) -> Self {
+    pub fn line_segment(vertices: [Vertex; 2]) -> Self {
         Self::new(
             Curve::Line(Line::from_points(
                 vertices.clone().map(|vertex| vertex.point().canonical()),

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -40,7 +40,7 @@ pub struct Cycle {
 }
 
 /// An edge of a shape
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edge {
     /// The curve that defines the edge's geometry
     ///

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -51,6 +51,16 @@ pub struct Edge {
     ///
     /// If there are no such vertices, that means the edge is connected to
     /// itself (like a full circle, for example).
+    ///
+    /// # Implementation note
+    ///
+    /// Since these vertices bound the edge, they must lie on the curve. This
+    /// isn't enforced at all, however. It would make sense to store 1D vertices
+    /// here, and indeed, this was the case in the past.
+    ///
+    /// It got in the way of some work, however, so it made sense to simplify
+    /// it by storing 3D vertices. It will probably make sense to revert this
+    /// and store 1D vertices again, at some point.
     pub vertices: Option<[Vertex<3>; 2]>,
 }
 

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -81,7 +81,7 @@ impl Edge {
     pub fn line_segment(vertices: [Vertex; 2]) -> Self {
         Self::new(
             Curve::Line(Line::from_points(
-                vertices.clone().map(|vertex| vertex.point().canonical()),
+                vertices.clone().map(|vertex| vertex.point()),
             )),
             Some(vertices),
         )

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -51,7 +51,7 @@ pub struct Edge {
     ///
     /// If there are no such vertices, that means the edge is connected to
     /// itself (like a full circle, for example).
-    pub vertices: Option<[Vertex<1>; 2]>,
+    pub vertices: Option<[Vertex<3>; 2]>,
 }
 
 impl Edge {
@@ -64,9 +64,6 @@ impl Edge {
     /// converted into curve coordinates, which is likely not the caller's
     /// intention.
     pub fn new(curve: Curve, vertices: Option<[Vertex<3>; 2]>) -> Self {
-        let vertices = vertices
-            .map(|vertices| vertices.map(|vertex| vertex.to_1d(&curve)));
-
         Self { curve, vertices }
     }
 

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -74,7 +74,7 @@ impl Edge {
     pub fn line_segment(vertices: [Vertex<3>; 2]) -> Self {
         Self::new(
             Curve::Line(Line::from_points(
-                vertices.map(|vertex| vertex.point().canonical()),
+                vertices.clone().map(|vertex| vertex.point().canonical()),
             )),
             Some(vertices),
         )

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -48,8 +48,8 @@ pub enum Face {
         ///
         /// # Implementation Note
         ///
-        /// Since these edges bound the face, they must lie in the face. We're
-        /// using [`Edges`] here, however, which has no such limitation.
+        /// Since these edges bound the face, they must lie in the surface.
+        /// We're using [`Edges`] here, however, which has no such limitation.
         ///
         /// It might be less error-prone, and possibly more efficient, to use a
         /// more specialized data structure here, that specifies the edges in

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -58,15 +58,6 @@ impl Vertices<'_> {
 pub struct Vertex<const D: usize>(geometry::Point<D>);
 
 impl<const D: usize> Vertex<D> {
-    /// Construct a new vertex
-    ///
-    /// This method is only intended for unit tests. All other code should call
-    /// [`Vertices::create`].
-    #[cfg(test)]
-    pub fn new(point: impl Into<geometry::Point<D>>) -> Self {
-        Self(point.into())
-    }
-
     /// Access the point that defines this vertex
     pub fn point(&self) -> geometry::Point<D> {
         self.0

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,4 +1,4 @@
-use crate::{kernel::geometry, math::Point};
+use crate::math::Point;
 
 use super::VerticesInner;
 
@@ -22,7 +22,7 @@ impl Vertices<'_> {
         self.vertices
             .add(&point.into(), point)
             .expect("Error adding vertex");
-        Vertex(point.into())
+        Vertex(point)
     }
 }
 
@@ -51,11 +51,11 @@ impl Vertices<'_> {
 /// This can be prevented outright by never creating a new `Vertex` instance
 /// for an existing vertex. Hence why this is strictly forbidden.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Vertex(geometry::Point<3>);
+pub struct Vertex(Point<3>);
 
 impl Vertex {
     /// Access the point that defines this vertex
-    pub fn point(&self) -> geometry::Point<3> {
+    pub fn point(&self) -> Point<3> {
         self.0
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,4 +1,4 @@
-use crate::kernel::geometry;
+use crate::{kernel::geometry, math::Point};
 
 use super::VerticesInner;
 
@@ -18,12 +18,11 @@ impl Vertices<'_> {
     /// This method is the only means to create `Vertex` instances, outside of
     /// unit tests. That puts this method is in a great position to enforce
     /// vertex uniqueness rules, instead of requiring the user to uphold those.
-    pub fn create(&mut self, point: impl Into<geometry::Point<3>>) -> Vertex {
-        let point = point.into();
+    pub fn create(&mut self, point: Point<3>) -> Vertex {
         self.vertices
-            .add(&point.canonical().into(), point.canonical())
+            .add(&point.into(), point)
             .expect("Error adding vertex");
-        Vertex(point)
+        Vertex(point.into())
     }
 }
 

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -18,10 +18,10 @@ impl Vertices<'_> {
     /// This method is the only means to create `Vertex` instances, outside of
     /// unit tests. That puts this method is in a great position to enforce
     /// vertex uniqueness rules, instead of requiring the user to uphold those.
-    pub fn create<const D: usize>(
+    pub fn create(
         &mut self,
-        point: impl Into<geometry::Point<D>>,
-    ) -> Vertex<D> {
+        point: impl Into<geometry::Point<3>>,
+    ) -> Vertex<3> {
         let point = point.into();
         self.vertices
             .add(&point.canonical().into(), point.canonical())

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -62,11 +62,6 @@ impl<const D: usize> Vertex<D> {
     pub fn point(&self) -> geometry::Point<D> {
         self.0
     }
-
-    /// Convert the vertex to its canonical form
-    pub fn to_canonical(&self) -> Vertex<3> {
-        Vertex(geometry::Point::new(self.0.canonical(), self.0.canonical()))
-    }
 }
 
 impl Vertex<3> {

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,4 +1,4 @@
-use crate::kernel::geometry::{self, Curve};
+use crate::kernel::geometry;
 
 use super::VerticesInner;
 
@@ -61,18 +61,5 @@ impl<const D: usize> Vertex<D> {
     /// Access the point that defines this vertex
     pub fn point(&self) -> geometry::Point<D> {
         self.0
-    }
-}
-
-impl Vertex<3> {
-    /// Convert the vertex to a 1-dimensional vertex
-    ///
-    /// Uses to provided curve to convert the vertex into a 1-dimensional vertex
-    /// in the curve's coordinate system.
-    pub fn to_1d(&self, curve: &Curve) -> Vertex<1> {
-        Vertex(geometry::Point::new(
-            curve.point_model_to_curve(&self.0.native()),
-            self.0.canonical(),
-        ))
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -18,10 +18,7 @@ impl Vertices<'_> {
     /// This method is the only means to create `Vertex` instances, outside of
     /// unit tests. That puts this method is in a great position to enforce
     /// vertex uniqueness rules, instead of requiring the user to uphold those.
-    pub fn create(
-        &mut self,
-        point: impl Into<geometry::Point<3>>,
-    ) -> Vertex<3> {
+    pub fn create(&mut self, point: impl Into<geometry::Point<3>>) -> Vertex {
         let point = point.into();
         self.vertices
             .add(&point.canonical().into(), point.canonical())
@@ -55,11 +52,11 @@ impl Vertices<'_> {
 /// This can be prevented outright by never creating a new `Vertex` instance
 /// for an existing vertex. Hence why this is strictly forbidden.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Vertex<const D: usize>(geometry::Point<D>);
+pub struct Vertex(geometry::Point<3>);
 
-impl<const D: usize> Vertex<D> {
+impl Vertex {
     /// Access the point that defines this vertex
-    pub fn point(&self) -> geometry::Point<D> {
+    pub fn point(&self) -> geometry::Point<3> {
         self.0
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -54,7 +54,7 @@ impl Vertices<'_> {
 ///
 /// This can be prevented outright by never creating a new `Vertex` instance
 /// for an existing vertex. Hence why this is strictly forbidden.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex<const D: usize>(geometry::Point<D>);
 
 impl<const D: usize> Vertex<D> {
@@ -73,7 +73,7 @@ impl<const D: usize> Vertex<D> {
     }
 
     /// Convert the vertex to its canonical form
-    pub fn to_canonical(self) -> Vertex<3> {
+    pub fn to_canonical(&self) -> Vertex<3> {
         Vertex(geometry::Point::new(self.0.canonical(), self.0.canonical()))
     }
 }
@@ -83,7 +83,7 @@ impl Vertex<3> {
     ///
     /// Uses to provided curve to convert the vertex into a 1-dimensional vertex
     /// in the curve's coordinate system.
-    pub fn to_1d(self, curve: &Curve) -> Vertex<1> {
+    pub fn to_1d(&self, curve: &Curve) -> Vertex<1> {
         Vertex(geometry::Point::new(
             curve.point_model_to_curve(&self.0.native()),
             self.0.canonical(),


### PR DESCRIPTION
Simplify some topology types, mostly `Vertex` and `Edge`. This came out of my work on #280, and these simplifications will make addressing that issue much easier.