### PR TITLE
:construction_worker: Add models to test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,22 @@ jobs:
       - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: test
+      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
+        with:
+          command: run
+          args: -- --model cuboid --export cuboid.3mf
+      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
+        with:
+          command: run
+          args: -- --model group --export group.3mf
+      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
+        with:
+          command: run
+          args: -- --model spacer --export spacer.3mf
+      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
+        with:
+          command: run
+          args: -- --model star --export star.3mf
 
   clippy:
     name: Clippy Check


### PR DESCRIPTION
I couldn't find a way to build the steps from the `models/` directory. Another approach is to have a dedicated `#[test]` that would run the models.