### PR TITLE
Don't run `input::Handler::new` example

### DIFF
--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -32,7 +32,7 @@ impl Handler {
     /// Returns a new Handler.
     ///
     /// # Examples
-    /// ```rust
+    /// ```rust no_run
     /// // Store initialization time for camera zoom calculations
     /// let instant = std::time::Instant::now();
     /// let input_handler = fj_viewer::input::Handler::new(instant);


### PR DESCRIPTION
For some reason, this takes multiple seconds to run, significantly
slowing down `cargo test`. I have no idea, why that would be the case,
so not running it is the only solution I can think of.

cc @freylint (just letting you know, because you added that example and in case you have any idea what's going on)