### PR TITLE
Make `Polygon` more testable

### DIFF
--- a/fj-kernel/src/algorithms/approximation.rs
+++ b/fj-kernel/src/algorithms/approximation.rs
@@ -149,6 +149,17 @@ fn approximate_edge(
     points
 }
 
+impl<T, P> From<T> for CycleApprox
+where
+    T: IntoIterator<Item = P>,
+    P: Into<Point<3>>,
+{
+    fn from(points: T) -> Self {
+        let points = points.into_iter().map(Into::into).collect();
+        Self { points }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use fj_math::{Point, Scalar};

--- a/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -34,8 +34,9 @@ pub fn triangulate(
                         surface.point_model_to_surface(vertex)
                     })
                     .collect();
-                let face_as_polygon =
-                    Polygon::new(approx.exterior, approx.interiors, surface);
+                let face_as_polygon = Polygon::new(surface)
+                    .with_exterior(approx.exterior)
+                    .with_interiors(approx.interiors);
 
                 let mut triangles = delaunay(points);
                 triangles.retain(|triangle| {

--- a/fj-kernel/src/algorithms/triangulation/polygon.rs
+++ b/fj-kernel/src/algorithms/triangulation/polygon.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 
 use fj_debug::{DebugInfo, TriangleEdgeCheck};
 use fj_math::{Point, Scalar, Segment};
@@ -12,7 +12,7 @@ use crate::{
 
 pub struct Polygon {
     surface: Surface,
-    segments: HashSet<[geometry::Point<2>; 2]>,
+    segments: Vec<[geometry::Point<2>; 2]>,
     max: Point<2>,
 }
 
@@ -20,7 +20,7 @@ impl Polygon {
     pub fn new(surface: Surface) -> Self {
         Self {
             surface,
-            segments: HashSet::new(),
+            segments: Vec::new(),
             max: Point::origin(),
         }
     }
@@ -54,7 +54,7 @@ impl Polygon {
                 point
             });
 
-            self.segments.insert(segment);
+            self.segments.push(segment);
         }
 
         self

--- a/fj-kernel/src/algorithms/triangulation/polygon.rs
+++ b/fj-kernel/src/algorithms/triangulation/polygon.rs
@@ -13,7 +13,7 @@ use crate::{
 pub struct Polygon {
     surface: Surface,
     segments: HashSet<[geometry::Point<2>; 2]>,
-    outside: Point<2>,
+    max: Point<2>,
 }
 
 impl Polygon {
@@ -48,12 +48,10 @@ impl Polygon {
             })
             .collect();
 
-        let outside = max * 2.;
-
         Self {
             surface,
             segments,
-            outside,
+            max,
         }
     }
 
@@ -97,7 +95,9 @@ impl Polygon {
         point: Point<2>,
         debug_info: &mut DebugInfo,
     ) -> bool {
-        let dir = self.outside - point;
+        let outside = self.max * 2.;
+
+        let dir = outside - point;
         let ray = Ray2 {
             origin: point.to_na(),
             dir: dir.to_na(),

--- a/fj-kernel/src/algorithms/triangulation/polygon.rs
+++ b/fj-kernel/src/algorithms/triangulation/polygon.rs
@@ -25,13 +25,13 @@ impl Polygon {
         }
     }
 
-    pub fn with_exterior(self, exterior: CycleApprox) -> Self {
+    pub fn with_exterior(self, exterior: impl Into<CycleApprox>) -> Self {
         self.with_approx(exterior)
     }
 
     pub fn with_interiors(
         mut self,
-        interiors: impl IntoIterator<Item = CycleApprox>,
+        interiors: impl IntoIterator<Item = impl Into<CycleApprox>>,
     ) -> Self {
         for interior in interiors {
             self = self.with_approx(interior);
@@ -40,8 +40,8 @@ impl Polygon {
         self
     }
 
-    fn with_approx(mut self, approx: CycleApprox) -> Self {
-        for segment in approx.segments() {
+    fn with_approx(mut self, approx: impl Into<CycleApprox>) -> Self {
+        for segment in approx.into().segments() {
             let segment = segment.points().map(|point| {
                 // Can't panic, unless the approximation wrongfully generates
                 // points that are not in the surface.
@@ -97,9 +97,10 @@ impl Polygon {
 
     pub fn contains_point(
         &self,
-        point: Point<2>,
+        point: impl Into<Point<2>>,
         debug_info: &mut DebugInfo,
     ) -> bool {
+        let point = point.into();
         let outside = self.max * 2.;
 
         let dir = outside - point;


### PR DESCRIPTION
Cleans up the newly introduced `Polygon` struct, making its API more amenable to being used in unit tests. This has been extracted from my local branch where I work towards addressing #105.