### PR TITLE
Properly define equality of topological types and handles

### DIFF
--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -158,12 +158,29 @@ mod tests {
             Scalar::from_f64(0.),
         );
 
-        let bottom_face = sketch.face;
+        let bottom_face = sketch.face.get().clone();
         let top_face =
-            Triangle::new([[0., 0., 1.], [1., 0., 1.], [0., 1., 1.]]).face;
+            Triangle::new([[0., 0., 1.], [1., 0., 1.], [0., 1., 1.]])
+                .face
+                .get()
+                .clone();
 
-        assert!(swept.faces().contains(&bottom_face));
-        assert!(swept.faces().contains(&top_face));
+        let mut contains_bottom_face = false;
+        let mut contains_top_face = false;
+
+        for face in swept.faces().all() {
+            if matches!(face.get(), Face::Face { .. }) {
+                if face.get().clone() == bottom_face {
+                    contains_bottom_face = true;
+                }
+                if face.get().clone() == top_face {
+                    contains_top_face = true;
+                }
+            }
+        }
+
+        assert!(contains_bottom_face);
+        assert!(contains_top_face);
 
         // Side faces are not tested, as those use triangle representation. The
         // plan is to start testing them, as they are transitioned to b-rep.

--- a/src/kernel/shape/faces.rs
+++ b/src/kernel/shape/faces.rs
@@ -25,12 +25,6 @@ impl Faces<'_> {
         handle
     }
 
-    /// Check whether the shape contains a specific face
-    #[cfg(test)]
-    pub fn contains(&self, face: &Face) -> bool {
-        self.faces.contains(&Storage::new(face.clone()))
-    }
-
     /// Access an iterator over all faces
     pub fn all(&self) -> impl Iterator<Item = Handle<Face>> + '_ {
         self.faces.iter().map(|storage| storage.handle())

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -1,4 +1,8 @@
-use std::{hash::Hash, ops::Deref, rc::Rc};
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+    rc::Rc,
+};
 
 /// A handle to an object stored within [`Shape`]
 ///
@@ -44,7 +48,7 @@ impl<T> Deref for Handle<T> {
 }
 
 /// Internal type used in collections within [`Shape`]
-#[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Eq, Ord, PartialOrd)]
 pub(super) struct Storage<T>(Rc<T>);
 
 impl<T> Storage<T> {
@@ -73,5 +77,17 @@ impl<T> Deref for Storage<T> {
 impl<T> Clone for Storage<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
+    }
+}
+
+impl<T> PartialEq for Storage<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<T> Hash for Storage<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Rc::as_ptr(&self.0).hash(state);
     }
 }

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -67,6 +67,10 @@ impl<T> Storage<T> {
     pub(super) fn handle(&self) -> Handle<T> {
         Handle(self.clone())
     }
+
+    fn ptr(&self) -> *const T {
+        Rc::as_ptr(&self.0)
+    }
 }
 
 impl<T> Deref for Storage<T> {
@@ -94,6 +98,6 @@ impl<T> PartialEq for Storage<T> {
 
 impl<T> Hash for Storage<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        Rc::as_ptr(&self.0).hash(state);
+        self.ptr().hash(state);
     }
 }

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     hash::{Hash, Hasher},
     ops::Deref,
     rc::Rc,
