### PR TITLE
Generate more correct shapes as result of 2D difference

### DIFF
--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -14,10 +14,13 @@ pub struct Cycles<'r> {
 impl Cycles<'_> {
     /// Add a cycle to the shape
     ///
+    /// # Panics
+    ///
+    /// Panics, if the edges of the cycles are not part of this shape.
+    ///
     /// # Implementation note
     ///
-    /// This method should at some point validate the cycle:
-    /// - That it refers to valid edges that are part of `Shape`.
+    /// The validation of the cycle should be extended to cover more cases:
     /// - That those edges form a cycle.
     /// - That the cycle is not self-overlapping.
     /// - That there exists no duplicate cycle, with the same edges.

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -2,11 +2,12 @@ use crate::kernel::topology::edges::Cycle;
 
 use super::{
     handle::{Handle, Storage},
-    CyclesInner,
+    CyclesInner, EdgesInner,
 };
 
 /// The cycles of a shape
 pub struct Cycles<'r> {
+    pub(super) edges: &'r mut EdgesInner,
     pub(super) cycles: &'r mut CyclesInner,
 }
 
@@ -21,6 +22,13 @@ impl Cycles<'_> {
     /// - That the cycle is not self-overlapping.
     /// - That there exists no duplicate cycle, with the same edges.
     pub fn add(&mut self, cycle: Cycle) -> Handle<Cycle> {
+        for edge in &cycle.edges {
+            assert!(
+                self.edges.contains(edge.storage()),
+                "Cycle validation failed: {edge:?} is not part of the shape",
+            );
+        }
+
         let storage = Storage::new(cycle);
         let handle = storage.handle();
         self.cycles.push(storage);
@@ -31,5 +39,39 @@ impl Cycles<'_> {
     /// Access an iterator over all cycles
     pub fn all(&self) -> impl Iterator<Item = Handle<Cycle>> + '_ {
         self.cycles.iter().map(|storage| storage.handle())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        kernel::{shape::Shape, topology::edges::Cycle},
+        math::Point,
+    };
+
+    #[test]
+    fn add_valid() {
+        let mut shape = Shape::new();
+
+        let a = shape.vertices().add(Point::from([0., 0., 0.]));
+        let b = shape.vertices().add(Point::from([1., 0., 0.]));
+
+        let edge = shape.edges().add_line_segment([a, b]);
+
+        shape.cycles().add(Cycle { edges: vec![edge] });
+    }
+
+    #[test]
+    #[should_panic]
+    fn add_invalid() {
+        let mut shape = Shape::new();
+        let mut other = Shape::new();
+
+        let a = other.vertices().add(Point::from([0., 0., 0.]));
+        let b = other.vertices().add(Point::from([1., 0., 0.]));
+
+        let edge = other.edges().add_line_segment([a, b]);
+
+        shape.cycles().add(Cycle { edges: vec![edge] });
     }
 }

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -9,14 +9,16 @@ use crate::{
 use super::{
     curves::Curves,
     handle::{Handle, Storage},
+    EdgesInner,
 };
 
 /// The edges of a shape
-pub struct Edges {
+pub struct Edges<'r> {
     pub(super) curves: Curves,
+    pub(super) edges: &'r mut EdgesInner,
 }
 
-impl Edges {
+impl Edges<'_> {
     /// Add an edge to the shape
     ///
     /// If vertices are provided in `vertices`, they must be on `curve`.
@@ -32,7 +34,12 @@ impl Edges {
     /// the future, it can add the edge to the proper internal data structures,
     /// and validate any constraints that apply to edge creation.
     pub fn add(&mut self, edge: Edge) -> Handle<Edge> {
-        Storage::new(edge).handle()
+        let storage = Storage::new(edge);
+        let handle = storage.handle();
+
+        self.edges.push(storage);
+
+        handle
     }
 
     /// Add a circle to the shape

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -28,6 +28,11 @@ impl<T> Handle<T> {
     pub fn get(&self) -> &T {
         self.0.deref()
     }
+
+    /// Internal method to access the [`Storage`] this handle refers to
+    pub(super) fn storage(&self) -> &Storage<T> {
+        &self.0
+    }
 }
 
 impl<T> Deref for Handle<T> {

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -86,6 +86,7 @@ impl Shape {
     pub fn edges(&mut self) -> Edges {
         Edges {
             curves: Curves,
+            vertices: &mut self.vertices,
             edges: &mut self.edges,
         }
     }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -8,7 +8,11 @@ pub mod vertices;
 
 use crate::math::Scalar;
 
-use super::topology::{edges::Cycle, faces::Face, vertices::Vertex};
+use super::topology::{
+    edges::{Cycle, Edge},
+    faces::Face,
+    vertices::Vertex,
+};
 
 use self::{
     curves::Curves, cycles::Cycles, edges::Edges, faces::Faces,
@@ -24,6 +28,7 @@ pub struct Shape {
     min_distance: Scalar,
 
     vertices: VerticesInner,
+    edges: EdgesInner,
     cycles: CyclesInner,
     faces: FacesInner,
 }
@@ -38,6 +43,7 @@ impl Shape {
             min_distance: Scalar::from_f64(5e-7), // 0.5 µm
 
             vertices: VerticesInner::new(),
+            edges: EdgesInner::new(),
             cycles: CyclesInner::new(),
             faces: FacesInner::new(),
         }
@@ -78,7 +84,10 @@ impl Shape {
 
     /// Access the shape's edges
     pub fn edges(&mut self) -> Edges {
-        Edges { curves: Curves }
+        Edges {
+            curves: Curves,
+            edges: &mut self.edges,
+        }
     }
 
     /// Access the shape's cycles
@@ -97,5 +106,6 @@ impl Shape {
 }
 
 type VerticesInner = Vec<Storage<Vertex>>;
+type EdgesInner = Vec<Storage<Edge>>;
 type CyclesInner = Vec<Storage<Cycle>>;
 type FacesInner = Vec<Storage<Face>>;

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -93,6 +93,7 @@ impl Shape {
     /// Access the shape's cycles
     pub fn cycles(&mut self) -> Cycles {
         Cycles {
+            edges: &mut self.edges,
             cycles: &mut self.cycles,
         }
     }

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -66,7 +66,7 @@ mod tests {
     const MIN_DISTANCE: f64 = 5e-7;
 
     #[test]
-    fn create_valid() {
+    fn add_valid() {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
         shape.vertices().add(Point::from([0., 0., 0.]));
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     #[ignore]
     #[should_panic]
-    fn create_invalid() {
+    fn add_invalid() {
         // Test is ignored, until vertex validation can be enabled for real.
         // See implementation note on `Vertices::create`.
 

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -43,9 +43,13 @@ impl ToShape for fj::Difference2d {
             [&mut a, &mut b].map(|shape| shape.cycles().all().next().unwrap());
 
         for cycle in cycles {
-            shape.cycles().add(Cycle {
-                edges: cycle.edges.clone(),
-            });
+            let mut edges = Vec::new();
+            for edge in &cycle.edges {
+                let edge = shape.edges().add(edge.get().clone());
+                edges.push(edge);
+            }
+
+            shape.cycles().add(Cycle { edges });
         }
 
         // Can't panic, as we just verified that both shapes have one face.


### PR DESCRIPTION
The `Shape` instance created as the result of a 2D difference isn't internally consistent. It contains objects that refer to other objects, which are part of one of the input `Shape`s, but not part of the result. As far as I can tell, this doesn't result in any bugs, but it limits algorithms that operate on the result's `Shape` instance.

This pull request improves the situation, making the result not fully correct, but much more so. It should be good enough to rewrite the sweep algorithm, so it no longer causes vertex validation warnings. This is required to address #242, and there's a WIP version of this rewrite in #278.