### PR TITLE
Start with a larger glyph cache size from the get go

### DIFF
--- a/src/graphics/config_ui.rs
+++ b/src/graphics/config_ui.rs
@@ -23,8 +23,9 @@ impl ConfigUi {
     ) -> Result<Self, InvalidFont> {
         let font =
             FontArc::try_from_slice(include_bytes!("fonts/B612-Bold.ttf"))?;
-        let glyph_brush =
-            GlyphBrushBuilder::using_font(font).build(device, color_format);
+        let glyph_brush = GlyphBrushBuilder::using_font(font)
+            .initial_cache_size((512, 512))
+            .build(device, color_format);
 
         let mut texts = HashMap::new();
         for element in Element::elements() {


### PR DESCRIPTION
This eliminates the startup warning

```2022-03-12T13:07:34.975288Z  WARN wgpu_glyph: Increasing glyph texture size (256, 256) -> (512, 512). Consider building with `.initial_cache_size((512, 512))` to avoid resizing```

Signed-off-by: Daniel Egger <daniel@eggers-club.de>