### PR TITLE
Upgrade to latest Rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.60.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
This one re-enables incremental compilation, so we can go back to using
the latest stable version.