### PR TITLE
Improve error validation infrastructure of `Shape` API

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -157,11 +157,11 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.geometry().add_point(a);
-        let v2 = shape.geometry().add_point(d);
+        let v1 = shape.geometry().add_point(a).unwrap();
+        let v2 = shape.geometry().add_point(d).unwrap();
 
-        let v1 = shape.vertices().add(Vertex { point: v1 });
-        let v2 = shape.vertices().add(Vertex { point: v2 });
+        let v1 = shape.vertices().add(Vertex { point: v1 }).unwrap();
+        let v2 = shape.vertices().add(Vertex { point: v2 }).unwrap();
 
         let points = vec![b, c];
 
@@ -201,17 +201,20 @@ mod tests {
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
 
-        let v1 = shape.geometry().add_point(a);
-        let v2 = shape.geometry().add_point(b);
-        let v3 = shape.geometry().add_point(c);
+        let v1 = shape.geometry().add_point(a).unwrap();
+        let v2 = shape.geometry().add_point(b).unwrap();
+        let v3 = shape.geometry().add_point(c).unwrap();
 
-        let v1 = shape.vertices().add(Vertex { point: v1 });
-        let v2 = shape.vertices().add(Vertex { point: v2 });
-        let v3 = shape.vertices().add(Vertex { point: v3 });
+        let v1 = shape.vertices().add(Vertex { point: v1 }).unwrap();
+        let v2 = shape.vertices().add(Vertex { point: v2 }).unwrap();
+        let v3 = shape.vertices().add(Vertex { point: v3 }).unwrap();
 
-        let ab = shape.edges().add_line_segment([v1.clone(), v2.clone()]);
-        let bc = shape.edges().add_line_segment([v2, v3.clone()]);
-        let ca = shape.edges().add_line_segment([v3, v1]);
+        let ab = shape
+            .edges()
+            .add_line_segment([v1.clone(), v2.clone()])
+            .unwrap();
+        let bc = shape.edges().add_line_segment([v2, v3.clone()]).unwrap();
+        let ca = shape.edges().add_line_segment([v3, v1]).unwrap();
 
         let cycle = Cycle {
             edges: vec![ab, bc, ca],
@@ -243,26 +246,33 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.geometry().add_point(a);
-        let v2 = shape.geometry().add_point(b);
-        let v3 = shape.geometry().add_point(c);
-        let v4 = shape.geometry().add_point(d);
+        let v1 = shape.geometry().add_point(a).unwrap();
+        let v2 = shape.geometry().add_point(b).unwrap();
+        let v3 = shape.geometry().add_point(c).unwrap();
+        let v4 = shape.geometry().add_point(d).unwrap();
 
-        let v1 = shape.vertices().add(Vertex { point: v1 });
-        let v2 = shape.vertices().add(Vertex { point: v2 });
-        let v3 = shape.vertices().add(Vertex { point: v3 });
-        let v4 = shape.vertices().add(Vertex { point: v4 });
+        let v1 = shape.vertices().add(Vertex { point: v1 }).unwrap();
+        let v2 = shape.vertices().add(Vertex { point: v2 }).unwrap();
+        let v3 = shape.vertices().add(Vertex { point: v3 }).unwrap();
+        let v4 = shape.vertices().add(Vertex { point: v4 }).unwrap();
 
-        let ab = shape.edges().add_line_segment([v1.clone(), v2.clone()]);
-        let bc = shape.edges().add_line_segment([v2, v3.clone()]);
-        let cd = shape.edges().add_line_segment([v3, v4.clone()]);
-        let da = shape.edges().add_line_segment([v4, v1]);
+        let ab = shape
+            .edges()
+            .add_line_segment([v1.clone(), v2.clone()])
+            .unwrap();
+        let bc = shape.edges().add_line_segment([v2, v3.clone()]).unwrap();
+        let cd = shape.edges().add_line_segment([v3, v4.clone()]).unwrap();
+        let da = shape.edges().add_line_segment([v4, v1]).unwrap();
 
-        let abcd = shape.cycles().add(Cycle {
-            edges: vec![ab, bc, cd, da],
-        });
+        let abcd = shape
+            .cycles()
+            .add(Cycle {
+                edges: vec![ab, bc, cd, da],
+            })
+            .unwrap();
 
-        let surface = shape.geometry().add_surface(Surface::x_y_plane());
+        let surface =
+            shape.geometry().add_surface(Surface::x_y_plane()).unwrap();
         let face = Face::Face {
             surface,
             cycles: vec![abcd],

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -29,8 +29,11 @@ pub fn sweep_shape(
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.vertices().all() {
-        let point = shape.geometry().add_point(vertex_orig.point() + path);
-        let vertex = shape.vertices().add(Vertex { point });
+        let point = shape
+            .geometry()
+            .add_point(vertex_orig.point() + path)
+            .unwrap();
+        let vertex = shape.vertices().add(Vertex { point }).unwrap();
         vertices.insert(vertex_orig, vertex);
     }
 
@@ -39,7 +42,8 @@ pub fn sweep_shape(
     for edge_orig in shape_orig.edges().all() {
         let curve = shape
             .geometry()
-            .add_curve(edge_orig.curve().transform(&translation));
+            .add_curve(edge_orig.curve().transform(&translation))
+            .unwrap();
 
         let vertices = edge_orig.vertices.clone().map(|vs| {
             vs.map(|vertex_orig| {
@@ -49,7 +53,7 @@ pub fn sweep_shape(
             })
         });
 
-        let edge = shape.edges().add(Edge { curve, vertices });
+        let edge = shape.edges().add(Edge { curve, vertices }).unwrap();
         edges.insert(edge_orig, edge);
     }
 
@@ -66,7 +70,7 @@ pub fn sweep_shape(
             })
             .collect();
 
-        let cycle = shape.cycles().add(Cycle { edges });
+        let cycle = shape.cycles().add(Cycle { edges }).unwrap();
         cycles.insert(cycle_orig, cycle);
     }
 
@@ -83,7 +87,8 @@ pub fn sweep_shape(
 
         let surface = shape
             .geometry()
-            .add_surface(face_orig.surface().transform(&translation));
+            .add_surface(face_orig.surface().transform(&translation))
+            .unwrap();
 
         let cycles = cycles_orig
             .iter()
@@ -94,7 +99,7 @@ pub fn sweep_shape(
             })
             .collect();
 
-        shape.faces().add(Face::Face { surface, cycles });
+        shape.faces().add(Face::Face { surface, cycles }).unwrap();
     }
 
     // We could use `vertices` to create the side edges and faces here, but the
@@ -129,7 +134,7 @@ pub fn sweep_shape(
     }
 
     for face in side_faces {
-        shape.faces().add(face);
+        shape.faces().add(face).unwrap();
     }
 
     shape
@@ -195,33 +200,46 @@ mod tests {
         fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> Self {
             let mut shape = Shape::new();
 
-            let a = shape.geometry().add_point(a.into());
-            let b = shape.geometry().add_point(b.into());
-            let c = shape.geometry().add_point(c.into());
+            let a = shape.geometry().add_point(a.into()).unwrap();
+            let b = shape.geometry().add_point(b.into()).unwrap();
+            let c = shape.geometry().add_point(c.into()).unwrap();
 
-            let a = shape.vertices().add(Vertex { point: a });
-            let b = shape.vertices().add(Vertex { point: b });
-            let c = shape.vertices().add(Vertex { point: c });
+            let a = shape.vertices().add(Vertex { point: a }).unwrap();
+            let b = shape.vertices().add(Vertex { point: b }).unwrap();
+            let c = shape.vertices().add(Vertex { point: c }).unwrap();
 
-            let ab = shape.edges().add_line_segment([a.clone(), b.clone()]);
-            let bc = shape.edges().add_line_segment([b.clone(), c.clone()]);
-            let ca = shape.edges().add_line_segment([c.clone(), a.clone()]);
+            let ab = shape
+                .edges()
+                .add_line_segment([a.clone(), b.clone()])
+                .unwrap();
+            let bc = shape
+                .edges()
+                .add_line_segment([b.clone(), c.clone()])
+                .unwrap();
+            let ca = shape
+                .edges()
+                .add_line_segment([c.clone(), a.clone()])
+                .unwrap();
 
-            let cycles = shape.cycles().add(Cycle {
-                edges: vec![ab, bc, ca],
-            });
+            let cycles = shape
+                .cycles()
+                .add(Cycle {
+                    edges: vec![ab, bc, ca],
+                })
+                .unwrap();
 
-            let surface = shape.geometry().add_surface(Surface::Swept(
-                Swept::plane_from_points(
+            let surface = shape
+                .geometry()
+                .add_surface(Surface::Swept(Swept::plane_from_points(
                     [a, b, c].map(|vertex| vertex.point()),
-                ),
-            ));
+                )))
+                .unwrap();
             let abc = Face::Face {
                 surface,
                 cycles: vec![cycles],
             };
 
-            let face = shape.faces().add(abc);
+            let face = shape.faces().add(abc).unwrap();
 
             Self { shape, face }
         }

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -34,35 +34,43 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
                     for edge in &cycle.edges {
                         let curve = transformed
                             .geometry()
-                            .add_curve(edge.curve().transform(transform));
+                            .add_curve(edge.curve().transform(transform))
+                            .unwrap();
 
                         let vertices =
                             edge.vertices().clone().map(|vertices| {
                                 vertices.map(|vertex| {
-                                    let point =
-                                        transformed.geometry().add_point(
+                                    let point = transformed
+                                        .geometry()
+                                        .add_point(
                                             transform.transform_point(
                                                 &vertex.point(),
                                             ),
-                                        );
+                                        )
+                                        .unwrap();
 
-                                    transformed.vertices().add(Vertex { point })
+                                    transformed
+                                        .vertices()
+                                        .add(Vertex { point })
+                                        .unwrap()
                                 })
                             });
 
                         let edge = Edge { curve, vertices };
-                        let edge = transformed.edges().add(edge);
+                        let edge = transformed.edges().add(edge).unwrap();
 
                         edges.push(edge);
                     }
 
-                    cycles_trans
-                        .push(transformed.cycles().add(Cycle { edges }));
+                    cycles_trans.push(
+                        transformed.cycles().add(Cycle { edges }).unwrap(),
+                    );
                 }
 
                 let surface = transformed
                     .geometry()
-                    .add_surface(surface.transform(transform));
+                    .add_surface(surface.transform(transform))
+                    .unwrap();
 
                 Face::Face {
                     cycles: cycles_trans,
@@ -78,7 +86,7 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
             }
         };
 
-        transformed.faces().add(face);
+        transformed.faces().add(face).unwrap();
     }
 
     transformed

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -2,7 +2,7 @@ use crate::kernel::topology::edges::Cycle;
 
 use super::{
     handle::{Handle, Storage},
-    CyclesInner, EdgesInner, ValidationResult,
+    CyclesInner, EdgesInner, ValidationError, ValidationResult,
 };
 
 /// The cycles of a shape
@@ -26,10 +26,9 @@ impl Cycles<'_> {
     /// - That there exists no duplicate cycle, with the same edges.
     pub fn add(&mut self, cycle: Cycle) -> ValidationResult<Cycle> {
         for edge in &cycle.edges {
-            assert!(
-                self.edges.contains(edge.storage()),
-                "Cycle validation failed: {edge:?} is not part of the shape",
-            );
+            if !self.edges.contains(edge.storage()) {
+                return Err(ValidationError::Structural);
+            }
         }
 
         let storage = Storage::new(cycle);
@@ -49,49 +48,54 @@ impl Cycles<'_> {
 mod tests {
     use crate::{
         kernel::{
-            shape::Shape,
-            topology::{edges::Cycle, vertices::Vertex},
+            shape::{handle::Handle, Shape, ValidationError},
+            topology::{
+                edges::{Cycle, Edge},
+                vertices::Vertex,
+            },
         },
         math::Point,
     };
 
     #[test]
     fn add() -> anyhow::Result<()> {
-        let mut shape = Shape::new();
+        struct TestShape {
+            inner: Shape,
+            edge: Handle<Edge>,
+        }
 
-        let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
-        let b = shape.geometry().add_point(Point::from([1., 0., 0.]))?;
+        impl TestShape {
+            fn new() -> anyhow::Result<Self> {
+                let mut inner = Shape::new();
 
-        let a = shape.vertices().add(Vertex { point: a })?;
-        let b = shape.vertices().add(Vertex { point: b })?;
+                let a =
+                    inner.geometry().add_point(Point::from([0., 0., 0.]))?;
+                let b =
+                    inner.geometry().add_point(Point::from([1., 0., 0.]))?;
 
-        let edge = shape.edges().add_line_segment([a, b])?;
+                let a = inner.vertices().add(Vertex { point: a })?;
+                let b = inner.vertices().add(Vertex { point: b })?;
 
-        shape.cycles().add(Cycle { edges: vec![edge] })?;
+                let edge = inner.edges().add_line_segment([a, b])?;
+
+                Ok(Self { inner, edge })
+            }
+        }
+
+        let mut shape = TestShape::new()?;
+        let other = TestShape::new()?;
+
+        // Trying to refer to edge that is not from the same shape. Should fail.
+        let result = shape.inner.cycles().add(Cycle {
+            edges: vec![other.edge],
+        });
+        assert!(matches!(result, Err(ValidationError::Structural)));
+
+        // Referring to edge that *is* from the same shape. Should work.
+        shape.inner.cycles().add(Cycle {
+            edges: vec![shape.edge],
+        })?;
 
         Ok(())
-    }
-
-    #[test]
-    #[should_panic]
-    fn add_invalid() {
-        let mut shape = Shape::new();
-        let mut other = Shape::new();
-
-        let a = shape
-            .geometry()
-            .add_point(Point::from([0., 0., 0.]))
-            .unwrap();
-        let b = shape
-            .geometry()
-            .add_point(Point::from([1., 0., 0.]))
-            .unwrap();
-
-        let a = other.vertices().add(Vertex { point: a }).unwrap();
-        let b = other.vertices().add(Vertex { point: b }).unwrap();
-
-        let edge = other.edges().add_line_segment([a, b]).unwrap();
-
-        shape.cycles().add(Cycle { edges: vec![edge] }).unwrap();
     }
 }

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -2,7 +2,7 @@ use crate::kernel::topology::edges::Cycle;
 
 use super::{
     handle::{Handle, Storage},
-    CyclesInner, EdgesInner,
+    CyclesInner, EdgesInner, ValidationResult,
 };
 
 /// The cycles of a shape
@@ -24,7 +24,7 @@ impl Cycles<'_> {
     /// - That those edges form a cycle.
     /// - That the cycle is not self-overlapping.
     /// - That there exists no duplicate cycle, with the same edges.
-    pub fn add(&mut self, cycle: Cycle) -> Handle<Cycle> {
+    pub fn add(&mut self, cycle: Cycle) -> ValidationResult<Cycle> {
         for edge in &cycle.edges {
             assert!(
                 self.edges.contains(edge.storage()),
@@ -36,7 +36,7 @@ impl Cycles<'_> {
         let handle = storage.handle();
         self.cycles.push(storage);
 
-        handle
+        Ok(handle)
     }
 
     /// Access an iterator over all cycles
@@ -59,15 +59,21 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new();
 
-        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
-        let b = shape.geometry().add_point(Point::from([1., 0., 0.]));
+        let a = shape
+            .geometry()
+            .add_point(Point::from([0., 0., 0.]))
+            .unwrap();
+        let b = shape
+            .geometry()
+            .add_point(Point::from([1., 0., 0.]))
+            .unwrap();
 
-        let a = shape.vertices().add(Vertex { point: a });
-        let b = shape.vertices().add(Vertex { point: b });
+        let a = shape.vertices().add(Vertex { point: a }).unwrap();
+        let b = shape.vertices().add(Vertex { point: b }).unwrap();
 
-        let edge = shape.edges().add_line_segment([a, b]);
+        let edge = shape.edges().add_line_segment([a, b]).unwrap();
 
-        shape.cycles().add(Cycle { edges: vec![edge] });
+        shape.cycles().add(Cycle { edges: vec![edge] }).unwrap();
     }
 
     #[test]
@@ -76,14 +82,20 @@ mod tests {
         let mut shape = Shape::new();
         let mut other = Shape::new();
 
-        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
-        let b = shape.geometry().add_point(Point::from([1., 0., 0.]));
+        let a = shape
+            .geometry()
+            .add_point(Point::from([0., 0., 0.]))
+            .unwrap();
+        let b = shape
+            .geometry()
+            .add_point(Point::from([1., 0., 0.]))
+            .unwrap();
 
-        let a = other.vertices().add(Vertex { point: a });
-        let b = other.vertices().add(Vertex { point: b });
+        let a = other.vertices().add(Vertex { point: a }).unwrap();
+        let b = other.vertices().add(Vertex { point: b }).unwrap();
 
-        let edge = other.edges().add_line_segment([a, b]);
+        let edge = other.edges().add_line_segment([a, b]).unwrap();
 
-        shape.cycles().add(Cycle { edges: vec![edge] });
+        shape.cycles().add(Cycle { edges: vec![edge] }).unwrap();
     }
 }

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -56,7 +56,7 @@ mod tests {
     };
 
     #[test]
-    fn add_valid() -> anyhow::Result<()> {
+    fn add() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
         let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;

--- a/src/kernel/shape/cycles.rs
+++ b/src/kernel/shape/cycles.rs
@@ -56,24 +56,20 @@ mod tests {
     };
 
     #[test]
-    fn add_valid() {
+    fn add_valid() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
-        let a = shape
-            .geometry()
-            .add_point(Point::from([0., 0., 0.]))
-            .unwrap();
-        let b = shape
-            .geometry()
-            .add_point(Point::from([1., 0., 0.]))
-            .unwrap();
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
+        let b = shape.geometry().add_point(Point::from([1., 0., 0.]))?;
 
-        let a = shape.vertices().add(Vertex { point: a }).unwrap();
-        let b = shape.vertices().add(Vertex { point: b }).unwrap();
+        let a = shape.vertices().add(Vertex { point: a })?;
+        let b = shape.vertices().add(Vertex { point: b })?;
 
-        let edge = shape.edges().add_line_segment([a, b]).unwrap();
+        let edge = shape.edges().add_line_segment([a, b])?;
 
-        shape.cycles().add(Cycle { edges: vec![edge] }).unwrap();
+        shape.cycles().add(Cycle { edges: vec![edge] })?;
+
+        Ok(())
     }
 
     #[test]

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -100,22 +100,18 @@ mod tests {
     };
 
     #[test]
-    fn add_valid() {
+    fn add_valid() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
-        let a = shape
-            .geometry()
-            .add_point(Point::from([0., 0., 0.]))
-            .unwrap();
-        let b = shape
-            .geometry()
-            .add_point(Point::from([1., 0., 0.]))
-            .unwrap();
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
+        let b = shape.geometry().add_point(Point::from([1., 0., 0.]))?;
 
-        let a = shape.vertices().add(Vertex { point: a }).unwrap();
-        let b = shape.vertices().add(Vertex { point: b }).unwrap();
+        let a = shape.vertices().add(Vertex { point: a })?;
+        let b = shape.vertices().add(Vertex { point: b })?;
 
-        shape.edges().add_line_segment([a, b]).unwrap();
+        shape.edges().add_line_segment([a, b])?;
+
+        Ok(())
     }
 
     #[test]

--- a/src/kernel/shape/edges.rs
+++ b/src/kernel/shape/edges.rs
@@ -100,7 +100,7 @@ mod tests {
     };
 
     #[test]
-    fn add_valid() -> anyhow::Result<()> {
+    fn add() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
         let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;

--- a/src/kernel/shape/faces.rs
+++ b/src/kernel/shape/faces.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::{
     handle::{Handle, Storage},
-    FacesInner,
+    FacesInner, ValidationResult,
 };
 
 /// The faces of a shape
@@ -16,13 +16,13 @@ pub struct Faces<'r> {
 
 impl Faces<'_> {
     /// Add a face to the shape
-    pub fn add(&mut self, face: Face) -> Handle<Face> {
+    pub fn add(&mut self, face: Face) -> ValidationResult<Face> {
         let storage = Storage::new(face);
         let handle = storage.handle();
 
         self.faces.push(storage);
 
-        handle
+        Ok(handle)
     }
 
     /// Access an iterator over all faces

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -3,24 +3,27 @@ use crate::{
     math::Point,
 };
 
-use super::handle::{Handle, Storage};
+use super::{handle::Storage, ValidationResult};
 
 /// API to access a shape's geometry
 pub struct Geometry;
 
 impl Geometry {
     /// Add a point to the shape
-    pub fn add_point(&mut self, point: Point<3>) -> Handle<Point<3>> {
-        Storage::new(point).handle()
+    pub fn add_point(&mut self, point: Point<3>) -> ValidationResult<Point<3>> {
+        Ok(Storage::new(point).handle())
     }
 
     /// Add a curve to the shape
-    pub fn add_curve(&mut self, curve: Curve) -> Handle<Curve> {
-        Storage::new(curve).handle()
+    pub fn add_curve(&mut self, curve: Curve) -> ValidationResult<Curve> {
+        Ok(Storage::new(curve).handle())
     }
 
     /// Add a surface to the shape
-    pub fn add_surface(&mut self, surface: Surface) -> Handle<Surface> {
-        Storage::new(surface).handle()
+    pub fn add_surface(
+        &mut self,
+        surface: Surface,
+    ) -> ValidationResult<Surface> {
+        Ok(Storage::new(surface).handle())
     }
 }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -116,7 +116,6 @@ pub enum ValidationError {
     /// Structural validation verifies, that all the object that an object
     /// refers to are already part of the shape.
     #[error("Structural validation failed")]
-    #[allow(unused)]
     Structural,
 
     /// Uniqueness validation failed

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -109,12 +109,13 @@ impl Shape {
 pub type ValidationResult<T> = Result<Handle<T>, ValidationError>;
 
 /// An error that can occur during a validation
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ValidationError {
     /// Structural validation failed
     ///
     /// Structural validation verifies, that all the object that an object
     /// refers to are already part of the shape.
+    #[error("Structural validation failed")]
     #[allow(unused)]
     Structural,
 
@@ -123,6 +124,7 @@ pub enum ValidationError {
     /// Uniqueness validation checks, that an object is unique. Uniqueness is
     /// only required for topological objects, as there's no harm in geometric
     /// objects being duplicated.
+    #[error("Uniqueness validation failed")]
     #[allow(unused)]
     Uniqueness,
 
@@ -131,6 +133,7 @@ pub enum ValidationError {
     /// Geometric validation checks, that various geometric constraints of an
     /// object are upheld. For example, edges or faces might not be allowed to
     /// intersect.
+    #[error("Geometric validation failed")]
     #[allow(unused)]
     Geometric,
 }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -106,7 +106,6 @@ impl Shape {
 }
 
 /// Returned by the various `add_` methods of the [`Shape`] API
-#[allow(unused)]
 pub type ValidationResult<T> = Result<Handle<T>, ValidationError>;
 
 /// An error that can occur during a validation

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -14,8 +14,12 @@ use super::topology::{
 };
 
 use self::{
-    cycles::Cycles, edges::Edges, faces::Faces, geometry::Geometry,
-    handle::Storage, vertices::Vertices,
+    cycles::Cycles,
+    edges::Edges,
+    faces::Faces,
+    geometry::Geometry,
+    handle::{Handle, Storage},
+    vertices::Vertices,
 };
 
 /// The boundary representation of a shape
@@ -99,6 +103,37 @@ impl Shape {
             faces: &mut self.faces,
         }
     }
+}
+
+/// Returned by the various `add_` methods of the [`Shape`] API
+#[allow(unused)]
+pub type ValidationResult<T> = Result<Handle<T>, ValidationError>;
+
+/// An error that can occur during a validation
+#[derive(Debug)]
+pub enum ValidationError {
+    /// Structural validation failed
+    ///
+    /// Structural validation verifies, that all the object that an object
+    /// refers to are already part of the shape.
+    #[allow(unused)]
+    Structural,
+
+    /// Uniqueness validation failed
+    ///
+    /// Uniqueness validation checks, that an object is unique. Uniqueness is
+    /// only required for topological objects, as there's no harm in geometric
+    /// objects being duplicated.
+    #[allow(unused)]
+    Uniqueness,
+
+    /// Geometric validation failed
+    ///
+    /// Geometric validation checks, that various geometric constraints of an
+    /// object are upheld. For example, edges or faces might not be allowed to
+    /// intersect.
+    #[allow(unused)]
+    Geometric,
 }
 
 type VerticesInner = Vec<Storage<Vertex>>;

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -74,20 +74,16 @@ mod tests {
     const MIN_DISTANCE: f64 = 5e-7;
 
     #[test]
-    fn add_valid() {
+    fn add_valid() -> anyhow::Result<()> {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let a = shape
-            .geometry()
-            .add_point(Point::from([0., 0., 0.]))
-            .unwrap();
-        let b = shape
-            .geometry()
-            .add_point(Point::from([5e-6, 0., 0.]))
-            .unwrap();
+        let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
+        let b = shape.geometry().add_point(Point::from([5e-6, 0., 0.]))?;
 
-        shape.vertices().add(Vertex { point: a }).unwrap();
-        shape.vertices().add(Vertex { point: b }).unwrap();
+        shape.vertices().add(Vertex { point: a })?;
+        shape.vertices().add(Vertex { point: b })?;
+
+        Ok(())
     }
 
     #[test]

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -77,34 +77,20 @@ mod tests {
     fn add() -> anyhow::Result<()> {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
-        let b = shape.geometry().add_point(Point::from([5e-6, 0., 0.]))?;
+        let point = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
+        shape.vertices().add(Vertex { point })?;
 
-        shape.vertices().add(Vertex { point: a })?;
-        shape.vertices().add(Vertex { point: b })?;
+        // `point` is too close to the original point. `assert!` is commented,
+        // because that only causes a warning to be logged right now.
+        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]))?;
+        let _result = shape.vertices().add(Vertex { point });
+        // assert!(matches!(result, Err(ValidationError::Uniqueness)));
+
+        // `point` is farther than `MIN_DISTANCE` away from original point.
+        // Should work.
+        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]))?;
+        shape.vertices().add(Vertex { point })?;
 
         Ok(())
-    }
-
-    #[test]
-    #[ignore]
-    #[should_panic]
-    fn add_invalid() {
-        // Test is ignored, until vertex validation can be enabled for real.
-        // See implementation note on `Vertices::create`.
-
-        let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
-
-        let a = shape
-            .geometry()
-            .add_point(Point::from([0., 0., 0.]))
-            .unwrap();
-        let b = shape
-            .geometry()
-            .add_point(Point::from([5e-8, 0., 0.]))
-            .unwrap();
-
-        shape.vertices().add(Vertex { point: a }).unwrap();
-        shape.vertices().add(Vertex { point: b }).unwrap();
     }
 }

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -74,7 +74,7 @@ mod tests {
     const MIN_DISTANCE: f64 = 5e-7;
 
     #[test]
-    fn add_valid() -> anyhow::Result<()> {
+    fn add() -> anyhow::Result<()> {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
         let a = shape.geometry().add_point(Point::from([0., 0., 0.]))?;

--- a/src/kernel/shape/vertices.rs
+++ b/src/kernel/shape/vertices.rs
@@ -4,7 +4,7 @@ use crate::{kernel::topology::vertices::Vertex, math::Scalar};
 
 use super::{
     handle::{Handle, Storage},
-    VerticesInner,
+    ValidationResult, VerticesInner,
 };
 
 /// The vertices of a shape
@@ -33,7 +33,7 @@ impl Vertices<'_> {
     /// In the future, this method is likely to validate more than just vertex
     /// uniqueness. See documentation of [`crate::kernel`] for some context on
     /// that.
-    pub fn add(&mut self, vertex: Vertex) -> Handle<Vertex> {
+    pub fn add(&mut self, vertex: Vertex) -> ValidationResult<Vertex> {
         // Make sure the new vertex is a minimum distance away from all existing
         // vertices. This minimum distance is defined to be half a µm, which
         // should provide more than enough precision for common use cases, while
@@ -53,7 +53,7 @@ impl Vertices<'_> {
         let handle = storage.handle();
         self.vertices.push(storage);
 
-        handle
+        Ok(handle)
     }
 
     /// Access iterator over all vertices
@@ -77,11 +77,17 @@ mod tests {
     fn add_valid() {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
-        let b = shape.geometry().add_point(Point::from([5e-6, 0., 0.]));
+        let a = shape
+            .geometry()
+            .add_point(Point::from([0., 0., 0.]))
+            .unwrap();
+        let b = shape
+            .geometry()
+            .add_point(Point::from([5e-6, 0., 0.]))
+            .unwrap();
 
-        shape.vertices().add(Vertex { point: a });
-        shape.vertices().add(Vertex { point: b });
+        shape.vertices().add(Vertex { point: a }).unwrap();
+        shape.vertices().add(Vertex { point: b }).unwrap();
     }
 
     #[test]
@@ -93,10 +99,16 @@ mod tests {
 
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let a = shape.geometry().add_point(Point::from([0., 0., 0.]));
-        let b = shape.geometry().add_point(Point::from([5e-8, 0., 0.]));
+        let a = shape
+            .geometry()
+            .add_point(Point::from([0., 0., 0.]))
+            .unwrap();
+        let b = shape
+            .geometry()
+            .add_point(Point::from([5e-8, 0., 0.]))
+            .unwrap();
 
-        shape.vertices().add(Vertex { point: a });
-        shape.vertices().add(Vertex { point: b });
+        shape.vertices().add(Vertex { point: a }).unwrap();
+        shape.vertices().add(Vertex { point: b }).unwrap();
     }
 }

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -17,12 +17,16 @@ impl ToShape for fj::Circle {
         // Circles have just a single round edge with no vertices. So none need
         // to be added here.
 
-        let edge = shape.edges().add_circle(Scalar::from_f64(self.radius));
-        shape.cycles().add(Cycle { edges: vec![edge] });
+        let edge = shape
+            .edges()
+            .add_circle(Scalar::from_f64(self.radius))
+            .unwrap();
+        shape.cycles().add(Cycle { edges: vec![edge] }).unwrap();
 
         let cycles = shape.cycles().all().collect();
-        let surface = shape.geometry().add_surface(Surface::x_y_plane());
-        shape.faces().add(Face::Face { cycles, surface });
+        let surface =
+            shape.geometry().add_surface(Surface::x_y_plane()).unwrap();
+        shape.faces().add(Face::Face { cycles, surface }).unwrap();
 
         shape
     }

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -53,22 +53,24 @@ impl ToShape for fj::Difference2d {
         for cycle in cycles_orig {
             let mut edges = Vec::new();
             for edge in &cycle.edges {
-                let curve = shape.geometry().add_curve(edge.curve());
+                let curve = shape.geometry().add_curve(edge.curve()).unwrap();
 
                 let vertices = edge.vertices().clone().map(|vs| {
                     vs.map(|vertex| {
                         vertices
                             .entry(vertex.clone())
-                            .or_insert_with(|| shape.vertices().add(vertex))
+                            .or_insert_with(|| {
+                                shape.vertices().add(vertex).unwrap()
+                            })
                             .clone()
                     })
                 });
 
-                let edge = shape.edges().add(Edge { curve, vertices });
+                let edge = shape.edges().add(Edge { curve, vertices }).unwrap();
                 edges.push(edge);
             }
 
-            let cycle = shape.cycles().add(Cycle { edges });
+            let cycle = shape.cycles().add(Cycle { edges }).unwrap();
             cycles.push(cycle);
         }
 
@@ -90,7 +92,7 @@ impl ToShape for fj::Difference2d {
         );
         let surface = surface_a;
 
-        shape.faces().add(Face::Face { cycles, surface });
+        shape.faces().add(Face::Face { cycles, surface }).unwrap();
 
         shape
     }

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -16,8 +16,9 @@ impl ToShape for fj::Sketch {
         let mut vertices = Vec::new();
 
         for [x, y] in self.to_points() {
-            let point = shape.geometry().add_point(Point::from([x, y, 0.]));
-            let vertex = shape.vertices().add(Vertex { point });
+            let point =
+                shape.geometry().add_point(Point::from([x, y, 0.])).unwrap();
+            let vertex = shape.vertices().add(Vertex { point }).unwrap();
             vertices.push(vertex);
         }
 
@@ -38,19 +39,20 @@ impl ToShape for fj::Sketch {
                 let a = window[0].clone();
                 let b = window[1].clone();
 
-                let edge = shape.edges().add_line_segment([a, b]);
+                let edge = shape.edges().add_line_segment([a, b]).unwrap();
                 edges.push(edge);
             }
 
-            shape.cycles().add(Cycle { edges });
+            shape.cycles().add(Cycle { edges }).unwrap();
         };
 
-        let surface = shape.geometry().add_surface(Surface::x_y_plane());
+        let surface =
+            shape.geometry().add_surface(Surface::x_y_plane()).unwrap();
         let face = Face::Face {
             cycles: shape.cycles().all().collect(),
             surface,
         };
-        shape.faces().add(face);
+        shape.faces().add(face).unwrap();
 
         shape
     }

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -19,10 +19,10 @@ impl ToShape for fj::Union {
         // See issue:
         // https://github.com/hannobraun/Fornjot/issues/42
         for face in a.faces().all() {
-            shape.faces().add(face.get().clone());
+            shape.faces().add(face.get().clone()).unwrap();
         }
         for face in b.faces().all() {
-            shape.faces().add(face.get().clone());
+            shape.faces().add(face.get().clone()).unwrap();
         }
 
         shape


### PR DESCRIPTION
There's a `ValidationError` now that can be returned, if something fails to validate. Most of its variants are unused as of now, but I've decided to leave them in, to document my design intent.

Methods that already do validation are updated to return `ValidationError`. All other method return `ValidationResult`, but actually never return the error variant. I expect that most of them will start doing validation, and returning `ValidationError`, soon.

This is a continuation of my work on #242 and #280.