### PR TITLE
Improve caching in CI and CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.target }}
 
       - name: Compile
         uses: actions-rs/cargo@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,12 +28,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+        # see https://github.com/actions-rs/toolchain/pull/209
+        # uses: actions-rs/toolchain@v1
         with:
           override: true
           profile: minimal
           target: ${{ matrix.target }}
-          toolchain: stable
 
       - name: Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+      - name: Setup Toolchain
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+        # see https://github.com/actions-rs/toolchain/pull/209
+        # uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          components: rustfmt
+          override: true
           profile: minimal
+          target: ${{ matrix.target }}
       - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: fmt
@@ -50,9 +53,14 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+      - name: Setup Toolchain
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+        # see https://github.com/actions-rs/toolchain/pull/209
+        # uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
@@ -82,10 +90,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+      - name: Setup Toolchain
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+        # see https://github.com/actions-rs/toolchain/pull/209
+        # uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          override: true
           profile: minimal
+          target: ${{ matrix.target }}
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - uses: actions-rs/clippy-check@9d09632661e31982c0be8af59aeb96b680641bc4


### PR DESCRIPTION
This change-set changes the `actions-rs/toolchain@v1` Action temporarily to a fork that supports `rust-toolchain.toml` as intended. The issue on the upstream Action is open, but not merged yet https://github.com/actions-rs/toolchain/pull/209. Once merged and released, we can switch back to the upstream Action in all workflow files.

In the CD workflow, the target is now included in the cache key. In my experiments, that improved caching, especially for the apple targets. Before, the aarch apple target would run with the x86_64 apple cache.

- [x] also adapt the changes to #391 
