### PR TITLE
Add initial version of validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,26 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  clippy:
+    name: Clippy Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Toolchain
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
+        # see https://github.com/actions-rs/toolchain/pull/209
+        # uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
+      - run: rustup component add clippy
+      - uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
+      - uses: actions-rs/clippy-check@9d09632661e31982c0be8af59aeb96b680641bc4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+
   test:
     name: Test
     strategy:
@@ -84,23 +104,3 @@ jobs:
         with:
           command: run
           args: -- --model star --export star.3mf
-
-  clippy:
-    name: Clippy Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-      - run: rustup component add clippy
-      - uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
-      - uses: actions-rs/clippy-check@9d09632661e31982c0be8af59aeb96b680641bc4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,16 +91,4 @@ jobs:
       - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: run
-          args: -- --model cuboid --export cuboid.3mf
-      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: run
-          args: -- --model group --export group.3mf
-      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: run
-          args: -- --model spacer --export spacer.3mf
-      - uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: run
-          args: -- --model star --export star.3mf
+          args: --package validator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,6 +2790,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "validator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "models/star",
 
     "tools/release-operator",
+    "tools/validator",
 ]
 default-members = [
     "crates/fj-app",

--- a/tools/release-operator/Cargo.toml
+++ b/tools/release-operator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "release-operator"
 version = "0.3.1"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/validator/Cargo.toml
+++ b/tools/validator/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "validator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.56"

--- a/tools/validator/Cargo.toml
+++ b/tools/validator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "validator"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1.0.56"

--- a/tools/validator/README.md
+++ b/tools/validator/README.md
@@ -1,0 +1,3 @@
+# Validator
+
+Used by the CI build to export (and in the future, validate) 3MF files.

--- a/tools/validator/src/main.rs
+++ b/tools/validator/src/main.rs
@@ -1,0 +1,27 @@
+use std::{fs, process::Command};
+
+use anyhow::{anyhow, bail};
+
+fn main() -> anyhow::Result<()> {
+    for model in fs::read_dir("models")? {
+        let model = model?;
+        let model = model.file_name().into_string().map_err(|err| {
+            anyhow!("Failed to convert directory name to `String`: {:?}", err)
+        })?;
+
+        let export_file = format!("{model}.3mf");
+
+        let exit_status = Command::new("cargo")
+            .arg("run")
+            .arg("--")
+            .args(["--model", &model])
+            .args(["--export", &export_file])
+            .status()?;
+
+        if !exit_status.success() {
+            bail!("Exporting model failed with error status: {}", exit_status);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This is a first step towards addressing #54. For now, the validator just exports each model without validating anything, which already has the advantage of not requiring each model to be specified manually in the CI configuration.

Close #307