### PR TITLE
Include crates.io publishing in the deployment workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -120,10 +120,27 @@ jobs:
               | awk '{print $1}' > "${file}.sha256"
           done
 
-      - name: Create GitHub Release
+      - name: Release | GitHub
         if: ${{ steps.release.outputs.release-detected == 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.release.outputs.tag-name }}
           name: ${{ steps.release.outputs.tag-name }}
           files: ${{ env.PROJ_NAME }}-*/${{ env.PROJ_NAME }}-*
+
+      - name: Release | Crates.io
+        if: ${{ steps.release.outputs.release-detected == 'true' }}
+        working-directory: ./release-operator
+        env:
+          RUST_LOG: info
+        run: |
+          # Publish to crates.io
+          cargo run -- publish \
+            --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
+            --crate ../fj-app \
+            --crate ../fj-debug \
+            --crate ../fj-host \
+            --crate ../fj-kernel \
+            --crate ../fj-math \
+            --crate ../fj-operations \
+            --crate ../fj

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,8 +138,8 @@ jobs:
           cargo run -- publish \
             --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
             --crate ../fj-app \
-            --crate ../fj-debug \
             --crate ../fj-host \
+            --crate ../fj-interop \
             --crate ../fj-kernel \
             --crate ../fj-math \
             --crate ../fj-operations \


### PR DESCRIPTION
This change-set includes publishing to crates.io in the deployment workflow.

Related issue: https://github.com/hannobraun/Fornjot/issues/104