### PR TITLE
Fully integrate edges and cycles into `Shape` API

### DIFF
--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -27,8 +27,8 @@ pub fn sweep_shape(
         top_faces.push(transform_face(face, &translation, &mut shape));
     }
 
-    for cycle in &original.edges().cycles {
-        let approx = Approximation::for_cycle(cycle, tolerance);
+    for cycle in original.cycles().all() {
+        let approx = Approximation::for_cycle(&cycle, tolerance);
 
         // This will only work correctly, if the cycle consists of one edge. If
         // there are more, this will create some kind of weird face chimera, a

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -1,4 +1,4 @@
-use crate::kernel::topology::edges::Cycle;
+use crate::kernel::topology::edges::{Cycle, Edge};
 
 /// The cycles of a shape
 pub struct Cycles<'r> {
@@ -6,6 +6,25 @@ pub struct Cycles<'r> {
 }
 
 impl Cycles<'_> {
+    /// Create a cycle
+    ///
+    /// # Implementation note
+    ///
+    /// This method should at some point validate the cycle:
+    /// - That it refers to valid edges that are part of `Shape`.
+    /// - That those edges form a cycle.
+    /// - That the cycle is not self-overlapping.
+    /// - That there exists no duplicate cycle, with the same edges.
+    pub fn create(&mut self, edges: impl IntoIterator<Item = Edge>) -> Cycle {
+        let cycle = Cycle {
+            edges: edges.into_iter().collect(),
+        };
+
+        self.cycles.push(cycle.clone());
+
+        cycle
+    }
+
     /// Access an iterator over all cycles
     pub fn all(&self) -> impl Iterator<Item = Cycle> + '_ {
         self.cycles.iter().cloned()

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -1,0 +1,13 @@
+use crate::kernel::topology::edges::Cycle;
+
+/// The cycles of a shape
+pub struct Cycles<'r> {
+    pub(super) cycles: &'r mut Vec<Cycle>,
+}
+
+impl Cycles<'_> {
+    /// Access an iterator over all cycles
+    pub fn all(&self) -> impl Iterator<Item = Cycle> + '_ {
+        self.cycles.iter().cloned()
+    }
+}

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -1,8 +1,10 @@
 use crate::kernel::topology::edges::{Cycle, Edge};
 
+use super::CyclesInner;
+
 /// The cycles of a shape
 pub struct Cycles<'r> {
-    pub(super) cycles: &'r mut Vec<Cycle>,
+    pub(super) cycles: &'r mut CyclesInner,
 }
 
 impl Cycles<'_> {

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -6,13 +6,9 @@ use crate::{
     math::{Point, Scalar, Vector},
 };
 
