### PR TITLE
Use boundary representation for non-continuous sweep side faces

### DIFF
--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -65,7 +65,7 @@ pub fn sweep_shape(
 
     // Create the new cycles.
     for cycle_source in source.topology().cycles() {
-        let edges = cycle_source
+        let edges_top = cycle_source
             .get()
             .edges
             .iter()
@@ -76,7 +76,10 @@ pub fn sweep_shape(
             })
             .collect();
 
-        let cycle = target.topology().add_cycle(Cycle { edges }).unwrap();
+        let cycle = target
+            .topology()
+            .add_cycle(Cycle { edges: edges_top })
+            .unwrap();
         source_to_top.cycles.insert(cycle_source, cycle);
     }
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -53,14 +53,14 @@ pub fn sweep_shape(
             })
         });
 
-        let edge = target
+        let edge_top = target
             .topology()
             .add_edge(Edge {
                 curve: curve_top,
                 vertices: vertices_top,
             })
             .unwrap();
-        source_to_top.edges.insert(edge_source, edge);
+        source_to_top.edges.insert(edge_source, edge_top);
     }
 
     // Create the new cycles.

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -70,27 +70,11 @@ pub fn sweep_shape(
 
     // Create top faces.
     for face_source in source.topology().faces().values() {
-        let cycles_source = match &face_source {
-            Face::Face { cycles, .. } => cycles,
-            _ => {
-                // Sketches are created using boundary representation, so this
-                // case can't happen.
-                unreachable!()
-            }
-        };
-
         let surface_top = target
             .geometry()
             .add_surface(face_source.surface().transform(&translation));
 
-        let cycles_top = cycles_source
-            .iter()
-            .map(|cycle_source| {
-                // Can't panic, as long as the source shape is valid. We've
-                // added all its cycles to the relation.
-                source_to_top.cycles.get(cycle_source).unwrap().clone()
-            })
-            .collect();
+        let cycles_top = source_to_top.cycles_for_face(&face_source);
 
         target
             .topology()
@@ -175,6 +159,22 @@ impl Relation {
             .edges
             .iter()
             .map(|edge| self.edges.get(edge).unwrap().clone())
+            .collect()
+    }
+
+    fn cycles_for_face(&self, face: &Face) -> Vec<Handle<Cycle>> {
+        let cycles = match face {
+            Face::Face { cycles, .. } => cycles,
+            _ => {
+                // Sketches are created using boundary representation, so this
+                // case can't happen.
+                unreachable!()
+            }
+        };
+
+        cycles
+            .iter()
+            .map(|cycle| self.cycles.get(cycle).unwrap().clone())
             .collect()
     }
 }

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -25,7 +25,7 @@ pub fn sweep_shape(
 
     let translation = Transform::translation(path);
 
-    let mut orig_to_top = Relation::new();
+    let mut source_to_top = Relation::new();
 
     // Create the new vertices.
     for vertex_orig in source.topology().vertices() {
@@ -33,7 +33,7 @@ pub fn sweep_shape(
             .geometry()
             .add_point(vertex_orig.get().point() + path);
         let vertex = target.topology().add_vertex(Vertex { point }).unwrap();
-        orig_to_top.vertices.insert(vertex_orig, vertex);
+        source_to_top.vertices.insert(vertex_orig, vertex);
     }
 
     // Create the new edges.
@@ -46,7 +46,7 @@ pub fn sweep_shape(
             vs.map(|vertex_orig| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its vertices to `vertices`.
-                orig_to_top.vertices.get(&vertex_orig).unwrap().clone()
+                source_to_top.vertices.get(&vertex_orig).unwrap().clone()
             })
         });
 
@@ -54,7 +54,7 @@ pub fn sweep_shape(
             .topology()
             .add_edge(Edge { curve, vertices })
             .unwrap();
-        orig_to_top.edges.insert(edge_orig, edge);
+        source_to_top.edges.insert(edge_orig, edge);
     }
 
     // Create the new cycles.
@@ -66,12 +66,12 @@ pub fn sweep_shape(
             .map(|edge_orig| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its edges to `edges`.
-                orig_to_top.edges.get(edge_orig).unwrap().clone()
+                source_to_top.edges.get(edge_orig).unwrap().clone()
             })
             .collect();
 
         let cycle = target.topology().add_cycle(Cycle { edges }).unwrap();
-        orig_to_top.cycles.insert(cycle_orig, cycle);
+        source_to_top.cycles.insert(cycle_orig, cycle);
     }
 
     // Create top faces.
