### PR TITLE
Almost implement vertex validation

### DIFF
--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -19,6 +19,11 @@ use self::{edges::Edges, handle::HandleInner, vertices::Vertices};
 /// still full of holes, forcing callers to just be careful for the time being.
 #[derive(Clone, Debug)]
 pub struct Shape {
+    /// The minimum distance between two vertices
+    ///
+    /// Use for vertex validation, to determine whether vertices are unique.
+    min_distance: Scalar,
+
     vertices: VerticesInner,
     edges: Edges,
 
@@ -29,6 +34,11 @@ impl Shape {
     /// Construct a new shape
     pub fn new() -> Self {
         Self {
+            // This should really come from `Self::DEFAULT_MIN_DISTANCE`, or a
+            // similarly named constant. Unfortunately `Scalar::from_f64` can't
+            // be `const` yet.
+            min_distance: Scalar::from_f64(5e-7), // 0.5 µm
+
             vertices: VerticesInner::new(),
             edges: Edges { cycles: Vec::new() },
             faces: Faces(Vec::new()),
@@ -38,6 +48,7 @@ impl Shape {
     /// Access the shape's vertices
     pub fn vertices(&mut self) -> Vertices {
         Vertices {
+            min_distance: self.min_distance,
             vertices: &mut self.vertices,
         }
     }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -45,6 +45,21 @@ impl Shape {
         }
     }
 
+    /// Override the minimum distance for this shape
+    ///
+    /// # Implementation note
+    ///
+    /// This functionality should be exposed to models, eventually. For now it's
+    /// just used in unit tests.
+    #[cfg(test)]
+    pub fn with_min_distance(
+        mut self,
+        min_distance: impl Into<Scalar>,
+    ) -> Self {
+        self.min_distance = min_distance.into();
+        self
+    }
+
     /// Access the shape's vertices
     pub fn vertices(&mut self) -> Vertices {
         Vertices {

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -10,6 +10,7 @@ use super::{handle::Handle, VerticesInner};
 
 /// The vertices of a shape
 pub struct Vertices<'r> {
+    pub(super) min_distance: Scalar,
     pub(super) vertices: &'r mut VerticesInner,
 }
 
@@ -31,10 +32,9 @@ impl Vertices<'_> {
         // vertices. This minimum distance is defined to be half a µm, which
         // should provide more than enough precision for common use cases, while
         // being large enough to catch all invalid cases.
-        let min_distance = Scalar::from_f64(0.0000005);
         match self.vertices.nearest_one(&point.into(), &squared_euclidean) {
             Ok((distance_squared, existing)) => {
-                if distance_squared < min_distance * min_distance {
+                if distance_squared < self.min_distance * self.min_distance {
                     let existing = existing.get();
 
                     warn!(

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -17,14 +17,23 @@ pub struct Vertices<'r> {
 impl Vertices<'_> {
     /// Create a vertex
     ///
-    /// The caller must make sure to uphold all rules regarding vertex
-    /// uniqueness.
+    /// Logs a warning, if the vertex is not unique, meaning if another vertex
+    /// defined by the same point already exists.
+    ///
+    /// In the context of of vertex uniqueness, points that are close to each
+    /// other are considered identical. The minimum distance between distinct
+    /// vertices can be configured using [`Shape::with_minimum_distance`].
     ///
     /// # Implementation note
     ///
-    /// This method is the only means to create `Vertex` instances, outside of
-    /// unit tests. That puts this method is in a great position to enforce
-    /// vertex uniqueness rules, instead of requiring the user to uphold those.
+    /// This method is intended to actually validate vertex uniqueness: To
+    /// panic, if duplicate vertices are found. This is currently not possible,
+    /// as the presence of bugs in the sweep and transform code would basically
+    /// break ever model, due to validation errors.
+    ///
+    /// In the future, this method is likely to validate more than just vertex
+    /// uniqueness. See documentation of [`crate::kernel`] for some context on
+    /// that.
     pub fn create(&mut self, point: Point<3>) -> Vertex {
         let handle = Handle::new(point);
 

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -64,9 +64,11 @@ impl Vertices<'_> {
 mod tests {
     use crate::{kernel::shape::Shape, math::Point};
 
+    const MIN_DISTANCE: f64 = 5e-7;
+
     #[test]
     fn create_valid() {
-        let mut shape = Shape::new();
+        let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
         shape.vertices().create(Point::from([0., 0., 0.]));
         shape.vertices().create(Point::from([5e-6, 0., 0.]));
@@ -76,7 +78,7 @@ mod tests {
     #[ignore]
     #[should_panic]
     fn create_invalid() {
-        let mut shape = Shape::new();
+        let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
         shape.vertices().create(Point::from([0., 0., 0.]));
         shape.vertices().create(Point::from([5e-8, 0., 0.]));

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -87,6 +87,9 @@ mod tests {
     #[ignore]
     #[should_panic]
     fn create_invalid() {
+        // Test is ignored, until vertex validation can be enabled for real.
+        // See implementation note on `Vertices::create`.
+
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
         shape.vertices().create(Point::from([0., 0., 0.]));


### PR DESCRIPTION
This pull request implements vertex validation (#242), but instead of failing when validation fails, it just emits a warning. This is necessary, as there are currently validation errors in the transform code (which also affects the sweep code), which would break all example models, if validation errors are fatal.

I'm currently working on fixing those validation errors, so vertex validation can be enabled for real.