### PR TITLE
fix: align output names

### DIFF
--- a/release-operator/src/github.rs
+++ b/release-operator/src/github.rs
@@ -1,5 +1,6 @@
 use cmd_lib::run_fun;
 use serde::Deserialize;
+use crate::release::Outputs;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct PullRequest {
@@ -68,7 +69,7 @@ pub struct Actions;
 
 impl Actions {
     // Set an "output" in GitHub Actions
-    pub fn set_output(key: &str, value: &str) {
+    pub fn set_output(key: Outputs, value: &str) {
         log::debug!("setting output name={key} value={value}");
         println!("::set-output name={key}::{value}");
     }

--- a/release-operator/src/github.rs
+++ b/release-operator/src/github.rs
@@ -1,6 +1,6 @@
+use crate::release::Outputs;
 use cmd_lib::run_fun;
 use serde::Deserialize;
-use crate::release::Outputs;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct PullRequest {

--- a/release-operator/src/release.rs
+++ b/release-operator/src/release.rs
@@ -1,9 +1,24 @@
+use std::fmt::{Display, Formatter};
 use crate::{Actions, GitHub};
 use regex::Regex;
 
 pub struct Release {
     sha: String,
     label: String,
+}
+
+pub enum Outputs {
+    ReleaseDetected,
+    TagName,
+}
+
+impl Display for Outputs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Outputs::ReleaseDetected => write!(f, "release-detected"),
+            Outputs::TagName => write!(f, "tag-name"),
+        }
+    }
 }
 
 impl Release {
@@ -37,14 +52,14 @@ impl Release {
 
     fn hit(&self, tag: &str) -> anyhow::Result<()> {
         log::info!("detected release of {tag}");
-        Actions::set_output("release-detected", "true");
-        Actions::set_output("tag-name", tag);
+        Actions::set_output(Outputs::ReleaseDetected, "true");
+        Actions::set_output(Outputs::TagName, tag);
         Ok(())
     }
 
     fn miss(&self) -> anyhow::Result<()> {
         log::info!("no release detected");
-        Actions::set_output("release-created", "false");
+        Actions::set_output(Outputs::ReleaseDetected, "false");
         Ok(())
     }
 }

--- a/release-operator/src/release.rs
+++ b/release-operator/src/release.rs
@@ -1,6 +1,6 @@
-use std::fmt::{Display, Formatter};
 use crate::{Actions, GitHub};
 use regex::Regex;
+use std::fmt::{Display, Formatter};
 
 pub struct Release {
     sha: String,


### PR DESCRIPTION
When no release was detected, the output name was incorrect due to the
usage of a stringly typed identifier. I implemented the outputs as an
enum to overcome the issue.