### PR TITLE
Fix issue on my new AMD GPU

### DIFF
--- a/fj-app/src/graphics/renderer.rs
+++ b/fj-app/src/graphics/renderer.rs
@@ -75,7 +75,7 @@ impl Renderer {
             format: color_format,
             width: window.width(),
             height: window.height(),
-            present_mode: wgpu::PresentMode::Fifo,
+            present_mode: wgpu::PresentMode::Mailbox,
         };
         surface.configure(&device, &surface_config);
 

--- a/fj-app/src/graphics/renderer.rs
+++ b/fj-app/src/graphics/renderer.rs
@@ -300,24 +300,24 @@ impl Renderer {
 
 #[derive(Error, Debug)]
 pub enum InitError {
-    #[error("I/O error")]
+    #[error("I/O error: {0}")]
     Io(#[from] io::Error),
 
     #[error("Error request adapter")]
     RequestAdapter,
 
-    #[error("Error requesting device")]
+    #[error("Error requesting device: {0}")]
     RequestDevice(#[from] wgpu::RequestDeviceError),
 
-    #[error("Error loading font")]
+    #[error("Error loading font: {0}")]
     InvalidFont(#[from] InvalidFont),
 }
 
 #[derive(Error, Debug)]
 pub enum DrawError {
-    #[error("Error acquiring output surface")]
+    #[error("Error acquiring output surface: {0}")]
     Surface(#[from] wgpu::SurfaceError),
 
-    #[error("Error drawing text")]
+    #[error("Error drawing text: {0}")]
     Text(String),
 }

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -15,7 +15,7 @@ use fj_kernel::algorithms::triangulate;
 use fj_math::{Aabb, Scalar, Triangle};
 use fj_operations::ToShape as _;
 use futures::executor::block_on;
-use tracing::trace;
+use tracing::{trace, warn};
 use tracing_subscriber::fmt::format;
 use tracing_subscriber::EnvFilter;
 use winit::{
@@ -227,7 +227,7 @@ fn main() -> anyhow::Result<()> {
                     match renderer.draw(camera, &draw_config) {
                         Ok(()) => {}
                         Err(err) => {
-                            panic!("Draw error: {}", err);
+                            warn!("Draw error: {}", err);
                         }
                     }
                 }

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -224,11 +224,8 @@ fn main() -> anyhow::Result<()> {
                 if let (Some(shape), Some(camera)) = (&shape, &mut camera) {
                     camera.update_planes(&shape.aabb);
 
-                    match renderer.draw(camera, &draw_config) {
-                        Ok(()) => {}
-                        Err(err) => {
-                            warn!("Draw error: {}", err);
-                        }
+                    if let Err(err) = renderer.draw(camera, &draw_config) {
+                        warn!("Draw error: {}", err);
                     }
                 }
             }


### PR DESCRIPTION
I got my new PC today, which has an AMD CPU/GPU. The old one had Intel, as does my laptop.

This pull request fixes a crash with that hardware, by logging a warning instead of panicking on a draw error. It then fixes the large number of warnings printed by switching the present mode from `PresentMode::Fifo` to `PresentMode::Mailbox`.