### PR TITLE
Allow Triangles to carry a color and transfer that to the vertices du…

### DIFF
--- a/src/graphics/vertices.rs
+++ b/src/graphics/vertices.rs
@@ -56,18 +56,19 @@ impl From<&Vec<Triangle<3>>> for Vertices {
             let [a, b, c] = triangle.points();
 
             let normal = (b - a).cross(&(c - a)).normalize();
+            let color = triangle.color();
 
-            mesh.push((a, normal));
-            mesh.push((b, normal));
-            mesh.push((c, normal));
+            mesh.push((a, normal, color));
+            mesh.push((b, normal, color));
+            mesh.push((c, normal, color));
         }
 
         let vertices = mesh
             .vertices()
-            .map(|(vertex, normal)| Vertex {
+            .map(|(vertex, normal, color)| Vertex {
                 position: vertex.into(),
                 normal: normal.into(),
-                color: [1.0, 0.0, 0.0, 1.0],
+                color: color.map(|v| f32::from(v) / 255.0),
             })
             .collect();
 

--- a/src/math/triangle.rs
+++ b/src/math/triangle.rs
@@ -17,6 +17,11 @@ impl<const D: usize> Triangle<D> {
     pub fn color(&self) -> [u8; 4] {
         self.color
     }
+
+    /// Set a new color for the particular triangle
+    pub fn set_color(&mut self, color: [u8; 4]) {
+        self.color = color;
+    }
 }
 
 impl Triangle<3> {
@@ -91,5 +96,15 @@ mod tests {
         let c = Point::from([1.0, 2.0]);
         let triangle = Triangle::from([a, b, c]);
         assert_eq!(triangle.color(), [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn triangle_set_color() {
+        let a = Point::from([0.0, 0.0]);
+        let b = Point::from([1.0, 1.0]);
+        let c = Point::from([1.0, 2.0]);
+        let mut triangle = Triangle::from([a, b, c]);
+        triangle.set_color([1, 2, 3, 4]);
+        assert_eq!(triangle.color(), [1, 2, 3, 4]);
     }
 }

--- a/src/math/triangle.rs
+++ b/src/math/triangle.rs
@@ -2,12 +2,20 @@ use super::{Point, Scalar};
 
 /// A triangle
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Triangle<const D: usize>([Point<D>; 3]);
+pub struct Triangle<const D: usize> {
+    points: [Point<D>; 3],
+    color: [u8; 4],
+}
 
 impl<const D: usize> Triangle<D> {
     /// Access the triangle's points
     pub fn points(&self) -> [Point<D>; 3] {
-        self.0
+        self.points
+    }
+
+    /// Return the specified color of the triangle in RGBA
+    pub fn color(&self) -> [u8; 4] {
+        self.color
     }
 }
 
@@ -27,7 +35,10 @@ impl<const D: usize> From<[Point<D>; 3]> for Triangle<D> {
 
         // A triangle is not valid if it doesn't span any area
         if area != Scalar::from(0.0) {
-            Self(points)
+            Self {
+                points,
+                color: [255, 0, 0, 255],
+            }
         } else {
             panic!("Invalid Triangle specified");
         }
@@ -71,5 +82,14 @@ mod tests {
         let b = Point::from([1.0, 1.0, 1.0]);
         let c = Point::from([2.0, 2.0, 2.0]);
         let _triangle = Triangle::from([a, b, c]);
+    }
+
+    #[test]
+    fn triangle_default_color() {
+        let a = Point::from([0.0, 0.0]);
+        let b = Point::from([1.0, 1.0]);
+        let c = Point::from([1.0, 2.0]);
+        let triangle = Triangle::from([a, b, c]);
+        assert_eq!(triangle.color(), [255, 0, 0, 255]);
     }
 }


### PR DESCRIPTION
…ring meshing

This moves the hardcoded color specification (still red with full
opacity) one level closer to the actual model.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>