### PR TITLE
Determine if the current crate is ahead or behind the registry

### DIFF
--- a/release-operator/Cargo.toml
+++ b/release-operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-operator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/release-operator/src/registry.rs
+++ b/release-operator/src/registry.rs
@@ -77,7 +77,8 @@ impl Crate {
                 .context("search crates.io for published crate version")?;
             log::debug!("{self} found as {version} on their side");
 
-            semver::Version::from_str(&version).context("parse their version")?
+            semver::Version::from_str(&version)
+                .context("parse their version")?
         };
 
         let ours = {
@@ -111,7 +112,7 @@ impl Crate {
 
         if ours < theirs {
             log::warn!("{self} has already been published as {ours}, which is a newer version");
-            return Ok(CrateState::Behind)
+            return Ok(CrateState::Behind);
         }
 
         Ok(CrateState::Ahead)


### PR DESCRIPTION
This change-set let's `release-operator` cover the case in which the crates.io registry has a newer version than ours in scope.

Related issue: https://github.com/hannobraun/Fornjot/issues/104