### PR TITLE
Make approximation more flexible

### DIFF
--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -6,7 +6,7 @@ use crate::topology::{Cycle, Face, Vertex};
 
 /// The approximation of a face
 #[derive(Debug, PartialEq)]
-pub struct Approximation {
+pub struct FaceApprox {
     /// All points that make up the approximation
     ///
     /// These could be actual vertices from the model, points that approximate
@@ -23,7 +23,7 @@ pub struct Approximation {
     pub segments: HashSet<Segment<3>>,
 }
 
-impl Approximation {
+impl FaceApprox {
     /// Compute the approximation of a face
     ///
     /// `tolerance` defines how far the approximation is allowed to deviate from
@@ -123,7 +123,7 @@ mod tests {
         topology::{Face, Vertex},
     };
 
-    use super::Approximation;
+    use super::FaceApprox;
 
     #[test]
     fn approximate_edge() -> anyhow::Result<()> {
@@ -167,8 +167,8 @@ mod tests {
             .build()?;
 
         assert_eq!(
-            Approximation::new(&face.get(), tolerance),
-            Approximation {
+            FaceApprox::new(&face.get(), tolerance),
+            FaceApprox {
                 points: set![a, b, c, d],
                 segments: set![
                     Segment::from([a, b]),

--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -48,16 +48,8 @@ impl FaceApprox {
         for cycle in face.all_cycles() {
             let cycle = CycleApprox::new(&cycle, tolerance);
 
-            let mut cycle_segments = Vec::new();
-            for segment in cycle.points.windows(2) {
-                let p0 = segment[0];
-                let p1 = segment[1];
-
-                cycle_segments.push(Segment::from([p0, p1]));
-            }
-
+            segments.extend(cycle.segments());
             points.extend(cycle.points);
-            segments.extend(cycle_segments);
         }
 
         Self { points, segments }
@@ -89,6 +81,22 @@ impl CycleApprox {
         points.dedup();
 
         Self { points }
+    }
+
+    /// Construct the segments that approximate the cycle
+    pub fn segments(&self) -> Vec<Segment<3>> {
+        let mut segments = Vec::new();
+
+        for segment in self.points.windows(2) {
+            // This can't panic, as we passed `2` to `windows`. Can be cleaned
+            // up, once `array_windows` is stable.
+            let p0 = segment[0];
+            let p1 = segment[1];
+
+            segments.push(Segment::from([p0, p1]));
+        }
+
+        segments
     }
 }
 

--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -4,7 +4,7 @@ use fj_math::{Point, Scalar, Segment};
 
 use crate::topology::{Cycle, Face, Vertex};
 
-/// The approximation of a face
+/// An approximation of a [`Face`]
 #[derive(Debug, PartialEq)]
 pub struct FaceApprox {
     /// All points that make up the approximation

--- a/fj-kernel/src/algorithms/mod.rs
+++ b/fj-kernel/src/algorithms/mod.rs
@@ -8,5 +8,7 @@ mod sweep;
 mod triangulation;
 
 pub use self::{
-    approximation::FaceApprox, sweep::sweep_shape, triangulation::triangulate,
+    approximation::{CycleApprox, FaceApprox},
+    sweep::sweep_shape,
+    triangulation::triangulate,
 };

--- a/fj-kernel/src/algorithms/mod.rs
+++ b/fj-kernel/src/algorithms/mod.rs
@@ -8,6 +8,5 @@ mod sweep;
 mod triangulation;
 
 pub use self::{
-    approximation::Approximation, sweep::sweep_shape,
-    triangulation::triangulate,
+    approximation::FaceApprox, sweep::sweep_shape, triangulation::triangulate,
 };

--- a/fj-kernel/src/algorithms/sweep.rs
+++ b/fj-kernel/src/algorithms/sweep.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use fj_math::{Scalar, Segment, Transform, Triangle, Vector};
+use fj_math::{Scalar, Transform, Triangle, Vector};
 
 use crate::{
     geometry::{Surface, SweptCurve},
@@ -138,9 +138,7 @@ pub fn sweep_shape(
             let approx = CycleApprox::new(&cycle_source.get(), tolerance);
 
             let mut quads = Vec::new();
-            for segment in approx.points.windows(2) {
-                let segment = Segment::from_points([segment[0], segment[1]]);
-
+            for segment in approx.segments() {
                 let [v0, v1] = segment.points();
                 let [v3, v2] = {
                     let segment = Transform::translation(path)

--- a/fj-kernel/src/algorithms/sweep.rs
+++ b/fj-kernel/src/algorithms/sweep.rs
@@ -8,7 +8,7 @@ use crate::{
     topology::{Cycle, Edge, Face, Vertex},
 };
 
-use super::approximation::approximate_cycle;
+use super::CycleApprox;
 
 /// Create a new shape by sweeping an existing one
 pub fn sweep_shape(
@@ -135,10 +135,10 @@ pub fn sweep_shape(
             // This is the last piece of code that still uses the triangle
             // representation.
 
-            let approx = approximate_cycle(&cycle_source.get(), tolerance);
+            let approx = CycleApprox::new(&cycle_source.get(), tolerance);
 
             let mut quads = Vec::new();
-            for segment in approx.windows(2) {
+            for segment in approx.points.windows(2) {
                 let segment = Segment::from_points([segment[0], segment[1]]);
 
                 let [v0, v1] = segment.points();

--- a/fj-kernel/src/algorithms/triangulation.rs
+++ b/fj-kernel/src/algorithms/triangulation.rs
@@ -11,7 +11,7 @@ use spade::HasPosition;
 
 use crate::{geometry, shape::Shape, topology::Face};
 
-use super::Approximation;
+use super::FaceApprox;
 
 /// Triangulate a shape
 pub fn triangulate(
@@ -25,7 +25,7 @@ pub fn triangulate(
         match &face {
             Face::Face { surface, color, .. } => {
                 let surface = surface.get();
-                let approx = Approximation::new(&face, tolerance);
+                let approx = FaceApprox::new(&face, tolerance);
 
                 let points: Vec<_> = approx
                     .points

--- a/fj-kernel/src/algorithms/triangulation.rs
+++ b/fj-kernel/src/algorithms/triangulation.rs
@@ -38,8 +38,10 @@ pub fn triangulate(
                     .collect();
 
                 let segments: Vec<_> = approx
-                    .segments
+                    .cycles
                     .into_iter()
+                    .map(|cycle| cycle.segments())
+                    .flatten()
                     .map(|segment| {
                         let [a, b] = segment.points();
 


### PR DESCRIPTION
Introduce `CycleApprox`, which is used to approximate cycles in `FaceApprox`. This adds more information about the structure of the original face to `FaceApprox`, providing more flexibility in the triangulation algorithm. This will be useful when I start to clean that up.

This is more progress towards #105.