### PR TITLE
Make adding geometry infallible

### DIFF
--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -157,8 +157,8 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.geometry().add_point(a).unwrap();
-        let v2 = shape.geometry().add_point(d).unwrap();
+        let v1 = shape.geometry().add_point(a);
+        let v2 = shape.geometry().add_point(d);
 
         let v1 = shape.topology().add_vertex(Vertex { point: v1 }).unwrap();
         let v2 = shape.topology().add_vertex(Vertex { point: v2 }).unwrap();
@@ -201,9 +201,9 @@ mod tests {
         let b = Point::from([2., 3., 5.]);
         let c = Point::from([3., 5., 8.]);
 
-        let v1 = shape.geometry().add_point(a).unwrap();
-        let v2 = shape.geometry().add_point(b).unwrap();
-        let v3 = shape.geometry().add_point(c).unwrap();
+        let v1 = shape.geometry().add_point(a);
+        let v2 = shape.geometry().add_point(b);
+        let v3 = shape.geometry().add_point(c);
 
         let v1 = shape.topology().add_vertex(Vertex { point: v1 }).unwrap();
         let v2 = shape.topology().add_vertex(Vertex { point: v2 }).unwrap();
@@ -246,10 +246,10 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.geometry().add_point(a).unwrap();
-        let v2 = shape.geometry().add_point(b).unwrap();
-        let v3 = shape.geometry().add_point(c).unwrap();
-        let v4 = shape.geometry().add_point(d).unwrap();
+        let v1 = shape.geometry().add_point(a);
+        let v2 = shape.geometry().add_point(b);
+        let v3 = shape.geometry().add_point(c);
+        let v4 = shape.geometry().add_point(d);
 
         let v1 = shape.topology().add_vertex(Vertex { point: v1 }).unwrap();
         let v2 = shape.topology().add_vertex(Vertex { point: v2 }).unwrap();
@@ -271,8 +271,7 @@ mod tests {
             })
             .unwrap();
 
