### PR TITLE
Simplify debug info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
 name = "fj-debug"
 version = "0.5.0"
 dependencies = [
+ "fj-math",
  "parry3d-f64",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,6 @@ name = "fj-debug"
 version = "0.5.0"
 dependencies = [
  "fj-math",
- "parry3d-f64",
 ]
 
 [[package]]

--- a/fj-app/src/graphics/vertices.rs
+++ b/fj-app/src/graphics/vertices.rs
@@ -44,6 +44,26 @@ impl Vertices {
         self.indices.push(self.indices.len() as u32);
         self.indices.push(self.indices.len() as u32);
     }
+
+    pub fn push_cross(
+        &mut self,
+        position: Point<f64, 3>,
+        normal: [f32; 3],
+        color: [f32; 4],
+    ) {
+        let d = 0.05;
+
+        self.push_line(
+            [position - vector![d, 0., 0.], position + vector![d, 0., 0.]],
+            normal,
+            color,
+        );
+        self.push_line(
+            [position - vector![0., d, 0.], position + vector![0., d, 0.]],
+            normal,
+            color,
+        );
+    }
 }
 
 impl From<&Vec<Triangle<3>>> for Vertices {
@@ -104,20 +124,9 @@ impl From<&DebugInfo> for Vertices {
 
             for &hit in &triangle_edge_check.hits {
                 let point = triangle_edge_check.ray.point_at(hit);
-
-                let d = 0.05;
                 let color = [0., 0., 0., 1.];
 
-                self_.push_line(
-                    [point - vector![d, 0., 0.], point + vector![d, 0., 0.]],
-                    normal,
-                    color,
-                );
-                self_.push_line(
-                    [point - vector![0., d, 0.], point + vector![0., d, 0.]],
-                    normal,
-                    color,
-                );
+                self_.push_cross(point, normal, color);
             }
         }
 

--- a/fj-app/src/graphics/vertices.rs
+++ b/fj-app/src/graphics/vertices.rs
@@ -112,21 +112,13 @@ impl From<&DebugInfo> for Vertices {
                 green
             };
 
-            self_.push_line(
-                [
-                    triangle_edge_check.ray.origin,
-                    triangle_edge_check.ray.origin
-                        + triangle_edge_check.ray.dir,
-                ],
-                normal,
-                color,
-            );
+            self_.push_cross(triangle_edge_check.origin.to_na(), normal, color);
 
             for &hit in &triangle_edge_check.hits {
-                let point = triangle_edge_check.ray.point_at(hit);
+                let line = hit.points().map(|point| point.to_na());
                 let color = [0., 0., 0., 1.];
 
-                self_.push_cross(point, normal, color);
+                self_.push_line(line, normal, color);
             }
         }
 

--- a/fj-debug/Cargo.toml
+++ b/fj-debug/Cargo.toml
@@ -10,9 +10,6 @@ license     = "0BSD"
 keywords    = ["cad", "programmatic", "code-cad"]
 
 
-[dependencies]
-parry3d-f64 = "0.8.0"
-
 [dependencies.fj-math]
 path    = "../fj-math"
 version = "0.5.0"

--- a/fj-debug/Cargo.toml
+++ b/fj-debug/Cargo.toml
@@ -12,3 +12,7 @@ keywords    = ["cad", "programmatic", "code-cad"]
 
 [dependencies]
 parry3d-f64 = "0.8.0"
+
+[dependencies.fj-math]
+path    = "../fj-math"
+version = "0.5.0"

--- a/fj-debug/src/lib.rs
+++ b/fj-debug/src/lib.rs
@@ -10,8 +10,6 @@
 use fj_math::{Point, Segment};
 
 /// Debug info from the CAD kernel that can be visualized
-///
-/// At this point, this is a placeholder that will be filled with life later.
 #[derive(Default)]
 pub struct DebugInfo {
     /// Rays being used during face triangulation

--- a/fj-debug/src/lib.rs
+++ b/fj-debug/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![deny(missing_docs)]
 
-use parry3d_f64::query::Ray;
+use fj_math::{Point, Segment};
 
 /// Debug info from the CAD kernel that can be visualized
 ///
@@ -36,18 +36,18 @@ impl DebugInfo {
 
 /// Record of a check to determine if a triangle edge is within a face
 pub struct TriangleEdgeCheck {
-    /// The ray used to perform the check
-    pub ray: Ray,
+    /// The origin of the ray used to perform the check
+    pub origin: Point<3>,
 
-    /// Where the ray hit any edges of the face
-    pub hits: Vec<f64>,
+    /// The points where the ray hit edges of the face
+    pub hits: Vec<Segment<3>>,
 }
 
 impl TriangleEdgeCheck {
     /// Construct a new instance
-    pub fn new(ray: Ray) -> Self {
+    pub fn new(origin: Point<3>) -> Self {
         Self {
-            ray,
+            origin,
             hits: Vec::new(),
         }
     }

--- a/fj-kernel/src/algorithms/triangulation/polygon.rs
+++ b/fj-kernel/src/algorithms/triangulation/polygon.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeSet;
 use fj_debug::{DebugInfo, TriangleEdgeCheck};
 use fj_math::{Point, PolyChain, Scalar, Segment};
 use parry2d_f64::query::{Ray as Ray2, RayCast as _};
-use parry3d_f64::query::Ray as Ray3;
 
 use crate::geometry::Surface;
 
@@ -102,10 +101,8 @@ impl Polygon {
             dir: dir.to_na(),
         };
 
-        let mut check = TriangleEdgeCheck::new(Ray3 {
-            origin: self.surface.point_surface_to_model(&point).to_na(),
-            dir: self.surface.vector_surface_to_model(&dir).to_na(),
-        });
+        let mut check =
+            TriangleEdgeCheck::new(self.surface.point_surface_to_model(&point));
 
         // We need to keep track of where our ray hits the edges. Otherwise, if
         // the ray hits a vertex, we might count that hit twice, as every vertex
@@ -130,7 +127,11 @@ impl Polygon {
                 let t = (t * eps).round() / eps;
 
                 if hits.insert(t) {
-                    check.hits.push(t.into_f64());
+                    let edge =
+                        Segment::from_points(edge.points().map(|point| {
+                            self.surface.point_surface_to_model(&point)
+                        }));
+                    check.hits.push(edge);
                 }
             }
         }


### PR DESCRIPTION
On my way towards addressing #105, I'm making changes to the triangulation algorithm. Some of the debug info it collects is no longer applicable in my local branch, so this change has become necessary.