### PR TITLE
Further refine the `Shape` API

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -38,9 +38,9 @@ impl Approximation {
     /// the actual edge.
     pub fn for_edge(edge: &Edge, tolerance: Scalar) -> Self {
         let mut points = Vec::new();
-        edge.curve().approx(tolerance, &mut points);
+        edge.curve.approx(tolerance, &mut points);
 
-        approximate_edge(points, edge.vertices().as_ref())
+        approximate_edge(points, edge.vertices.as_ref())
     }
 
     /// Compute an approximation for a cycle

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -169,8 +169,8 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.vertices().create(a);
-        let v2 = shape.vertices().create(d);
+        let v1 = shape.vertices().add(a);
+        let v2 = shape.vertices().add(d);
 
         let points = vec![b, c];
 
@@ -207,9 +207,9 @@ mod tests {
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
 
-        let v1 = shape.vertices().create(a);
-        let v2 = shape.vertices().create(b);
-        let v3 = shape.vertices().create(c);
+        let v1 = shape.vertices().add(a);
+        let v2 = shape.vertices().add(b);
+        let v3 = shape.vertices().add(c);
 
         let ab = shape.edges().create_line_segment([v1.clone(), v2.clone()]);
         let bc = shape.edges().create_line_segment([v2, v3.clone()]);
@@ -245,10 +245,10 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.vertices().create(a);
-        let v2 = shape.vertices().create(b);
-        let v3 = shape.vertices().create(c);
-        let v4 = shape.vertices().create(d);
+        let v1 = shape.vertices().add(a);
+        let v2 = shape.vertices().add(b);
+        let v3 = shape.vertices().add(c);
+        let v4 = shape.vertices().add(d);
 
         let ab = shape.edges().create_line_segment([v1.clone(), v2.clone()]);
         let bc = shape.edges().create_line_segment([v2, v3.clone()]);

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -150,7 +150,10 @@ mod tests {
         kernel::{
             geometry::Surface,
             shape::Shape,
-            topology::{edges::Cycle, faces::Face},
+            topology::{
+                edges::{Cycle, Edge},
+                faces::Face,
+            },
         },
         math::{Point, Scalar, Segment},
     };
@@ -211,9 +214,11 @@ mod tests {
         let v2 = shape.vertices().add(b);
         let v3 = shape.vertices().add(c);
 
-        let ab = shape.edges().create_line_segment([v1.clone(), v2.clone()]);
-        let bc = shape.edges().create_line_segment([v2, v3.clone()]);
-        let ca = shape.edges().create_line_segment([v3, v1]);
+        let ab = shape
+            .edges()
+            .add(Edge::line_segment([v1.clone(), v2.clone()]));
+        let bc = shape.edges().add(Edge::line_segment([v2, v3.clone()]));
+        let ca = shape.edges().add(Edge::line_segment([v3, v1]));
 
         let cycle = Cycle {
             edges: vec![ab, bc, ca],
@@ -250,10 +255,12 @@ mod tests {
         let v3 = shape.vertices().add(c);
         let v4 = shape.vertices().add(d);
 
-        let ab = shape.edges().create_line_segment([v1.clone(), v2.clone()]);
-        let bc = shape.edges().create_line_segment([v2, v3.clone()]);
-        let cd = shape.edges().create_line_segment([v3, v4.clone()]);
-        let da = shape.edges().create_line_segment([v4, v1]);
+        let ab = shape
+            .edges()
+            .add(Edge::line_segment([v1.clone(), v2.clone()]));
+        let bc = shape.edges().add(Edge::line_segment([v2, v3.clone()]));
+        let cd = shape.edges().add(Edge::line_segment([v3, v4.clone()]));
+        let da = shape.edges().add(Edge::line_segment([v4, v1]));
 
         let abcd = Cycle {
             edges: vec![ab, bc, cd, da],

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -108,9 +108,9 @@ mod tests {
         fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> Self {
             let mut shape = Shape::new();
 
-            let a = shape.vertices().create(a.into());
-            let b = shape.vertices().create(b.into());
-            let c = shape.vertices().create(c.into());
+            let a = shape.vertices().add(a.into());
+            let b = shape.vertices().add(b.into());
+            let c = shape.vertices().add(c.into());
 
             let ab = shape.edges().create_line_segment([a.clone(), b.clone()]);
             let bc = shape.edges().create_line_segment([b.clone(), c.clone()]);

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -71,7 +71,10 @@ mod tests {
         kernel::{
             geometry::{surfaces::Swept, Surface},
             shape::Shape,
-            topology::{edges::Cycle, faces::Face},
+            topology::{
+                edges::{Cycle, Edge},
+                faces::Face,
+            },
         },
         math::{Point, Scalar, Vector},
     };
@@ -112,9 +115,15 @@ mod tests {
             let b = shape.vertices().add(b.into());
             let c = shape.vertices().add(c.into());
 
-            let ab = shape.edges().create_line_segment([a.clone(), b.clone()]);
-            let bc = shape.edges().create_line_segment([b.clone(), c.clone()]);
-            let ca = shape.edges().create_line_segment([c.clone(), a.clone()]);
+            let ab = shape
+                .edges()
+                .add(Edge::line_segment([a.clone(), b.clone()]));
+            let bc = shape
+                .edges()
+                .add(Edge::line_segment([b.clone(), c.clone()]));
+            let ca = shape
+                .edges()
+                .add(Edge::line_segment([c.clone(), a.clone()]));
 
             let abc = Face::Face {
                 surface: Surface::Swept(Swept::plane_from_points(

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -50,11 +50,11 @@ pub fn transform_face(
                         })
                     });
 
-                    edges.push(
-                        shape
-                            .edges()
-                            .create(edge.curve.transform(transform), vertices),
-                    );
+                    let edge = shape
+                        .edges()
+                        .create(edge.curve.transform(transform), vertices);
+
+                    edges.push(edge);
                 }
 
                 cycles_trans.push(Cycle { edges });

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -1,7 +1,10 @@
 use crate::{
     kernel::{
         shape::Shape,
-        topology::{edges::Cycle, faces::Face},
+        topology::{
+            edges::{Cycle, Edge},
+            faces::Face,
+        },
     },
     math::Transform,
 };
@@ -50,9 +53,11 @@ pub fn transform_face(
                         })
                     });
 
-                    let edge = shape
-                        .edges()
-                        .create(edge.curve.transform(transform), vertices);
+                    let edge = Edge {
+                        curve: edge.curve.transform(transform),
+                        vertices,
+                    };
+                    let edge = shape.edges().create(edge);
 
                     edges.push(edge);
                 }

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -41,7 +41,7 @@ pub fn transform_face(
                 let mut edges = Vec::new();
 
                 for edge in cycle.edges {
-                    let vertices = edge.vertices().map(|vertices| {
+                    let vertices = edge.vertices.clone().map(|vertices| {
                         vertices.map(|vertex| {
                             let point =
                                 transform.transform_point(&vertex.point());
@@ -51,10 +51,9 @@ pub fn transform_face(
                     });
 
                     edges.push(
-                        shape.edges().create(
-                            edge.curve().transform(transform),
-                            vertices,
-                        ),
+                        shape
+                            .edges()
+                            .create(edge.curve.transform(transform), vertices),
                     );
                 }
 

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -57,7 +57,7 @@ pub fn transform_face(
                         curve: edge.curve.transform(transform),
                         vertices,
                     };
-                    let edge = shape.edges().create(edge);
+                    let edge = shape.edges().add(edge);
 
                     edges.push(edge);
                 }

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -46,7 +46,7 @@ pub fn transform_face(
                             let point =
                                 transform.transform_point(&vertex.point());
 
-                            shape.vertices().create(point)
+                            shape.vertices().add(point)
                         })
                     });
 

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -20,7 +20,7 @@ impl Cycles<'_> {
     /// - That those edges form a cycle.
     /// - That the cycle is not self-overlapping.
     /// - That there exists no duplicate cycle, with the same edges.
-    pub fn create(&mut self, cycle: Cycle) -> Handle<Cycle> {
+    pub fn add(&mut self, cycle: Cycle) -> Handle<Cycle> {
         let storage = Storage::new(cycle);
         let handle = storage.handle();
         self.cycles.push(storage);

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -1,6 +1,9 @@
 use crate::kernel::topology::edges::{Cycle, Edge};
 
-use super::{handle::Handle, CyclesInner};
+use super::{
+    handle::{Handle, Storage},
+    CyclesInner,
+};
 
 /// The cycles of a shape
 pub struct Cycles<'r> {
@@ -20,14 +23,15 @@ impl Cycles<'_> {
     pub fn create(
         &mut self,
         edges: impl IntoIterator<Item = Handle<Edge>>,
-    ) -> Cycle {
+    ) -> Handle<Cycle> {
         let cycle = Cycle {
             edges: edges.into_iter().collect(),
         };
 
         self.cycles.push(cycle.clone());
 
-        cycle
+        let storage = Storage::new(cycle);
+        storage.handle()
     }
 
     /// Access an iterator over all cycles

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -1,6 +1,6 @@
 use crate::kernel::topology::edges::{Cycle, Edge};
 
-use super::CyclesInner;
+use super::{handle::Handle, CyclesInner};
 
 /// The cycles of a shape
 pub struct Cycles<'r> {
@@ -17,7 +17,10 @@ impl Cycles<'_> {
     /// - That those edges form a cycle.
     /// - That the cycle is not self-overlapping.
     /// - That there exists no duplicate cycle, with the same edges.
-    pub fn create(&mut self, edges: impl IntoIterator<Item = Edge>) -> Cycle {
+    pub fn create(
+        &mut self,
+        edges: impl IntoIterator<Item = Handle<Edge>>,
+    ) -> Cycle {
         let cycle = Cycle {
             edges: edges.into_iter().collect(),
         };

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -28,17 +28,15 @@ impl Cycles<'_> {
             edges: edges.into_iter().collect(),
         };
 
-        self.cycles.push(cycle.clone());
-
         let storage = Storage::new(cycle);
-        storage.handle()
+        let handle = storage.handle();
+        self.cycles.push(storage);
+
+        handle
     }
 
     /// Access an iterator over all cycles
-    pub fn all(&self) -> impl Iterator<Item = Handle<Cycle>> + '_ {
-        self.cycles
-            .iter()
-            .cloned()
-            .map(|cycle| Storage::new(cycle).handle())
+    pub fn all(&self) -> impl Iterator<Item = Storage<Cycle>> + '_ {
+        self.cycles.iter().cloned()
     }
 }

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -35,7 +35,10 @@ impl Cycles<'_> {
     }
 
     /// Access an iterator over all cycles
-    pub fn all(&self) -> impl Iterator<Item = Cycle> + '_ {
-        self.cycles.iter().cloned()
+    pub fn all(&self) -> impl Iterator<Item = Handle<Cycle>> + '_ {
+        self.cycles
+            .iter()
+            .cloned()
+            .map(|cycle| Storage::new(cycle).handle())
     }
 }

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -1,4 +1,4 @@
-use crate::kernel::topology::edges::{Cycle, Edge};
+use crate::kernel::topology::edges::Cycle;
 
 use super::{
     handle::{Handle, Storage},
@@ -20,14 +20,7 @@ impl Cycles<'_> {
     /// - That those edges form a cycle.
     /// - That the cycle is not self-overlapping.
     /// - That there exists no duplicate cycle, with the same edges.
-    pub fn create(
-        &mut self,
-        edges: impl IntoIterator<Item = Handle<Edge>>,
-    ) -> Handle<Cycle> {
-        let cycle = Cycle {
-            edges: edges.into_iter().collect(),
-        };
-
+    pub fn create(&mut self, cycle: Cycle) -> Handle<Cycle> {
         let storage = Storage::new(cycle);
         let handle = storage.handle();
         self.cycles.push(storage);

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -11,7 +11,7 @@ pub struct Cycles<'r> {
 }
 
 impl Cycles<'_> {
-    /// Create a cycle
+    /// Add a cycle to the shape
     ///
     /// # Implementation note
     ///

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -6,7 +6,7 @@ use crate::{
     math::{Point, Scalar, Vector},
 };
 
-use super::handle::Handle;
+use super::handle::{Handle, Storage};
 
 /// The edges of a shape
 pub struct Edges;
@@ -30,8 +30,9 @@ impl Edges {
         &mut self,
         curve: Curve,
         vertices: Option<[Handle<Vertex>; 2]>,
-    ) -> Edge {
-        Edge { curve, vertices }
+    ) -> Handle<Edge> {
+        let edge = Edge { curve, vertices };
+        Storage::new(edge).handle()
     }
 
     /// Create a line segment
@@ -41,7 +42,7 @@ impl Edges {
     pub fn create_line_segment(
         &mut self,
         vertices: [Handle<Vertex>; 2],
-    ) -> Edge {
+    ) -> Handle<Edge> {
         self.create(
             Curve::Line(Line::from_points(
                 vertices.clone().map(|vertex| vertex.point()),
@@ -54,7 +55,7 @@ impl Edges {
     ///
     /// Calls [`Edges::create`] internally, and inherits its limitations and
     /// requirements.
-    pub fn create_circle(&mut self, radius: Scalar) -> Edge {
+    pub fn create_circle(&mut self, radius: Scalar) -> Handle<Edge> {
         self.create(
             Curve::Circle(Circle {
                 center: Point::origin(),

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -1,7 +1,7 @@
 use crate::{
     kernel::{
-        geometry::{Circle, Curve, Line},
-        topology::{edges::Edge, vertices::Vertex},
+        geometry::{Circle, Curve},
+        topology::edges::Edge,
     },
     math::{Point, Scalar, Vector},
 };
@@ -28,22 +28,6 @@ impl Edges {
     /// and validate any constraints that apply to edge creation.
     pub fn add(&mut self, edge: Edge) -> Handle<Edge> {
         Storage::new(edge).handle()
-    }
-
-    /// Create a line segment
-    ///
-    /// Calls [`Edges::create`] internally, and inherits its limitations and
-    /// requirements.
-    pub fn create_line_segment(
-        &mut self,
-        vertices: [Handle<Vertex>; 2],
-    ) -> Handle<Edge> {
-        self.add(Edge {
-            curve: Curve::Line(Line::from_points(
-                vertices.clone().map(|vertex| vertex.point()),
-            )),
-            vertices: Some(vertices),
-        })
     }
 
     /// Create a circle

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -26,7 +26,7 @@ impl Edges {
     /// Right now this is just an overly complicated constructor for `Edge`. In
     /// the future, it can add the edge to the proper internal data structures,
     /// and validate any constraints that apply to edge creation.
-    pub fn create(&mut self, edge: Edge) -> Handle<Edge> {
+    pub fn add(&mut self, edge: Edge) -> Handle<Edge> {
         Storage::new(edge).handle()
     }
 
@@ -38,7 +38,7 @@ impl Edges {
         &mut self,
         vertices: [Handle<Vertex>; 2],
     ) -> Handle<Edge> {
-        self.create(Edge {
+        self.add(Edge {
             curve: Curve::Line(Line::from_points(
                 vertices.clone().map(|vertex| vertex.point()),
             )),
@@ -51,7 +51,7 @@ impl Edges {
     /// Calls [`Edges::create`] internally, and inherits its limitations and
     /// requirements.
     pub fn create_circle(&mut self, radius: Scalar) -> Handle<Edge> {
-        self.create(Edge {
+        self.add(Edge {
             curve: Curve::Circle(Circle {
                 center: Point::origin(),
                 radius: Vector::from([radius, Scalar::ZERO]),

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -6,7 +6,7 @@ use super::handle::{Handle, Storage};
 pub struct Edges;
 
 impl Edges {
-    /// Create an edge
+    /// Add an edge to the shape
     ///
     /// If vertices are provided in `vertices`, they must be on `curve`.
     ///

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -1,10 +1,4 @@
-use crate::{
-    kernel::{
-        geometry::{Circle, Curve},
-        topology::edges::Edge,
-    },
-    math::{Point, Scalar, Vector},
-};
+use crate::kernel::topology::edges::Edge;
 
 use super::handle::{Handle, Storage};
 
@@ -28,19 +22,5 @@ impl Edges {
     /// and validate any constraints that apply to edge creation.
     pub fn add(&mut self, edge: Edge) -> Handle<Edge> {
         Storage::new(edge).handle()
-    }
-
-    /// Create a circle
-    ///
-    /// Calls [`Edges::create`] internally, and inherits its limitations and
-    /// requirements.
-    pub fn create_circle(&mut self, radius: Scalar) -> Handle<Edge> {
-        self.add(Edge {
-            curve: Curve::Circle(Circle {
-                center: Point::origin(),
-                radius: Vector::from([radius, Scalar::ZERO]),
-            }),
-            vertices: None,
-        })
     }
 }

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -26,12 +26,7 @@ impl Edges {
     /// Right now this is just an overly complicated constructor for `Edge`. In
     /// the future, it can add the edge to the proper internal data structures,
     /// and validate any constraints that apply to edge creation.
-    pub fn create(
-        &mut self,
-        curve: Curve,
-        vertices: Option<[Handle<Vertex>; 2]>,
-    ) -> Handle<Edge> {
-        let edge = Edge { curve, vertices };
+    pub fn create(&mut self, edge: Edge) -> Handle<Edge> {
         Storage::new(edge).handle()
     }
 
@@ -43,12 +38,12 @@ impl Edges {
         &mut self,
         vertices: [Handle<Vertex>; 2],
     ) -> Handle<Edge> {
-        self.create(
-            Curve::Line(Line::from_points(
+        self.create(Edge {
+            curve: Curve::Line(Line::from_points(
                 vertices.clone().map(|vertex| vertex.point()),
             )),
-            Some(vertices),
-        )
+            vertices: Some(vertices),
+        })
     }
 
     /// Create a circle
@@ -56,12 +51,12 @@ impl Edges {
     /// Calls [`Edges::create`] internally, and inherits its limitations and
     /// requirements.
     pub fn create_circle(&mut self, radius: Scalar) -> Handle<Edge> {
-        self.create(
-            Curve::Circle(Circle {
+        self.create(Edge {
+            curve: Curve::Circle(Circle {
                 center: Point::origin(),
                 radius: Vector::from([radius, Scalar::ZERO]),
             }),
-            None,
-        )
+            vertices: None,
+        })
     }
 }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -81,4 +81,4 @@ impl Shape {
 }
 
 type VerticesInner = Vec<Storage<Vertex>>;
-type CyclesInner = Vec<Cycle>;
+type CyclesInner = Vec<Storage<Cycle>>;

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -33,7 +33,7 @@ impl Vertices<'_> {
     /// In the future, this method is likely to validate more than just vertex
     /// uniqueness. See documentation of [`crate::kernel`] for some context on
     /// that.
-    pub fn create(&mut self, vertex: impl Into<Vertex>) -> Handle<Vertex> {
+    pub fn add(&mut self, vertex: impl Into<Vertex>) -> Handle<Vertex> {
         let vertex = vertex.into();
 
         // Make sure the new vertex is a minimum distance away from all existing
@@ -69,8 +69,8 @@ mod tests {
     fn create_valid() {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        shape.vertices().create(Point::from([0., 0., 0.]));
-        shape.vertices().create(Point::from([5e-6, 0., 0.]));
+        shape.vertices().add(Point::from([0., 0., 0.]));
+        shape.vertices().add(Point::from([5e-6, 0., 0.]));
     }
 
     #[test]
@@ -82,7 +82,7 @@ mod tests {
 
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        shape.vertices().create(Point::from([0., 0., 0.]));
-        shape.vertices().create(Point::from([5e-8, 0., 0.]));
+        shape.vertices().add(Point::from([0., 0., 0.]));
+        shape.vertices().add(Point::from([5e-8, 0., 0.]));
     }
 }

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -14,7 +14,7 @@ pub struct Vertices<'r> {
 }
 
 impl Vertices<'_> {
-    /// Create a vertex
+    /// Add a vertex to the shape
     ///
     /// Logs a warning, if the vertex is not unique, meaning if another vertex
     /// defined by the same point already exists.

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -3,7 +3,10 @@ use crate::{
     kernel::{
         geometry::Surface,
         shape::Shape,
-        topology::faces::{Face, Faces},
+        topology::{
+            edges::Edge,
+            faces::{Face, Faces},
+        },
     },
     math::{Aabb, Point, Scalar},
 };
@@ -17,7 +20,9 @@ impl ToShape for fj::Circle {
         // Circles have just a single round edge with no vertices. So none need
         // to be added here.
 
-        let edge = shape.edges().create_circle(Scalar::from_f64(self.radius));
+        let edge = shape
+            .edges()
+            .add(Edge::circle(Scalar::from_f64(self.radius)));
         shape.cycles().create([edge]);
 
         shape.faces = Faces(vec![Face::Face {

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -4,7 +4,7 @@ use crate::{
         geometry::Surface,
         shape::Shape,
         topology::{
-            edges::Edge,
+            edges::{Cycle, Edge},
             faces::{Face, Faces},
         },
     },
@@ -23,7 +23,7 @@ impl ToShape for fj::Circle {
         let edge = shape
             .edges()
             .add(Edge::circle(Scalar::from_f64(self.radius)));
-        shape.cycles().create([edge]);
+        shape.cycles().create(Cycle { edges: vec![edge] });
 
         shape.faces = Faces(vec![Face::Face {
             cycles: shape

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -23,7 +23,7 @@ impl ToShape for fj::Circle {
         let edge = shape
             .edges()
             .add(Edge::circle(Scalar::from_f64(self.radius)));
-        shape.cycles().create(Cycle { edges: vec![edge] });
+        shape.cycles().add(Cycle { edges: vec![edge] });
 
         shape.faces = Faces(vec![Face::Face {
             cycles: shape

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -26,7 +26,11 @@ impl ToShape for fj::Circle {
         shape.cycles().create([edge]);
 
         shape.faces = Faces(vec![Face::Face {
-            cycles: shape.cycles().all().collect(),
+            cycles: shape
+                .cycles()
+                .all()
+                .map(|handle| (*handle).clone())
+                .collect(),
             surface: Surface::x_y_plane(),
         }]);
 

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -2,7 +2,10 @@ use crate::{
     debug::DebugInfo,
     kernel::{
         shape::Shape,
-        topology::faces::{Face, Faces},
+        topology::{
+            edges::Cycle,
+            faces::{Face, Faces},
+        },
     },
     math::{Aabb, Scalar},
 };
@@ -23,8 +26,12 @@ impl ToShape for fj::Difference2d {
             let a = a.cycles().all().next().unwrap();
             let b = b.cycles().all().next().unwrap();
 
-            shape.cycles().create(a.edges.clone());
-            shape.cycles().create(b.edges.clone());
+            shape.cycles().create(Cycle {
+                edges: a.edges.clone(),
+            });
+            shape.cycles().create(Cycle {
+                edges: b.edges.clone(),
+            });
         } else {
             // See issue:
             // https://github.com/hannobraun/Fornjot/issues/95

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -23,8 +23,8 @@ impl ToShape for fj::Difference2d {
             let a = a.cycles().all().next().unwrap();
             let b = b.cycles().all().next().unwrap();
 
-            shape.cycles().create(a.edges);
-            shape.cycles().create(b.edges);
+            shape.cycles().create(a.edges.clone());
+            shape.cycles().create(b.edges.clone());
         } else {
             // See issue:
             // https://github.com/hannobraun/Fornjot/issues/95

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -26,10 +26,10 @@ impl ToShape for fj::Difference2d {
             let a = a.cycles().all().next().unwrap();
             let b = b.cycles().all().next().unwrap();
 
-            shape.cycles().create(Cycle {
+            shape.cycles().add(Cycle {
                 edges: a.edges.clone(),
             });
-            shape.cycles().create(Cycle {
+            shape.cycles().add(Cycle {
                 edges: b.edges.clone(),
             });
         } else {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -4,7 +4,7 @@ use crate::{
         geometry::Surface,
         shape::Shape,
         topology::{
-            edges::Edge,
+            edges::{Cycle, Edge},
             faces::{Face, Faces},
         },
     },
@@ -44,7 +44,7 @@ impl ToShape for fj::Sketch {
                 edges.push(edge);
             }
 
-            shape.cycles().create(edges);
+            shape.cycles().create(Cycle { edges });
         };
 
         let face = Face::Face {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -44,7 +44,7 @@ impl ToShape for fj::Sketch {
                 edges.push(edge);
             }
 
-            shape.cycles().create(Cycle { edges });
+            shape.cycles().add(Cycle { edges });
         };
 
         let face = Face::Face {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -3,7 +3,10 @@ use crate::{
     kernel::{
         geometry::Surface,
         shape::Shape,
-        topology::faces::{Face, Faces},
+        topology::{
+            edges::Edge,
+            faces::{Face, Faces},
+        },
     },
     math::{Aabb, Point, Scalar},
 };
@@ -37,7 +40,7 @@ impl ToShape for fj::Sketch {
                 let a = window[0].clone();
                 let b = window[1].clone();
 
-                let edge = shape.edges().create_line_segment([a, b]);
+                let edge = shape.edges().add(Edge::line_segment([a, b]));
                 edges.push(edge);
             }
 

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -48,7 +48,11 @@ impl ToShape for fj::Sketch {
         };
 
         let face = Face::Face {
-            cycles: shape.cycles().all().collect(),
+            cycles: shape
+                .cycles()
+                .all()
+                .map(|handle| (*handle).clone())
+                .collect(),
             surface: Surface::x_y_plane(),
         };
         shape.faces = Faces(vec![face]);

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -16,7 +16,7 @@ impl ToShape for fj::Sketch {
         let mut vertices = Vec::new();
 
         for [x, y] in self.to_points() {
-            let vertex = shape.vertices().create(Point::from([x, y, 0.]));
+            let vertex = shape.vertices().add(Point::from([x, y, 0.]));
             vertices.push(vertex);
         }
 

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -15,19 +15,12 @@ pub struct Cycle {
 /// An edge of a shape
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edge {
-    pub(crate) curve: Curve,
-    pub(crate) vertices: Option<[Handle<Vertex>; 2]>,
-}
-
-impl Edge {
     /// Access the curve that defines the edge's geometry
     ///
     /// The edge can be a segment of the curve that is bounded by two vertices,
     /// or if the curve is continuous (i.e. connects to itself), the edge could
     /// be defined by the whole curve, and have no bounding vertices.
-    pub fn curve(&self) -> Curve {
-        self.curve
-    }
+    pub curve: Curve,
 
     /// Access the vertices that bound the edge on the curve
     ///
@@ -43,7 +36,5 @@ impl Edge {
     /// It got in the way of some work, however, so it made sense to simplify
     /// it by storing 3D vertices. It will probably make sense to revert this
     /// and store 1D vertices again, at some point.
-    pub fn vertices(&self) -> Option<[Handle<Vertex>; 2]> {
-        self.vertices.clone()
-    }
+    pub vertices: Option<[Handle<Vertex>; 2]>,
 }

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -1,4 +1,7 @@
-use crate::kernel::{geometry::Curve, shape::handle::Handle};
+use crate::kernel::{
+    geometry::{Curve, Line},
+    shape::handle::Handle,
+};
 
 use super::vertices::Vertex;
 
@@ -37,4 +40,16 @@ pub struct Edge {
     /// it by storing 3D vertices. It will probably make sense to revert this
     /// and store 1D vertices again, at some point.
     pub vertices: Option<[Handle<Vertex>; 2]>,
+}
+
+impl Edge {
+    /// Create a line segment
+    pub fn line_segment(vertices: [Handle<Vertex>; 2]) -> Self {
+        Edge {
+            curve: Curve::Line(Line::from_points(
+                vertices.clone().map(|vertex| vertex.point()),
+            )),
+            vertices: Some(vertices),
+        }
+    }
 }

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -9,7 +9,7 @@ use super::vertices::Vertex;
 /// one.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
-    pub edges: Vec<Edge>,
+    pub edges: Vec<Handle<Edge>>,
 }
 
 /// An edge of a shape

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -1,6 +1,9 @@
-use crate::kernel::{
-    geometry::{Curve, Line},
-    shape::handle::Handle,
+use crate::{
+    kernel::{
+        geometry::{Circle, Curve, Line},
+        shape::handle::Handle,
+    },
+    math::{Point, Scalar, Vector},
 };
 
 use super::vertices::Vertex;
@@ -50,6 +53,17 @@ impl Edge {
                 vertices.clone().map(|vertex| vertex.point()),
             )),
             vertices: Some(vertices),
+        }
+    }
+
+    /// Create a circle
+    pub fn circle(radius: Scalar) -> Self {
+        Edge {
+            curve: Curve::Circle(Circle {
+                center: Point::origin(),
+                radius: Vector::from([radius, Scalar::ZERO]),
+            }),
+            vertices: None,
         }
     }
 }


### PR DESCRIPTION
More work towards #280. This pull request refines the way that the `Shape` sub-APIs interact with the topology types, opting to leave the topology types as something simple that can be constructed by itself, but can then be added to the shape.