### PR TITLE
Don't use `mesh::Triangle` in `Face`

### DIFF
--- a/fj-kernel/src/algorithms/sweep.rs
+++ b/fj-kernel/src/algorithms/sweep.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use fj_interop::mesh::Triangle;
-use fj_math::{Scalar, Transform, Vector};
+use fj_math::{Scalar, Transform, Triangle, Vector};
 
 use crate::{
     geometry::{Surface, SweptCurve},
@@ -150,10 +149,10 @@ pub fn sweep_shape(
                 quads.push([v0, v1, v2, v3]);
             }
 
-            let mut side_face: Vec<Triangle> = Vec::new();
+            let mut side_face: Vec<(Triangle<3>, _)> = Vec::new();
             for [v0, v1, v2, v3] in quads {
-                side_face.push(Triangle::new([v0, v1, v2], color));
-                side_face.push(Triangle::new([v0, v2, v3], color));
+                side_face.push(([v0, v1, v2].into(), color));
+                side_face.push(([v0, v2, v3].into(), color));
             }
 
             target.insert(Face::Triangles(side_face)).unwrap();

--- a/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -68,8 +68,8 @@ pub fn triangulate(
                 }
             }
             Face::Triangles(triangles) => {
-                for triangle in triangles {
-                    mesh.push_triangle(triangle.inner, triangle.color);
+                for &(triangle, color) in triangles {
+                    mesh.push_triangle(triangle, color);
                 }
             }
         }

--- a/fj-kernel/src/shape/geometry.rs
+++ b/fj-kernel/src/shape/geometry.rs
@@ -1,4 +1,3 @@
-use fj_interop::mesh::Triangle;
 use fj_math::{Point, Transform};
 
 use crate::{
@@ -45,11 +44,8 @@ impl Geometry<'_> {
         self.faces.update(|mut face| {
             use std::ops::DerefMut as _;
             if let Face::Triangles(triangles) = face.deref_mut() {
-                for triangle in triangles {
-                    *triangle = Triangle {
-                        inner: transform.transform_triangle(&triangle.inner),
-                        ..*triangle
-                    };
+                for (triangle, _) in triangles {
+                    *triangle = transform.transform_triangle(triangle);
                 }
             }
         });

--- a/fj-kernel/src/topology/faces.rs
+++ b/fj-kernel/src/topology/faces.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 
-use fj_interop::mesh::Triangle;
+use fj_interop::mesh::Color;
+use fj_math::Triangle;
 
 use crate::{
     geometry::Surface,
@@ -61,7 +62,7 @@ pub enum Face {
     /// The plan is to eventually represent faces as a geometric surface,
     /// bounded by edges. While the transition is being made, this variant is
     /// still required.
-    Triangles(Vec<Triangle>),
+    Triangles(Vec<(Triangle<3>, Color)>),
 }
 
 impl Face {


### PR DESCRIPTION
I only added it there very recently. It was a nice stopgap, but now it
looks like `Mesh` and `mesh::Triangle` might be developing in a
direction that makes using it there no longer appropriate.

In any case, this is actually simpler, so no downside really, regardless
of what happens with `mesh::Triangle`.