-use super::CyclesInner;
-
 /// The edges of a shape
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Edges {
-    pub(super) cycles: CyclesInner,
-}
+pub struct Edges;
 
 impl Edges {
     /// Create an edge

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 /// The edges of a shape
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edges;
 
 impl Edges {

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -12,12 +12,7 @@ use crate::{
 /// The edges of a shape
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edges {
-    /// The cycles that the edges of the shape form
-    ///
-    /// Code reading this field generally assumes that cycles do not overlap.
-    /// This precondition is currently not checked, and must be upheld by all
-    /// code writing to this field.
-    pub cycles: Vec<Cycle>,
+    pub(super) cycles: Vec<Cycle>,
 }
 
 impl Edges {

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -1,18 +1,17 @@
 use crate::{
     kernel::{
         geometry::{Circle, Curve, Line},
-        topology::{
-            edges::{Cycle, Edge},
-            vertices::Vertex,
-        },
+        topology::{edges::Edge, vertices::Vertex},
     },
     math::{Point, Scalar, Vector},
 };
 
+use super::CyclesInner;
+
 /// The edges of a shape
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edges {
-    pub(super) cycles: Vec<Cycle>,
+    pub(super) cycles: CyclesInner,
 }
 
 impl Edges {

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -16,17 +16,6 @@ pub struct Edges {
 }
 
 impl Edges {
-    /// Construct a new instance of `Edges`, with a single cycle
-    pub fn single_cycle(edges: impl IntoIterator<Item = Edge>) -> Self {
-        let cycle = Cycle {
-            edges: edges.into_iter().collect(),
-        };
-
-        Self {
-            cycles: vec![cycle],
-        }
-    }
-
     /// Create an edge
     ///
     /// If vertices are provided in `vertices`, they must be on `curve`.

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -26,7 +26,6 @@ pub struct Shape {
     min_distance: Scalar,
 
     vertices: VerticesInner,
-    edges: Edges,
     cycles: CyclesInner,
 
     pub faces: Faces,
@@ -42,7 +41,6 @@ impl Shape {
             min_distance: Scalar::from_f64(5e-7), // 0.5 µm
 
             vertices: VerticesInner::new(),
-            edges: Edges,
             cycles: CyclesInner::new(),
             faces: Faces(Vec::new()),
         }
@@ -72,8 +70,8 @@ impl Shape {
     }
 
     /// Access the shape's edges
-    pub fn edges(&mut self) -> &mut Edges {
-        &mut self.edges
+    pub fn edges(&mut self) -> Edges {
+        Edges
     }
 
     /// Access the shape's cycles

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -5,7 +5,7 @@ pub mod vertices;
 
 use crate::math::{Point, Scalar};
 
-use super::topology::faces::Faces;
+use super::topology::{edges::Cycle, faces::Faces};
 
 use self::{
     cycles::Cycles, edges::Edges, handle::HandleInner, vertices::Vertices,
@@ -83,3 +83,4 @@ impl Shape {
 }
 
 type VerticesInner = Vec<HandleInner<Point<3>>>;
+type CyclesInner = Vec<Cycle>;

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -27,6 +27,7 @@ pub struct Shape {
 
     vertices: VerticesInner,
     edges: Edges,
+    cycles: CyclesInner,
 
     pub faces: Faces,
 }
@@ -41,7 +42,8 @@ impl Shape {
             min_distance: Scalar::from_f64(5e-7), // 0.5 µm
 
             vertices: VerticesInner::new(),
-            edges: Edges { cycles: Vec::new() },
+            edges: Edges,
+            cycles: CyclesInner::new(),
             faces: Faces(Vec::new()),
         }
     }
@@ -77,7 +79,7 @@ impl Shape {
     /// Access the shape's cycles
     pub fn cycles(&mut self) -> Cycles {
         Cycles {
-            cycles: &mut self.edges.cycles,
+            cycles: &mut self.cycles,
         }
     }
 }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -1,3 +1,4 @@
+pub mod cycles;
 pub mod edges;
 pub mod handle;
 pub mod vertices;
@@ -6,7 +7,9 @@ use crate::math::{Point, Scalar};
 
 use super::topology::faces::Faces;
 
-use self::{edges::Edges, handle::HandleInner, vertices::Vertices};
+use self::{
+    cycles::Cycles, edges::Edges, handle::HandleInner, vertices::Vertices,
+};
 
 /// The boundary representation of a shape
 ///
@@ -69,6 +72,13 @@ impl Shape {
     /// Access the shape's edges
     pub fn edges(&mut self) -> &mut Edges {
         &mut self.edges
+    }
+
+    /// Access the shape's cycles
+    pub fn cycles(&mut self) -> Cycles {
+        Cycles {
+            cycles: &mut self.edges.cycles,
+        }
     }
 }
 

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -17,9 +17,8 @@ impl ToShape for fj::Circle {
         // Circles have just a single round edge with no vertices. So none need
         // to be added here.
 
-        *shape.edges() = Edges::single_cycle([shape
-            .edges()
-            .create_circle(Scalar::from_f64(self.radius))]);
+        let edge = shape.edges().create_circle(Scalar::from_f64(self.radius));
+        *shape.edges() = Edges::single_cycle([edge]);
 
         shape.faces = Faces(vec![Face::Face {
             cycles: shape.cycles().all().collect(),

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -2,7 +2,7 @@ use crate::{
     debug::DebugInfo,
     kernel::{
         geometry::Surface,
-        shape::{edges::Edges, Shape},
+        shape::Shape,
         topology::faces::{Face, Faces},
     },
     math::{Aabb, Point, Scalar},
@@ -18,7 +18,7 @@ impl ToShape for fj::Circle {
         // to be added here.
 
         let edge = shape.edges().create_circle(Scalar::from_f64(self.radius));
-        *shape.edges() = Edges::single_cycle([edge]);
+        shape.cycles().create([edge]);
 
         shape.faces = Faces(vec![Face::Face {
             cycles: shape.cycles().all().collect(),

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -22,7 +22,7 @@ impl ToShape for fj::Circle {
             .create_circle(Scalar::from_f64(self.radius))]);
 
         shape.faces = Faces(vec![Face::Face {
-            cycles: shape.edges().cycles.clone(),
+            cycles: shape.cycles().all().collect(),
             surface: Surface::x_y_plane(),
         }]);
 

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -1,7 +1,7 @@
 use crate::{
     debug::DebugInfo,
     kernel::{
-        shape::{edges::Edges, Shape},
+        shape::Shape,
         topology::faces::{Face, Faces},
     },
     math::{Aabb, Scalar},
@@ -19,21 +19,20 @@ impl ToShape for fj::Difference2d {
         let mut a = self.a.to_shape(tolerance, debug_info);
         let mut b = self.b.to_shape(tolerance, debug_info);
 
-        *shape.edges() = {
-            if a.cycles().all().count() == 1 && b.cycles().all().count() == 1 {
-                let a = a.cycles().all().next().unwrap();
-                let b = b.cycles().all().next().unwrap();
+        if a.cycles().all().count() == 1 && b.cycles().all().count() == 1 {
+            let a = a.cycles().all().next().unwrap();
+            let b = b.cycles().all().next().unwrap();
 
-                Edges { cycles: vec![a, b] }
-            } else {
-                // See issue:
-                // https://github.com/hannobraun/Fornjot/issues/95
-                todo!(
-                    "The 2-dimensional difference operation only supports one \
-                    cycle in each operand."
-                );
-            }
-        };
+            shape.cycles().create(a.edges);
+            shape.cycles().create(b.edges);
+        } else {
+            // See issue:
+            // https://github.com/hannobraun/Fornjot/issues/95
+            todo!(
+                "The 2-dimensional difference operation only supports one \
+                cycle in each operand."
+            );
+        }
 
         shape.faces = {
             let (a, b) = if a.faces.0.len() == 1 && b.faces.0.len() == 1 {

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -20,20 +20,21 @@ impl ToShape for fj::Difference2d {
         let mut b = self.b.to_shape(tolerance, debug_info);
 
         *shape.edges() = {
-            let (a, b) =
-                if a.edges().cycles.len() == 1 && b.edges().cycles.len() == 1 {
-                    (
-                        a.edges().cycles.pop().unwrap(),
-                        b.edges().cycles.pop().unwrap(),
-                    )
-                } else {
-                    // See issue:
-                    // https://github.com/hannobraun/Fornjot/issues/95
-                    todo!(
+            let (a, b) = if a.cycles().all().count() == 1
+                && b.cycles().all().count() == 1
+            {
+                (
+                    a.cycles().all().next().unwrap(),
+                    b.cycles().all().next().unwrap(),
+                )
+            } else {
+                // See issue:
+                // https://github.com/hannobraun/Fornjot/issues/95
+                todo!(
                     "The 2-dimensional difference operation only supports one \
                     cycle in each operand."
                 );
-                };
+            };
 
             Edges { cycles: vec![a, b] }
         };

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -20,13 +20,11 @@ impl ToShape for fj::Difference2d {
         let mut b = self.b.to_shape(tolerance, debug_info);
 
         *shape.edges() = {
-            let (a, b) = if a.cycles().all().count() == 1
-                && b.cycles().all().count() == 1
-            {
-                (
-                    a.cycles().all().next().unwrap(),
-                    b.cycles().all().next().unwrap(),
-                )
+            if a.cycles().all().count() == 1 && b.cycles().all().count() == 1 {
+                let a = a.cycles().all().next().unwrap();
+                let b = b.cycles().all().next().unwrap();
+
+                Edges { cycles: vec![a, b] }
             } else {
                 // See issue:
                 // https://github.com/hannobraun/Fornjot/issues/95
@@ -34,9 +32,7 @@ impl ToShape for fj::Difference2d {
                     "The 2-dimensional difference operation only supports one \
                     cycle in each operand."
                 );
-            };
-
-            Edges { cycles: vec![a, b] }
+            }
         };
 
         shape.faces = {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -2,7 +2,7 @@ use crate::{
     debug::DebugInfo,
     kernel::{
         geometry::Surface,
-        shape::{edges::Edges, Shape},
+        shape::Shape,
         topology::faces::{Face, Faces},
     },
     math::{Aabb, Point, Scalar},
@@ -20,7 +20,7 @@ impl ToShape for fj::Sketch {
             vertices.push(vertex);
         }
 
-        *shape.edges() = {
+        {
             if !vertices.is_empty() {
                 // Add the first vertex at the end again, to close the loop.
                 //
@@ -41,7 +41,7 @@ impl ToShape for fj::Sketch {
                 edges.push(edge);
             }
 
-            Edges::single_cycle(edges)
+            shape.cycles().create(edges);
         };
 
         let face = Face::Face {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -45,7 +45,7 @@ impl ToShape for fj::Sketch {
         };
 
         let face = Face::Face {
-            cycles: shape.edges().cycles.clone(),
+            cycles: shape.cycles().all().collect(),
             surface: Surface::x_y_plane(),
         };
         shape.faces = Faces(vec![face]);


### PR DESCRIPTION
This pull request is another step towards #280. It makes edge and cycle creation go through `Shape`, paving the way for more clean-ups of `Shape`'s internal structure, and validations of the shape.