### PR TITLE
Make `Handle` more flexible

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -114,8 +114,8 @@ fn approximate_edge(
     // the same vertex would be understood to refer to very close, but distinct
     // vertices.
     if let Some([a, b]) = vertices {
-        points.insert(0, a.get().point());
-        points.push(b.get().point());
+        points.insert(0, a.point());
+        points.push(b.point());
     }
 
     let mut segment_points = points.clone();

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -118,7 +118,7 @@ mod tests {
 
             let abc = Face::Face {
                 surface: Surface::Swept(Swept::plane_from_points(
-                    [a, b, c].map(|vertex| vertex.get().point()),
+                    [a, b, c].map(|vertex| vertex.point()),
                 )),
                 cycles: vec![Cycle {
                     edges: vec![ab, bc, ca],

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -43,8 +43,8 @@ pub fn transform_face(
                 for edge in cycle.edges {
                     let vertices = edge.vertices().map(|vertices| {
                         vertices.map(|vertex| {
-                            let point = transform
-                                .transform_point(&vertex.get().point());
+                            let point =
+                                transform.transform_point(&vertex.point());
 
                             shape.vertices().create(point)
                         })

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -44,7 +44,7 @@ impl Edges {
     ) -> Edge {
         self.create(
             Curve::Line(Line::from_points(
-                vertices.clone().map(|vertex| vertex.get().point()),
+                vertices.clone().map(|vertex| vertex.point()),
             )),
             Some(vertices),
         )

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -22,7 +22,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.get().eq(other.get())
+        self.0.eq(&other.0)
     }
 }
 
@@ -31,7 +31,7 @@ where
     T: Hash,
 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.get().hash(state)
+        self.0.hash(state)
     }
 }
 

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -1,11 +1,11 @@
-use std::{cell::Cell, hash::Hash, rc::Rc};
+use std::{hash::Hash, rc::Rc};
 
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Handle<T: Copy>(HandleInner<T>);
 
 impl<T: Copy> Handle<T> {
     pub(super) fn new(value: T) -> Self {
-        Self(Rc::new(Cell::new(value)))
+        Self(Rc::new(value))
     }
 
     pub(super) fn inner(&self) -> HandleInner<T> {
@@ -13,7 +13,7 @@ impl<T: Copy> Handle<T> {
     }
 
     pub fn get(&self) -> T {
-        self.0.get()
+        *self.0
     }
 }
 
@@ -35,4 +35,4 @@ where
     }
 }
 
-pub(super) type HandleInner<T> = Rc<Cell<T>>;
+pub(super) type HandleInner<T> = Rc<T>;

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -12,8 +12,8 @@ impl<T: Copy> Handle<T> {
         self.0.clone()
     }
 
-    pub fn get(&self) -> T {
-        *self.0
+    pub fn get(&self) -> &T {
+        &*self.0
     }
 }
 
@@ -22,7 +22,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.get().eq(&other.get())
+        self.get().eq(other.get())
     }
 }
 

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -1,17 +1,34 @@
 use std::{hash::Hash, ops::Deref, rc::Rc};
 
-#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
-pub struct Handle<T>(HandleInner<T>);
+#[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Storage<T>(Rc<T>);
 
-impl<T> Handle<T> {
+impl<T> Storage<T> {
     pub(super) fn new(value: T) -> Self {
         Self(Rc::new(value))
     }
 
-    pub(super) fn inner(&self) -> HandleInner<T> {
-        self.0.clone()
+    pub(super) fn handle(&self) -> Handle<T> {
+        Handle(self.clone())
     }
 }
+
+impl<T> Deref for Storage<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T> Clone for Storage<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Handle<T>(Storage<T>);
 
 impl<T> Deref for Handle<T> {
     type Target = T;
@@ -20,23 +37,3 @@ impl<T> Deref for Handle<T> {
         self.0.deref()
     }
 }
-
-impl<T> PartialEq for Handle<T>
-where
-    T: PartialEq,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.0.eq(&other.0)
-    }
-}
-
-impl<T> Hash for Handle<T>
-where
-    T: Hash,
-{
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state)
-    }
-}
-
-pub(super) type HandleInner<T> = Rc<T>;

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -1,9 +1,9 @@
 use std::{hash::Hash, rc::Rc};
 
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
-pub struct Handle<T: Copy>(HandleInner<T>);
+pub struct Handle<T>(HandleInner<T>);
 
-impl<T: Copy> Handle<T> {
+impl<T> Handle<T> {
     pub(super) fn new(value: T) -> Self {
         Self(Rc::new(value))
     }
@@ -17,7 +17,7 @@ impl<T: Copy> Handle<T> {
     }
 }
 
-impl<T: Copy> PartialEq for Handle<T>
+impl<T> PartialEq for Handle<T>
 where
     T: PartialEq,
 {
@@ -26,7 +26,7 @@ where
     }
 }
 
-impl<T: Copy> Hash for Handle<T>
+impl<T> Hash for Handle<T>
 where
     T: Hash,
 {

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, rc::Rc};
+use std::{hash::Hash, ops::Deref, rc::Rc};
 
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Handle<T>(HandleInner<T>);
@@ -11,9 +11,13 @@ impl<T> Handle<T> {
     pub(super) fn inner(&self) -> HandleInner<T> {
         self.0.clone()
     }
+}
 
-    pub fn get(&self) -> &T {
-        &*self.0
+impl<T> Deref for Handle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
     }
 }
 

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -7,9 +7,7 @@ use crate::math::Scalar;
 
 use super::topology::{edges::Cycle, faces::Faces, vertices::Vertex};
 
-use self::{
-    cycles::Cycles, edges::Edges, handle::HandleInner, vertices::Vertices,
-};
+use self::{cycles::Cycles, edges::Edges, handle::Storage, vertices::Vertices};
 
 /// The boundary representation of a shape
 ///
@@ -82,5 +80,5 @@ impl Shape {
     }
 }
 
-type VerticesInner = Vec<HandleInner<Vertex>>;
+type VerticesInner = Vec<Storage<Vertex>>;
 type CyclesInner = Vec<Cycle>;

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -2,7 +2,10 @@ use tracing::warn;
 
 use crate::{kernel::topology::vertices::Vertex, math::Scalar};
 
-use super::{handle::Handle, VerticesInner};
+use super::{
+    handle::{Handle, Storage},
+    VerticesInner,
+};
 
 /// The vertices of a shape
 pub struct Vertices<'r> {
@@ -48,8 +51,9 @@ impl Vertices<'_> {
             }
         }
 
-        let handle = Handle::new(vertex);
-        self.vertices.push(handle.inner());
+        let storage = Storage::new(vertex);
+        let handle = storage.handle();
+        self.vertices.push(storage);
 
         handle
     }

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -38,8 +38,7 @@ impl Vertices<'_> {
         // should provide more than enough precision for common use cases, while
         // being large enough to catch all invalid cases.
         for existing in &*self.vertices {
-            let distance =
-                (existing.get().point() - vertex.point()).magnitude();
+            let distance = (existing.point() - vertex.point()).magnitude();
 
             if distance < self.min_distance {
                 warn!(


### PR DESCRIPTION
These are some cleanups on the way to #280. The main attraction here is the removal of `Handle<T>`'s `Copy` bound, which would have prevented other topology types (`Edge`, for example`) to be referenced using `Handle`s.