### PR TITLE
Coloring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         .parse()
         .unwrap();
 
-    let outer_edge = fj::Circle { radius: outer };
-    let inner_edge = fj::Circle { radius: inner };
+    let outer_edge = fj::Circle::from_radius(outer);
+    let inner_edge = fj::Circle::from_radius(inner);
 
     let footprint = fj::Difference {
         a: outer_edge.into(),

--- a/README.md
+++ b/README.md
@@ -57,10 +57,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
     let outer_edge = fj::Circle::from_radius(outer);
     let inner_edge = fj::Circle::from_radius(inner);
 
-    let footprint = fj::Difference {
-        a: outer_edge.into(),
-        b: inner_edge.into(),
-    };
+    let footprint = fj::Difference2d::from_objects(outer_edge.into(), inner_edge.into());
 
     let spacer = fj::Sweep {
         shape: footprint.into(),

--- a/README.md
+++ b/README.md
@@ -59,10 +59,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
 
     let footprint = fj::Difference2d::from_objects(outer_edge.into(), inner_edge.into());
 
-    let spacer = fj::Sweep {
-        shape: footprint.into(),
-        length: height,
-    };
+    let spacer = fj::Sweep::from_shape_and_length(footprint.into(), height);
 
     spacer.into()
 }

--- a/fj/src/shape_2d.rs
+++ b/fj/src/shape_2d.rs
@@ -16,27 +16,60 @@ pub enum Shape2d {
     Sketch(Sketch),
 }
 
+impl Shape2d {
+    /// Get the rendering color of the larger object in RGBA
+    pub fn color(&self) -> [u8; 4] {
+        match &self {
+            Shape2d::Circle(c) => c.color(),
+            Shape2d::Sketch(s) => s.color(),
+            Shape2d::Difference(d) => d.color(),
+        }
+    }
+}
+
 /// A circle
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct Circle {
     /// The radius of the circle
     radius: f64,
+    // The color of the circle in RGBA
+    color: [u8; 4],
 }
 
 impl Circle {
+    /// Construct a new circle with a specific radius
     pub fn from_radius(radius: f64) -> Self {
-        Self { radius }
+        Self {
+            radius,
+            color: [255, 0, 0, 255],
+        }
     }
 
     pub fn radius(&self) -> f64 {
         self.radius
     }
+
+    /// Set the rendering color of the circle in RGBA
+    pub fn with_color(mut self, color: [u8; 4]) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Set the rendering color of the circle in RGBA
+    pub fn set_color(&mut self, color: [u8; 4]) {
+        self.color = color;
+    }
+
+    /// Get the rendering color of the circle in RGBA
+    pub fn color(&self) -> [u8; 4] {
+        self.color
+    }
 }
 
 impl From<Circle> for Shape {
     fn from(shape: Circle) -> Self {
-        Self::Shape2d(Shape2d::Circle(shape))
+        Self::Shape2d(shape.into())
     }
 }
 
@@ -60,6 +93,11 @@ pub struct Difference2d {
 impl Difference2d {
     pub fn from_objects(a: Shape2d, b: Shape2d) -> Self {
         Self { a, b }
+    }
+
+    /// Get the rendering color of the larger object in RGBA
+    pub fn color(&self) -> [u8; 4] {
+        self.a.color()
     }
 
     pub fn a(&self) -> &Shape2d {
@@ -100,6 +138,8 @@ pub struct Sketch {
     ptr: *mut [f64; 2],
     length: usize,
     capacity: usize,
+    // The color of the sketch in RGBA
+    color: [u8; 4],
 }
 
 impl Sketch {
@@ -118,6 +158,7 @@ impl Sketch {
             ptr,
             length,
             capacity,
+            color: [255, 0, 0, 255],
         }
     }
 
@@ -141,17 +182,33 @@ impl Sketch {
 
         ret
     }
+
+    /// Set the rendering color of the sketch in RGBA
+    pub fn with_color(mut self, color: [u8; 4]) -> Self {
+        self.color = color;
+        self
+    }
+
+    /// Set the rendering color of the sketch in RGBA
+    pub fn set_color(&mut self, color: [u8; 4]) {
+        self.color = color;
+    }
+
+    /// Get the rendering color of the sketch in RGBA
+    pub fn color(&self) -> [u8; 4] {
+        self.color
+    }
 }
 
 impl From<Sketch> for Shape {
     fn from(shape: Sketch) -> Self {
-        Self::Shape2d(Shape2d::Sketch(shape))
+        Self::Shape2d(shape.into())
     }
 }
 
 impl From<Sketch> for Shape2d {
     fn from(shape: Sketch) -> Self {
-        Self::Sketch(shape)
+        Shape2d::Sketch(shape)
     }
 }
 

--- a/fj/src/shape_2d.rs
+++ b/fj/src/shape_2d.rs
@@ -21,7 +21,17 @@ pub enum Shape2d {
 #[repr(C)]
 pub struct Circle {
     /// The radius of the circle
-    pub radius: f64,
+    radius: f64,
+}
+
+impl Circle {
+    pub fn from_radius(radius: f64) -> Self {
+        Self { radius }
+    }
+
+    pub fn radius(&self) -> f64 {
+        self.radius
+    }
 }
 
 impl From<Circle> for Shape {

--- a/fj/src/shape_2d.rs
+++ b/fj/src/shape_2d.rs
@@ -51,15 +51,29 @@ impl From<Circle> for Shape2d {
 #[repr(C)]
 pub struct Difference2d {
     /// The original shape
-    pub a: Shape2d,
+    a: Shape2d,
 
     /// The shape being subtracted
-    pub b: Shape2d,
+    b: Shape2d,
+}
+
+impl Difference2d {
+    pub fn from_objects(a: Shape2d, b: Shape2d) -> Self {
+        Self { a, b }
+    }
+
+    pub fn a(&self) -> &Shape2d {
+        &self.a
+    }
+
+    pub fn b(&self) -> &Shape2d {
+        &self.b
+    }
 }
 
 impl From<Difference2d> for Shape {
     fn from(shape: Difference2d) -> Self {
-        Self::Shape2d(Shape2d::Difference(Box::new(shape)))
+        Self::Shape2d(shape.into())
     }
 }
 

--- a/fj/src/shape_3d.rs
+++ b/fj/src/shape_3d.rs
@@ -62,15 +62,29 @@ impl From<Transform> for Shape3d {
 #[repr(C)]
 pub struct Sweep {
     /// The 2-dimensional shape being swept
-    pub shape: Shape2d,
+    shape: Shape2d,
 
     /// The length of the sweep
-    pub length: f64,
+    length: f64,
+}
+
+impl Sweep {
+    pub fn from_shape_and_length(shape: Shape2d, length: f64) -> Self {
+        Self { shape, length }
+    }
+
+    pub fn shape(&self) -> &Shape2d {
+        &self.shape
+    }
+
+    pub fn length(&self) -> f64 {
+        self.length
+    }
 }
 
 impl From<Sweep> for Shape {
     fn from(shape: Sweep) -> Self {
-        Self::Shape3d(Shape3d::Sweep(shape))
+        Self::Shape3d(shape.into())
     }
 }
 

--- a/fj/src/shape_3d.rs
+++ b/fj/src/shape_3d.rs
@@ -80,6 +80,10 @@ impl Sweep {
     pub fn length(&self) -> f64 {
         self.length
     }
+
+    pub fn color(&self) -> [u8; 4] {
+        self.shape().color()
+    }
 }
 
 impl From<Sweep> for Shape {

--- a/fj/src/syntax.rs
+++ b/fj/src/syntax.rs
@@ -44,7 +44,7 @@ where
 {
     fn sweep(&self, length: f64) -> crate::Sweep {
         let shape = self.clone().into();
-        crate::Sweep { shape, length }
+        crate::Sweep::from_shape_and_length(shape, length)
     }
 }
 

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -12,7 +12,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         [ x / 2., -y / 2.],
         [ x / 2.,  y / 2.],
         [-x / 2.,  y / 2.],
-    ]);
+    ]).with_color([100,255,0,200]);
 
     let cuboid = fj::Sweep::from_shape_and_length(rectangle.into(), z);
 

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -14,10 +14,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         [-x / 2.,  y / 2.],
     ]);
 
-    let cuboid = fj::Sweep {
-        shape: rectangle.into(),
-        length: z,
-    };
+    let cuboid = fj::Sweep::from_shape_and_length(rectangle.into(), z);
 
     cuboid.into()
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -18,8 +18,8 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         .parse()
         .unwrap();
 
-    let outer_edge = fj::Circle { radius: outer };
-    let inner_edge = fj::Circle { radius: inner };
+    let outer_edge = fj::Circle::from_radius(outer);
+    let inner_edge = fj::Circle::from_radius(inner);
 
     let footprint = fj::Difference2d {
         a: outer_edge.into(),

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -23,10 +23,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
 
     let footprint = fj::Difference2d::from_objects(outer_edge.into(), inner_edge.into());
 
-    let spacer = fj::Sweep {
-        shape: footprint.into(),
-        length: height,
-    };
+    let spacer = fj::Sweep::from_shape_and_length(footprint.into(), height);
 
     spacer.into()
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -12,16 +12,18 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         .unwrap_or(&"0.5".to_owned())
         .parse()
         .unwrap();
-    let height = args
+    let height: f64 = args
         .get("height")
         .unwrap_or(&"1.0".to_owned())
         .parse()
         .unwrap();
 
-    let outer_edge = fj::Circle::from_radius(outer);
+    let outer_edge =
+        fj::Circle::from_radius(outer).with_color([0, 0, 255, 255]);
     let inner_edge = fj::Circle::from_radius(inner);
 
-    let footprint = fj::Difference2d::from_objects(outer_edge.into(), inner_edge.into());
+    let footprint =
+        fj::Difference2d::from_objects(outer_edge.into(), inner_edge.into());
 
     let spacer = fj::Sweep::from_shape_and_length(footprint.into(), height);
 

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -21,10 +21,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
     let outer_edge = fj::Circle::from_radius(outer);
     let inner_edge = fj::Circle::from_radius(inner);
 
-    let footprint = fj::Difference2d {
-        a: outer_edge.into(),
-        b: inner_edge.into(),
-    };
+    let footprint = fj::Difference2d::from_objects(outer_edge.into(), inner_edge.into());
 
     let spacer = fj::Sweep {
         shape: footprint.into(),

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -53,10 +53,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
     let outer = fj::Sketch::from_points(outer);
     let inner = fj::Sketch::from_points(inner);
 
-    let footprint = fj::Difference2d {
-        a: outer.into(),
-        b: inner.into(),
-    };
+    let footprint = fj::Difference2d::from_objects(outer.into(), inner.into());
 
     let star = fj::Sweep {
         shape: footprint.into(),

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -50,7 +50,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         inner.push([x / 2., y / 2.]);
     }
 
-    let outer = fj::Sketch::from_points(outer);
+    let outer = fj::Sketch::from_points(outer).with_color ([0, 255, 0, 200]);
     let inner = fj::Sketch::from_points(inner);
 
     let footprint = fj::Difference2d::from_objects(outer.into(), inner.into());

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -55,10 +55,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
 
     let footprint = fj::Difference2d::from_objects(outer.into(), inner.into());
 
-    let star = fj::Sweep {
-        shape: footprint.into(),
-        length: h,
-    };
+    let star = fj::Sweep::from_shape_and_length(footprint.into(), h);
 
     star.into()
 }

--- a/src/kernel/algorithms/approximation.rs
+++ b/src/kernel/algorithms/approximation.rs
@@ -275,6 +275,7 @@ mod tests {
         let face = Face::Face {
             surface,
             cycles: vec![abcd],
+            color: [255, 0, 0, 255],
         };
 
         assert_eq!(

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -25,7 +25,11 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
 
     for face in original.topology().faces() {
         let face = match face.get().clone() {
-            Face::Face { cycles, surface } => {
+            Face::Face {
+                cycles,
+                surface,
+                color,
+            } => {
                 let mut cycles_trans = Vec::new();
 
                 for cycle in cycles {
@@ -75,6 +79,7 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
                 Face::Face {
                     cycles: cycles_trans,
                     surface,
+                    color,
                 }
             }
             Face::Triangles(mut triangles) => {

--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -190,7 +190,10 @@ impl Topology<'_> {
     /// cycles it refers to are part of the shape). Returns an error, if that is
     /// not the case.
     pub fn add_face(&mut self, face: Face) -> ValidationResult<Face> {
-        if let Face::Face { surface, cycles } = &face {
+        if let Face::Face {
+            surface, cycles, ..
+        } = &face
+        {
             let mut missing_surface = None;
             let mut missing_cycles = HashSet::new();
 
@@ -371,6 +374,7 @@ mod tests {
             .add_face(Face::Face {
                 surface: surface.clone(),
                 cycles: vec![cycle.clone()],
+                color: [255, 0, 0, 255],
             })
             .unwrap_err();
         assert!(err.missing_surface(&surface));
@@ -383,6 +387,7 @@ mod tests {
         shape.topology().add_face(Face::Face {
             surface,
             cycles: vec![cycle],
+            color: [255, 0, 0, 255],
         })?;
 
         Ok(())

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -19,7 +19,7 @@ impl ToShape for fj::Circle {
 
         let edge = shape
             .topology()
-            .add_circle(Scalar::from_f64(self.radius))
+            .add_circle(Scalar::from_f64(self.radius()))
             .unwrap();
         shape
             .topology()
@@ -38,8 +38,8 @@ impl ToShape for fj::Circle {
 
     fn bounding_volume(&self) -> Aabb<3> {
         Aabb {
-            min: Point::from([-self.radius, -self.radius, 0.0]),
-            max: Point::from([self.radius, self.radius, 0.0]),
+            min: Point::from([-self.radius(), -self.radius(), 0.0]),
+            max: Point::from([self.radius(), self.radius(), 0.0]),
         }
     }
 }

--- a/src/kernel/shapes/circle.rs
+++ b/src/kernel/shapes/circle.rs
@@ -30,7 +30,11 @@ impl ToShape for fj::Circle {
         let surface = shape.geometry().add_surface(Surface::x_y_plane());
         shape
             .topology()
-            .add_face(Face::Face { cycles, surface })
+            .add_face(Face::Face {
+                cycles,
+                surface,
+                color: self.color(),
+            })
             .unwrap();
 
         shape

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -95,7 +95,11 @@ impl ToShape for fj::Difference2d {
 
         shape
             .topology()
-            .add_face(Face::Face { cycles, surface })
+            .add_face(Face::Face {
+                cycles,
+                surface,
+                color: self.color(),
+            })
             .unwrap();
 
         shape

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -22,7 +22,7 @@ impl ToShape for fj::Difference2d {
 
         let mut shape = Shape::new();
 
-        let [mut a, mut b] = [&self.a, &self.b]
+        let [mut a, mut b] = [&self.a(), &self.b()]
             .map(|shape| shape.to_shape(tolerance, debug_info));
 
         for shape in [&mut a, &mut b] {
@@ -105,6 +105,6 @@ impl ToShape for fj::Difference2d {
         // This is a conservative estimate of the bounding box: It's never going
         // to be bigger than the bounding box of the original shape that another
         // is being subtracted from.
-        self.a.bounding_volume()
+        self.a().bounding_volume()
     }
 }

--- a/src/kernel/shapes/sketch.rs
+++ b/src/kernel/shapes/sketch.rs
@@ -49,6 +49,7 @@ impl ToShape for fj::Sketch {
         let face = Face::Face {
             cycles: shape.topology().cycles().collect(),
             surface,
+            color: self.color(),
         };
         shape.topology().add_face(face).unwrap();
 

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -12,6 +12,7 @@ impl ToShape for fj::Sweep {
             self.shape().to_shape(tolerance, debug_info),
             Vector::from([0., 0., self.length()]),
             tolerance,
+            self.color(),
         )
     }
 

--- a/src/kernel/shapes/sweep.rs
+++ b/src/kernel/shapes/sweep.rs
@@ -9,15 +9,15 @@ use super::ToShape;
 impl ToShape for fj::Sweep {
     fn to_shape(&self, tolerance: Scalar, debug_info: &mut DebugInfo) -> Shape {
         sweep_shape(
-            self.shape.to_shape(tolerance, debug_info),
-            Vector::from([0., 0., self.length]),
+            self.shape().to_shape(tolerance, debug_info),
+            Vector::from([0., 0., self.length()]),
             tolerance,
         )
     }
 
     fn bounding_volume(&self) -> Aabb<3> {
-        let mut aabb = self.shape.bounding_volume();
-        aabb.max.z = self.length.into();
+        let mut aabb = self.shape().bounding_volume();
+        aabb.max.z = self.length().into();
         aabb
     }
 }

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -103,6 +103,7 @@ fn copy_shape(mut orig: Shape, target: &mut Shape) {
             Face::Face {
                 surface,
                 cycles: cs,
+                color,
             } => {
                 target
                     .topology()
@@ -112,6 +113,7 @@ fn copy_shape(mut orig: Shape, target: &mut Shape) {
                             .iter()
                             .map(|cycle| cycles[cycle].clone())
                             .collect(),
+                        color: *color,
                     })
                     .unwrap();
             }

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -47,6 +47,7 @@ pub enum Face {
         /// It might be less error-prone to specify the edges in surface
         /// coordinates.
         cycles: Vec<Handle<Cycle>>,
+        color: [u8; 4],
     },
 
     /// The triangles of the face
@@ -98,7 +99,7 @@ impl Face {
         debug_info: &mut DebugInfo,
     ) {
         match self {
-            Self::Face { surface, .. } => {
+            Self::Face { surface, color, .. } => {
                 let approx = Approximation::for_face(self, tolerance);
 
                 let points: Vec<_> = approx
@@ -223,7 +224,9 @@ impl Face {
 
                 out.extend(triangles.into_iter().map(|triangle| {
                     let [a, b, c] = triangle.map(|point| point.canonical());
-                    Triangle::from([a, b, c])
+                    let mut t = Triangle::from([a, b, c]);
+                    t.set_color(*color);
+                    t
                 }));
             }
             Self::Triangles(triangles) => out.extend(triangles),


### PR DESCRIPTION
Implement basic coloring support for shapes

The examples have been extended to demonstrate the coloring of objects. A few bits and pieces are probably still missing or could be improved but let's look at those in another step.

Closes #291

Signed-off-by: Daniel Egger <daniel@eggers-club.de>
