### PR TITLE
Have `release-operator` publish to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +1935,7 @@ name = "release-operator"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "clap",
  "cmd_lib",
  "env_logger",
@@ -1983,6 +2015,9 @@ name = "semver"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,7 @@ dependencies = [
  "env_logger",
  "log",
  "regex",
+ "secstr",
  "semver",
  "serde",
  "serde_json",
@@ -1967,6 +1968,15 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secstr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa8c1d89e7dc5e2776fbf507d8b088ff61bbaf83bf4da1cc9ed1c061358104"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/release-operator/Cargo.toml
+++ b/release-operator/Cargo.toml
@@ -6,20 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow     = "1.0.56"
-cmd_lib    = "1.3.0"
-env_logger = "0.9.0"
-log        = "0.4.16"
-regex      = "1.5.5"
-secstr     = "0.5.0"
-semver     = "1.0.7"
-serde_json = "1.0.79"
-
-[dependencies.serde]
-version  = "1.0.136"
-features = ["derive"]
+anyhow         = "1.0.56"
+cargo_metadata = "0.14.2"
+cmd_lib        = "1.3.0"
+env_logger     = "0.9.0"
+log            = "0.4.16"
+regex          = "1.5.5"
+secstr         = "0.5.0"
+semver         = "1.0.7"
+serde_json     = "1.0.79"
 
 [dependencies.clap]
 version  = "3.1.8"
 features = ["std", "derive", "env"]
 default_features = false
+
+[dependencies.serde]
+version  = "1.0.136"
+features = ["derive"]

--- a/release-operator/Cargo.toml
+++ b/release-operator/Cargo.toml
@@ -11,6 +11,7 @@ cmd_lib    = "1.3.0"
 env_logger = "0.9.0"
 log        = "0.4.16"
 regex      = "1.5.5"
+secstr     = "0.5.0"
 semver     = "1.0.7"
 serde_json = "1.0.79"
 

--- a/release-operator/README.md
+++ b/release-operator/README.md
@@ -122,7 +122,7 @@ cargo run -- publish \
 
 The `--token` can also be set using on the environment using `CARGO_REGISTRY_TOKEN`.
 
-The `--crate` option should be repeated for every crate to publish. Since the example is called from the `release-operator` sub0directory, all paths are relative to that location. The order matters; the crates are published top to bottom.
+The `--crate` option should be repeated for every crate to publish. Since the example is called from the `release-operator` subdirectory, all paths are relative to that location. The order matters; the crates are published top to bottom.
 
 There is an option `--dry-run` flag, which defaults to `false`. Set it to run the entire process without uploading any artifacts.
 

--- a/release-operator/README.md
+++ b/release-operator/README.md
@@ -52,6 +52,8 @@ As seen above, the release operator requires the maintainer to:
 
 ## Usage
 
+### Detect a Release
+
 ```shell
 # release-operator/
 cargo run -- detect --sha <commit-sha> --label <release-label>
@@ -59,7 +61,7 @@ cargo run -- detect --sha <commit-sha> --label <release-label>
 
 Where `<commit-sha>` can be set using `GITHUB_SHA` (present by default in GitHub Actions), and `<release-label>` can be set using `RELEASE_LABEL` (defaults to `autorelease`).
 
-## GitHub Actions
+#### GitHub Actions
 
 To embed the operator in a workflow, include these steps _before_ anything related to the project's source code:
 
@@ -101,12 +103,28 @@ To embed the operator in a workflow, include these steps _before_ anything relat
 # to determine if they shall execute.
 ```
 
-## Outputs
+#### Outputs
 
 The release operator defines "outputs" which can be read by subsequent steps within a GitHub Actions workflow:
 
 - `release-detected` (string `"true"|"false"`) this output is always set to indicate if a release was detected or not
 - `tag-name` (string) set to the tag name, if a release was detected
+
+### Publish a List of Crates
+
+```shell
+# release-operator/
+cargo run -- publish \
+  --token <crates.io-token> \
+  --crate ../fj \
+  --crate ../fj-host
+```
+
+The `--token` can also be set using on the environment using `CARGO_REGISTRY_TOKEN`.
+
+The `--crate` option should be repeated for every crate to publish. Since the example is called from the `release-operator` sub0directory, all paths are relative to that location. The order matters; the crates are published top to bottom.
+
+There is an option `--dry-run` flag, which defaults to `false`. Set it to run the entire process without uploading any artifacts.
 
 ## Logging
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -63,6 +63,8 @@ fn main() -> anyhow::Result<()> {
     log::trace!("starting release-operator process");
 
     let cli = Cli::parse();
+    // Please mind: this operation is safe due to the usage of `secstr::SecStr`
+    // which will redact any secrets, like the crates.io token.
     log::debug!("got arguments: {cli:#?}");
 
     match &cli.command {

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -45,6 +45,10 @@ struct PublishArgs {
     /// Repeatable option to provide a list of paths to crates
     #[clap(short, long = "crate")]
     crates: Vec<Crate>,
+
+    /// Perform all checks without uploading
+    #[clap(long)]
+    dry_run: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -73,7 +77,8 @@ fn main() -> anyhow::Result<()> {
                 .detect()?;
         }
         Commands::Publish(args) => {
-            Registry::new(&args.token, &args.crates).publish_crates()?;
+            Registry::new(&args.token, &args.crates, args.dry_run)
+                .publish_crates()?;
         }
     }
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -10,14 +10,14 @@ use crate::release::Release;
 use clap::{Args, Parser, Subcommand};
 use secstr::SecStr;
 
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[clap(version, propagate_version = true)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 enum Commands {
     /// Detect a release and set respective Action outputs
     Detect(DetectArgs),
@@ -62,15 +62,14 @@ fn main() -> anyhow::Result<()> {
     log::trace!("starting release-operator process");
 
     let cli = Cli::parse();
+    log::debug!("got arguments: {cli:#?}");
 
     match &cli.command {
         Commands::Detect(args) => {
-            log::debug!("got arguments: {args:#?}");
             Release::new(args.sha.to_owned(), args.label.to_owned())
                 .detect()?;
         }
         Commands::Publish(args) => {
-            log::debug!("got arguments: {args:#?}");
             Registry::new(&args.token, &args.crates).publish()?;
         }
     }

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -54,6 +54,11 @@ fn main() -> anyhow::Result<()> {
     );
     env_logger::init();
 
+    if log::log_enabled!(log::Level::Trace) {
+        // see https://docs.rs/cmd_lib/latest/cmd_lib/fn.set_debug.html
+        std::env::set_var("CMD_LIB_DEBUG", "1");
+    }
+
     let start = std::time::Instant::now();
     log::trace!("starting release-operator process");
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -1,10 +1,14 @@
 mod github;
+mod registry;
 mod release;
 
 use crate::github::{Actions, GitHub};
+use std::path::PathBuf;
 
+use crate::registry::Registry;
 use crate::release::Release;
 use clap::{Args, Parser, Subcommand};
+use secstr::SecStr;
 
 #[derive(Parser)]
 #[clap(version, propagate_version = true)]
@@ -33,9 +37,18 @@ struct DetectArgs {
     label: String,
 }
 
+/// Represent a crate to process
+type Crate = PathBuf;
+
 #[derive(Args, Debug)]
 struct PublishArgs {
+    /// Token to access crates.io for publishing
+    #[clap(short, long, env = "CARGO_REGISTRY_TOKEN")]
+    token: SecStr,
 
+    /// Repeatable option to provide a list of paths to crates
+    #[clap(short, long = "crate")]
+    crates: Vec<Crate>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -55,9 +68,10 @@ fn main() -> anyhow::Result<()> {
             log::debug!("got arguments: {args:#?}");
             Release::new(args.sha.to_owned(), args.label.to_owned())
                 .detect()?;
-        },
+        }
         Commands::Publish(args) => {
             log::debug!("got arguments: {args:#?}");
+            Registry::new(&args.token, &args.crates).publish()?;
         }
     }
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> anyhow::Result<()> {
                 .detect()?;
         }
         Commands::Publish(args) => {
-            Registry::new(&args.token, &args.crates).publish()?;
+            Registry::new(&args.token, &args.crates).publish_crates()?;
         }
     }
 

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -3,9 +3,8 @@ mod registry;
 mod release;
 
 use crate::github::{Actions, GitHub};
-use std::path::PathBuf;
 
-use crate::registry::Registry;
+use crate::registry::{Crate, Registry};
 use crate::release::Release;
 use clap::{Args, Parser, Subcommand};
 use secstr::SecStr;
@@ -36,9 +35,6 @@ struct DetectArgs {
     #[clap(short, long, env = "RELEASE_LABEL", default_value = "autorelease")]
     label: String,
 }
-
-/// Represent a crate to process
-type Crate = PathBuf;
 
 #[derive(Args, Debug)]
 struct PublishArgs {

--- a/release-operator/src/main.rs
+++ b/release-operator/src/main.rs
@@ -17,6 +17,9 @@ struct Cli {
 enum Commands {
     /// Detect a release and set respective Action outputs
     Detect(DetectArgs),
+
+    /// Publish a list of crates to crates.io
+    Publish(PublishArgs),
 }
 
 #[derive(Args, Debug)]
@@ -28,6 +31,11 @@ struct DetectArgs {
     /// Marker label to look for
     #[clap(short, long, env = "RELEASE_LABEL", default_value = "autorelease")]
     label: String,
+}
+
+#[derive(Args, Debug)]
+struct PublishArgs {
+
 }
 
 fn main() -> anyhow::Result<()> {
@@ -47,6 +55,9 @@ fn main() -> anyhow::Result<()> {
             log::debug!("got arguments: {args:#?}");
             Release::new(args.sha.to_owned(), args.label.to_owned())
                 .detect()?;
+        },
+        Commands::Publish(args) => {
+            log::debug!("got arguments: {args:#?}");
         }
     }
 

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -1,0 +1,20 @@
+use crate::Crate;
+use secstr::SecStr;
+
+pub struct Registry {
+    token: SecStr,
+    crates: Vec<Crate>,
+}
+
+impl Registry {
+    pub fn new(token: &SecStr, crates: &[Crate]) -> Self {
+        Self {
+            token: token.to_owned(),
+            crates: crates.to_owned(),
+        }
+    }
+
+    pub fn publish(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -1,20 +1,59 @@
-use crate::Crate;
 use secstr::SecStr;
+use std::path::PathBuf;
+use std::str::FromStr;
 
 pub struct Registry {
     token: SecStr,
     crates: Vec<Crate>,
 }
 
+#[derive(Clone, Debug)]
+pub struct Crate {
+    path: PathBuf,
+}
+
 impl Registry {
     pub fn new(token: &SecStr, crates: &[Crate]) -> Self {
         Self {
             token: token.to_owned(),
-            crates: crates.to_owned(),
+            crates: crates.to_vec(),
         }
     }
 
     pub fn publish(&self) -> anyhow::Result<()> {
+        for c in &self.crates {
+            c.validate()?.preflight()?.submit()?;
+        }
+
         Ok(())
+    }
+}
+
+impl Crate {
+    fn validate(&self) -> anyhow::Result<&Self> {
+        // todo check if the path is readable
+        // todo check if there is a Cargo.toml
+        Ok(self)
+    }
+
+    fn preflight(&self) -> anyhow::Result<&Self> {
+        // todo run `cargo search` to determine which version the registry knows
+        //      compare the version to the local one and abort if they match
+        Ok(self)
+    }
+
+    fn submit(&self) -> anyhow::Result<&Self> {
+        // todo run `cargo publish`
+        Ok(self)
+    }
+}
+
+impl FromStr for Crate {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Crate {
+            path: PathBuf::from(s),
+        })
     }
 }

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -107,7 +107,7 @@ impl Crate {
         Ok(CrateState::Outdated)
     }
 
-    fn submit(&self, token: &SecStr, dry_run: bool) -> anyhow::Result<&Self> {
+    fn submit(&self, token: &SecStr, dry_run: bool) -> anyhow::Result<()> {
         log::info!("{self} publishing new version");
 
         std::env::set_current_dir(&self.path)
@@ -133,7 +133,7 @@ impl Crate {
             },
         )?;
 
-        Ok(self)
+        Ok(())
     }
 }
 

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -63,7 +63,7 @@ impl Crate {
 
             let version = cmd_lib::run_fun!(cargo search "${name}" | head -n1 | awk r#"{print $3}"# | tr -d '"')
                 .context("search crates.io for published crate version")?;
-            log::trace!("{self} found as {version} on their side");
+            log::debug!("{self} found as {version} on their side");
 
             version
         };
@@ -87,7 +87,7 @@ impl Crate {
                 .ok_or_else(|| anyhow!("could not find package"))?;
 
             let version = package.version.to_string();
-            log::trace!("{self} found as {version} on our side");
+            log::debug!("{self} found as {version} on our side");
 
             version
         };

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -91,10 +91,10 @@ impl Crate {
 
         if ours == theirs {
             log::info!("{self} has already been published as {ours}");
-            return Ok(false);
+            return Ok(true);
         }
 
-        Ok(true)
+        Ok(false)
     }
 
     fn submit(&self, token: &SecStr) -> anyhow::Result<&Self> {

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use secstr::SecStr;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -22,9 +22,15 @@ impl Registry {
         }
     }
 
-    pub fn publish(&self) -> anyhow::Result<()> {
+    pub fn publish_crates(&self) -> anyhow::Result<()> {
         for c in &self.crates {
-            c.validate()?.preflight()?.submit()?;
+            c.validate()?;
+
+            if c.already_published()? {
+                continue;
+            }
+
+            c.submit(&self.token)?;
         }
 
         Ok(())
@@ -32,23 +38,69 @@ impl Registry {
 }
 
 impl Crate {
-    fn validate(&self) -> anyhow::Result<&Self> {
+    fn validate(&self) -> anyhow::Result<()> {
         match self.path.exists() {
-            true => Ok(self),
+            true => Ok(()),
             false => Err(anyhow!(
                 "given path to the '{self}' crate is either not readable or does not exist"
             )),
         }
     }
 
-    fn preflight(&self) -> anyhow::Result<&Self> {
-        // todo run `cargo search` to determine which version the registry knows
-        //      compare the version to the local one and abort if they match
-        Ok(self)
+    fn already_published(&self) -> anyhow::Result<bool> {
+        let theirs = {
+            let name = format!("{self}");
+            let search_result = cmd_lib::run_fun!(cargo search "${name}")
+                .context("search for crate on crates.io")?;
+
+            if search_result.is_empty() {
+                log::info!("{self} has not been published yet");
+                return Ok(true);
+            }
+
+            let version = cmd_lib::run_fun!(cargo search "${name}" | head -n1 | awk r#"{print $3}"# | tr -d '"')
+                .context("search crates.io for published crate version")?;
+            log::trace!("{self} found as {version} on their side");
+
+            version
+        };
+
+        let ours = {
+            let name = format!("{self}");
+            let cargo_toml_location = std::fs::canonicalize(&self.path)
+                .context("absolute path to Cargo.toml")?;
+            let mut cmd = cargo_metadata::MetadataCommand::new();
+            cmd.manifest_path(format!(
+                "{}/Cargo.toml",
+                cargo_toml_location.to_string_lossy()
+            ))
+            .no_deps();
+
+            let metadata = cmd.exec()?;
+            let package = metadata
+                .packages
+                .iter()
+                .find(|p| p.name == name)
+                .ok_or_else(|| anyhow!("could not find package"))?;
+
+            let version = package.version.to_string();
+            log::trace!("{self} found as {version} on our side");
+
+            version
+        };
+
+        if ours == theirs {
+            log::info!("{self} has already been published as {ours}");
+            return Ok(false);
+        }
+
+        Ok(true)
     }
 
-    fn submit(&self) -> anyhow::Result<&Self> {
+    fn submit(&self, token: &SecStr) -> anyhow::Result<&Self> {
         // todo run `cargo publish`
+        // todo support a dry-run mode
+        let _ = token;
         Ok(self)
     }
 }

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 pub struct Registry {
     token: SecStr,
     crates: Vec<Crate>,
+    dry_run: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -15,10 +16,11 @@ pub struct Crate {
 }
 
 impl Registry {
-    pub fn new(token: &SecStr, crates: &[Crate]) -> Self {
+    pub fn new(token: &SecStr, crates: &[Crate], dry_run: bool) -> Self {
         Self {
             token: token.to_owned(),
             crates: crates.to_vec(),
+            dry_run,
         }
     }
 
@@ -30,7 +32,7 @@ impl Registry {
                 continue;
             }
 
-            c.submit(&self.token)?;
+            c.submit(&self.token, self.dry_run)?;
         }
 
         Ok(())
@@ -97,10 +99,11 @@ impl Crate {
         Ok(false)
     }
 
-    fn submit(&self, token: &SecStr) -> anyhow::Result<&Self> {
+    fn submit(&self, token: &SecStr, dry_run: bool) -> anyhow::Result<&Self> {
         // todo run `cargo publish`
         // todo support a dry-run mode
         let _ = token;
+        let _ = dry_run;
         Ok(self)
     }
 }

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -108,6 +108,8 @@ impl Crate {
     }
 
     fn submit(&self, token: &SecStr, dry_run: bool) -> anyhow::Result<&Self> {
+        log::info!("{self} publishing new version");
+
         std::env::set_current_dir(&self.path)
             .context("switch working directory to the crate in scope")?;
 

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use secstr::SecStr;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -32,9 +33,12 @@ impl Registry {
 
 impl Crate {
     fn validate(&self) -> anyhow::Result<&Self> {
-        // todo check if the path is readable
-        // todo check if there is a Cargo.toml
-        Ok(self)
+        match self.path.exists() {
+            true => Ok(self),
+            false => Err(anyhow!(
+                "given path to the '{self}' crate is either not readable or does not exist"
+            )),
+        }
     }
 
     fn preflight(&self) -> anyhow::Result<&Self> {

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -1,4 +1,5 @@
 use secstr::SecStr;
+use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -55,5 +56,14 @@ impl FromStr for Crate {
         Ok(Crate {
             path: PathBuf::from(s),
         })
+    }
+}
+
+impl Display for Crate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(name) = self.path.file_name() {
+            return write!(f, "{}", name.to_string_lossy());
+        }
+        write!(f, "{:?}", self.path)
     }
 }

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -35,7 +35,7 @@ impl Registry {
         for c in &self.crates {
             c.validate()?;
 
-            match c.already_published()? {
+            match c.determine_state()? {
                 CrateState::Published => continue,
                 CrateState::Unknown | CrateState::Outdated => {
                     c.submit(&self.token, self.dry_run)?;
@@ -57,7 +57,7 @@ impl Crate {
         }
     }
 
-    fn already_published(&self) -> anyhow::Result<CrateState> {
+    fn determine_state(&self) -> anyhow::Result<CrateState> {
         let theirs = {
             let name = format!("{self}");
             let search_result = cmd_lib::run_fun!(cargo search "${name}")


### PR DESCRIPTION
This change-set introduces a new sub-command to `release-operator`, called `publish`. It will enable the CD workflow to publish a given list of crates to crates.io. It will be integrated into said workflow in a separate pull-request.

## Todo

- [x] documentation
- [x] dry-run mode
- [x] crates.io publishing