### PR TITLE
Document `fj-host`

### DIFF
--- a/fj-host/src/lib.rs
+++ b/fj-host/src/lib.rs
@@ -3,6 +3,8 @@
 //! Fornjot models are loaded into the Fornjot application as plugins. This
 //! crate contains the code required to host plugins.
 
+#![deny(missing_docs)]
+
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsStr,


### PR DESCRIPTION
Follow-up to #381. I forgot to update the documentation of `fj-host`.