### PR TITLE
Make `cargo run` work again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ members = [
 
     "release-operator",
 ]
+default-members = ["fj-app"]

--- a/fj-app/src/config.rs
+++ b/fj-app/src/config.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 pub struct Config {
     pub default_path: Option<PathBuf>,
     pub default_model: Option<PathBuf>,
+    pub target_dir: Option<PathBuf>,
 }
 
 impl Config {

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let model = Model::from_path(path, None)?;
+    let model = Model::from_path(path, config.target_dir)?;
 
     let mut parameters = HashMap::new();
     for parameter in args.parameters {

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let model = Model::from_path(path)?;
+    let model = Model::from_path(path, None)?;
 
     let mut parameters = HashMap::new();
     for parameter in args.parameters {

--- a/fj-app/src/model.rs
+++ b/fj-app/src/model.rs
@@ -9,7 +9,10 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn from_path(path: PathBuf) -> io::Result<Self> {
+    pub fn from_path(
+        path: PathBuf,
+        target_dir: Option<PathBuf>,
+    ) -> io::Result<Self> {
         let name = {
             // Can't panic. It only would, if the path ends with "..", and we
             // are canonicalizing it here to prevent that.
@@ -31,7 +34,8 @@ impl Model {
                 format!("lib{}.so", name)
             };
 
-            path.join("target/debug").join(file)
+            let target_dir = target_dir.unwrap_or_else(|| path.join("target"));
+            target_dir.join("debug").join(file)
         };
 
         let manifest_path = path.join("Cargo.toml");

--- a/fj.toml
+++ b/fj.toml
@@ -5,3 +5,7 @@ default_path = "models"
 # The default models that is loaded, if none is specified. If this is a relative
 # path, it should be relative to `default_path`.
 default_model = "star"
+
+# The `target/` directory, where compiled model libraries are located. By
+# default, this is expected to be in the model directory.
+target_dir = "target"


### PR DESCRIPTION
I thought I had tested this, but obviously not. I broke it in #368, and this pull request fixes it.