### PR TITLE
Clean up `Model`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> anyhow::Result<()> {
     let mut path = config.default_path;
     path.push(args.model.unwrap_or(config.default_model));
 
-    let model = Model::from_path(path);
+    let model = Model::from_path(path)?;
 
     let mut parameters = HashMap::new();
     for parameter in args.parameters {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,11 @@ fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
     let config = Config::load()?;
-    let model = Model::from_path(
-        config.default_path,
-        args.model.unwrap_or(config.default_model),
-    );
+
+    let mut path = config.default_path;
+    path.push(args.model.unwrap_or(config.default_model));
+
+    let model = Model::from_path(path);
 
     let mut parameters = HashMap::new();
     for parameter in args.parameters {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
     let config = Config::load()?;
-    let model = Model::new(
+    let model = Model::from_path(
         config.default_path,
         args.model.unwrap_or(config.default_model),
     );

--- a/src/model.rs
+++ b/src/model.rs
@@ -9,7 +9,7 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn from_path(path: PathBuf) -> Result<Self, io::Error> {
+    pub fn from_path(path: PathBuf) -> io::Result<Self> {
         let name = {
             // Can't panic. It only would, if the path ends with "..", and we
             // are canonicalizing it here to prevent that.

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,7 +12,7 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(base_path: PathBuf, rel_path: PathBuf) -> Self {
+    pub fn from_path(base_path: PathBuf, rel_path: PathBuf) -> Self {
         let mut path = base_path;
         path.push(rel_path);
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,10 +12,7 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn from_path(base_path: PathBuf, rel_path: PathBuf) -> Self {
-        let mut path = base_path;
-        path.push(rel_path);
-
+    pub fn from_path(path: PathBuf) -> Self {
         Self { path }
     }
 


### PR DESCRIPTION
These are some cleanups to `Model`, from my aborted attempt to address #9.