### PR TITLE
Add missing documentation to public API of fj-viewer.

### DIFF
--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -110,7 +110,7 @@ impl Camera {
             .inverse_transform_point(&Point::origin())
     }
 
-    /// Transform the position of the cursor on the near plane to model space
+    /// Transform the position of the cursor on the near plane to model space.
     pub fn cursor_to_model_space(
         &self,
         cursor: PhysicalPosition<f64>,
@@ -133,7 +133,7 @@ impl Camera {
         self.camera_to_model().inverse_transform_point(&cursor)
     }
 
-    /// Compute the point on the model, that the cursor currently points to
+    /// Compute the point on the model, that the cursor currently points to.
     pub fn focus_point(
         &self,
         window: &Window,
@@ -169,7 +169,7 @@ impl Camera {
         FocusPoint(min_t.map(|t| ray.point_at(t)))
     }
 
-    /// Access the transform from camera to model space
+    /// Access the transform from camera to model space.
     pub fn camera_to_model(&self) -> Transform<f64, TAffine, 3> {
         // Using a mutable variable cleanly takes care of any type inference
         // problems that this operation would otherwise have.
@@ -227,7 +227,7 @@ impl Camera {
     }
 }
 
-/// The point on the model that the cursor is currently pointing at
+/// The point on the model that the cursor is currently pointing at.
 ///
 /// Such a point might or might not exist, depending on whether the cursor is
 /// pointing at the model or not.

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -1,3 +1,4 @@
+//! Viewer camera module
 use std::f64::consts::FRAC_PI_2;
 
 use fj_interop::mesh::Mesh;
@@ -28,6 +29,7 @@ pub struct Camera {
     /// point, which means they must include a translational component.
     pub rotation: Transform<f64, TAffine, 3>,
 
+    /// The locational part of the transform
     pub translation: Translation<f64, 3>,
 }
 
@@ -37,6 +39,7 @@ impl Camera {
 
     const INITIAL_FIELD_OF_VIEW_IN_X: f64 = FRAC_PI_2; // 90 degrees
 
+    /// Returns a new camera aligned for viewing a bounding box
     pub fn new(aabb: &Aabb<3>) -> Self {
         let initial_distance = {
             // Let's make sure we choose a distance, so that the model fills
@@ -63,7 +66,7 @@ impl Camera {
             let distance_from_model =
                 furthest_point / (Self::INITIAL_FIELD_OF_VIEW_IN_X / 2.).atan();
 
-            // An finally, the distance from the origin is trivial now.
+            // And finally, the distance from the origin is trivial now.
             highest_point + distance_from_model
         };
 
@@ -86,18 +89,22 @@ impl Camera {
         }
     }
 
+    /// Returns the distance between the camera and the minimum distance for rendering.
     pub fn near_plane(&self) -> f64 {
         self.near_plane
     }
 
+    /// Returns the distance between the camera and the maximum distance for rendering..
     pub fn far_plane(&self) -> f64 {
         self.far_plane
     }
 
+    /// Returns the horizontal field of view of the camera.
     pub fn field_of_view_in_x(&self) -> f64 {
         Self::INITIAL_FIELD_OF_VIEW_IN_X
     }
 
+    /// Returns the position of the camera in world space.
     pub fn position(&self) -> Point<f64, 3> {
         self.camera_to_model()
             .inverse_transform_point(&Point::origin())
@@ -174,6 +181,7 @@ impl Camera {
         transform
     }
 
+    /// Update the max and minimum rendering distance for this camera.
     pub fn update_planes(&mut self, aabb: &Aabb<3>) {
         let view_transform = self.camera_to_model();
         let view_direction = Vector::from([0., 0., -1.]);

--- a/crates/fj-viewer/src/graphics/draw_config.rs
+++ b/crates/fj-viewer/src/graphics/draw_config.rs
@@ -1,13 +1,13 @@
-//! High level configuration for graphics rendering.
+//! High level configuration for graphics rendering
 
+/// High level configuration for rendering the active model
 #[derive(Debug)]
-/// High level configuration for rendering the active model.
 pub struct DrawConfig {
-    /// Toggle for displaying the shaded model.
+    /// Toggle for displaying the shaded model
     pub draw_model: bool,
-    /// Toggle for displaying the wireframe model.
+    /// Toggle for displaying the wireframe model
     pub draw_mesh: bool,
-    /// Toggle for displaying model debug information.
+    /// Toggle for displaying model debug information
     pub draw_debug: bool,
 }
 

--- a/crates/fj-viewer/src/graphics/draw_config.rs
+++ b/crates/fj-viewer/src/graphics/draw_config.rs
@@ -1,7 +1,13 @@
+//! High level configuration for graphics rendering.
+
 #[derive(Debug)]
+/// High level configuration for rendering the active model.
 pub struct DrawConfig {
+    /// Toggle for displaying the shaded model.
     pub draw_model: bool,
+    /// Toggle for displaying the wireframe model.
     pub draw_mesh: bool,
+    /// Toggle for displaying model debug information.
     pub draw_debug: bool,
 }
 

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -1,3 +1,5 @@
+//! Rendering primitives, routines, and and structures.
+
 mod config_ui;
 mod draw_config;
 mod drawables;

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -1,4 +1,4 @@
-//! Rendering primitives, routines, and and structures.
+//! Rendering primitives, routines, and structures.
 
 mod config_ui;
 mod draw_config;

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -38,7 +38,7 @@ impl Renderer {
     /// Returns a new `Renderer`
     ///
     /// # Arguments
-    /// - `window` - a `winit::Window` with a surface to render onto.
+    /// - `window` - a `crate::window::Window` with a surface to render onto.
     ///
     /// # Examples
     /// ```rust no_run

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -15,8 +15,8 @@ use super::{
     uniforms::Uniforms, vertices::Vertices, DEPTH_FORMAT,
 };
 
+/// Graphics rendering state and target abstraction
 #[derive(Debug)]
-/// Graphics rendering state and target abstraction.
 pub struct Renderer {
     surface: wgpu::Surface,
     device: wgpu::Device,
@@ -35,7 +35,7 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    /// Returns a new `Renderer`
+    /// Returns a new `Renderer`.
     ///
     /// # Arguments
     /// - `window` - a `crate::window::Window` with a surface to render onto.
@@ -178,7 +178,7 @@ impl Renderer {
         self.geometries = Geometries::new(&self.device, &mesh, &lines, aabb);
     }
 
-    /// Resizes the render surface
+    /// Resizes the render surface.
     ///
     /// # Arguments
     /// - `size`: The target size for the render surface.
@@ -321,8 +321,8 @@ impl Renderer {
     }
 }
 
+/// Error describing the set of render surface initialization errors
 #[derive(Error, Debug)]
-/// Error describing the set of render surface initialization errors.
 pub enum InitError {
     #[error("I/O error: {0}")]
     /// General IO error
@@ -347,10 +347,10 @@ pub enum InitError {
     InvalidFont(#[from] InvalidFont),
 }
 
-#[derive(Error, Debug)]
-/// Graphics rendering error.
+/// Graphics rendering error
 ///
 /// Describes errors related to non intialization graphics errors.
+#[derive(Error, Debug)]
 pub enum DrawError {
     #[error("Error acquiring output surface: {0}")]
     /// Surface drawing error.

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -330,8 +330,6 @@ pub enum InitError {
 
     #[error("Error request adapter")]
     /// Graphics accelerator acquisition error
-    ///
-    /// TODO Document when this occurs
     RequestAdapter,
 
     #[error("Error requesting device: {0}")]

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -16,6 +16,7 @@ use super::{
 };
 
 #[derive(Debug)]
+/// Graphics rendering state and target abstraction.
 pub struct Renderer {
     surface: wgpu::Surface,
     device: wgpu::Device,
@@ -34,6 +35,22 @@ pub struct Renderer {
 }
 
 impl Renderer {
+    /// Returns a new `Renderer`
+    ///
+    /// # Arguments
+    /// - `window` - a `winit::Window` with a surface to render onto.
+    ///
+    /// # Examples
+    /// ```rust no_run
+    /// use fj_viewer::{graphics, window};
+    ///
+    /// // Create window
+    /// let event_loop = winit::event_loop::EventLoop::new();
+    /// let window = window::Window::new(&event_loop);
+    ///
+    /// // Attach renderer to the window
+    /// let mut renderer = graphics::Renderer::new(&window);
+    /// ```
     pub async fn new(window: &Window) -> Result<Self, InitError> {
         let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
 
@@ -151,6 +168,7 @@ impl Renderer {
         })
     }
 
+    /// Updates the geometry of the model being rendered.
     pub fn update_geometry(
         &mut self,
         mesh: Vertices,
@@ -160,6 +178,10 @@ impl Renderer {
         self.geometries = Geometries::new(&self.device, &mesh, &lines, aabb);
     }
 
+    /// Resizes the render surface
+    ///
+    /// # Arguments
+    /// - `size`: The target size for the render surface.
     pub fn handle_resize(&mut self, size: PhysicalSize<u32>) {
         self.surface_config.width = size.width;
         self.surface_config.height = size.height;
@@ -171,6 +193,7 @@ impl Renderer {
         self.depth_view = depth_view;
     }
 
+    /// Draws the renderer, camera, and config state to the window.
     pub fn draw(
         &mut self,
         camera: &Camera,
@@ -299,25 +322,43 @@ impl Renderer {
 }
 
 #[derive(Error, Debug)]
+/// Error describing the set of render surface initialization errors.
 pub enum InitError {
     #[error("I/O error: {0}")]
+    /// General IO error
     Io(#[from] io::Error),
 
     #[error("Error request adapter")]
+    /// Graphics accelerator acquisition error
+    ///
+    /// TODO Document when this occurs
     RequestAdapter,
 
     #[error("Error requesting device: {0}")]
+    /// Device request errors
+    ///
+    /// See: [wgpu::RequestDeviceError](https://docs.rs/wgpu/latest/wgpu/struct.RequestDeviceError.html)
     RequestDevice(#[from] wgpu::RequestDeviceError),
 
     #[error("Error loading font: {0}")]
+    /// Error loading font
+    ///
+    /// See: [ab_glyph::InvalidFont](https://docs.rs/ab_glyph/latest/ab_glyph/struct.InvalidFont.html)
     InvalidFont(#[from] InvalidFont),
 }
 
 #[derive(Error, Debug)]
+/// Graphics rendering error.
+///
+/// Describes errors related to non intialization graphics errors.
 pub enum DrawError {
     #[error("Error acquiring output surface: {0}")]
+    /// Surface drawing error.
+    ///
+    /// See - [wgpu::SurfaceError](https://docs.rs/wgpu/latest/wgpu/enum.SurfaceError.html)
     Surface(#[from] wgpu::SurfaceError),
 
     #[error("Error drawing text: {0}")]
+    /// Text rasterisation error.
     Text(String),
 }

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -17,6 +17,9 @@ use crate::{
 
 use super::{movement::Movement, rotation::Rotation, zoom::Zoom};
 
+/// Input handling abstraction.
+///
+/// Takes user input and applies them to application state.
 pub struct Handler {
     cursor: Option<PhysicalPosition<f64>>,
 
@@ -26,6 +29,14 @@ pub struct Handler {
 }
 
 impl Handler {
+    /// Returns a new Handler.
+    ///
+    /// # Examples
+    /// ```rust
+    /// // Store initialization time for camera zoom calculations
+    /// let instant = std::time::Instant::now();
+    /// let input_handler = fj_viewer::input::Handler::new(instant);
+    /// ````
     pub fn new(now: Instant) -> Self {
         Self {
             cursor: None,
@@ -36,10 +47,12 @@ impl Handler {
         }
     }
 
+    /// Returns the state of the cursor position.
     pub fn cursor(&self) -> Option<PhysicalPosition<f64>> {
         self.cursor
     }
 
+    /// Applies user input to `actions`.
     pub fn handle_keyboard_input(
         &mut self,
         input: KeyboardInput,
@@ -63,6 +76,7 @@ impl Handler {
         }
     }
 
+    /// Applies cursor movement to `camera`.
     pub fn handle_cursor_moved(
         &mut self,
         cursor: PhysicalPosition<f64>,
@@ -80,6 +94,7 @@ impl Handler {
         self.cursor = Some(cursor);
     }
 
+    /// Updates `state` and `focus_point` when mouse is clickled.
     pub fn handle_mouse_input(
         &mut self,
         button: MouseButton,
@@ -103,6 +118,7 @@ impl Handler {
         }
     }
 
+    /// Updates zoom state from the scroll wheel.
     pub fn handle_mouse_wheel(
         &mut self,
         delta: MouseScrollDelta,
@@ -116,6 +132,7 @@ impl Handler {
         self.zoom.push_input_delta(delta, now);
     }
 
+    /// Update application state from user input.
     pub fn update(
         &mut self,
         delta_t: f64,
@@ -134,15 +151,21 @@ impl Handler {
 }
 
 #[derive(Default)]
+/// Hight level application state container.
 pub struct Actions {
+    /// Application exit state.
     pub exit: bool,
 
+    /// Toggle for the shaded display of the model.
     pub toggle_model: bool,
+    /// Toggle for the model's wireframe.
     pub toggle_mesh: bool,
+    /// Toggle for debug information.
     pub toggle_debug: bool,
 }
 
 impl Actions {
+    /// Returns a new `Actions`.
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{movement::Movement, rotation::Rotation, zoom::Zoom};
 
-/// Input handling abstraction.
+/// Input handling abstraction
 ///
 /// Takes user input and applies them to application state.
 pub struct Handler {
@@ -150,8 +150,10 @@ impl Handler {
     }
 }
 
+/// Intermediate input state container
+///
+/// Used as a per frame state container for sending application state to `winit`.
 #[derive(Default)]
-/// Hight level application state container.
 pub struct Actions {
     /// Application exit state.
     pub exit: bool,

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -36,7 +36,7 @@ impl Handler {
     /// // Store initialization time for camera zoom calculations
     /// let instant = std::time::Instant::now();
     /// let input_handler = fj_viewer::input::Handler::new(instant);
-    /// ````
+    /// ```
     pub fn new(now: Instant) -> Self {
         Self {
             cursor: None,

--- a/crates/fj-viewer/src/input/mod.rs
+++ b/crates/fj-viewer/src/input/mod.rs
@@ -1,3 +1,5 @@
+//! User input parsing and propagation.
+
 mod handler;
 mod movement;
 mod rotation;

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A model viewer which allows basic navigation and rendering of generated models.
 
+#![warn(missing_docs)]
+
 pub mod camera;
 pub mod graphics;
 pub mod input;

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -1,3 +1,7 @@
+//! Fornjot Model Viewer
+//!
+//! A model viewer which allows basic navigation and rendering of generated models.
+
 pub mod camera;
 pub mod graphics;
 pub mod input;

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -21,12 +21,11 @@ use crate::{
     window::Window,
 };
 
-/// Intilizes a model viewer for a given model and enters its process loop.
+/// Initializes a model viewer for a given model and enters its process loop.
 pub fn run(
     watcher: Watcher,
     shape_processor: ShapeProcessor,
 ) -> Result<(), graphics::InitError> {
-    // TODO(frey) document internals of this fuction. Maybe refactor.
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop);
 

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -1,3 +1,8 @@
+//! Model viewer initialization and event processing.
+//!
+//! Provides the functionality to create a window and perform basic viewing
+//! with programmed models.
+
 use std::time::Instant;
 
 use fj_host::Watcher;
@@ -16,10 +21,12 @@ use crate::{
     window::Window,
 };
 
+/// Intilizes a model viewer for a given model and enters its process loop.
 pub fn run(
     watcher: Watcher,
     shape_processor: ShapeProcessor,
 ) -> Result<(), graphics::InitError> {
+    // TODO(frey) document internals of this fuction. Maybe refactor.
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop);
 

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -1,4 +1,4 @@
-//! Model viewer initialization and event processing.
+//! Model viewer initialization and event processing
 //!
 //! Provides the functionality to create a window and perform basic viewing
 //! with programmed models.

--- a/crates/fj-viewer/src/window.rs
+++ b/crates/fj-viewer/src/window.rs
@@ -1,4 +1,4 @@
-//! Cad viewer utility windowing abstraction
+//! CAD viewer utility windowing abstraction
 
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 

--- a/crates/fj-viewer/src/window.rs
+++ b/crates/fj-viewer/src/window.rs
@@ -9,7 +9,7 @@ impl Window {
     /// Returns a new window with the given `EventLoop`.
     ///
     /// # Examples
-    /// ```rust
+    /// ```rust no_run
     /// let event_loop = winit::event_loop::EventLoop::new();
     /// let window = fj_viewer::window::Window::new(&event_loop);
     /// ```

--- a/crates/fj-viewer/src/window.rs
+++ b/crates/fj-viewer/src/window.rs
@@ -1,8 +1,18 @@
+//! Cad viewer utility windowing abstraction
+
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
+/// Window abstraction providing details such as the width or height and easing initialization.
 pub struct Window(winit::window::Window);
 
 impl Window {
+    /// Returns a new window with the given `EventLoop`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// let event_loop = winit::event_loop::EventLoop::new();
+    /// let window = fj_viewer::window::Window::new(&event_loop);
+    /// ```
     pub fn new(event_loop: &EventLoop<()>) -> Self {
         let window = WindowBuilder::new()
             .with_title("Fornjot")
@@ -15,14 +25,17 @@ impl Window {
         Self(window)
     }
 
+    /// Returns a shared reference to the wrapped window
     pub fn inner(&self) -> &winit::window::Window {
         &self.0
     }
 
+    /// Returns the width of the window
     pub fn width(&self) -> u32 {
         self.0.inner_size().width
     }
 
+    /// Returns the height of the window
     pub fn height(&self) -> u32 {
         self.0.inner_size().height
     }


### PR DESCRIPTION
This PR aims to add the missing docs signified by:
> cargo clippy -- -D missing_docs
<details>
<summary> output of `cargo clippy -- -D missing_docs`</summary>
<code>
error: missing documentation for the crate
 --> crates/fj-viewer/src/lib.rs:1:1
  |
1 | / pub mod camera;
2 | | pub mod graphics;
3 | | pub mod input;
4 | | pub mod run;
5 | | pub mod window;
  | |_______________^
  |
  = note: requested on the command line with `-D missing-docs`

error: missing documentation for a module
 --> crates/fj-viewer/src/lib.rs:1:1
  |
1 | pub mod camera;
  | ^^^^^^^^^^^^^^^

error: missing documentation for a struct field
  --> crates/fj-viewer/src/camera.rs:31:5
   |
31 |     pub translation: Translation<f64, 3>,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/camera.rs:40:5
   |
40 |     pub fn new(aabb: &Aabb<3>) -> Self {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/camera.rs:89:5
   |
89 |     pub fn near_plane(&self) -> f64 {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/camera.rs:93:5
   |
93 |     pub fn far_plane(&self) -> f64 {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/camera.rs:97:5
   |
97 |     pub fn field_of_view_in_x(&self) -> f64 {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/camera.rs:101:5
    |
101 |     pub fn position(&self) -> Point<f64, 3> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/camera.rs:177:5
    |
177 |     pub fn update_planes(&mut self, aabb: &Aabb<3>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a module
 --> crates/fj-viewer/src/lib.rs:2:1
  |
2 | pub mod graphics;
  | ^^^^^^^^^^^^^^^^^

error: missing documentation for a struct
 --> crates/fj-viewer/src/graphics/draw_config.rs:2:1
  |
2 | pub struct DrawConfig {
  | ^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct field
 --> crates/fj-viewer/src/graphics/draw_config.rs:3:5
  |
3 |     pub draw_model: bool,
  |     ^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct field
 --> crates/fj-viewer/src/graphics/draw_config.rs:4:5
  |
4 |     pub draw_mesh: bool,
  |     ^^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct field
 --> crates/fj-viewer/src/graphics/draw_config.rs:5:5
  |
5 |     pub draw_debug: bool,
  |     ^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct
  --> crates/fj-viewer/src/graphics/renderer.rs:19:1
   |
19 | pub struct Renderer {
   | ^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/graphics/renderer.rs:37:5
   |
37 |     pub async fn new(window: &Window) -> Result<Self, InitError> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/graphics/renderer.rs:154:5
    |
154 | /     pub fn update_geometry(
155 | |         &mut self,
156 | |         mesh: Vertices,
157 | |         lines: Vertices,
...   |
160 | |         self.geometries = Geometries::new(&self.device, &mesh, &lines, aabb);
161 | |     }
    | |_____^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/graphics/renderer.rs:163:5
    |
163 |     pub fn handle_resize(&mut self, size: PhysicalSize<u32>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/graphics/renderer.rs:174:5
    |
174 | /     pub fn draw(
175 | |         &mut self,
176 | |         camera: &Camera,
177 | |         config: &DrawConfig,
...   |
248 | |         Ok(())
249 | |     }
    | |_____^

error: missing documentation for an enum
   --> crates/fj-viewer/src/graphics/renderer.rs:302:1
    |
302 | pub enum InitError {
    | ^^^^^^^^^^^^^^^^^^

error: missing documentation for a variant
   --> crates/fj-viewer/src/graphics/renderer.rs:304:5
    |
304 |     Io(#[from] io::Error),
    |     ^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a variant
   --> crates/fj-viewer/src/graphics/renderer.rs:307:5
    |
307 |     RequestAdapter,
    |     ^^^^^^^^^^^^^^

error: missing documentation for a variant
   --> crates/fj-viewer/src/graphics/renderer.rs:310:5
    |
310 |     RequestDevice(#[from] wgpu::RequestDeviceError),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a variant
   --> crates/fj-viewer/src/graphics/renderer.rs:313:5
    |
313 |     InvalidFont(#[from] InvalidFont),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an enum
   --> crates/fj-viewer/src/graphics/renderer.rs:317:1
    |
317 | pub enum DrawError {
    | ^^^^^^^^^^^^^^^^^^

error: missing documentation for a variant
   --> crates/fj-viewer/src/graphics/renderer.rs:319:5
    |
319 |     Surface(#[from] wgpu::SurfaceError),
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a variant
   --> crates/fj-viewer/src/graphics/renderer.rs:322:5
    |
322 |     Text(String),
    |     ^^^^^^^^^^^^

error: missing documentation for a module
 --> crates/fj-viewer/src/lib.rs:3:1
  |
3 | pub mod input;
  | ^^^^^^^^^^^^^^

error: missing documentation for a struct
  --> crates/fj-viewer/src/input/handler.rs:20:1
   |
20 | pub struct Handler {
   | ^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/input/handler.rs:29:5
   |
29 |     pub fn new(now: Instant) -> Self {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/input/handler.rs:39:5
   |
39 |     pub fn cursor(&self) -> Option<PhysicalPosition<f64>> {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/input/handler.rs:43:5
   |
43 | /     pub fn handle_keyboard_input(
44 | |         &mut self,
45 | |         input: KeyboardInput,
46 | |         actions: &mut Actions,
...  |
63 | |         }
64 | |     }
   | |_____^

error: missing documentation for an associated function
  --> crates/fj-viewer/src/input/handler.rs:66:5
   |
66 | /     pub fn handle_cursor_moved(
67 | |         &mut self,
68 | |         cursor: PhysicalPosition<f64>,
69 | |         camera: &mut Camera,
...  |
80 | |         self.cursor = Some(cursor);
81 | |     }
   | |_____^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/input/handler.rs:83:5
    |
83  | /     pub fn handle_mouse_input(
84  | |         &mut self,
85  | |         button: MouseButton,
86  | |         state: ElementState,
...   |
103 | |         }
104 | |     }
    | |_____^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/input/handler.rs:106:5
    |
106 | /     pub fn handle_mouse_wheel(
107 | |         &mut self,
108 | |         delta: MouseScrollDelta,
109 | |         now: Instant,
...   |
116 | |         self.zoom.push_input_delta(delta, now);
117 | |     }
    | |_____^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/input/handler.rs:119:5
    |
119 | /     pub fn update(
120 | |         &mut self,
121 | |         delta_t: f64,
122 | |         now: Instant,
...   |
132 | |         camera.translation.z -= self.zoom.speed();
133 | |     }
    | |_____^

error: missing documentation for a struct
   --> crates/fj-viewer/src/input/handler.rs:137:1
    |
137 | pub struct Actions {
    | ^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct field
   --> crates/fj-viewer/src/input/handler.rs:138:5
    |
138 |     pub exit: bool,
    |     ^^^^^^^^^^^^^^

error: missing documentation for a struct field
   --> crates/fj-viewer/src/input/handler.rs:140:5
    |
140 |     pub toggle_model: bool,
    |     ^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct field
   --> crates/fj-viewer/src/input/handler.rs:141:5
    |
141 |     pub toggle_mesh: bool,
    |     ^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a struct field
   --> crates/fj-viewer/src/input/handler.rs:142:5
    |
142 |     pub toggle_debug: bool,
    |     ^^^^^^^^^^^^^^^^^^^^^^

error: missing documentation for an associated function
   --> crates/fj-viewer/src/input/handler.rs:146:5
    |
146 |     pub fn new() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^

error: missing documentation for a module
 --> crates/fj-viewer/src/lib.rs:4:1
  |
4 | pub mod run;
  | ^^^^^^^^^^^^

error: missing documentation for a function
   --> crates/fj-viewer/src/run.rs:19:1
    |
19  | / pub fn run(
20  | |     watcher: Watcher,
21  | |     shape_processor: ShapeProcessor,
22  | | ) -> Result<(), graphics::InitError> {
...   |
150 | |     });
151 | | }
    | |_^
</code>
</details>
I recommend merging this before #486 to avoid breaking the CI/CD.

- [x] fj-viewer
  - [x] self
  - [x] window
  - [x] run
  - [x] camera
  - [x] input
    - [x] self
    - [x] handler
  - [x] graphics
    - [x] self
    - [x] draw_config
    - [x] renderer
- [x] Consistency pass
  - [x] root level
  - [x] input
  - [x] graphics 
