### PR TITLE
Remove `Deref` implementation from `Handle`

### DIFF
--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -72,8 +72,8 @@ pub fn sweep_shape(
     }
 
     // Create top faces.
-    for face_orig in shape_orig.topology().faces() {
-        let cycles_orig = match &*face_orig {
+    for face_orig in shape_orig.topology().faces().values() {
+        let cycles_orig = match &face_orig {
             Face::Face { cycles, .. } => cycles,
             _ => {
                 // Sketches are created using boundary representation, so this
@@ -108,7 +108,7 @@ pub fn sweep_shape(
     // We could use `vertices` to create the side edges and faces here, but the
     // side walls are created below, in triangle representation.
 
-    for cycle in shape_orig.topology().cycles() {
+    for cycle in shape_orig.topology().cycles().values() {
         let approx = Approximation::for_cycle(&cycle, tolerance);
 
         // This will only work correctly, if the cycle consists of one edge. If

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -30,7 +30,8 @@ pub fn sweep_shape(
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.topology().vertices() {
-        let point = shape.geometry().add_point(vertex_orig.point() + path);
+        let point =
+            shape.geometry().add_point(vertex_orig.get().point() + path);
         let vertex = shape.topology().add_vertex(Vertex { point }).unwrap();
         vertices.insert(vertex_orig, vertex);
     }
@@ -40,9 +41,9 @@ pub fn sweep_shape(
     for edge_orig in shape_orig.topology().edges() {
         let curve = shape
             .geometry()
-            .add_curve(edge_orig.curve().transform(&translation));
+            .add_curve(edge_orig.get().curve().transform(&translation));
 
-        let vertices = edge_orig.vertices.clone().map(|vs| {
+        let vertices = edge_orig.get().vertices.clone().map(|vs| {
             vs.map(|vertex_orig| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its vertices to `vertices`.
@@ -58,6 +59,7 @@ pub fn sweep_shape(
     let mut cycles = HashMap::new();
     for cycle_orig in shape_orig.topology().cycles() {
         let edges = cycle_orig
+            .get()
             .edges
             .iter()
             .map(|edge_orig| {
@@ -240,7 +242,7 @@ mod tests {
 
             let surface = shape.geometry().add_surface(Surface::Swept(
                 Swept::plane_from_points(
-                    [a, b, c].map(|vertex| vertex.point()),
+                    [a, b, c].map(|vertex| vertex.get().point()),
                 ),
             ));
             let abc = Face::Face {

--- a/src/kernel/algorithms/transform.rs
+++ b/src/kernel/algorithms/transform.rs
@@ -35,7 +35,9 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
                 for cycle in cycles {
                     let mut edges = Vec::new();
 
-                    for edge in &cycle.edges {
+                    for edge in &cycle.get().edges {
+                        let edge = edge.get();
+
                         let curve = transformed
                             .geometry()
                             .add_curve(edge.curve().transform(transform));
@@ -74,7 +76,7 @@ pub fn transform_shape(mut original: Shape, transform: &Transform) -> Shape {
 
                 let surface = transformed
                     .geometry()
-                    .add_surface(surface.transform(transform));
+                    .add_surface(surface.get().transform(transform));
 
                 Face::Face {
                     cycles: cycles_trans,

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{
     handle::{Handle, Storage},
-    Curves, Points, Surfaces,
+    Curves, Iter, Points, Surfaces,
 };
 
 /// API to access a shape's geometry
@@ -61,17 +61,17 @@ impl Geometry<'_> {
     }
 
     /// Access an iterator over all points
-    pub fn points(&self) -> impl Iterator<Item = Handle<Point<3>>> + '_ {
-        self.points.iter().map(|storage| storage.handle())
+    pub fn points(&self) -> Iter<Point<3>> {
+        Iter::new(self.points)
     }
 
     /// Access an iterator over all curves
-    pub fn curves(&self) -> impl Iterator<Item = Handle<Curve>> + '_ {
-        self.curves.iter().map(|storage| storage.handle())
+    pub fn curves(&self) -> Iter<Curve> {
+        Iter::new(self.curves)
     }
 
     /// Access an iterator over all surfaces
-    pub fn surfaces(&self) -> impl Iterator<Item = Handle<Surface>> + '_ {
-        self.surfaces.iter().map(|storage| storage.handle())
+    pub fn surfaces(&self) -> Iter<Surface> {
+        Iter::new(self.surfaces)
     }
 }

--- a/src/kernel/shape/geometry.rs
+++ b/src/kernel/shape/geometry.rs
@@ -61,16 +61,22 @@ impl Geometry<'_> {
     }
 
     /// Access an iterator over all points
+    ///
+    /// The caller must not make any assumptions about the order of points.
     pub fn points(&self) -> Iter<Point<3>> {
         Iter::new(self.points)
     }
 
     /// Access an iterator over all curves
+    ///
+    /// The caller must not make any assumptions about the order of curves.
     pub fn curves(&self) -> Iter<Curve> {
         Iter::new(self.curves)
     }
 
     /// Access an iterator over all surfaces
+    ///
+    /// The caller must not make any assumptions about the order of surfaces.
     pub fn surfaces(&self) -> Iter<Surface> {
         Iter::new(self.surfaces)
     }

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -65,7 +65,7 @@ where
 
 /// Internal type used in collections within [`Shape`]
 #[derive(Debug, Eq, Ord, PartialOrd)]
-pub(super) struct Storage<T>(Arc<T>);
+pub struct Storage<T>(Arc<T>);
 
 impl<T> Storage<T> {
     /// Create a [`Storage`] instance that wraps the provided object

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -46,14 +46,6 @@ impl<T> Handle<T> {
     }
 }
 
-impl<T> Deref for Handle<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
 impl<T> fmt::Debug for Handle<T>
 where
     T: fmt::Debug,

--- a/src/kernel/shape/handle.rs
+++ b/src/kernel/shape/handle.rs
@@ -33,9 +33,6 @@ pub struct Handle<T>(Storage<T>);
 
 impl<T> Handle<T> {
     /// Access the object that the handle references
-    ///
-    /// `Handle` also implements `Deref`, but as that can be inconvenient to use
-    /// in some cases, this method is an inherent proxy for that.
     pub fn get(&self) -> &T {
         self.0.deref()
     }

--- a/src/kernel/shape/iter.rs
+++ b/src/kernel/shape/iter.rs
@@ -1,0 +1,29 @@
+use std::{iter, slice};
+
+use super::{
+    handle::{Handle, Storage},
+    Store,
+};
+
+pub struct Iter<'r, T> {
+    inner: Inner<'r, T>,
+}
+
+impl<'r, T> Iter<'r, T> {
+    pub(super) fn new(store: &'r Store<T>) -> Self {
+        let handle: fn(&Storage<T>) -> Handle<T> = |storage| storage.handle();
+        let inner = store.iter().map(handle);
+        Self { inner }
+    }
+}
+
+impl<T> Iterator for Iter<'_, T> {
+    type Item = Handle<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+type Inner<'r, T> =
+    iter::Map<slice::Iter<'r, Storage<T>>, fn(&Storage<T>) -> Handle<T>>;

--- a/src/kernel/shape/iter.rs
+++ b/src/kernel/shape/iter.rs
@@ -15,6 +15,16 @@ impl<'r, T> Iter<'r, T> {
         let inner = store.iter().map(handle);
         Self { inner }
     }
+
+    /// Convert this iterator over handles into an iterator over values
+    ///
+    /// This is a convenience method, for cases where no `Handle` is needed.
+    pub fn values(self) -> impl Iterator<Item = T> + 'r
+    where
+        T: Clone,
+    {
+        self.inner.map(|handle| handle.get().clone())
+    }
 }
 
 impl<T> Iterator for Iter<'_, T> {

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -104,11 +104,13 @@ impl Shape {
     }
 }
 
-type Points = Vec<Storage<Point<3>>>;
-type Curves = Vec<Storage<Curve>>;
-type Surfaces = Vec<Storage<Surface>>;
+type Points = Store<Point<3>>;
+type Curves = Store<Curve>;
+type Surfaces = Store<Surface>;
 
-type Vertices = Vec<Storage<Vertex>>;
-type Edges = Vec<Storage<Edge>>;
-type Cycles = Vec<Storage<Cycle>>;
-type Faces = Vec<Storage<Face>>;
+type Vertices = Store<Vertex>;
+type Edges = Store<Edge>;
+type Cycles = Store<Cycle>;
+type Faces = Store<Face>;
+
+type Store<T> = Vec<Storage<T>>;

--- a/src/kernel/shape/mod.rs
+++ b/src/kernel/shape/mod.rs
@@ -1,11 +1,13 @@
 pub mod geometry;
 pub mod handle;
+pub mod iter;
 pub mod topology;
 pub mod validate;
 
 pub use self::{
     geometry::Geometry,
     handle::Handle,
+    iter::Iter,
     topology::Topology,
     validate::{ValidationError, ValidationResult},
 };

--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -237,11 +237,15 @@ impl Topology<'_> {
     }
 
     /// Access an iterator over all cycles
+    ///
+    /// The caller must not make any assumptions about the order of cycles.
     pub fn cycles(&self) -> Iter<Cycle> {
         Iter::new(self.cycles)
     }
 
     /// Access an iterator over all faces
+    ///
+    /// The caller must not make any assumptions about the order of faces.
     pub fn faces(&self) -> Iter<Face> {
         Iter::new(self.faces)
     }

--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -146,7 +146,7 @@ impl Topology<'_> {
         vertices: [Handle<Vertex>; 2],
     ) -> ValidationResult<Edge> {
         let curve = self.geometry.add_curve(Curve::Line(Line::from_points(
-            vertices.clone().map(|vertex| vertex.point()),
+            vertices.clone().map(|vertex| vertex.get().point()),
         )));
         self.add_edge(Edge {
             curve,

--- a/src/kernel/shape/topology.rs
+++ b/src/kernel/shape/topology.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{
     handle::{Handle, Storage},
-    Cycles, Edges, Faces, Geometry, ValidationError, ValidationResult,
+    Cycles, Edges, Faces, Geometry, Iter, ValidationError, ValidationResult,
     Vertices,
 };
 
@@ -225,25 +225,25 @@ impl Topology<'_> {
     /// Access iterator over all vertices
     ///
     /// The caller must not make any assumptions about the order of vertices.
-    pub fn vertices(&self) -> impl Iterator<Item = Handle<Vertex>> + '_ {
-        self.vertices.iter().map(|storage| storage.handle())
+    pub fn vertices(&self) -> Iter<Vertex> {
+        Iter::new(self.vertices)
     }
 
     /// Access iterator over all edges
     ///
     /// The caller must not make any assumptions about the order of edges.
-    pub fn edges(&self) -> impl Iterator<Item = Handle<Edge>> + '_ {
-        self.edges.iter().map(|storage| storage.handle())
+    pub fn edges(&self) -> Iter<Edge> {
+        Iter::new(self.edges)
     }
 
     /// Access an iterator over all cycles
-    pub fn cycles(&self) -> impl Iterator<Item = Handle<Cycle>> + '_ {
-        self.cycles.iter().map(|storage| storage.handle())
+    pub fn cycles(&self) -> Iter<Cycle> {
+        Iter::new(self.cycles)
     }
 
     /// Access an iterator over all faces
-    pub fn faces(&self) -> impl Iterator<Item = Handle<Face>> + '_ {
-        self.faces.iter().map(|storage| storage.handle())
+    pub fn faces(&self) -> Iter<Face> {
+        Iter::new(self.faces)
     }
 
     pub fn triangles(

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -53,7 +53,9 @@ impl ToShape for fj::Difference2d {
 
         for cycle in cycles_orig {
             let mut edges = Vec::new();
-            for edge in &cycle.edges {
+            for edge in &cycle.get().edges {
+                let edge = edge.get();
+
                 let curve = shape.geometry().add_curve(edge.curve());
 
                 let vertices = edge.vertices().clone().map(|vs| {

--- a/src/kernel/shapes/difference_2d.rs
+++ b/src/kernel/shapes/difference_2d.rs
@@ -85,7 +85,7 @@ impl ToShape for fj::Difference2d {
 
         // Can't panic, as we just verified that both shapes have one face.
         let [face_a, face_b] = [&mut a, &mut b]
-            .map(|shape| shape.topology().faces().next().unwrap());
+            .map(|shape| shape.topology().faces().values().next().unwrap());
 
         assert!(
             face_a.surface() == face_b.surface(),

--- a/src/kernel/shapes/union.rs
+++ b/src/kernel/shapes/union.rs
@@ -67,7 +67,7 @@ fn copy_shape(mut orig: Shape, target: &mut Shape) {
         let vertex = target
             .topology()
             .add_vertex(Vertex {
-                point: points[&vertex_orig.point].clone(),
+                point: points[&vertex_orig.get().point].clone(),
             })
             .unwrap();
         vertices.insert(vertex_orig, vertex);
@@ -76,8 +76,8 @@ fn copy_shape(mut orig: Shape, target: &mut Shape) {
         let edge = target
             .topology()
             .add_edge(Edge {
-                curve: curves[&edge_orig.curve].clone(),
-                vertices: edge_orig.vertices.as_ref().map(|vs| {
+                curve: curves[&edge_orig.get().curve].clone(),
+                vertices: edge_orig.get().vertices.as_ref().map(|vs| {
                     vs.clone().map(|vertex| vertices[&vertex].clone())
                 }),
             })
@@ -89,6 +89,7 @@ fn copy_shape(mut orig: Shape, target: &mut Shape) {
             .topology()
             .add_cycle(Cycle {
                 edges: cycle_orig
+                    .get()
                     .edges
                     .iter()
                     .map(|edge| edges[edge].clone())

--- a/src/kernel/topology/faces.rs
+++ b/src/kernel/topology/faces.rs
@@ -100,6 +100,7 @@ impl Face {
     ) {
         match self {
             Self::Face { surface, color, .. } => {
+                let surface = surface.get();
                 let approx = Approximation::for_face(self, tolerance);
 
                 let points: Vec<_> = approx


### PR DESCRIPTION
This is preparation for cleaning up the transform code, which in turn will allow vertex validation to be enabled (#242).