### PR TITLE
Expand `Mesh` API with methods that work with triangles

### DIFF
--- a/fj-app/src/camera.rs
+++ b/fj-app/src/camera.rs
@@ -131,7 +131,7 @@ impl Camera {
         &self,
         window: &Window,
         cursor: Option<PhysicalPosition<f64>>,
-        triangles: &Mesh<fj_math::Point<3>>,
+        mesh: &Mesh<fj_math::Point<3>>,
     ) -> FocusPoint {
         let cursor = match cursor {
             Some(cursor) => cursor,
@@ -147,7 +147,7 @@ impl Camera {
 
         let mut min_t = None;
 
-        for triangle in triangles.triangles() {
+        for triangle in mesh.triangles() {
             let t = triangle.inner.to_parry().cast_local_ray(
                 &ray,
                 f64::INFINITY,

--- a/fj-app/src/camera.rs
+++ b/fj-app/src/camera.rs
@@ -1,6 +1,6 @@
 use std::f64::consts::FRAC_PI_2;
 
-use fj_interop::mesh::Triangle;
+use fj_interop::mesh::Mesh;
 use fj_math::{Aabb, Scalar};
 use nalgebra::{Point, TAffine, Transform, Translation, Vector};
 use parry3d_f64::query::{Ray, RayCast as _};
@@ -131,7 +131,7 @@ impl Camera {
         &self,
         window: &Window,
         cursor: Option<PhysicalPosition<f64>>,
-        triangles: &[Triangle],
+        triangles: &Mesh<fj_math::Point<3>>,
     ) -> FocusPoint {
         let cursor = match cursor {
             Some(cursor) => cursor,
@@ -147,7 +147,7 @@ impl Camera {
 
         let mut min_t = None;
 
-        for triangle in triangles {
+        for triangle in triangles.triangles() {
             let t = triangle.inner.to_parry().cast_local_ray(
                 &ray,
                 f64::INFINITY,

--- a/fj-app/src/graphics/vertices.rs
+++ b/fj-app/src/graphics/vertices.rs
@@ -76,9 +76,9 @@ impl From<&Vec<Triangle>> for Vertices {
             let normal = (b - a).cross(&(c - a)).normalize();
             let color = triangle.color;
 
-            mesh.push((a, normal, color));
-            mesh.push((b, normal, color));
-            mesh.push((c, normal, color));
+            mesh.push_vertex((a, normal, color));
+            mesh.push_vertex((b, normal, color));
+            mesh.push_vertex((c, normal, color));
         }
 
         let vertices = mesh

--- a/fj-app/src/graphics/vertices.rs
+++ b/fj-app/src/graphics/vertices.rs
@@ -1,7 +1,7 @@
 use bytemuck::{Pod, Zeroable};
 use fj_interop::{
     debug::DebugInfo,
-    mesh::{Index, Mesh, Triangle},
+    mesh::{Index, Mesh},
 };
 use nalgebra::{vector, Point};
 
@@ -66,11 +66,11 @@ impl Vertices {
     }
 }
 
-impl From<&Vec<Triangle>> for Vertices {
-    fn from(triangles: &Vec<Triangle>) -> Self {
+impl From<&Mesh<fj_math::Point<3>>> for Vertices {
+    fn from(triangles: &Mesh<fj_math::Point<3>>) -> Self {
         let mut mesh = Mesh::new();
 
-        for triangle in triangles {
+        for triangle in triangles.triangles() {
             let [a, b, c] = triangle.inner.points();
 
             let normal = (b - a).cross(&(c - a)).normalize();

--- a/fj-app/src/graphics/vertices.rs
+++ b/fj-app/src/graphics/vertices.rs
@@ -68,7 +68,7 @@ impl Vertices {
 
 impl From<&Mesh<fj_math::Point<3>>> for Vertices {
     fn from(triangles: &Mesh<fj_math::Point<3>>) -> Self {
-        let mut mesh = Mesh::new();
+        let mut m = Mesh::new();
 
         for triangle in triangles.triangles() {
             let [a, b, c] = triangle.inner.points();
@@ -76,12 +76,12 @@ impl From<&Mesh<fj_math::Point<3>>> for Vertices {
             let normal = (b - a).cross(&(c - a)).normalize();
             let color = triangle.color;
 
-            mesh.push_vertex((a, normal, color));
-            mesh.push_vertex((b, normal, color));
-            mesh.push_vertex((c, normal, color));
+            m.push_vertex((a, normal, color));
+            m.push_vertex((b, normal, color));
+            m.push_vertex((c, normal, color));
         }
 
-        let vertices = mesh
+        let vertices = m
             .vertices()
             .map(|(vertex, normal, color)| Vertex {
                 position: vertex.into(),
@@ -90,7 +90,7 @@ impl From<&Mesh<fj_math::Point<3>>> for Vertices {
             })
             .collect();
 
-        let indices = mesh.indices().collect();
+        let indices = m.indices().collect();
 
         Self { vertices, indices }
     }

--- a/fj-app/src/graphics/vertices.rs
+++ b/fj-app/src/graphics/vertices.rs
@@ -67,10 +67,10 @@ impl Vertices {
 }
 
 impl From<&Mesh<fj_math::Point<3>>> for Vertices {
-    fn from(triangles: &Mesh<fj_math::Point<3>>) -> Self {
+    fn from(mesh: &Mesh<fj_math::Point<3>>) -> Self {
         let mut m = Mesh::new();
 
-        for triangle in triangles.triangles() {
+        for triangle in mesh.triangles() {
             let [a, b, c] = triangle.inner.points();
 
             let normal = (b - a).cross(&(c - a)).normalize();

--- a/fj-app/src/input/handler.rs
+++ b/fj-app/src/input/handler.rs
@@ -122,9 +122,9 @@ impl Handler {
         now: Instant,
         camera: &mut Camera,
         window: &Window,
-        triangles: &Mesh<Point<3>>,
+        mesh: &Mesh<Point<3>>,
     ) {
-        let focus_point = camera.focus_point(window, self.cursor, triangles);
+        let focus_point = camera.focus_point(window, self.cursor, mesh);
 
         self.zoom.discard_old_events(now);
         self.zoom.update_speed(now, delta_t, focus_point, camera);

--- a/fj-app/src/input/handler.rs
+++ b/fj-app/src/input/handler.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
-use fj_interop::mesh::Triangle;
+use fj_interop::mesh::Mesh;
+use fj_math::Point;
 use winit::{
     dpi::PhysicalPosition,
     event::{
@@ -121,7 +122,7 @@ impl Handler {
         now: Instant,
         camera: &mut Camera,
         window: &Window,
-        triangles: &[Triangle],
+        triangles: &Mesh<Point<3>>,
     ) {
         let focus_point = camera.focus_point(window, self.cursor, triangles);
 

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -89,7 +89,7 @@ fn main() -> anyhow::Result<()> {
 
         for triangle in shape.triangles {
             for vertex in triangle.inner.points() {
-                mesh_maker.push(vertex);
+                mesh_maker.push_vertex(vertex);
             }
         }
 

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -84,13 +84,10 @@ fn main() -> anyhow::Result<()> {
         let shape = model.load_once(&parameters)?;
         let shape = shape_processor.process(&shape);
 
-        let vertices = shape
-            .triangles
-            .vertices()
-            .map(|vertex| vertex.into())
-            .collect();
+        let vertices =
+            shape.mesh.vertices().map(|vertex| vertex.into()).collect();
 
-        let indices: Vec<_> = shape.triangles.indices().collect();
+        let indices: Vec<_> = shape.mesh.indices().collect();
         let triangles = indices
             .chunks(3)
             .map(|triangle| {
@@ -181,7 +178,7 @@ fn main() -> anyhow::Result<()> {
                     let focus_point = camera.focus_point(
                         &window,
                         input_handler.cursor(),
-                        &shape.triangles,
+                        &shape.mesh,
                     );
 
                     input_handler.handle_mouse_input(
@@ -207,7 +204,7 @@ fn main() -> anyhow::Result<()> {
                         now,
                         camera,
                         &window,
-                        &shape.triangles,
+                        &shape.mesh,
                     );
                 }
 
@@ -294,7 +291,7 @@ impl ShapeProcessor {
 
         ProcessedShape {
             aabb,
-            triangles,
+            mesh: triangles,
             debug_info,
         }
     }
@@ -302,14 +299,14 @@ impl ShapeProcessor {
 
 struct ProcessedShape {
     aabb: Aabb<3>,
-    triangles: Mesh<Point<3>>,
+    mesh: Mesh<Point<3>>,
     debug_info: DebugInfo,
 }
 
 impl ProcessedShape {
     fn update_geometry(&self, renderer: &mut Renderer) {
         renderer.update_geometry(
-            (&self.triangles).into(),
+            (&self.mesh).into(),
             (&self.debug_info).into(),
             self.aabb,
         );

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -283,7 +283,7 @@ impl ShapeProcessor {
         };
 
         let mut debug_info = DebugInfo::new();
-        let triangles = triangulate(
+        let mesh = triangulate(
             shape.to_shape(tolerance, &mut debug_info),
             tolerance,
             &mut debug_info,
@@ -291,7 +291,7 @@ impl ShapeProcessor {
 
         ProcessedShape {
             aabb,
-            mesh: triangles,
+            mesh,
             debug_info,
         }
     }

--- a/fj-app/src/main.rs
+++ b/fj-app/src/main.rs
@@ -292,11 +292,9 @@ impl ShapeProcessor {
         };
 
         let mut debug_info = DebugInfo::new();
-        let mut triangles = Vec::new();
-        triangulate(
+        let triangles = triangulate(
             shape.to_shape(tolerance, &mut debug_info),
             tolerance,
-            &mut triangles,
             &mut debug_info,
         );
 

--- a/fj-interop/src/mesh.rs
+++ b/fj-interop/src/mesh.rs
@@ -2,12 +2,15 @@
 
 use std::{collections::HashMap, hash::Hash};
 
+use fj_math::Point;
+
 /// A triangle mesh
 pub struct Mesh<V> {
     vertices: Vec<V>,
     indices: Vec<Index>,
 
     indices_by_vertex: HashMap<V, Index>,
+    triangles: Vec<Triangle>,
 }
 
 impl<V> Mesh<V>
@@ -31,6 +34,25 @@ where
         self.indices.push(index);
     }
 
+    /// Determine whether the mesh contains the provided triangle
+    ///
+    /// Returns true, if a triangle with any combination of the points of the
+    /// provided triangle is part of the mesh.
+    pub fn contains_triangle(
+        &self,
+        triangle: impl Into<fj_math::Triangle<3>>,
+    ) -> bool {
+        let triangle = triangle.into().normalize();
+
+        for t in &self.triangles {
+            if triangle == t.inner.normalize() {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Access the vertices of the mesh
     pub fn vertices(&self) -> impl Iterator<Item = V> + '_ {
         self.vertices.iter().copied()
@@ -39,6 +61,28 @@ where
     /// Access the indices of the mesh
     pub fn indices(&self) -> impl Iterator<Item = Index> + '_ {
         self.indices.iter().copied()
+    }
+
+    /// Access the triangles of the mesh
+    pub fn triangles(&self) -> impl Iterator<Item = Triangle> + '_ {
+        self.triangles.iter().copied()
+    }
+}
+
+impl Mesh<Point<3>> {
+    /// Add a triangle to the mesh
+    pub fn push_triangle(
+        &mut self,
+        triangle: impl Into<fj_math::Triangle<3>>,
+        color: Color,
+    ) {
+        let triangle = triangle.into();
+
+        for point in triangle.points() {
+            self.push_vertex(point);
+        }
+
+        self.triangles.push(Triangle::new(triangle, color));
     }
 }
 
@@ -50,6 +94,7 @@ impl<V> Default for Mesh<V> {
             vertices: Default::default(),
             indices: Default::default(),
             indices_by_vertex: Default::default(),
+            triangles: Default::default(),
         }
     }
 }

--- a/fj-interop/src/mesh.rs
+++ b/fj-interop/src/mesh.rs
@@ -20,7 +20,7 @@ where
     }
 
     /// Add a vertex to the mesh
-    pub fn push(&mut self, vertex: V) {
+    pub fn push_vertex(&mut self, vertex: V) {
         let index =
             *self.indices_by_vertex.entry(vertex).or_insert_with(|| {
                 let index = self.vertices.len();

--- a/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -15,9 +15,10 @@ use super::FaceApprox;
 pub fn triangulate(
     mut shape: Shape,
     tolerance: Scalar,
-    out: &mut Vec<Triangle>,
     debug_info: &mut DebugInfo,
-) {
+) -> Vec<Triangle> {
+    let mut out = Vec::new();
+
     for face in shape.topology().faces() {
         let face = face.get();
         match &face {
@@ -69,6 +70,8 @@ pub fn triangulate(
             Face::Triangles(triangles) => out.extend(triangles),
         }
     }
+
+    out
 }
 
 #[cfg(test)]
@@ -138,10 +141,10 @@ mod tests {
     fn triangulate(shape: Shape) -> Triangles {
         let tolerance = Scalar::ONE;
 
-        let mut triangles = Vec::new();
         let mut debug_info = DebugInfo::new();
 
-        super::triangulate(shape, tolerance, &mut triangles, &mut debug_info);
+        let mut triangles =
+            super::triangulate(shape, tolerance, &mut debug_info);
 
         for triangle in &mut triangles {
             *triangle = Triangle {

--- a/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -17,7 +17,7 @@ pub fn triangulate(
     tolerance: Scalar,
     debug_info: &mut DebugInfo,
 ) -> Mesh<Point<3>> {
-    let mut out = Mesh::new();
+    let mut mesh = Mesh::new();
 
     for face in shape.topology().faces() {
         let face = face.get();
@@ -64,18 +64,18 @@ pub fn triangulate(
 
                 for triangle in triangles {
                     let points = triangle.map(|point| point.canonical());
-                    out.push_triangle(points, *color);
+                    mesh.push_triangle(points, *color);
                 }
             }
             Face::Triangles(triangles) => {
                 for triangle in triangles {
-                    out.push_triangle(triangle.inner, triangle.color);
+                    mesh.push_triangle(triangle.inner, triangle.color);
                 }
             }
         }
     }
 
-    out
+    mesh
 }
 
 #[cfg(test)]

--- a/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -95,10 +95,10 @@ mod tests {
             .build()?;
 
         let triangles = triangulate(shape);
-        assert!(triangles.contains([a, b, d]));
-        assert!(triangles.contains([b, c, d]));
-        assert!(!triangles.contains([a, b, c]));
-        assert!(!triangles.contains([a, c, d]));
+        assert!(triangles.contains_triangle([a, b, d]));
+        assert!(triangles.contains_triangle([b, c, d]));
+        assert!(!triangles.contains_triangle([a, b, c]));
+        assert!(!triangles.contains_triangle([a, c, d]));
 
         Ok(())
     }
@@ -126,14 +126,14 @@ mod tests {
 
         // Should contain some triangles from the polygon. Don't need to test
         // them all.
-        assert!(triangles.contains([a, e, h]));
-        assert!(triangles.contains([a, d, h]));
+        assert!(triangles.contains_triangle([a, e, h]));
+        assert!(triangles.contains_triangle([a, d, h]));
 
         // Shouldn't contain any possible triangle from the hole.
-        assert!(!triangles.contains([e, f, g]));
-        assert!(!triangles.contains([e, g, h]));
-        assert!(!triangles.contains([e, f, h]));
-        assert!(!triangles.contains([f, g, h]));
+        assert!(!triangles.contains_triangle([e, f, g]));
+        assert!(!triangles.contains_triangle([e, g, h]));
+        assert!(!triangles.contains_triangle([e, f, h]));
+        assert!(!triangles.contains_triangle([f, g, h]));
 
         Ok(())
     }
@@ -160,7 +160,10 @@ mod tests {
     struct Triangles(Vec<Triangle>);
 
     impl Triangles {
-        fn contains(&self, triangle: impl Into<fj_math::Triangle<3>>) -> bool {
+        fn contains_triangle(
+            &self,
+            triangle: impl Into<fj_math::Triangle<3>>,
+        ) -> bool {
             let triangle =
                 Triangle::new(triangle.into().normalize(), [255, 0, 0, 255]);
             self.0.contains(&triangle)


### PR DESCRIPTION
This is part of a series of changes to clean up `Mesh`, as part of my larger work on #141.