### PR TITLE
Add sub-command support to the release-operator

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -104,7 +104,7 @@ jobs:
           RUST_LOG: info
         run: |
           # Run release operator
-          cargo run
+          cargo run -- detect
 
       - name: Binaries | Download
         if: ${{ steps.release.outputs.release-detected == 'true' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "release-operator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/release-operator/Cargo.toml
+++ b/release-operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-operator"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/release-operator/README.md
+++ b/release-operator/README.md
@@ -54,7 +54,7 @@ As seen above, the release operator requires the maintainer to:
 
 ```shell
 # release-operator/
-cargo run -- --sha <commit-sha> --label <release-label>
+cargo run -- detect --sha <commit-sha> --label <release-label>
 ```
 
 Where `<commit-sha>` can be set using `GITHUB_SHA` (present by default in GitHub Actions), and `<release-label>` can be set using `RELEASE_LABEL` (defaults to `autorelease`).
@@ -94,7 +94,7 @@ To embed the operator in a workflow, include these steps _before_ anything relat
     RELEASE_LABEL: autorelease
   run: |
     # release operator
-    cargo run
+    cargo run -- detect
 
 # Subsequent steps can use:
 #   if: ${{ steps.release.outputs.release-detected == 'true' }}

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[clap(version)]
-struct Cmd {
+struct Cli {
     /// Commit sha to work on
     #[clap(short, long, env = "GITHUB_SHA")]
     sha: String,
@@ -28,10 +28,10 @@ fn main() -> anyhow::Result<()> {
     let start = std::time::Instant::now();
     log::trace!("starting release-operator process");
 
-    let args = Cmd::parse();
+    let cli = Cli::parse();
     log::debug!("got arguments: {args:#?}");
 
-    Release::new(args.sha, args.label).detect()?;
+    Release::new(cli.sha, cli.label).detect()?;
 
     log::trace!(
         "finished release-operator process, took {:?}",

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Detect a release and set respective outputs
+    /// Detect a release and sets respective Action outputs
     Detect(DetectArgs),
 }
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -4,11 +4,23 @@ mod release;
 use crate::github::{Actions, GitHub};
 
 use crate::release::Release;
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 
-#[derive(Parser, Debug)]
-#[clap(version)]
+#[derive(Parser)]
+#[clap(version, propagate_version = true)]
 struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Detect a release and set respective outputs
+    Detect(DetectArgs),
+}
+
+#[derive(Args, Debug)]
+struct DetectArgs {
     /// Commit sha to work on
     #[clap(short, long, env = "GITHUB_SHA")]
     sha: String,
@@ -29,9 +41,13 @@ fn main() -> anyhow::Result<()> {
     log::trace!("starting release-operator process");
 
     let cli = Cli::parse();
-    log::debug!("got arguments: {args:#?}");
 
-    Release::new(cli.sha, cli.label).detect()?;
+    match &cli.command {
+        Commands::Detect(opts) => {
+            log::debug!("got arguments: {opts:#?}");
+            Release::new(opts.sha.to_owned(), opts.label.to_owned()).detect()?;
+        }
+    }
 
     log::trace!(
         "finished release-operator process, took {:?}",

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -43,9 +43,9 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Detect(opts) => {
-            log::debug!("got arguments: {opts:#?}");
-            Release::new(opts.sha.to_owned(), opts.label.to_owned()).detect()?;
+        Commands::Detect(args) => {
+            log::debug!("got arguments: {args:#?}");
+            Release::new(args.sha.to_owned(), args.label.to_owned()).detect()?;
         }
     }
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -45,7 +45,8 @@ fn main() -> anyhow::Result<()> {
     match &cli.command {
         Commands::Detect(args) => {
             log::debug!("got arguments: {args:#?}");
-            Release::new(args.sha.to_owned(), args.label.to_owned()).detect()?;
+            Release::new(args.sha.to_owned(), args.label.to_owned())
+                .detect()?;
         }
     }
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Detect a release and sets respective Action outputs
+    /// Detect a release and set respective Action outputs
     Detect(DetectArgs),
 }
 


### PR DESCRIPTION
This change-set moves the existing functionality of the release-operator into a sub-command. See https://github.com/hannobraun/Fornjot/issues/104#issuecomment-1079002976 for the relevant discussion.