### PR TITLE
Create structurally valid shapes as result of union and 2D diff operations

### DIFF
--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -3,7 +3,10 @@ use crate::{
     math::Point,
 };
 
-use super::handle::{Handle, Storage};
+use super::{
+    handle::{Handle, Storage},
+    Curves, Points, Surfaces,
+};
 
 /// API to access a shape's geometry
 ///
@@ -20,21 +23,40 @@ use super::handle::{Handle, Storage};
 /// - Geometric validation doesn't apply either. It simply doesn't matter, if
 ///   curves or surfaces intersect, for example, as long as they don't do that
 ///   where an edge or face is defined.
-pub struct Geometry;
+pub struct Geometry<'r> {
+    pub(super) points: &'r mut Points,
+    pub(super) curves: &'r mut Curves,
+    pub(super) surfaces: &'r mut Surfaces,
+}
 
-impl Geometry {
+impl Geometry<'_> {
     /// Add a point to the shape
     pub fn add_point(&mut self, point: Point<3>) -> Handle<Point<3>> {
-        Storage::new(point).handle()
+        let storage = Storage::new(point);
+        let handle = storage.handle();
+
+        self.points.push(storage);
+
+        handle
     }
 
     /// Add a curve to the shape
     pub fn add_curve(&mut self, curve: Curve) -> Handle<Curve> {
-        Storage::new(curve).handle()
+        let storage = Storage::new(curve);
+        let handle = storage.handle();
+
+        self.curves.push(storage);
+
+        handle
     }
 
     /// Add a surface to the shape
     pub fn add_surface(&mut self, surface: Surface) -> Handle<Surface> {
-        Storage::new(surface).handle()
+        let storage = Storage::new(surface);
+        let handle = storage.handle();
+
+        self.surfaces.push(storage);
+
+        handle
     }
 }

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -59,4 +59,19 @@ impl Geometry<'_> {
 
         handle
     }
+
+    /// Access an iterator over all points
+    pub fn points(&self) -> impl Iterator<Item = Handle<Point<3>>> + '_ {
+        self.points.iter().map(|storage| storage.handle())
+    }
+
+    /// Access an iterator over all curves
+    pub fn curves(&self) -> impl Iterator<Item = Handle<Curve>> + '_ {
+        self.curves.iter().map(|storage| storage.handle())
+    }
+
+    /// Access an iterator over all surfaces
+    pub fn surfaces(&self) -> impl Iterator<Item = Handle<Surface>> + '_ {
+        self.surfaces.iter().map(|storage| storage.handle())
+    }
 }

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -5,12 +5,15 @@ pub mod validate;
 
 pub use self::validate::{ValidationError, ValidationResult};
 
-use crate::math::Scalar;
+use crate::math::{Point, Scalar};
 