@@ -94,7 +94,7 @@ pub fn sweep_shape(
             .map(|cycle_orig| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its cycles to `cycles`.
-                orig_to_top.cycles.get(cycle_orig).unwrap().clone()
+                source_to_top.cycles.get(cycle_orig).unwrap().clone()
             })
             .collect();
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -76,11 +76,11 @@ pub fn sweep_shape(
             })
             .collect();
 
-        let cycle = target
+        let cycle_top = target
             .topology()
             .add_cycle(Cycle { edges: edges_top })
             .unwrap();
-        source_to_top.cycles.insert(cycle_source, cycle);
+        source_to_top.cycles.insert(cycle_source, cycle_top);
     }
 
     // Create top faces.

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -25,8 +25,6 @@ pub fn sweep_shape(
 
     let translation = Transform::translation(path);
 
-    let mut side_faces = Vec::new();
-
     // Create the new vertices.
     let mut vertices = HashMap::new();
     for vertex_orig in shape_orig.topology().vertices() {
@@ -141,11 +139,10 @@ pub fn sweep_shape(
             s.set_color(color);
         }
 
-        side_faces.push(Face::Triangles(side_face));
-    }
-
-    for face in side_faces {
-        shape.topology().add_face(face).unwrap();
+        shape
+            .topology()
+            .add_face(Face::Triangles(side_face))
+            .unwrap();
     }
 
     shape

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -58,8 +58,8 @@ pub fn sweep_shape(
     }
 
     // Create the new cycles.
-    for cycle_orig in source.topology().cycles() {
-        let edges = cycle_orig
+    for cycle_source in source.topology().cycles() {
+        let edges = cycle_source
             .get()
             .edges
             .iter()
@@ -71,7 +71,7 @@ pub fn sweep_shape(
             .collect();
 
         let cycle = target.topology().add_cycle(Cycle { edges }).unwrap();
-        source_to_top.cycles.insert(cycle_orig, cycle);
+        source_to_top.cycles.insert(cycle_source, cycle);
     }
 
     // Create top faces.

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -76,7 +76,7 @@ pub fn sweep_shape(
 
     // Create top faces.
     for face_source in source.topology().faces().values() {
-        let cycles_orig = match &face_source {
+        let cycles_source = match &face_source {
             Face::Face { cycles, .. } => cycles,
             _ => {
                 // Sketches are created using boundary representation, so this
@@ -89,7 +89,7 @@ pub fn sweep_shape(
             .geometry()
             .add_surface(face_source.surface().transform(&translation));
 
-        let cycles = cycles_orig
+        let cycles = cycles_source
             .iter()
             .map(|cycle_orig| {
                 // Can't panic, as long as the original shape is valid. We've

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -45,13 +45,7 @@ pub fn sweep_shape(
             .geometry()
             .add_curve(edge_source.get().curve().transform(&translation));
 
-        let vertices_top = edge_source.get().vertices.clone().map(|vs| {
-            vs.map(|vertex_source| {
-                // Can't panic, as long as the source shape is valid. We've
-                // added all its vertices to the relation.
-                source_to_top.vertices.get(&vertex_source).unwrap().clone()
-            })
-        });
+        let vertices_top = source_to_top.vertices_for_edge(&edge_source);
 
         let edge_top = target
             .topology()
@@ -173,6 +167,15 @@ impl Relation {
             edges: HashMap::new(),
             cycles: HashMap::new(),
         }
+    }
+
+    fn vertices_for_edge(
+        &self,
+        edge: &Handle<Edge>,
+    ) -> Option<[Handle<Vertex>; 2]> {
+        edge.get().vertices.clone().map(|vertices| {
+            vertices.map(|vertex| self.vertices.get(&vertex).unwrap().clone())
+        })
     }
 }
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -94,7 +94,7 @@ pub fn sweep_shape(
             }
         };
 
-        let surface = target
+        let surface_top = target
             .geometry()
             .add_surface(face_source.surface().transform(&translation));
 
@@ -110,7 +110,7 @@ pub fn sweep_shape(
         target
             .topology()
             .add_face(Face::Face {
-                surface,
+                surface: surface_top,
                 cycles,
                 color,
             })

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -29,10 +29,13 @@ pub fn sweep_shape(
 
     // Create the new vertices.
     for vertex_source in source.topology().vertices() {
-        let point = target
+        let point_top = target
             .geometry()
             .add_point(vertex_source.get().point() + path);
-        let vertex = target.topology().add_vertex(Vertex { point }).unwrap();
+        let vertex = target
+            .topology()
+            .add_vertex(Vertex { point: point_top })
+            .unwrap();
         source_to_top.vertices.insert(vertex_source, vertex);
     }
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -21,7 +21,7 @@ pub fn sweep_shape(
     tolerance: Scalar,
     color: [u8; 4],
 ) -> Shape {
-    let mut shape = source.clone();
+    let mut target = source.clone();
 
     let translation = Transform::translation(path);
 
@@ -29,15 +29,16 @@ pub fn sweep_shape(
 
     // Create the new vertices.
     for vertex_orig in source.topology().vertices() {
-        let point =
-            shape.geometry().add_point(vertex_orig.get().point() + path);
-        let vertex = shape.topology().add_vertex(Vertex { point }).unwrap();
+        let point = target
+            .geometry()
+            .add_point(vertex_orig.get().point() + path);
+        let vertex = target.topology().add_vertex(Vertex { point }).unwrap();
         orig_to_top.vertices.insert(vertex_orig, vertex);
     }
 
     // Create the new edges.
     for edge_orig in source.topology().edges() {
-        let curve = shape
+        let curve = target
             .geometry()
             .add_curve(edge_orig.get().curve().transform(&translation));
 
@@ -49,7 +50,10 @@ pub fn sweep_shape(
             })
         });
 
-        let edge = shape.topology().add_edge(Edge { curve, vertices }).unwrap();
+        let edge = target
+            .topology()
+            .add_edge(Edge { curve, vertices })
+            .unwrap();
         orig_to_top.edges.insert(edge_orig, edge);
     }
 
@@ -66,7 +70,7 @@ pub fn sweep_shape(
             })
             .collect();
 
-        let cycle = shape.topology().add_cycle(Cycle { edges }).unwrap();
+        let cycle = target.topology().add_cycle(Cycle { edges }).unwrap();
         orig_to_top.cycles.insert(cycle_orig, cycle);
     }
 
@@ -81,7 +85,7 @@ pub fn sweep_shape(
             }
         };
 
-        let surface = shape
+        let surface = target
             .geometry()
             .add_surface(face_orig.surface().transform(&translation));
 
@@ -94,7 +98,7 @@ pub fn sweep_shape(
             })
             .collect();
 
-        shape
+        target
             .topology()
             .add_face(Face::Face {
                 surface,
@@ -138,13 +142,13 @@ pub fn sweep_shape(
             s.set_color(color);
         }
 
-        shape
+        target
             .topology()
             .add_face(Face::Triangles(side_face))
             .unwrap();
     }
 
-    shape
+    target
 }
 
 struct Relation {

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -37,12 +37,12 @@ pub fn sweep_shape(
     }
 
     // Create the new edges.
-    for edge_orig in source.topology().edges() {
+    for edge_source in source.topology().edges() {
         let curve = target
             .geometry()
-            .add_curve(edge_orig.get().curve().transform(&translation));
+            .add_curve(edge_source.get().curve().transform(&translation));
 
-        let vertices = edge_orig.get().vertices.clone().map(|vs| {
+        let vertices = edge_source.get().vertices.clone().map(|vs| {
             vs.map(|vertex_orig| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its vertices to `vertices`.
@@ -54,7 +54,7 @@ pub fn sweep_shape(
             .topology()
             .add_edge(Edge { curve, vertices })
             .unwrap();
-        source_to_top.edges.insert(edge_orig, edge);
+        source_to_top.edges.insert(edge_source, edge);
     }
 
     // Create the new cycles.

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -28,12 +28,12 @@ pub fn sweep_shape(
     let mut source_to_top = Relation::new();
 
     // Create the new vertices.
-    for vertex_orig in source.topology().vertices() {
+    for vertex_source in source.topology().vertices() {
         let point = target
             .geometry()
-            .add_point(vertex_orig.get().point() + path);
+            .add_point(vertex_source.get().point() + path);
         let vertex = target.topology().add_vertex(Vertex { point }).unwrap();
-        source_to_top.vertices.insert(vertex_orig, vertex);
+        source_to_top.vertices.insert(vertex_source, vertex);
     }
 
     // Create the new edges.

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -75,8 +75,8 @@ pub fn sweep_shape(
     }
 
     // Create top faces.
-    for face_orig in source.topology().faces().values() {
-        let cycles_orig = match &face_orig {
+    for face_source in source.topology().faces().values() {
+        let cycles_orig = match &face_source {
             Face::Face { cycles, .. } => cycles,
             _ => {
                 // Sketches are created using boundary representation, so this
@@ -87,7 +87,7 @@ pub fn sweep_shape(
 
         let surface = target
             .geometry()
-            .add_surface(face_orig.surface().transform(&translation));
+            .add_surface(face_source.surface().transform(&translation));
 
         let cycles = cycles_orig
             .iter()

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -45,7 +45,7 @@ pub fn sweep_shape(
             .geometry()
             .add_curve(edge_source.get().curve().transform(&translation));
 
-        let vertices = edge_source.get().vertices.clone().map(|vs| {
+        let vertices_top = edge_source.get().vertices.clone().map(|vs| {
             vs.map(|vertex_source| {
                 // Can't panic, as long as the source shape is valid. We've
                 // added all its vertices to the relation.
@@ -57,7 +57,7 @@ pub fn sweep_shape(
             .topology()
             .add_edge(Edge {
                 curve: curve_top,
-                vertices,
+                vertices: vertices_top,
             })
             .unwrap();
         source_to_top.edges.insert(edge_source, edge);

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -41,7 +41,7 @@ pub fn sweep_shape(
 
     // Create the new edges.
     for edge_source in source.topology().edges() {
-        let curve = target
+        let curve_top = target
             .geometry()
             .add_curve(edge_source.get().curve().transform(&translation));
 
@@ -55,7 +55,10 @@ pub fn sweep_shape(
 
         let edge = target
             .topology()
-            .add_edge(Edge { curve, vertices })
+            .add_edge(Edge {
+                curve: curve_top,
+                vertices,
+            })
             .unwrap();
         source_to_top.edges.insert(edge_source, edge);
     }

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -43,10 +43,10 @@ pub fn sweep_shape(
             .add_curve(edge_source.get().curve().transform(&translation));
 
         let vertices = edge_source.get().vertices.clone().map(|vs| {
-            vs.map(|vertex_orig| {
+            vs.map(|vertex_source| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its vertices to `vertices`.
-                source_to_top.vertices.get(&vertex_orig).unwrap().clone()
+                source_to_top.vertices.get(&vertex_source).unwrap().clone()
             })
         });
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -98,7 +98,7 @@ pub fn sweep_shape(
             .geometry()
             .add_surface(face_source.surface().transform(&translation));
 
-        let cycles = cycles_source
+        let cycles_top = cycles_source
             .iter()
             .map(|cycle_source| {
                 // Can't panic, as long as the source shape is valid. We've
@@ -111,7 +111,7 @@ pub fn sweep_shape(
             .topology()
             .add_face(Face::Face {
                 surface: surface_top,
-                cycles,
+                cycles: cycles_top,
                 color,
             })
             .unwrap();

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -32,11 +32,11 @@ pub fn sweep_shape(
         let point_top = target
             .geometry()
             .add_point(vertex_source.get().point() + path);
-        let vertex = target
+        let vertex_top = target
             .topology()
             .add_vertex(Vertex { point: point_top })
             .unwrap();
-        source_to_top.vertices.insert(vertex_source, vertex);
+        source_to_top.vertices.insert(vertex_source, vertex_top);
     }
 
     // Create the new edges.

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -91,10 +91,10 @@ pub fn sweep_shape(
 
         let cycles = cycles_source
             .iter()
-            .map(|cycle_orig| {
+            .map(|cycle_source| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its cycles to `cycles`.
-                source_to_top.cycles.get(cycle_orig).unwrap().clone()
+                source_to_top.cycles.get(cycle_source).unwrap().clone()
             })
             .collect();
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -16,19 +16,19 @@ use super::approximation::Approximation;
 
 /// Create a new shape by sweeping an existing one
 pub fn sweep_shape(
-    mut shape_orig: Shape,
+    mut source: Shape,
     path: Vector<3>,
     tolerance: Scalar,
     color: [u8; 4],
 ) -> Shape {
-    let mut shape = shape_orig.clone();
+    let mut shape = source.clone();
 
     let translation = Transform::translation(path);
 
     let mut orig_to_top = Relation::new();
 
     // Create the new vertices.
-    for vertex_orig in shape_orig.topology().vertices() {
+    for vertex_orig in source.topology().vertices() {
         let point =
             shape.geometry().add_point(vertex_orig.get().point() + path);
         let vertex = shape.topology().add_vertex(Vertex { point }).unwrap();
@@ -36,7 +36,7 @@ pub fn sweep_shape(
     }
 
     // Create the new edges.
-    for edge_orig in shape_orig.topology().edges() {
+    for edge_orig in source.topology().edges() {
         let curve = shape
             .geometry()
             .add_curve(edge_orig.get().curve().transform(&translation));
@@ -54,7 +54,7 @@ pub fn sweep_shape(
     }
 
     // Create the new cycles.
-    for cycle_orig in shape_orig.topology().cycles() {
+    for cycle_orig in source.topology().cycles() {
         let edges = cycle_orig
             .get()
             .edges
@@ -71,7 +71,7 @@ pub fn sweep_shape(
     }
 
     // Create top faces.
-    for face_orig in shape_orig.topology().faces().values() {
+    for face_orig in source.topology().faces().values() {
         let cycles_orig = match &face_orig {
             Face::Face { cycles, .. } => cycles,
             _ => {
@@ -107,7 +107,7 @@ pub fn sweep_shape(
     // We could use `vertices` to create the side edges and faces here, but the
     // side walls are created below, in triangle representation.
 
-    for cycle in shape_orig.topology().cycles().values() {
+    for cycle in source.topology().cycles().values() {
         let approx = Approximation::for_cycle(&cycle, tolerance);
 
         // This will only work correctly, if the cycle consists of one edge. If

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -63,10 +63,10 @@ pub fn sweep_shape(
             .get()
             .edges
             .iter()
-            .map(|edge_orig| {
+            .map(|edge_source| {
                 // Can't panic, as long as the original shape is valid. We've
                 // added all its edges to `edges`.
-                source_to_top.edges.get(edge_orig).unwrap().clone()
+                source_to_top.edges.get(edge_source).unwrap().clone()
             })
             .collect();
 

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -44,8 +44,8 @@ pub fn sweep_shape(
 
         let vertices = edge_source.get().vertices.clone().map(|vs| {
             vs.map(|vertex_source| {
-                // Can't panic, as long as the original shape is valid. We've
-                // added all its vertices to `vertices`.
+                // Can't panic, as long as the source shape is valid. We've
+                // added all its vertices to the relation.
                 source_to_top.vertices.get(&vertex_source).unwrap().clone()
             })
         });
@@ -64,8 +64,8 @@ pub fn sweep_shape(
             .edges
             .iter()
             .map(|edge_source| {
-                // Can't panic, as long as the original shape is valid. We've
-                // added all its edges to `edges`.
+                // Can't panic, as long as the source shape is valid. We've
+                // added all its edges to the relation.
                 source_to_top.edges.get(edge_source).unwrap().clone()
             })
             .collect();
@@ -92,8 +92,8 @@ pub fn sweep_shape(
         let cycles = cycles_source
             .iter()
             .map(|cycle_source| {
-                // Can't panic, as long as the original shape is valid. We've
-                // added all its cycles to `cycles`.
+                // Can't panic, as long as the source shape is valid. We've
+                // added all its cycles to the relation.
                 source_to_top.cycles.get(cycle_source).unwrap().clone()
             })
             .collect();

--- a/src/kernel/algorithms/sweep.rs
+++ b/src/kernel/algorithms/sweep.rs
@@ -59,16 +59,7 @@ pub fn sweep_shape(
 
     // Create the new cycles.
     for cycle_source in source.topology().cycles() {
-        let edges_top = cycle_source
-            .get()
-            .edges
-            .iter()
-            .map(|edge_source| {
-                // Can't panic, as long as the source shape is valid. We've
-                // added all its edges to the relation.
-                source_to_top.edges.get(edge_source).unwrap().clone()
-            })
-            .collect();
+        let edges_top = source_to_top.edges_for_cycle(&cycle_source);
 
         let cycle_top = target
             .topology()
@@ -176,6 +167,15 @@ impl Relation {
         edge.get().vertices.clone().map(|vertices| {
             vertices.map(|vertex| self.vertices.get(&vertex).unwrap().clone())
         })
+    }
+
+    fn edges_for_cycle(&self, cycle: &Handle<Cycle>) -> Vec<Handle<Edge>> {
+        cycle
+            .get()
+            .edges
+            .iter()
+            .map(|edge| self.edges.get(edge).unwrap().clone())
+            .collect()
     }
 }
 


### PR DESCRIPTION
This ports another case, non-continuous side faces of sweeps, to using boundary representation (#97). The last edge case to still use triangle representation are continuous side faces of sweeps. Using boundary representation for those is blocked by #250.

This adds a lot of code. That's not great. But it's fine, for two reasons:
1. As I remark in one of the commit messages, I believe there will are yet-to-be-discovered extensions to the `Shape` API that will make this kind of code much cleaner. Until I know what those are, a bit of mess is okay.
2. The new sweep code is tedious, but it's not very error-prone. In fact, while that last commit took a while to write, it worked on the first try. Thanks to the structural validation in the `Shape` API, most errors you can make here will blow up in your face pretty much immediately.

For now, I'm happy to get one step closer to addressing #97, and I'm looking forward to the great cleanups that my future self will surely come up with.