@@ -27,7 +28,7 @@ use std::{
 /// The equality of [`Handle`] is very strictly defined in terms of identity.
 /// Two [`Handle`]s are considered equal, if they refer to objects in the same
 /// memory location.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Handle<T>(Storage<T>);
 
 impl<T> Handle<T> {
@@ -50,6 +51,15 @@ impl<T> Deref for Handle<T> {
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
+    }
+}
+
+impl<T> fmt::Debug for Handle<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: {:?}", self.0.ptr(), self.get())
     }
 }
 

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -21,6 +21,12 @@ use std::{
 ///    any other way. This means that if the `Shape` needs to be modified, any
 ///    objects can be updated once, without requiring an update of all the other
 ///    objects that reference it.
+///
+/// # Equality
+///
+/// The equality of [`Handle`] is very strictly defined in terms of identity.
+/// Two [`Handle`]s are considered equal, if they refer to objects in the same
+/// memory location.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Handle<T>(Storage<T>);
 

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -76,24 +76,16 @@ impl ToShape for fj::Difference2d {
         let [face_a, face_b] =
             [&mut a, &mut b].map(|shape| shape.faces().all().next().unwrap());
 
-        let (surface_a, surface_b) =
-            match (face_a.get().clone(), face_b.get().clone()) {
-                (
-                    Face::Face {
-                        surface: surface_a, ..
-                    },
-                    Face::Face {
-                        surface: surface_b, ..
-                    },
-                ) => (surface_a, surface_b),
-                _ => {
-                    // None of the 2D types still use triangle representation.
-                    unreachable!()
-                }
-            };
+        let surface_a = match (face_a.get().clone(), face_b.get().clone()) {
+            (Face::Face { surface, .. }, Face::Face { .. }) => surface,
+            _ => {
+                // None of the 2D types still use triangle representation.
+                unreachable!()
+            }
+        };
 
         assert!(
-            surface_a == surface_b,
+            face_a.surface() == face_b.surface(),
             "Trying to subtract sketches with different surfaces."
         );
         let surface = surface_a;

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -9,6 +9,11 @@ use super::vertices::Vertex;
 /// The end of each edge in the cycle must connect to the beginning of the next
 /// edge. The end of the last edge must connect to the beginning of the first
 /// one.
+///
+/// # Equality
+///
+/// Please refer to [`crate::kernel::topology`] for documentation on the
+/// equality of topological objects.
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Cycle {
     pub edges: Vec<Handle<Edge>>,
@@ -39,6 +44,11 @@ impl Hash for Cycle {
 }
 
 /// An edge of a shape
+///
+/// # Equality
+///
+/// Please refer to [`crate::kernel::topology`] for documentation on the
+/// equality of topological objects.
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Edge {
     /// Access the curve that defines the edge's geometry

--- a/src/kernel/topology/edges.rs
+++ b/src/kernel/topology/edges.rs
@@ -1,3 +1,5 @@
+use std::hash::{Hash, Hasher};
+
 use crate::kernel::{geometry::Curve, shape::handle::Handle};
 
 use super::vertices::Vertex;
@@ -7,7 +9,7 @@ use super::vertices::Vertex;
 /// The end of each edge in the cycle must connect to the beginning of the next
 /// edge. The end of the last edge must connect to the beginning of the first
 /// one.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Cycle {
     pub edges: Vec<Handle<Edge>>,
 }
@@ -22,8 +24,22 @@ impl Cycle {
     }
 }
 
+impl PartialEq for Cycle {
+    fn eq(&self, other: &Self) -> bool {
+        self.edges().eq(other.edges())
+    }
+}
+
+impl Hash for Cycle {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for edge in self.edges() {
+            edge.hash(state);
+        }
+    }
+}
+
 /// An edge of a shape
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Edge {
     /// Access the curve that defines the edge's geometry
     ///
@@ -66,5 +82,18 @@ impl Edge {
         self.vertices
             .as_ref()
             .map(|[a, b]| [a.get().clone(), b.get().clone()])
+    }
+}
+
+impl PartialEq for Edge {
+    fn eq(&self, other: &Self) -> bool {
+        self.curve() == other.curve() && self.vertices() == other.vertices()
+    }
+}
+
+impl Hash for Edge {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.curve().hash(state);
+        self.vertices().hash(state);
     }
 }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -1,4 +1,7 @@
-use std::collections::BTreeSet;
+use std::{
+    collections::BTreeSet,
+    hash::{Hash, Hasher},
+};
 
 use parry2d_f64::query::{Ray as Ray2, RayCast as _};
 use parry3d_f64::query::Ray as Ray3;
