### PR TITLE
Use preferred color format

### DIFF
--- a/src/graphics/config_ui.rs
+++ b/src/graphics/config_ui.rs
@@ -8,7 +8,7 @@ use wgpu_glyph::{
 
 use crate::math::Aabb;
 
-use super::{draw_config::DrawConfig, COLOR_FORMAT};
+use super::draw_config::DrawConfig;
 
 #[derive(Debug)]
 pub struct ConfigUi {
@@ -17,11 +17,14 @@ pub struct ConfigUi {
 }
 
 impl ConfigUi {
-    pub fn new(device: &wgpu::Device) -> Result<Self, InvalidFont> {
+    pub fn new(
+        device: &wgpu::Device,
+        color_format: wgpu::TextureFormat,
+    ) -> Result<Self, InvalidFont> {
         let font =
             FontArc::try_from_slice(include_bytes!("fonts/B612-Bold.ttf"))?;
         let glyph_brush =
-            GlyphBrushBuilder::using_font(font).build(device, COLOR_FORMAT);
+            GlyphBrushBuilder::using_font(font).build(device, color_format);
 
         let mut texts = HashMap::new();
         for element in Element::elements() {

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -14,5 +14,4 @@ pub use self::{
     renderer::{DrawError, Renderer},
 };
 
-const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8UnormSrgb;
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;

--- a/src/graphics/pipelines.rs
+++ b/src/graphics/pipelines.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use super::{
     shaders::{Shader, Shaders},
     vertices::Vertex,
-    COLOR_FORMAT, DEPTH_FORMAT,
+    DEPTH_FORMAT,
 };
 
 #[derive(Debug)]
@@ -17,6 +17,7 @@ impl Pipelines {
     pub fn new(
         device: &wgpu::Device,
         bind_group_layout: &wgpu::BindGroupLayout,
+        color_format: wgpu::TextureFormat,
     ) -> Self {
         let pipeline_layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -34,6 +35,7 @@ impl Pipelines {
                 shaders.model(),
                 wgpu::PrimitiveTopology::TriangleList,
                 wgpu::PolygonMode::Fill,
+                color_format,
             ),
             mesh: Pipeline::new(
                 device,
@@ -41,6 +43,7 @@ impl Pipelines {
                 shaders.mesh(),
                 wgpu::PrimitiveTopology::TriangleList,
                 wgpu::PolygonMode::Line,
+                color_format,
             ),
             lines: Pipeline::new(
                 device,
@@ -48,6 +51,7 @@ impl Pipelines {
                 shaders.lines(),
                 wgpu::PrimitiveTopology::LineList,
                 wgpu::PolygonMode::Line,
+                color_format,
             ),
         }
     }
@@ -63,6 +67,7 @@ impl Pipeline {
         shader: Shader,
         topology: wgpu::PrimitiveTopology,
         polygon_mode: wgpu::PolygonMode,
+        color_format: wgpu::TextureFormat,
     ) -> Self {
         let pipeline =
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -111,7 +116,7 @@ impl Pipeline {
                     module: shader.module,
                     entry_point: shader.frag_entry,
                     targets: &[wgpu::ColorTargetState {
-                        format: COLOR_FORMAT,
+                        format: color_format,
                         blend: Some(
                             wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
                         ),

--- a/src/graphics/renderer.rs
+++ b/src/graphics/renderer.rs
@@ -11,7 +11,7 @@ use crate::{camera::Camera, math::Aabb, math::Point, window::Window};
 use super::{
     config_ui::ConfigUi, draw_config::DrawConfig, drawables::Drawables,
     geometries::Geometries, pipelines::Pipelines, transform::Transform,
-    uniforms::Uniforms, vertices::Vertices, COLOR_FORMAT, DEPTH_FORMAT,
+    uniforms::Uniforms, vertices::Vertices, DEPTH_FORMAT,
 };
 
 #[derive(Debug)]
@@ -65,9 +65,13 @@ impl Renderer {
             )
             .await?;
 
+        let color_format = surface
+            .get_preferred_format(&adapter)
+            .expect("Error determining preferred color format");
+
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            format: COLOR_FORMAT,
+            format: color_format,
             width: window.width(),
             height: window.height(),
             present_mode: wgpu::PresentMode::Fifo,
@@ -123,9 +127,10 @@ impl Renderer {
                 max: Point::from([0.0, 0.0, 0.0]),
             },
         );
-        let pipelines = Pipelines::new(&device, &bind_group_layout);
+        let pipelines =
+            Pipelines::new(&device, &bind_group_layout, color_format);
 
-        let config_ui = ConfigUi::new(&device)?;
+        let config_ui = ConfigUi::new(&device, color_format)?;
 
         Ok(Self {
             surface,


### PR DESCRIPTION
The hardcoded color format seems to only work for specific hardware.
This might be more widely usable.