### PR TITLE
Improve correctness of 2D difference result

### DIFF
--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -44,11 +44,11 @@ impl ToShape for fj::Difference2d {
         }
 
         // Can't panic, as we just verified that both shapes have one cycle.
-        let cycles =
+        let cycles_orig =
             [&mut a, &mut b].map(|shape| shape.cycles().all().next().unwrap());
 
         let mut vertices = HashMap::new();
-        for cycle in cycles {
+        for cycle in cycles_orig {
             let mut edges = Vec::new();
             for edge in &cycle.edges {
                 let curve = shape.geometry().add_curve(edge.curve());

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -48,6 +48,8 @@ impl ToShape for fj::Difference2d {
             [&mut a, &mut b].map(|shape| shape.cycles().all().next().unwrap());
 
         let mut vertices = HashMap::new();
+        let mut cycles = Vec::new();
+
         for cycle in cycles_orig {
             let mut edges = Vec::new();
             for edge in &cycle.edges {
@@ -66,25 +68,24 @@ impl ToShape for fj::Difference2d {
                 edges.push(edge);
             }
 
-            shape.cycles().add(Cycle { edges });
+            let cycle = shape.cycles().add(Cycle { edges });
+            cycles.push(cycle);
         }
 
         // Can't panic, as we just verified that both shapes have one face.
         let [face_a, face_b] =
             [&mut a, &mut b].map(|shape| shape.faces().all().next().unwrap());
 
-        let (cycles_a, cycles_b, surface_a, surface_b) =
+        let (surface_a, surface_b) =
             match (face_a.get().clone(), face_b.get().clone()) {
                 (
                     Face::Face {
-                        cycles: a,
-                        surface: surface_a,
+                        surface: surface_a, ..
                     },
                     Face::Face {
-                        cycles: b,
-                        surface: surface_b,
+                        surface: surface_b, ..
                     },
-                ) => (a, b, surface_a, surface_b),
+                ) => (surface_a, surface_b),
                 _ => {
                     // None of the 2D types still use triangle representation.
                     unreachable!()
@@ -96,9 +97,6 @@ impl ToShape for fj::Difference2d {
             "Trying to subtract sketches with different surfaces."
         );
         let surface = surface_a;
-
-        let mut cycles = cycles_a;
-        cycles.extend(cycles_b);
 
         shape.faces().add(Face::Face { cycles, surface });
 


### PR DESCRIPTION
This is another problem that I found as I'm working towards #280. This case would be caught by doing structural validation of faces, which I have added in my local WIP branch. That work isn't quite ready to merge yet, which is why it isn't part of this pull request. I will get it merged later though, so this error can't be re-introduced.