### PR TITLE
Shade "back sides" the same as "front sides"

### DIFF
--- a/src/graphics/shader.wgsl
+++ b/src/graphics/shader.wgsl
@@ -35,7 +35,7 @@ let pi: f32 = 3.14159265359;
 fn frag_model(in: VertexOutput) -> [[location(0)]] vec4<f32> {
     let light = vec3<f32>(0.0, 0.0, -1.0);
 
-    let angle = acos(dot(light, -in.normal));
+    let angle = acos(abs(dot(light, -in.normal)));
     let f_angle = angle / (pi / 2.0);
 
     let f_normal = max(1.0 - f_angle, 0.0);


### PR DESCRIPTION
The shader used to shade the "back side" of a face, as defined by the
vertex normal, differently than the front sides.

This minimally invasive change removes that distinction. A surface
normal is still needed for shading, to compute the angle between the
surface and the light, but the direction of that normal is ignored.

Close #173