### PR TITLE
Make all math types `#[repr(C)]`

### DIFF
--- a/fj-math/src/aabb.rs
+++ b/fj-math/src/aabb.rs
@@ -4,6 +4,7 @@ use super::{Point, Vector};
 
 /// An axis-aligned bounding box (AABB)
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
 pub struct Aabb<const D: usize> {
     /// The minimum coordinates of the AABB
     pub min: Point<D>,

--- a/fj-math/src/point.rs
+++ b/fj-math/src/point.rs
@@ -10,6 +10,7 @@ use super::{
 /// The dimensionality of the point is defined by the const generic `D`
 /// parameter.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
 pub struct Point<const D: usize> {
     /// The coordinates of the point
     pub coords: Vector<D>,

--- a/fj-math/src/scalar.rs
+++ b/fj-math/src/scalar.rs
@@ -9,6 +9,7 @@ use decorum::R64;
 /// [`Ord`], and [`Hash`], enabling `Scalar` (and types built on top of it), to
 /// be used as keys in hash maps, hash sets, and similar types.
 #[derive(Clone, Copy)]
+#[repr(C)]
 pub struct Scalar(f64);
 
 impl Scalar {

--- a/fj-math/src/segment.rs
+++ b/fj-math/src/segment.rs
@@ -7,6 +7,7 @@ use super::Point;
 /// The dimensionality of the segment is defined by the const generic `D`
 /// parameter.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
 pub struct Segment<const D: usize> {
     points: [Point<D>; 2],
 }

--- a/fj-math/src/transform.rs
+++ b/fj-math/src/transform.rs
@@ -1,6 +1,7 @@
 use super::{Aabb, Point, Segment, Triangle, Vector};
 
 /// A transform
+#[repr(C)]
 pub struct Transform(parry3d_f64::math::Isometry<f64>);
 
 impl Transform {

--- a/fj-math/src/triangle.rs
+++ b/fj-math/src/triangle.rs
@@ -5,6 +5,7 @@ use super::{Point, Scalar};
 /// The dimensionality of the triangle is defined by the const generic `D`
 /// parameter.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
 pub struct Triangle<const D: usize> {
     points: [Point<D>; 3],
     color: [u8; 4],

--- a/fj-math/src/vector.rs
+++ b/fj-math/src/vector.rs
@@ -10,6 +10,7 @@ use super::{
 /// The dimensionality of the vector is defined by the const generic `D`
 /// parameter.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[repr(C)]
 pub struct Vector<const D: usize> {
     /// The vector components
     pub components: [Scalar; D],


### PR DESCRIPTION
This is a minor addition, from my aborted attempt to implement #122.