### PR TITLE
Add `Shape::get_handle`, `Shape::get_handle_or_insert`

### DIFF
--- a/fj-kernel/src/shape/api.rs
+++ b/fj-kernel/src/shape/api.rs
@@ -92,6 +92,21 @@ impl Shape {
             .find(|obj| &obj.get() == object)
     }
 
+    /// Get handle of an identical object, if it exists, or add the object
+    ///
+    /// In any case, returns a handle that refers to an object that is identical
+    /// to the provided object.
+    pub fn get_handle_or_insert<T>(&mut self, object: T) -> ValidationResult<T>
+    where
+        T: Object,
+    {
+        if let Some(handle) = self.get_handle(&object) {
+            return Ok(handle);
+        }
+
+        self.insert(object)
+    }
+
     /// Access the shape's geometry
     pub fn geometry(&mut self) -> Geometry {
         Geometry {

--- a/fj-kernel/src/shape/object.rs
+++ b/fj-kernel/src/shape/object.rs
@@ -8,7 +8,10 @@ use crate::{
 use super::validate::Validate;
 
 /// Marker trait for geometric and topological objects
-pub trait Object: 'static + Validate + private::Sealed {}
+pub trait Object:
+    'static + Clone + PartialEq + Validate + private::Sealed
+{
+}
 
 impl private::Sealed for Point<3> {}
 impl private::Sealed for Curve {}

--- a/fj-kernel/src/shape/stores.rs
+++ b/fj-kernel/src/shape/stores.rs
@@ -28,7 +28,7 @@ pub struct Stores {
 }
 
 impl Stores {
-    pub fn get<T>(&mut self) -> Store<T>
+    pub fn get<T>(&self) -> Store<T>
     where
         T: Object,
     {


### PR DESCRIPTION
These methods can be useful for users of `fj-kernel`, but I also have some work-in-progress code that uses them within the kernel, to great benefit. Specifically, they are useful building blocks for extending the builder API, which can be used to simplify test code, which in turn is going to be useful for addressing #105.