-        let surface =
-            shape.geometry().add_surface(Surface::x_y_plane()).unwrap();
+        let surface = shape.geometry().add_surface(Surface::x_y_plane());
         let face = Face::Face {
             surface,
             cycles: vec![abcd],

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -29,10 +29,7 @@ pub fn sweep_shape(
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.topology().vertices() {
-        let point = shape
-            .geometry()
-            .add_point(vertex_orig.point() + path)
-            .unwrap();
+        let point = shape.geometry().add_point(vertex_orig.point() + path);
         let vertex = shape.topology().add_vertex(Vertex { point }).unwrap();
         vertices.insert(vertex_orig, vertex);
     }
@@ -42,8 +39,7 @@ pub fn sweep_shape(
     for edge_orig in shape_orig.topology().edges() {
         let curve = shape
             .geometry()
-            .add_curve(edge_orig.curve().transform(&translation))
-            .unwrap();
+            .add_curve(edge_orig.curve().transform(&translation));
 
         let vertices = edge_orig.vertices.clone().map(|vs| {
             vs.map(|vertex_orig| {
@@ -87,8 +83,7 @@ pub fn sweep_shape(
 
         let surface = shape
             .geometry()
-            .add_surface(face_orig.surface().transform(&translation))
-            .unwrap();
+            .add_surface(face_orig.surface().transform(&translation));
 
         let cycles = cycles_orig
             .iter()
@@ -203,9 +198,9 @@ mod tests {
         fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> Self {
             let mut shape = Shape::new();
 
-            let a = shape.geometry().add_point(a.into()).unwrap();
-            let b = shape.geometry().add_point(b.into()).unwrap();
-            let c = shape.geometry().add_point(c.into()).unwrap();
+            let a = shape.geometry().add_point(a.into());
+            let b = shape.geometry().add_point(b.into());
+            let c = shape.geometry().add_point(c.into());
 
             let a = shape.topology().add_vertex(Vertex { point: a }).unwrap();
             let b = shape.topology().add_vertex(Vertex { point: b }).unwrap();
@@ -231,12 +226,11 @@ mod tests {
                 })
                 .unwrap();
 
-            let surface = shape
-                .geometry()
-                .add_surface(Surface::Swept(Swept::plane_from_points(
+            let surface = shape.geometry().add_surface(Surface::Swept(
+                Swept::plane_from_points(
                     [a, b, c].map(|vertex| vertex.point()),
-                )))
-                .unwrap();
+                ),
+            ));
             let abc = Face::Face {
                 surface,
                 cycles: vec![cycles],

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -34,20 +34,17 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
                     for edge in &cycle.edges {
                         let curve = transformed
                             .geometry()
-                            .add_curve(edge.curve().transform(transform))
-                            .unwrap();
+                            .add_curve(edge.curve().transform(transform));
 
                         let vertices =
                             edge.vertices().clone().map(|vertices| {
                                 vertices.map(|vertex| {
-                                    let point = transformed
-                                        .geometry()
-                                        .add_point(
+                                    let point =
+                                        transformed.geometry().add_point(
                                             transform.transform_point(
                                                 &vertex.point(),
                                             ),
-                                        )
-                                        .unwrap();
+                                        );
 
                                     transformed
                                         .topology()
@@ -73,8 +70,7 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
 
                 let surface = transformed
                     .geometry()
-                    .add_surface(surface.transform(transform))
-                    .unwrap();
+                    .add_surface(surface.transform(transform));
 
                 Face::Face {
                     cycles: cycles_trans,

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -6,6 +6,20 @@ use crate::{
 use super::handle::{Handle, Storage};
 
 /// API to access a shape's geometry
+///
+/// Other than topology, geometry doesn't need to be validated. Hence adding
+/// geometry is infallible.
+///
+/// There are several reasons for this:
+/// - Geometry doesn't refer to other objects, so structural validation doesn't
+///   apply.
+/// - There simply no reason that geometry needs to be unique. In addition, it's
+///   probably quite hard to rule out generating duplicate geometry. Think about
+///   line segment edges that are on identical lines, but are created
+///   separately.
+/// - Geometric validation doesn't apply either. It simply doesn't matter, if
+///   curves or surfaces intersect, for example, as long as they don't do that
+///   where an edge or face is defined.
 pub struct Geometry;
 
 impl Geometry {

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -3,27 +3,24 @@ use crate::{
     math::Point,
 };
 
-use super::{handle::Storage, ValidationResult};
+use super::handle::{Handle, Storage};
 
 /// API to access a shape's geometry
 pub struct Geometry;
 
 impl Geometry {
     /// Add a point to the shape
-    pub fn add_point(&mut self, point: Point<3>) -> ValidationResult<Point<3>> {
-        Ok(Storage::new(point).handle())
+    pub fn add_point(&mut self, point: Point<3>) -> Handle<Point<3>> {
+        Storage::new(point).handle()
     }
 
     /// Add a curve to the shape
-    pub fn add_curve(&mut self, curve: Curve) -> ValidationResult<Curve> {
-        Ok(Storage::new(curve).handle())
+    pub fn add_curve(&mut self, curve: Curve) -> Handle<Curve> {
+        Storage::new(curve).handle()
     }
 
     /// Add a surface to the shape
-    pub fn add_surface(
-        &mut self,
-        surface: Surface,
-    ) -> ValidationResult<Surface> {
-        Ok(Storage::new(surface).handle())
+    pub fn add_surface(&mut self, surface: Surface) -> Handle<Surface> {
+        Storage::new(surface).handle()
     }
 }

--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -120,7 +120,7 @@ impl Topology<'_> {
         let curve = self.geometry.add_curve(Curve::Circle(Circle {
             center: Point::origin(),
             radius: Vector::from([radius, Scalar::ZERO]),
-        }))?;
+        }));
         self.add_edge(Edge {
             curve,
             vertices: None,
@@ -137,7 +137,7 @@ impl Topology<'_> {
     ) -> ValidationResult<Edge> {
         let curve = self.geometry.add_curve(Curve::Line(Line::from_points(
             vertices.clone().map(|vertex| vertex.point()),
-        )))?;
+        )));
         self.add_edge(Edge {
             curve,
             vertices: Some(vertices),
@@ -228,18 +228,18 @@ mod tests {
     fn add_vertex() -> anyhow::Result<()> {
         let mut shape = Shape::new().with_min_distance(MIN_DISTANCE);
 
-        let point = shape.geometry().add_point(Point::from([0., 0., 0.]))?;
+        let point = shape.geometry().add_point(Point::from([0., 0., 0.]));
         shape.topology().add_vertex(Vertex { point })?;
 
         // `point` is too close to the original point. `assert!` is commented,
         // because that only causes a warning to be logged right now.
-        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]))?;
+        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]));
         let _result = shape.topology().add_vertex(Vertex { point });
         // assert!(matches!(result, Err(ValidationError::Uniqueness)));
 
         // `point` is farther than `MIN_DISTANCE` away from original point.
         // Should work.
-        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]))?;
+        let point = shape.geometry().add_point(Point::from([5e-6, 0., 0.]));
         shape.topology().add_vertex(Vertex { point })?;
 
         Ok(())
@@ -250,8 +250,8 @@ mod tests {
         let mut shape = Shape::new();
         let mut other = Shape::new();
 
-        let a = other.geometry().add_point(Point::from([0., 0., 0.]))?;
-        let b = other.geometry().add_point(Point::from([1., 0., 0.]))?;
+        let a = other.geometry().add_point(Point::from([0., 0., 0.]));
+        let b = other.geometry().add_point(Point::from([1., 0., 0.]));
 
         let a = other.topology().add_vertex(Vertex { point: a })?;
         let b = other.topology().add_vertex(Vertex { point: b })?;
@@ -260,14 +260,14 @@ mod tests {
         let result = shape.topology().add_line_segment([a.clone(), b.clone()]);
         assert!(matches!(result, Err(ValidationError::Structural)));
 
-        let a = shape.geometry().add_point(a.point())?;
+        let a = shape.geometry().add_point(a.point());
         let a = shape.topology().add_vertex(Vertex { point: a })?;
 
         // Shouldn't work. Only `a` has been added to `shape`.
         let result = shape.topology().add_line_segment([a.clone(), b.clone()]);
         assert!(matches!(result, Err(ValidationError::Structural)));
 
-        let b = shape.geometry().add_point(b.point())?;
+        let b = shape.geometry().add_point(b.point());
         let b = shape.topology().add_vertex(Vertex { point: b })?;
 
         // Both `a` and `b` have been added to `shape`. Should work!
@@ -287,10 +287,8 @@ mod tests {
             fn new() -> anyhow::Result<Self> {
                 let mut inner = Shape::new();
 
-                let a =
-                    inner.geometry().add_point(Point::from([0., 0., 0.]))?;
-                let b =
-                    inner.geometry().add_point(Point::from([1., 0., 0.]))?;
+                let a = inner.geometry().add_point(Point::from([0., 0., 0.]));
+                let b = inner.geometry().add_point(Point::from([1., 0., 0.]));
 
                 let a = inner.topology().add_vertex(Vertex { point: a })?;
                 let b = inner.topology().add_vertex(Vertex { point: b })?;

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -27,8 +27,7 @@ impl ToShape for fj::Circle {
             .unwrap();
 
         let cycles = shape.topology().cycles().collect();
-        let surface =
-            shape.geometry().add_surface(Surface::x_y_plane()).unwrap();
+        let surface = shape.geometry().add_surface(Surface::x_y_plane());
         shape
             .topology()
             .add_face(Face::Face { cycles, surface })

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -53,7 +53,7 @@ impl ToShape for fj::Difference2d {
         for cycle in cycles_orig {
             let mut edges = Vec::new();
             for edge in &cycle.edges {
-                let curve = shape.geometry().add_curve(edge.curve()).unwrap();
+                let curve = shape.geometry().add_curve(edge.curve());
 
                 let vertices = edge.vertices().clone().map(|vs| {
                     vs.map(|vertex| {

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -16,8 +16,7 @@ impl ToShape for fj::Sketch {
         let mut vertices = Vec::new();
 
         for [x, y] in self.to_points() {
-            let point =
-                shape.geometry().add_point(Point::from([x, y, 0.])).unwrap();
+            let point = shape.geometry().add_point(Point::from([x, y, 0.]));
             let vertex = shape.topology().add_vertex(Vertex { point }).unwrap();
             vertices.push(vertex);
         }
@@ -46,8 +45,7 @@ impl ToShape for fj::Sketch {
             shape.topology().add_cycle(Cycle { edges }).unwrap();
         };
 
-        let surface =
-            shape.geometry().add_surface(Surface::x_y_plane()).unwrap();
+        let surface = shape.geometry().add_surface(Surface::x_y_plane());
         let face = Face::Face {
             cycles: shape.topology().cycles().collect(),
             surface,


### PR DESCRIPTION
More progress towards #280. Reverts a design mistake (making those methods fallible in the first place) and adds documentation on the concept of geometry validation.