### PR TITLE
Add convenient APIs to build `Vertex` and `Edge`

### DIFF
--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -134,11 +134,8 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.geometry().add_point(a);
-        let v2 = shape.geometry().add_point(d);
-
-        let v1 = shape.topology().add_vertex(Vertex { point: v1 })?;
-        let v2 = shape.topology().add_vertex(Vertex { point: v2 })?;
+        let v1 = Vertex::build(&mut shape).from_point(a)?;
+        let v2 = Vertex::build(&mut shape).from_point(d)?;
 
         let points = vec![b, c];
 
@@ -170,15 +167,10 @@ mod tests {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
-        let v1 = shape.geometry().add_point(a);
-        let v2 = shape.geometry().add_point(b);
-        let v3 = shape.geometry().add_point(c);
-        let v4 = shape.geometry().add_point(d);
-
-        let v1 = shape.topology().add_vertex(Vertex { point: v1 })?;
-        let v2 = shape.topology().add_vertex(Vertex { point: v2 })?;
-        let v3 = shape.topology().add_vertex(Vertex { point: v3 })?;
-        let v4 = shape.topology().add_vertex(Vertex { point: v4 })?;
+        let v1 = Vertex::build(&mut shape).from_point(a)?;
+        let v2 = Vertex::build(&mut shape).from_point(b)?;
+        let v3 = Vertex::build(&mut shape).from_point(c)?;
+        let v4 = Vertex::build(&mut shape).from_point(d)?;
 
         let ab = shape
             .topology()

--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -120,7 +120,7 @@ mod tests {
     use crate::{
         geometry::Surface,
         shape::Shape,
-        topology::{Cycle, Face, Vertex},
+        topology::{Cycle, Edge, Face, Vertex},
     };
 
     use super::Approximation;
@@ -170,12 +170,14 @@ mod tests {
         let v3 = Vertex::build(&mut shape).from_point(c)?;
         let v4 = Vertex::build(&mut shape).from_point(d)?;
 
-        let ab = shape
-            .topology()
-            .add_line_segment([v1.clone(), v2.clone()])?;
-        let bc = shape.topology().add_line_segment([v2, v3.clone()])?;
-        let cd = shape.topology().add_line_segment([v3, v4.clone()])?;
-        let da = shape.topology().add_line_segment([v4, v1])?;
+        let ab = Edge::build(&mut shape)
+            .line_segment_from_vertices([v1.clone(), v2.clone()])?;
+        let bc = Edge::build(&mut shape)
+            .line_segment_from_vertices([v2, v3.clone()])?;
+        let cd = Edge::build(&mut shape)
+            .line_segment_from_vertices([v3, v4.clone()])?;
+        let da =
+            Edge::build(&mut shape).line_segment_from_vertices([v4, v1])?;
 
         let abcd = shape.topology().add_cycle(Cycle {
             edges: vec![ab, bc, cd, da],

--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -137,19 +137,17 @@ mod tests {
         let v1 = Vertex::build(&mut shape).from_point(a)?;
         let v2 = Vertex::build(&mut shape).from_point(d)?;
 
-        let points = vec![b, c];
-
         // Regular edge
         assert_eq!(
             super::approximate_edge(
-                points.clone(),
+                vec![b, c],
                 Some([v1.get().clone(), v2.get().clone()])
             ),
             vec![a, b, c, d],
         );
 
         // Continuous edge
-        assert_eq!(super::approximate_edge(points, None), vec![b, c, b],);
+        assert_eq!(super::approximate_edge(vec![b, c], None), vec![b, c, b],);
 
         Ok(())
     }

--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -126,7 +126,7 @@ mod tests {
     use super::Approximation;
 
     #[test]
-    fn approximate_edge() {
+    fn approximate_edge() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
         let a = Point::from([1., 2., 3.]);
@@ -137,8 +137,8 @@ mod tests {
         let v1 = shape.geometry().add_point(a);
         let v2 = shape.geometry().add_point(d);
 
-        let v1 = shape.topology().add_vertex(Vertex { point: v1 }).unwrap();
-        let v2 = shape.topology().add_vertex(Vertex { point: v2 }).unwrap();
+        let v1 = shape.topology().add_vertex(Vertex { point: v1 })?;
+        let v2 = shape.topology().add_vertex(Vertex { point: v2 })?;
 
         let points = vec![b, c];
 
@@ -153,10 +153,12 @@ mod tests {
 
         // Continuous edge
         assert_eq!(super::approximate_edge(points, None), vec![b, c, b],);
+
+        Ok(())
     }
 
     #[test]
-    fn for_face_closed() {
+    fn for_face_closed() -> anyhow::Result<()> {
         // Test a closed face, i.e. one that is completely encircled by edges.
 
         let tolerance = Scalar::ONE;
@@ -173,25 +175,21 @@ mod tests {
         let v3 = shape.geometry().add_point(c);
         let v4 = shape.geometry().add_point(d);
 
-        let v1 = shape.topology().add_vertex(Vertex { point: v1 }).unwrap();
-        let v2 = shape.topology().add_vertex(Vertex { point: v2 }).unwrap();
-        let v3 = shape.topology().add_vertex(Vertex { point: v3 }).unwrap();
-        let v4 = shape.topology().add_vertex(Vertex { point: v4 }).unwrap();
+        let v1 = shape.topology().add_vertex(Vertex { point: v1 })?;
+        let v2 = shape.topology().add_vertex(Vertex { point: v2 })?;
+        let v3 = shape.topology().add_vertex(Vertex { point: v3 })?;
+        let v4 = shape.topology().add_vertex(Vertex { point: v4 })?;
 
         let ab = shape
             .topology()
-            .add_line_segment([v1.clone(), v2.clone()])
-            .unwrap();
-        let bc = shape.topology().add_line_segment([v2, v3.clone()]).unwrap();
-        let cd = shape.topology().add_line_segment([v3, v4.clone()]).unwrap();
-        let da = shape.topology().add_line_segment([v4, v1]).unwrap();
+            .add_line_segment([v1.clone(), v2.clone()])?;
+        let bc = shape.topology().add_line_segment([v2, v3.clone()])?;
+        let cd = shape.topology().add_line_segment([v3, v4.clone()])?;
+        let da = shape.topology().add_line_segment([v4, v1])?;
 
-        let abcd = shape
-            .topology()
-            .add_cycle(Cycle {
-                edges: vec![ab, bc, cd, da],
-            })
-            .unwrap();
+        let abcd = shape.topology().add_cycle(Cycle {
+            edges: vec![ab, bc, cd, da],
+        })?;
 
         let surface = shape.geometry().add_surface(Surface::x_y_plane());
         let face = Face::Face {
@@ -213,5 +211,7 @@ mod tests {
                 ],
             }
         );
+
+        Ok(())
     }
 }

--- a/fj-kernel/src/algorithms/sweep.rs
+++ b/fj-kernel/src/algorithms/sweep.rs
@@ -347,7 +347,7 @@ mod tests {
     use crate::{
         geometry::{Surface, SweptCurve},
         shape::{Handle, Shape},
-        topology::{Cycle, Face, Vertex},
+        topology::{Cycle, Edge, Face, Vertex},
     };
 
     use super::sweep_shape;
@@ -410,12 +410,12 @@ mod tests {
             let b = shape.topology().add_vertex(Vertex { point: b })?;
             let c = shape.topology().add_vertex(Vertex { point: c })?;
 
-            let ab =
-                shape.topology().add_line_segment([a.clone(), b.clone()])?;
-            let bc =
-                shape.topology().add_line_segment([b.clone(), c.clone()])?;
-            let ca =
-                shape.topology().add_line_segment([c.clone(), a.clone()])?;
+            let ab = Edge::build(&mut shape)
+                .line_segment_from_vertices([a.clone(), b.clone()])?;
+            let bc = Edge::build(&mut shape)
+                .line_segment_from_vertices([b.clone(), c.clone()])?;
+            let ca = Edge::build(&mut shape)
+                .line_segment_from_vertices([c.clone(), a.clone()])?;
 
             let cycles = shape.topology().add_cycle(Cycle {
                 edges: vec![ab, bc, ca],

--- a/fj-kernel/src/algorithms/sweep.rs
+++ b/fj-kernel/src/algorithms/sweep.rs
@@ -353,8 +353,8 @@ mod tests {
     use super::sweep_shape;
 
     #[test]
-    fn sweep() {
-        let sketch = Triangle::new([[0., 0., 0.], [1., 0., 0.], [0., 1., 0.]]);
+    fn sweep() -> anyhow::Result<()> {
+        let sketch = Triangle::new([[0., 0., 0.], [1., 0., 0.], [0., 1., 0.]])?;
 
         let mut swept = sweep_shape(
             sketch.shape,
@@ -365,7 +365,7 @@ mod tests {
 
         let bottom_face = sketch.face.get().clone();
         let top_face =
-            Triangle::new([[0., 0., 1.], [1., 0., 1.], [0., 1., 1.]])
+            Triangle::new([[0., 0., 1.], [1., 0., 1.], [0., 1., 1.]])?
                 .face
                 .get()
                 .clone();
@@ -389,6 +389,8 @@ mod tests {
 
         // Side faces are not tested, as those use triangle representation. The
         // plan is to start testing them, as they are transitioned to b-rep.
+
+        Ok(())
     }
 
     pub struct Triangle {
@@ -397,36 +399,27 @@ mod tests {
     }
 
     impl Triangle {
-        fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> Self {
+        fn new([a, b, c]: [impl Into<Point<3>>; 3]) -> anyhow::Result<Self> {
             let mut shape = Shape::new();
 
             let a = shape.geometry().add_point(a.into());
             let b = shape.geometry().add_point(b.into());
             let c = shape.geometry().add_point(c.into());
 
-            let a = shape.topology().add_vertex(Vertex { point: a }).unwrap();
-            let b = shape.topology().add_vertex(Vertex { point: b }).unwrap();
-            let c = shape.topology().add_vertex(Vertex { point: c }).unwrap();
+            let a = shape.topology().add_vertex(Vertex { point: a })?;
+            let b = shape.topology().add_vertex(Vertex { point: b })?;
+            let c = shape.topology().add_vertex(Vertex { point: c })?;
 
-            let ab = shape
-                .topology()
-                .add_line_segment([a.clone(), b.clone()])
-                .unwrap();
-            let bc = shape
-                .topology()
-                .add_line_segment([b.clone(), c.clone()])
-                .unwrap();
-            let ca = shape
-                .topology()
-                .add_line_segment([c.clone(), a.clone()])
-                .unwrap();
+            let ab =
+                shape.topology().add_line_segment([a.clone(), b.clone()])?;
+            let bc =
+                shape.topology().add_line_segment([b.clone(), c.clone()])?;
+            let ca =
+                shape.topology().add_line_segment([c.clone(), a.clone()])?;
 
-            let cycles = shape
-                .topology()
-                .add_cycle(Cycle {
-                    edges: vec![ab, bc, ca],
-                })
-                .unwrap();
+            let cycles = shape.topology().add_cycle(Cycle {
+                edges: vec![ab, bc, ca],
+            })?;
 
             let surface = shape.geometry().add_surface(Surface::SweptCurve(
                 SweptCurve::plane_from_points(
@@ -440,9 +433,9 @@ mod tests {
                 color: [255, 0, 0, 255],
             };
 
-            let face = shape.topology().add_face(abc).unwrap();
+            let face = shape.topology().add_face(abc)?;
 
-            Self { shape, face }
+            Ok(Self { shape, face })
         }
     }
 }

--- a/fj-kernel/src/shape/topology.rs
+++ b/fj-kernel/src/shape/topology.rs
@@ -3,14 +3,13 @@ use std::collections::HashSet;
 use fj_math::{Point, Scalar, Vector};
 
 use crate::{
-    geometry::{Circle, Curve, Line},
+    geometry::{Circle, Curve},
     topology::{Cycle, Edge, Face, Vertex},
 };
 
 use super::{
-    handle::{Handle, Storage},
-    Cycles, Edges, Geometry, Iter, StructuralIssues, ValidationError,
-    ValidationResult, Vertices,
+    handle::Storage, Cycles, Edges, Geometry, Iter, StructuralIssues,
+    ValidationError, ValidationResult, Vertices,
 };
 
 /// The vertices of a shape
@@ -125,23 +124,6 @@ impl Topology<'_> {
         self.add_edge(Edge {
             curve,
             vertices: None,
-        })
-    }
-
-    /// Add a line segment to the shape
-    ///
-    /// Calls [`Edges::add`] internally, and is subject to the same
-    /// restrictions.
-    pub fn add_line_segment(
-        &mut self,
-        vertices: [Handle<Vertex>; 2],
-    ) -> ValidationResult<Edge> {
-        let curve = self.geometry.add_curve(Curve::Line(Line::from_points(
-            vertices.clone().map(|vertex| vertex.get().point()),
-        )));
-        self.add_edge(Edge {
-            curve,
-            vertices: Some(vertices),
         })
     }
 
@@ -412,7 +394,8 @@ mod tests {
                 let point = self.geometry().add_point(point);
                 self.topology().add_vertex(Vertex { point }).unwrap()
             });
-            let edge = self.topology().add_line_segment(vertices)?;
+            let edge = Edge::build(&mut self.inner)
+                .line_segment_from_vertices(vertices)?;
 
             Ok(edge)
         }

--- a/fj-kernel/src/shape/topology.rs
+++ b/fj-kernel/src/shape/topology.rs
@@ -298,8 +298,8 @@ mod tests {
         let mut other = TestShape::new();
 
         let curve = other.add_curve();
-        let a = other.add_vertex()?;
-        let b = other.add_vertex()?;
+        let a = Vertex::build(&mut other).from_point([1., 0., 0.])?;
+        let b = Vertex::build(&mut other).from_point([2., 0., 0.])?;
 
         // Shouldn't work. Nothing has been added to `shape`.
         let err = shape
@@ -314,8 +314,8 @@ mod tests {
         assert!(err.missing_vertex(&b));
 
         let curve = shape.add_curve();
-        let a = shape.add_vertex()?;
-        let b = shape.add_vertex()?;
+        let a = Vertex::build(&mut shape).from_point([1., 0., 0.])?;
+        let b = Vertex::build(&mut shape).from_point([2., 0., 0.])?;
 
         // Everything has been added to `shape` now. Should work!
         shape.topology().add_edge(Edge {

--- a/fj-kernel/src/shape/topology.rs
+++ b/fj-kernel/src/shape/topology.rs
@@ -1,11 +1,8 @@
 use std::collections::HashSet;
 
-use fj_math::{Point, Scalar, Vector};
+use fj_math::Scalar;
 
-use crate::{
-    geometry::{Circle, Curve},
-    topology::{Cycle, Edge, Face, Vertex},
-};
+use crate::topology::{Cycle, Edge, Face, Vertex};
 
 use super::{
     handle::Storage, Cycles, Edges, Geometry, Iter, StructuralIssues,
@@ -110,21 +107,6 @@ impl Topology<'_> {
         self.edges.push(storage);
 
         Ok(handle)
-    }
-
-    /// Add a circle to the shape
-    ///
-    /// Calls [`Edges::add`] internally, and is subject to the same
-    /// restrictions.
-    pub fn add_circle(&mut self, radius: Scalar) -> ValidationResult<Edge> {
-        let curve = self.geometry.add_curve(Curve::Circle(Circle {
-            center: Point::origin(),
-            radius: Vector::from([radius, Scalar::ZERO]),
-        }));
-        self.add_edge(Edge {
-            curve,
-            vertices: None,
-        })
     }
 
     /// Add a cycle to the shape

--- a/fj-kernel/src/shape/topology.rs
+++ b/fj-kernel/src/shape/topology.rs
@@ -404,19 +404,16 @@ mod tests {
             self.geometry().add_surface(Surface::x_y_plane())
         }
 
-        fn add_vertex(&mut self) -> anyhow::Result<Handle<Vertex>> {
-            let point = self.next_point;
-            self.next_point.x += Scalar::ONE;
-
-            let point = self.geometry().add_point(point);
-            let vertex = self.topology().add_vertex(Vertex { point })?;
-
-            Ok(vertex)
-        }
-
         fn add_edge(&mut self) -> anyhow::Result<Handle<Edge>> {
-            let vertices = [(); 2].map(|()| self.add_vertex().unwrap());
+            let vertices = [(); 2].map(|()| {
+                let point = self.next_point;
+                self.next_point.x += Scalar::ONE;
+
+                let point = self.geometry().add_point(point);
+                self.topology().add_vertex(Vertex { point }).unwrap()
+            });
             let edge = self.topology().add_line_segment(vertices)?;
+
             Ok(edge)
         }
 

--- a/fj-kernel/src/topology/builder.rs
+++ b/fj-kernel/src/topology/builder.rs
@@ -1,0 +1,28 @@
+use fj_math::Point;
+
+use crate::shape::{Shape, ValidationResult};
+
+use super::Vertex;
+
+/// API for building a [`Vertex`]
+pub struct VertexBuilder<'r> {
+    shape: &'r mut Shape,
+}
+
+impl<'r> VertexBuilder<'r> {
+    /// Construct a new instance of `VertexBuilder`
+    pub fn new(shape: &'r mut Shape) -> Self {
+        Self { shape }
+    }
+
+    /// Build a [`Vertex`] from a point
+    pub fn from_point(
+        self,
+        point: impl Into<Point<3>>,
+    ) -> ValidationResult<Vertex> {
+        let point = self.shape.geometry().add_point(point.into());
+        let vertex = self.shape.topology().add_vertex(Vertex { point })?;
+
+        Ok(vertex)
+    }
+}

--- a/fj-kernel/src/topology/builder.rs
+++ b/fj-kernel/src/topology/builder.rs
@@ -1,7 +1,7 @@
-use fj_math::Point;
+use fj_math::{Point, Scalar, Vector};
 
 use crate::{
-    geometry::{Curve, Line},
+    geometry::{Circle, Curve, Line},
     shape::{Handle, Shape, ValidationResult},
 };
 
@@ -39,6 +39,20 @@ impl<'r> EdgeBuilder<'r> {
     /// Construct a new instance of `EdgeBuilder`
     pub fn new(shape: &'r mut Shape) -> Self {
         Self { shape }
+    }
+
+    /// Build a circle from a radius
+    pub fn circle(self, radius: Scalar) -> ValidationResult<Edge> {
+        let curve = self.shape.geometry().add_curve(Curve::Circle(Circle {
+            center: Point::origin(),
+            radius: Vector::from([radius, Scalar::ZERO]),
+        }));
+        let edge = self.shape.topology().add_edge(Edge {
+            curve,
+            vertices: None,
+        })?;
+
+        Ok(edge)
     }
 
     /// Build a line segment from two vertices

--- a/fj-kernel/src/topology/builder.rs
+++ b/fj-kernel/src/topology/builder.rs
@@ -1,8 +1,11 @@
 use fj_math::Point;
 
-use crate::shape::{Shape, ValidationResult};
+use crate::{
+    geometry::{Curve, Line},
+    shape::{Handle, Shape, ValidationResult},
+};
 
-use super::Vertex;
+use super::{Edge, Vertex};
 
 /// API for building a [`Vertex`]
 pub struct VertexBuilder<'r> {
@@ -24,5 +27,36 @@ impl<'r> VertexBuilder<'r> {
         let vertex = self.shape.topology().add_vertex(Vertex { point })?;
 
         Ok(vertex)
+    }
+}
+
+/// API for building an [`Edge`]
+pub struct EdgeBuilder<'r> {
+    shape: &'r mut Shape,
+}
+
+impl<'r> EdgeBuilder<'r> {
+    /// Construct a new instance of `EdgeBuilder`
+    pub fn new(shape: &'r mut Shape) -> Self {
+        Self { shape }
+    }
+
+    /// Build a line segment from two vertices
+    pub fn line_segment_from_vertices(
+        self,
+        vertices: [Handle<Vertex>; 2],
+    ) -> ValidationResult<Edge> {
+        let curve =
+            self.shape
+                .geometry()
+                .add_curve(Curve::Line(Line::from_points(
+                    vertices.clone().map(|vertex| vertex.get().point()),
+                )));
+        let edge = self.shape.topology().add_edge(Edge {
+            curve,
+            vertices: Some(vertices),
+        })?;
+
+        Ok(edge)
     }
 }

--- a/fj-kernel/src/topology/edges.rs
+++ b/fj-kernel/src/topology/edges.rs
@@ -1,8 +1,11 @@
 use std::hash::{Hash, Hasher};
 
-use crate::{geometry::Curve, shape::Handle};
+use crate::{
+    geometry::Curve,
+    shape::{Handle, Shape},
+};
 
-use super::vertices::Vertex;
+use super::{vertices::Vertex, EdgeBuilder};
 
 /// A cycle of connected edges
 ///
@@ -77,6 +80,11 @@ pub struct Edge {
 }
 
 impl Edge {
+    /// Build an edge using the [`EdgeBuilder`] API
+    pub fn build(shape: &mut Shape) -> EdgeBuilder {
+        EdgeBuilder::new(shape)
+    }
+
     /// Access the curve that the edge refers to
     ///
     /// This is a convenience method that saves the caller from dealing with the

--- a/fj-kernel/src/topology/mod.rs
+++ b/fj-kernel/src/topology/mod.rs
@@ -16,11 +16,13 @@
 //! definition of identity. Two [`Handle`]s are only considered equal, if they
 //! refer to objects in the same memory location.
 
+mod builder;
 mod edges;
 mod faces;
 mod vertices;
 
 pub use self::{
+    builder::VertexBuilder,
     edges::{Cycle, Edge},
     faces::Face,
     vertices::Vertex,

--- a/fj-kernel/src/topology/mod.rs
+++ b/fj-kernel/src/topology/mod.rs
@@ -22,7 +22,7 @@ mod faces;
 mod vertices;
 
 pub use self::{
-    builder::VertexBuilder,
+    builder::{EdgeBuilder, VertexBuilder},
     edges::{Cycle, Edge},
     faces::Face,
     vertices::Vertex,

--- a/fj-kernel/src/topology/vertices.rs
+++ b/fj-kernel/src/topology/vertices.rs
@@ -2,7 +2,9 @@ use std::hash::Hash;
 
 use fj_math::Point;
 
-use crate::shape::Handle;
+use crate::shape::{Handle, Shape};
+
+use super::VertexBuilder;
 
 /// A vertex
 ///
@@ -24,6 +26,11 @@ pub struct Vertex {
 }
 
 impl Vertex {
+    /// Build a vertex using the [`VertexBuilder`] API
+    pub fn build(shape: &mut Shape) -> VertexBuilder {
+        VertexBuilder::new(shape)
+    }
+
     /// Access the point that the vertex refers to
     ///
     /// This is a convenience method that saves the caller from dealing with the

--- a/fj-operations/src/circle.rs
+++ b/fj-operations/src/circle.rs
@@ -2,7 +2,7 @@ use fj_debug::DebugInfo;
 use fj_kernel::{
     geometry::Surface,
     shape::Shape,
-    topology::{Cycle, Face},
+    topology::{Cycle, Edge, Face},
 };
 use fj_math::{Aabb, Point, Scalar};
 
@@ -15,9 +15,8 @@ impl ToShape for fj::Circle {
         // Circles have just a single round edge with no vertices. So none need
         // to be added here.
 
-        let edge = shape
-            .topology()
-            .add_circle(Scalar::from_f64(self.radius()))
+        let edge = Edge::build(&mut shape)
+            .circle(Scalar::from_f64(self.radius()))
             .unwrap();
         shape
             .topology()

--- a/fj-operations/src/sketch.rs
+++ b/fj-operations/src/sketch.rs
@@ -2,7 +2,7 @@ use fj_debug::DebugInfo;
 use fj_kernel::{
     geometry::Surface,
     shape::Shape,
-    topology::{Cycle, Face, Vertex},
+    topology::{Cycle, Edge, Face, Vertex},
 };
 use fj_math::{Aabb, Point, Scalar};
 
@@ -36,7 +36,9 @@ impl ToShape for fj::Sketch {
                 let a = window[0].clone();
                 let b = window[1].clone();
 
-                let edge = shape.topology().add_line_segment([a, b]).unwrap();
+                let edge = Edge::build(&mut shape)
+                    .line_segment_from_vertices([a, b])
+                    .unwrap();
                 edges.push(edge);
             }
 


### PR DESCRIPTION
Adds new "builder" APIs for `Vertex` and `Edge`, and introduces them into unit tests. This significantly cleans up some of the test code, and this pull request is only the beginning. These APIs have much more potential to further clean up test code.

This has the side effect of replacing the convenience methods for constructing edges that `Topology` used to have, making the `Shape` API more regular, potentially allowing for further clean-ups there.

This is part of my work towards #105. I will need to update the approximation code (and the approximation test suite) to make more progress there, and these new builder APIs make it much easier to update the tests, and thus the code overall.