-use super::topology::{
-    edges::{Cycle, Edge},
-    faces::Face,
-    vertices::Vertex,
+use super::{
+    geometry::{Curve, Surface},
+    topology::{
+        edges::{Cycle, Edge},
+        faces::Face,
+        vertices::Vertex,
+    },
 };
 
 use self::{geometry::Geometry, handle::Storage, topology::Topology};
@@ -22,6 +25,10 @@ pub struct Shape {
     ///
     /// Use for vertex validation, to determine whether vertices are unique.
     min_distance: Scalar,
+
+    points: Points,
+    curves: Curves,
+    surfaces: Surfaces,
 
     vertices: Vertices,
     edges: Edges,
@@ -37,6 +44,10 @@ impl Shape {
             // similarly named constant. Unfortunately `Scalar::from_f64` can't
             // be `const` yet.
             min_distance: Scalar::from_f64(5e-7), // 0.5 µm
+
+            points: Points::new(),
+            curves: Curves::new(),
+            surfaces: Surfaces::new(),
 
             vertices: Vertices::new(),
             edges: Edges::new(),
@@ -62,7 +73,11 @@ impl Shape {
 
     /// Access the shape's geometry
     pub fn geometry(&mut self) -> Geometry {
-        Geometry
+        Geometry {
+            points: &mut self.points,
+            curves: &mut self.curves,
+            surfaces: &mut self.surfaces,
+        }
     }
 
     /// Access the shape's topology
@@ -70,7 +85,11 @@ impl Shape {
         Topology {
             min_distance: self.min_distance,
 
-            geometry: Geometry,
+            geometry: Geometry {
+                points: &mut self.points,
+                curves: &mut self.curves,
+                surfaces: &mut self.surfaces,
+            },
 
             vertices: &mut self.vertices,
             edges: &mut self.edges,
@@ -79,6 +98,10 @@ impl Shape {
         }
     }
 }
+
+type Points = Vec<Storage<Point<3>>>;
+type Curves = Vec<Storage<Curve>>;
+type Surfaces = Vec<Storage<Surface>>;
 
 type Vertices = Vec<Storage<Vertex>>;
 type Edges = Vec<Storage<Edge>>;

--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -25,7 +25,7 @@ use super::{
 pub struct Topology<'r> {
     pub(super) min_distance: Scalar,
 
-    pub(super) geometry: Geometry,
+    pub(super) geometry: Geometry<'r>,
 
     pub(super) vertices: &'r mut Vertices,
     pub(super) edges: &'r mut Edges,

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -7,6 +7,7 @@ use crate::{
         topology::{
             edges::{Cycle, Edge},
             faces::Face,
+            vertices::Vertex,
         },
     },
     math::{Aabb, Scalar},
@@ -60,7 +61,12 @@ impl ToShape for fj::Difference2d {
                         vertices
                             .entry(vertex.clone())
                             .or_insert_with(|| {
-                                shape.topology().add_vertex(vertex).unwrap()
+                                let point =
+                                    shape.geometry().add_point(vertex.point());
+                                shape
+                                    .topology()
+                                    .add_vertex(Vertex { point })
+                                    .unwrap()
                             })
                             .clone()
                     })

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -87,19 +87,11 @@ impl ToShape for fj::Difference2d {
         let [face_a, face_b] = [&mut a, &mut b]
             .map(|shape| shape.topology().faces().next().unwrap());
 
-        let surface_a = match (face_a.get().clone(), face_b.get().clone()) {
-            (Face::Face { surface, .. }, Face::Face { .. }) => surface,
-            _ => {
-                // None of the 2D types still use triangle representation.
-                unreachable!()
-            }
-        };
-
         assert!(
             face_a.surface() == face_b.surface(),
             "Trying to subtract sketches with different surfaces."
         );
-        let surface = surface_a;
+        let surface = shape.geometry().add_surface(face_a.surface());
 
         shape
             .topology()

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -1,6 +1,15 @@
+use std::collections::HashMap;
+
 use crate::{
     debug::DebugInfo,
-    kernel::shape::Shape,
+    kernel::{
+        shape::Shape,
+        topology::{
+            edges::{Cycle, Edge},
+            faces::Face,
+            vertices::Vertex,
+        },
+    },
     math::{Aabb, Scalar},
 };
 
@@ -33,7 +42,82 @@ impl ToShape for fj::Union {
 }
 
 fn copy_shape(mut orig: Shape, target: &mut Shape) {
-    for face in orig.topology().faces() {
-        target.topology().add_face(face.get().clone()).unwrap();
+    let mut points = HashMap::new();
+    let mut curves = HashMap::new();
+    let mut surfaces = HashMap::new();
+
+    let mut vertices = HashMap::new();
+    let mut edges = HashMap::new();
+    let mut cycles = HashMap::new();
+
+    for point_orig in orig.geometry().points() {
+        let point = target.geometry().add_point(*point_orig.get());
+        points.insert(point_orig, point);
+    }
+    for curve_orig in orig.geometry().curves() {
+        let curve = target.geometry().add_curve(*curve_orig.get());
+        curves.insert(curve_orig, curve);
+    }
+    for surface_orig in orig.geometry().surfaces() {
+        let surface = target.geometry().add_surface(*surface_orig.get());
+        surfaces.insert(surface_orig, surface);
+    }
+
+    for vertex_orig in orig.topology().vertices() {
+        let vertex = target
+            .topology()
+            .add_vertex(Vertex {
+                point: points[&vertex_orig.point].clone(),
+            })
+            .unwrap();
+        vertices.insert(vertex_orig, vertex);
+    }
+    for edge_orig in orig.topology().edges() {
+        let edge = target
+            .topology()
+            .add_edge(Edge {
+                curve: curves[&edge_orig.curve].clone(),
+                vertices: edge_orig.vertices.as_ref().map(|vs| {
+                    vs.clone().map(|vertex| vertices[&vertex].clone())
+                }),
+            })
+            .unwrap();
+        edges.insert(edge_orig, edge);
+    }
+    for cycle_orig in orig.topology().cycles() {
+        let cycle = target
+            .topology()
+            .add_cycle(Cycle {
+                edges: cycle_orig
+                    .edges
+                    .iter()
+                    .map(|edge| edges[edge].clone())
+                    .collect(),
+            })
+            .unwrap();
+        cycles.insert(cycle_orig, cycle);
+    }
+
+    for face_orig in orig.topology().faces() {
+        match face_orig.get() {
+            Face::Face {
+                surface,
+                cycles: cs,
+            } => {
+                target
+                    .topology()
+                    .add_face(Face::Face {
+                        surface: surfaces[surface].clone(),
+                        cycles: cs
+                            .iter()
+                            .map(|cycle| cycles[cycle].clone())
+                            .collect(),
+                    })
+                    .unwrap();
+            }
+            face @ Face::Triangles(_) => {
+                target.topology().add_face(face.clone()).unwrap();
+            }
+        }
     }
 }

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -10,20 +10,16 @@ impl ToShape for fj::Union {
     fn to_shape(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Shape {
         let mut shape = Shape::new();
 
-        let mut a = self.a.to_shape(tolerance, debug_info);
-        let mut b = self.b.to_shape(tolerance, debug_info);
+        let a = self.a.to_shape(tolerance, debug_info);
+        let b = self.b.to_shape(tolerance, debug_info);
 
         // This doesn't create a true union, as it doesn't eliminate, merge, or
         // split faces.
         //
         // See issue:
         // https://github.com/hannobraun/Fornjot/issues/42
-        for face in a.topology().faces() {
-            shape.topology().add_face(face.get().clone()).unwrap();
-        }
-        for face in b.topology().faces() {
-            shape.topology().add_face(face.get().clone()).unwrap();
-        }
+        copy_shape(a, &mut shape);
+        copy_shape(b, &mut shape);
 
         shape
     }
@@ -33,5 +29,11 @@ impl ToShape for fj::Union {
         let b = self.b.bounding_volume();
 
         a.merged(&b)
+    }
+}
+
+fn copy_shape(mut orig: Shape, target: &mut Shape) {
+    for face in orig.topology().faces() {
+        target.topology().add_face(face.get().clone()).unwrap();
     }
 }


### PR DESCRIPTION
This came out of my work towards #280. I have a local branch with full structural validation implemented (which would complete #280), and this pull request fixes the problems that came up.