### PR TITLE
Track points as part of `Shape`

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -169,8 +169,11 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.vertices().add(Vertex { point: a });
-        let v2 = shape.vertices().add(Vertex { point: d });
+        let v1 = shape.geometry().add_point(a);
+        let v2 = shape.geometry().add_point(d);
+
+        let v1 = shape.vertices().add(Vertex { point: v1 });
+        let v2 = shape.vertices().add(Vertex { point: v2 });
 
         let points = vec![b, c];
 
@@ -207,9 +210,13 @@ mod tests {
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
 
-        let v1 = shape.vertices().add(Vertex { point: a });
-        let v2 = shape.vertices().add(Vertex { point: b });
-        let v3 = shape.vertices().add(Vertex { point: c });
+        let v1 = shape.geometry().add_point(a);
+        let v2 = shape.geometry().add_point(b);
+        let v3 = shape.geometry().add_point(c);
+
+        let v1 = shape.vertices().add(Vertex { point: v1 });
+        let v2 = shape.vertices().add(Vertex { point: v2 });
+        let v3 = shape.vertices().add(Vertex { point: v3 });
 
         let ab = shape.edges().add_line_segment([v1.clone(), v2.clone()]);
         let bc = shape.edges().add_line_segment([v2, v3.clone()]);
@@ -245,10 +252,15 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.vertices().add(Vertex { point: a });
-        let v2 = shape.vertices().add(Vertex { point: b });
-        let v3 = shape.vertices().add(Vertex { point: c });
-        let v4 = shape.vertices().add(Vertex { point: d });
+        let v1 = shape.geometry().add_point(a);
+        let v2 = shape.geometry().add_point(b);
+        let v3 = shape.geometry().add_point(c);
+        let v4 = shape.geometry().add_point(d);
+
+        let v1 = shape.vertices().add(Vertex { point: v1 });
+        let v2 = shape.vertices().add(Vertex { point: v2 });
+        let v3 = shape.vertices().add(Vertex { point: v3 });
+        let v4 = shape.vertices().add(Vertex { point: v4 });
 
         let ab = shape.edges().add_line_segment([v1.clone(), v2.clone()]);
         let bc = shape.edges().add_line_segment([v2, v3.clone()]);

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -150,7 +150,7 @@ mod tests {
         kernel::{
             geometry::Surface,
             shape::Shape,
-            topology::{edges::Cycle, faces::Face},
+            topology::{edges::Cycle, faces::Face, vertices::Vertex},
         },
         math::{Point, Scalar, Segment},
     };
@@ -169,8 +169,8 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.vertices().add(a);
-        let v2 = shape.vertices().add(d);
+        let v1 = shape.vertices().add(Vertex { point: a });
+        let v2 = shape.vertices().add(Vertex { point: d });
 
         let points = vec![b, c];
 
@@ -207,9 +207,9 @@ mod tests {
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
 
-        let v1 = shape.vertices().add(a);
-        let v2 = shape.vertices().add(b);
-        let v3 = shape.vertices().add(c);
+        let v1 = shape.vertices().add(Vertex { point: a });
+        let v2 = shape.vertices().add(Vertex { point: b });
+        let v3 = shape.vertices().add(Vertex { point: c });
 
         let ab = shape.edges().add_line_segment([v1.clone(), v2.clone()]);
         let bc = shape.edges().add_line_segment([v2, v3.clone()]);
@@ -245,10 +245,10 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.vertices().add(a);
-        let v2 = shape.vertices().add(b);
-        let v3 = shape.vertices().add(c);
-        let v4 = shape.vertices().add(d);
+        let v1 = shape.vertices().add(Vertex { point: a });
+        let v2 = shape.vertices().add(Vertex { point: b });
+        let v3 = shape.vertices().add(Vertex { point: c });
+        let v4 = shape.vertices().add(Vertex { point: d });
 
         let ab = shape.edges().add_line_segment([v1.clone(), v2.clone()]);
         let bc = shape.edges().add_line_segment([v2, v3.clone()]);

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -114,8 +114,8 @@ fn approximate_edge(
     // the same vertex would be understood to refer to very close, but distinct
     // vertices.
     if let Some([a, b]) = vertices {
-        points.insert(0, a.point);
-        points.push(b.point);
+        points.insert(0, a.point());
+        points.push(b.point());
     }
 
     let mut segment_points = points.clone();

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -29,7 +29,7 @@ pub fn sweep_shape(
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.vertices().all() {
-        let point = vertex_orig.point() + path;
+        let point = shape.geometry().add_point(vertex_orig.point() + path);
         let vertex = shape.vertices().add(Vertex { point });
         vertices.insert(vertex_orig, vertex);
     }
@@ -178,9 +178,13 @@ mod tests {
         fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> Self {
             let mut shape = Shape::new();
 
-            let a = shape.vertices().add(Vertex { point: a.into() });
-            let b = shape.vertices().add(Vertex { point: b.into() });
-            let c = shape.vertices().add(Vertex { point: c.into() });
+            let a = shape.geometry().add_point(a.into());
+            let b = shape.geometry().add_point(b.into());
+            let c = shape.geometry().add_point(c.into());
+
+            let a = shape.vertices().add(Vertex { point: a });
+            let b = shape.vertices().add(Vertex { point: b });
+            let c = shape.vertices().add(Vertex { point: c });
 
             let ab = shape.edges().add_line_segment([a.clone(), b.clone()]);
             let bc = shape.edges().add_line_segment([b.clone(), c.clone()]);

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -29,7 +29,7 @@ pub fn sweep_shape(
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.vertices().all() {
-        let point = vertex_orig.point + path;
+        let point = vertex_orig.point() + path;
         let vertex = shape.vertices().add(Vertex { point });
         vertices.insert(vertex_orig, vertex);
     }
@@ -191,7 +191,9 @@ mod tests {
             });
 
             let surface = shape.geometry().add_surface(Surface::Swept(
-                Swept::plane_from_points([a, b, c].map(|vertex| vertex.point)),
+                Swept::plane_from_points(
+                    [a, b, c].map(|vertex| vertex.point()),
+                ),
             ));
             let abc = Face::Face {
                 surface,

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -28,7 +28,8 @@ pub fn sweep_shape(
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.vertices().all() {
-        let vertex = shape.vertices().add(vertex_orig.point + path);
+        let point = vertex_orig.point + path;
+        let vertex = shape.vertices().add(point);
         vertices.insert(vertex_orig, vertex);
     }
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -6,6 +6,7 @@ use crate::{
         topology::{
             edges::{Cycle, Edge},
             faces::Face,
+            vertices::Vertex,
         },
     },
     math::{Scalar, Transform, Vector},
@@ -29,7 +30,7 @@ pub fn sweep_shape(
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.vertices().all() {
         let point = vertex_orig.point + path;
-        let vertex = shape.vertices().add(point);
+        let vertex = shape.vertices().add(Vertex { point });
         vertices.insert(vertex_orig, vertex);
     }
 
@@ -140,7 +141,7 @@ mod tests {
         kernel::{
             geometry::{surfaces::Swept, Surface},
             shape::{handle::Handle, Shape},
-            topology::{edges::Cycle, faces::Face},
+            topology::{edges::Cycle, faces::Face, vertices::Vertex},
         },
         math::{Point, Scalar, Vector},
     };
@@ -177,9 +178,9 @@ mod tests {
         fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> Self {
             let mut shape = Shape::new();
 
-            let a = shape.vertices().add(a.into());
-            let b = shape.vertices().add(b.into());
-            let c = shape.vertices().add(c.into());
+            let a = shape.vertices().add(Vertex { point: a.into() });
+            let b = shape.vertices().add(Vertex { point: b.into() });
+            let c = shape.vertices().add(Vertex { point: c.into() });
 
             let ab = shape.edges().add_line_segment([a.clone(), b.clone()]);
             let bc = shape.edges().add_line_segment([b.clone(), c.clone()]);

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -3,7 +3,7 @@ use crate::{
         shape::Shape,
         topology::{
             edges::{Cycle, Edge},
-            faces::Face,
+            faces::Face, vertices::Vertex,
         },
     },
     math::Transform,
@@ -40,7 +40,7 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
                                 let point =
                                     transform.transform_point(&vertex.point);
 
-                                transformed.vertices().add(point)
+                                transformed.vertices().add(Vertex { point })
                             })
                         });
 

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -3,7 +3,8 @@ use crate::{
         shape::Shape,
         topology::{
             edges::{Cycle, Edge},
-            faces::Face, vertices::Vertex,
+            faces::Face,
+            vertices::Vertex,
         },
     },
     math::Transform,
@@ -38,7 +39,7 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
                         let vertices = edge.vertices.clone().map(|vertices| {
                             vertices.map(|vertex| {
                                 let point =
-                                    transform.transform_point(&vertex.point);
+                                    transform.transform_point(&vertex.point());
 
                                 transformed.vertices().add(Vertex { point })
                             })

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -38,8 +38,9 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
 
                         let vertices = edge.vertices.clone().map(|vertices| {
                             vertices.map(|vertex| {
-                                let point =
-                                    transform.transform_point(&vertex.point());
+                                let point = transformed.geometry().add_point(
+                                    transform.transform_point(&vertex.point()),
+                                );
 
                                 transformed.vertices().add(Vertex { point })
                             })

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -56,8 +56,11 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new();
 
-        let a = shape.vertices().add(Point::from([0., 0., 0.]));
-        let b = shape.vertices().add(Point::from([1., 0., 0.]));
+        let a = Point::from([0., 0., 0.]);
+        let b = Point::from([1., 0., 0.]);
+
+        let a = shape.vertices().add(a);
+        let b = shape.vertices().add(b);
 
         let edge = shape.edges().add_line_segment([a, b]);
 
@@ -70,8 +73,11 @@ mod tests {
         let mut shape = Shape::new();
         let mut other = Shape::new();
 
-        let a = other.vertices().add(Point::from([0., 0., 0.]));
-        let b = other.vertices().add(Point::from([1., 0., 0.]));
+        let a = Point::from([0., 0., 0.]);
+        let b = Point::from([1., 0., 0.]);
+
+        let a = other.vertices().add(a);
+        let b = other.vertices().add(b);
 
         let edge = other.edges().add_line_segment([a, b]);
 

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -48,7 +48,10 @@ impl Cycles<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        kernel::{shape::Shape, topology::edges::Cycle},
+        kernel::{
+            shape::Shape,
+            topology::{edges::Cycle, vertices::Vertex},
+        },
         math::Point,
     };
 
@@ -59,8 +62,8 @@ mod tests {
         let a = Point::from([0., 0., 0.]);
         let b = Point::from([1., 0., 0.]);
 
-        let a = shape.vertices().add(a);
-        let b = shape.vertices().add(b);
+        let a = shape.vertices().add(Vertex { point: a });
+        let b = shape.vertices().add(Vertex { point: b });
 
         let edge = shape.edges().add_line_segment([a, b]);
 
@@ -76,8 +79,8 @@ mod tests {
         let a = Point::from([0., 0., 0.]);
         let b = Point::from([1., 0., 0.]);
 
-        let a = other.vertices().add(a);
-        let b = other.vertices().add(b);
+        let a = other.vertices().add(Vertex { point: a });
+        let b = other.vertices().add(Vertex { point: b });
 
         let edge = other.edges().add_line_segment([a, b]);
 

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -59,8 +59,8 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new();
 
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([1., 0., 0.]);
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = shape.geometry().add_point(Point::from([1., 0., 0.]));
 
         let a = shape.vertices().add(Vertex { point: a });
         let b = shape.vertices().add(Vertex { point: b });
@@ -76,8 +76,8 @@ mod tests {
         let mut shape = Shape::new();
         let mut other = Shape::new();
 
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([1., 0., 0.]);
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = shape.geometry().add_point(Point::from([1., 0., 0.]));
 
         let a = other.vertices().add(Vertex { point: a });
         let b = other.vertices().add(Vertex { point: b });

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -76,7 +76,7 @@ impl Edges<'_> {
         vertices: [Handle<Vertex>; 2],
     ) -> Handle<Edge> {
         let curve = self.geometry.add_curve(Curve::Line(Line::from_points(
-            vertices.clone().map(|vertex| vertex.point),
+            vertices.clone().map(|vertex| vertex.point()),
         )));
         self.add(Edge {
             curve,

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -94,7 +94,10 @@ impl Edges<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{kernel::shape::Shape, math::Point};
+    use crate::{
+        kernel::{shape::Shape, topology::vertices::Vertex},
+        math::Point,
+    };
 
     #[test]
     fn add_valid() {
@@ -103,8 +106,8 @@ mod tests {
         let a = Point::from([0., 0., 0.]);
         let b = Point::from([1., 0., 0.]);
 
-        let a = shape.vertices().add(a);
-        let b = shape.vertices().add(b);
+        let a = shape.vertices().add(Vertex { point: a });
+        let b = shape.vertices().add(Vertex { point: b });
 
         shape.edges().add_line_segment([a, b]);
     }
@@ -118,8 +121,8 @@ mod tests {
         let a = Point::from([0., 0., 0.]);
         let b = Point::from([1., 0., 0.]);
 
-        let a = other.vertices().add(a);
-        let b = other.vertices().add(b);
+        let a = other.vertices().add(Vertex { point: a });
+        let b = other.vertices().add(Vertex { point: b });
 
         shape.edges().add_line_segment([a, b]);
     }

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -103,8 +103,8 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new();
 
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([1., 0., 0.]);
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = shape.geometry().add_point(Point::from([1., 0., 0.]));
 
         let a = shape.vertices().add(Vertex { point: a });
         let b = shape.vertices().add(Vertex { point: b });
@@ -118,8 +118,8 @@ mod tests {
         let mut shape = Shape::new();
         let mut other = Shape::new();
 
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([1., 0., 0.]);
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = shape.geometry().add_point(Point::from([1., 0., 0.]));
 
         let a = other.vertices().add(Vertex { point: a });
         let b = other.vertices().add(Vertex { point: b });

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -100,8 +100,11 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new();
 
-        let a = shape.vertices().add(Point::from([0., 0., 0.]));
-        let b = shape.vertices().add(Point::from([1., 0., 0.]));
+        let a = Point::from([0., 0., 0.]);
+        let b = Point::from([1., 0., 0.]);
+
+        let a = shape.vertices().add(a);
+        let b = shape.vertices().add(b);
 
         shape.edges().add_line_segment([a, b]);
     }
@@ -112,8 +115,11 @@ mod tests {
         let mut shape = Shape::new();
         let mut other = Shape::new();
 
-        let a = other.vertices().add(Point::from([0., 0., 0.]));
-        let b = other.vertices().add(Point::from([1., 0., 0.]));
+        let a = Point::from([0., 0., 0.]);
+        let b = Point::from([1., 0., 0.]);
+
+        let a = other.vertices().add(a);
+        let b = other.vertices().add(b);
 
         shape.edges().add_line_segment([a, b]);
     }

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -1,4 +1,7 @@
-use crate::kernel::geometry::{Curve, Surface};
+use crate::{
+    kernel::geometry::{Curve, Surface},
+    math::Point,
+};
 
 use super::handle::{Handle, Storage};
 
@@ -6,6 +9,11 @@ use super::handle::{Handle, Storage};
 pub struct Geometry;
 
 impl Geometry {
+    /// Add a point to the shape
+    pub fn add_point(&mut self, point: Point<3>) -> Handle<Point<3>> {
+        Storage::new(point).handle()
+    }
+
     /// Add a curve to the shape
     pub fn add_curve(&mut self, curve: Curve) -> Handle<Curve> {
         Storage::new(curve).handle()

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -76,8 +76,11 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        shape.vertices().add(Point::from([0., 0., 0.]));
-        shape.vertices().add(Point::from([5e-6, 0., 0.]));
+        let a = Point::from([0., 0., 0.]);
+        let b = Point::from([5e-6, 0., 0.]);
+
+        shape.vertices().add(a);
+        shape.vertices().add(b);
     }
 
     #[test]
@@ -89,7 +92,10 @@ mod tests {
 
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        shape.vertices().add(Point::from([0., 0., 0.]));
-        shape.vertices().add(Point::from([5e-8, 0., 0.]));
+        let a = Point::from([0., 0., 0.]);
+        let b = Point::from([5e-8, 0., 0.]);
+
+        shape.vertices().add(a);
+        shape.vertices().add(b);
     }
 }

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -77,8 +77,8 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([5e-6, 0., 0.]);
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = shape.geometry().add_point(Point::from([5e-6, 0., 0.]));
 
         shape.vertices().add(Vertex { point: a });
         shape.vertices().add(Vertex { point: b });
@@ -93,8 +93,8 @@ mod tests {
 
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([5e-8, 0., 0.]);
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = shape.geometry().add_point(Point::from([5e-8, 0., 0.]));
 
         shape.vertices().add(Vertex { point: a });
         shape.vertices().add(Vertex { point: b });

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -68,7 +68,10 @@ impl Vertices<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{kernel::shape::Shape, math::Point};
+    use crate::{
+        kernel::{shape::Shape, topology::vertices::Vertex},
+        math::Point,
+    };
 
     const MIN_DISTANCE: f64 = 5e-7;
 
@@ -79,8 +82,8 @@ mod tests {
         let a = Point::from([0., 0., 0.]);
         let b = Point::from([5e-6, 0., 0.]);
 
-        shape.vertices().add(a);
-        shape.vertices().add(b);
+        shape.vertices().add(Vertex { point: a });
+        shape.vertices().add(Vertex { point: b });
     }
 
     #[test]
@@ -95,7 +98,7 @@ mod tests {
         let a = Point::from([0., 0., 0.]);
         let b = Point::from([5e-8, 0., 0.]);
 
-        shape.vertices().add(a);
-        shape.vertices().add(b);
+        shape.vertices().add(Vertex { point: a });
+        shape.vertices().add(Vertex { point: b });
     }
 }

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -33,9 +33,7 @@ impl Vertices<'_> {
     /// In the future, this method is likely to validate more than just vertex
     /// uniqueness. See documentation of [`crate::kernel`] for some context on
     /// that.
-    pub fn add(&mut self, vertex: impl Into<Vertex>) -> Handle<Vertex> {
-        let vertex = vertex.into();
-
+    pub fn add(&mut self, vertex: Vertex) -> Handle<Vertex> {
         // Make sure the new vertex is a minimum distance away from all existing
         // vertices. This minimum distance is defined to be half a µm, which
         // should provide more than enough precision for common use cases, while

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -39,7 +39,7 @@ impl Vertices<'_> {
         // should provide more than enough precision for common use cases, while
         // being large enough to catch all invalid cases.
         for existing in &*self.vertices {
-            let distance = (existing.point - vertex.point).magnitude();
+            let distance = (existing.point() - vertex.point()).magnitude();
 
             if distance < self.min_distance {
                 warn!(

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -55,9 +55,9 @@ impl ToShape for fj::Difference2d {
 
                 let vertices = edge.vertices.clone().map(|vs| {
                     vs.map(|vertex| {
-                        let vertex = *vertex.get();
+                        let vertex = vertex.get().clone();
                         vertices
-                            .entry(vertex)
+                            .entry(vertex.clone())
                             .or_insert_with(|| shape.vertices().add(vertex))
                             .clone()
                     })

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -3,7 +3,7 @@ use crate::{
     kernel::{
         geometry::Surface,
         shape::Shape,
-        topology::{edges::Cycle, faces::Face},
+        topology::{edges::Cycle, faces::Face, vertices::Vertex},
     },
     math::{Aabb, Point, Scalar},
 };
@@ -17,7 +17,7 @@ impl ToShape for fj::Sketch {
 
         for [x, y] in self.to_points() {
             let point = Point::from([x, y, 0.]);
-            let vertex = shape.vertices().add(point);
+            let vertex = shape.vertices().add(Vertex { point });
             vertices.push(vertex);
         }
 

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -16,7 +16,8 @@ impl ToShape for fj::Sketch {
         let mut vertices = Vec::new();
 
         for [x, y] in self.to_points() {
-            let vertex = shape.vertices().add(Point::from([x, y, 0.]));
+            let point = Point::from([x, y, 0.]);
+            let vertex = shape.vertices().add(point);
             vertices.push(vertex);
         }
 

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -16,7 +16,7 @@ impl ToShape for fj::Sketch {
         let mut vertices = Vec::new();
 
         for [x, y] in self.to_points() {
-            let point = Point::from([x, y, 0.]);
+            let point = shape.geometry().add_point(Point::from([x, y, 0.]));
             let vertex = shape.vertices().add(Vertex { point });
             vertices.push(vertex);
         }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -8,7 +8,7 @@ use crate::math::Point;
 ///
 /// Points, on the other hand, might be used to approximate a shape for various
 /// purposes, without presenting any deeper truth about the shape's structure.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     pub point: Point<3>,
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -12,3 +12,10 @@ use crate::math::Point;
 pub struct Vertex {
     pub point: Point<3>,
 }
+
+impl Vertex {
+    /// Access the point of the vertex
+    pub fn point(&self) -> Point<3> {
+        self.point
+    }
+}

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,4 +1,4 @@
-use crate::math::Point;
+use crate::{kernel::shape::handle::Handle, math::Point};
 
 /// A vertex
 ///
@@ -10,12 +10,12 @@ use crate::math::Point;
 /// purposes, without presenting any deeper truth about the shape's structure.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
-    pub point: Point<3>,
+    pub point: Handle<Point<3>>,
 }
 
 impl Vertex {
     /// Access the point of the vertex
     pub fn point(&self) -> Point<3> {
-        self.point
+        *self.point.get()
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -12,9 +12,3 @@ use crate::math::Point;
 pub struct Vertex {
     pub point: Point<3>,
 }
-
-impl From<Point<3>> for Vertex {
-    fn from(point: Point<3>) -> Self {
-        Self { point }
-    }
-}

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -14,7 +14,10 @@ pub struct Vertex {
 }
 
 impl Vertex {
-    /// Access the point of the vertex
+    /// Access the point that the vertex refers to
+    ///
+    /// This is a convenience method that saves the caller from dealing with the
+    /// `Handle`.
     pub fn point(&self) -> Point<3> {
         *self.point.get()
     }


### PR DESCRIPTION
This makes the handling of geometry and topology much more consistent. All geometry and topology is now tracked in `Shape`, explicitly, and all topology types refer to their geometry using `Handle`s.

It comes of the cost of convenience though, and by itself, this might not be a worthwhile trade-off. But I'm working on changes that require all geometry to be updated at once (as part of #280). This pull request paves the way for that.