### PR TITLE
Improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3dec3b229449b1a54bd96dc32108086263d6830624e576dc0e6c80e619a0130"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1648,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "renderdoc-sys"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,9 +1967,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ path    = "fj"
 
 [dependencies.tracing-subscriber]
 version  = "0.3.9"
-features = ["fmt"]
+features = ["env-filter", "fmt"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::{collections::HashMap, sync::mpsc, time::Instant};
 use futures::executor::block_on;
 use notify::Watcher as _;
 use tracing::trace;
+use tracing_subscriber::fmt::format;
 use tracing_subscriber::EnvFilter;
 use winit::{
     event::{Event, WindowEvent},
@@ -37,6 +38,7 @@ use crate::{
 fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
+        .event_format(format().pretty())
         .init();
 
     let args = Args::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::{collections::HashMap, sync::mpsc, time::Instant};
 use futures::executor::block_on;
 use notify::Watcher as _;
 use tracing::trace;
+use tracing_subscriber::EnvFilter;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -34,7 +35,9 @@ use crate::{
 };
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
 
     let args = Args::parse();
     let model = Model::new(args.model);

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,16 @@ use crate::{
 };
 
 fn main() -> anyhow::Result<()> {
+    // Respect `RUST_LOG`. If that's not defined or erroneous, log warnings and
+    // above.
+    //
+    // It would be better to fail, if `RUST_LOG` is erroneous, but I don't know
+    // how to distinguish between that and the "not defined" case.
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("WARN")),
+        )
         .event_format(format().pretty())
         .init();
 


### PR DESCRIPTION
Respect the `RUST_LOG` variable, log warnings and above by default, and switch to pretty output format.

Close #156