@@ -18,7 +21,7 @@ use crate::{
 use super::edges::Cycle;
 
 /// A face of a shape
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub enum Face {
     /// A face of a shape
     ///
@@ -219,6 +222,21 @@ impl Face {
                 }));
             }
             Self::Triangles(triangles) => out.extend(triangles),
+        }
+    }
+}
+
+impl PartialEq for Face {
+    fn eq(&self, other: &Self) -> bool {
+        self.surface() == other.surface() && self.cycles().eq(other.cycles())
+    }
+}
+
+impl Hash for Face {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.surface().hash(state);
+        for cycle in self.cycles() {
+            cycle.hash(state);
         }
     }
 }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -21,6 +21,11 @@ use crate::{
 use super::edges::Cycle;
 
 /// A face of a shape
+///
+/// # Equality
+///
+/// Please refer to [`crate::kernel::topology`] for documentation on the
+/// equality of topological objects.
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub enum Face {
     /// A face of a shape

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -1,3 +1,12 @@
+//! Topological objects
+//!
+//! # Equality
+//!
+//! Equality of topological objects is defined in terms of the geometry they
+//! refer to. That means two topological objects that refer to identical
+//! geometry are considered equal, even if they contain [`Handle`]s that refer
+//! to objects in different [`Shape`] instances.
+
 pub mod edges;
 pub mod faces;
 pub mod vertices;

--- a/src/kernel/topology/mod.rs
+++ b/src/kernel/topology/mod.rs
@@ -6,6 +6,10 @@
 //! refer to. That means two topological objects that refer to identical
 //! geometry are considered equal, even if they contain [`Handle`]s that refer
 //! to objects in different [`Shape`] instances.
+//!
+//! This is different from the equality of [`Handle`], which follows a strict
+//! definition of identity. Two [`Handle`]s are only considered equal, if they
+//! refer to objects in the same memory location.
 
 pub mod edges;
 pub mod faces;

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use crate::{kernel::shape::handle::Handle, math::Point};
 
 /// A vertex
@@ -8,7 +10,7 @@ use crate::{kernel::shape::handle::Handle, math::Point};
 ///
 /// Points, on the other hand, might be used to approximate a shape for various
 /// purposes, without presenting any deeper truth about the shape's structure.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Vertex {
     pub point: Handle<Point<3>>,
 }
@@ -20,5 +22,17 @@ impl Vertex {
     /// [`Handle`].
     pub fn point(&self) -> Point<3> {
         *self.point.get()
+    }
+}
+
+impl PartialEq for Vertex {
+    fn eq(&self, other: &Self) -> bool {
+        self.point() == other.point()
+    }
+}
+
+impl Hash for Vertex {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.point().hash(state);
     }
 }

--- a/src/kernel/topology/vertices.rs
+++ b/src/kernel/topology/vertices.rs
@@ -10,6 +10,11 @@ use crate::{kernel::shape::handle::Handle, math::Point};
 ///
 /// Points, on the other hand, might be used to approximate a shape for various
 /// purposes, without presenting any deeper truth about the shape's structure.
+///
+/// # Equality
+///
+/// Please refer to [`crate::kernel::topology`] for documentation on the
+/// equality of topological objects.
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Vertex {
     pub point: Handle<Point<3>>,


### PR DESCRIPTION
In this pull request, `Handle` equality is defined in terms of memory locations. This means that handles that refer to objects in different shapes are considered not equal, even if the objects they refer to are considered equal. That is was different before was weird, and has masked at least one shape correctness problem that I fixed in a previous pull request.

Topological objects contain `Handle`s to refer to other objects, but having them be considered not equal due to their `Handle`s being considered not equal, would be a problem, and would make comparing them very inconvenient. For this reason, they are now defined in terms of the objects they refer to, not the `Handle`s used to refer to those objects.

This cleanup came out of my work on #280.