### PR TITLE
Relax interface of `fj-viewer::{window, input::Handler}`

### DIFF
--- a/crates/fj-viewer/docs/phantom_type.md
+++ b/crates/fj-viewer/docs/phantom_type.md
@@ -1,0 +1,4 @@
+# Phantom Types
+This type is part of an implementation of  the `Phantom Type Pattern`.
+For more information on this pattern see:
+- [Rust by Example: Phantom Type Parameters](https://doc.rust-lang.org/stable/rust-by-example/generics/phantom.html)

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -114,7 +114,7 @@ impl Camera {
     pub fn cursor_to_model_space(
         &self,
         cursor: PhysicalPosition<f64>,
-        window: &Window,
+        window: &Window<winit::window::Window>,
     ) -> Point<f64, 3> {
         let width = window.width() as f64;
         let height = window.height() as f64;
@@ -136,7 +136,7 @@ impl Camera {
     /// Compute the point on the model, that the cursor currently points to.
     pub fn focus_point(
         &self,
-        window: &Window,
+        window: &Window<winit::window::Window>,
         cursor: Option<PhysicalPosition<f64>>,
         mesh: &Mesh<fj_math::Point<3>>,
     ) -> FocusPoint {

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -51,7 +51,9 @@ impl Renderer {
     /// // Attach renderer to the window
     /// let mut renderer = graphics::Renderer::new(&window);
     /// ```
-    pub async fn new(window: &Window) -> Result<Self, InitError> {
+    pub async fn new(
+        window: &Window<winit::window::Window>,
+    ) -> Result<Self, InitError> {
         let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
 
         // This is sound, as `window` is an object to create a surface upon.

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -101,7 +101,7 @@ impl Handler<Winit> {
         self.cursor = Some(cursor);
     }
 
-    /// Updates `state` and `focus_point` when mouse is clickled.
+    /// Updates `state` and `focus_point` when mouse is clicked.
     pub fn handle_mouse_input(
         &mut self,
         button: MouseButton,

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -21,6 +21,8 @@ use super::{movement::Movement, rotation::Rotation, zoom::Zoom};
 /// Input handling abstraction
 ///
 /// Takes user input and applies them to application state.
+///
+#[doc = include_str!("../../docs/phantom_type.md")]
 pub struct Handler<T> {
     cursor: Option<PhysicalPosition<f64>>,
 

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -81,7 +81,7 @@ impl Handler {
         &mut self,
         cursor: PhysicalPosition<f64>,
         camera: &mut Camera,
-        window: &Window,
+        window: &Window<winit::window::Window>,
     ) {
         if let Some(previous) = self.cursor {
             let diff_x = cursor.x - previous.x;
@@ -138,7 +138,7 @@ impl Handler {
         delta_t: f64,
         now: Instant,
         camera: &mut Camera,
-        window: &Window,
+        window: &Window<winit::window::Window>,
         mesh: &Mesh<Point<3>>,
     ) {
         let focus_point = camera.focus_point(window, self.cursor, mesh);

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -13,6 +13,7 @@ use winit::{
 use crate::{
     camera::{Camera, FocusPoint},
     window::Window,
+    Winit,
 };
 
 use super::{movement::Movement, rotation::Rotation, zoom::Zoom};
@@ -20,15 +21,17 @@ use super::{movement::Movement, rotation::Rotation, zoom::Zoom};
 /// Input handling abstraction
 ///
 /// Takes user input and applies them to application state.
-pub struct Handler {
+pub struct Handler<T> {
     cursor: Option<PhysicalPosition<f64>>,
 
     movement: Movement,
     rotation: Rotation,
     zoom: Zoom,
+
+    backend: std::marker::PhantomData<T>,
 }
 
-impl Handler {
+impl Handler<Winit> {
     /// Returns a new Handler.
     ///
     /// # Examples
@@ -44,6 +47,8 @@ impl Handler {
             movement: Movement::new(),
             rotation: Rotation::new(),
             zoom: Zoom::new(now),
+
+            backend: std::marker::PhantomData,
         }
     }
 

--- a/crates/fj-viewer/src/input/movement.rs
+++ b/crates/fj-viewer/src/input/movement.rs
@@ -36,7 +36,7 @@ impl Movement {
         &mut self,
         cursor: Option<PhysicalPosition<f64>>,
         camera: &mut Camera,
-        window: &Window,
+        window: &Window<winit::window::Window>,
     ) {
         if let (Some(previous), Some(cursor)) = (self.cursor, cursor) {
             let previous = camera.cursor_to_model_space(previous, window);

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -10,7 +10,7 @@ pub mod input;
 pub mod run;
 pub mod window;
 
-/// Marker describing types implemted with winit.
+/// Marker describing types implemented with winit.
 ///
 /// See: [Rust by Example: Phantom Types](https://doc.rust-lang.org/stable/rust-by-example/generics/phantom.html)
 pub struct Winit();

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -9,3 +9,8 @@ pub mod graphics;
 pub mod input;
 pub mod run;
 pub mod window;
+
+/// Marker describing types implemted with winit.
+///
+/// See: [Rust by Example: Phantom Types](https://doc.rust-lang.org/stable/rust-by-example/generics/phantom.html)
+pub struct Winit();

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -10,7 +10,7 @@ pub mod input;
 pub mod run;
 pub mod window;
 
-/// Marker describing types implemented with winit.
+/// Marker type describing types implemented with `winit`.
 ///
-/// See: [Rust by Example: Phantom Types](https://doc.rust-lang.org/stable/rust-by-example/generics/phantom.html)
+#[doc = include_str!("../docs/phantom_type.md")]
 pub struct Winit();

--- a/crates/fj-viewer/src/window.rs
+++ b/crates/fj-viewer/src/window.rs
@@ -3,9 +3,15 @@
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 /// Window abstraction providing details such as the width or height and easing initialization.
-pub struct Window(winit::window::Window);
+///
+/// See: [Rust Newtype: Rust by Example](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Window<T> {
+    window: T,
+}
 
-impl Window {
+impl Window<winit::window::Window> {
     /// Returns a new window with the given `EventLoop`.
     ///
     /// # Examples
@@ -22,21 +28,21 @@ impl Window {
             .build(event_loop)
             .unwrap();
 
-        Self(window)
+        Self { window }
     }
 
     /// Returns a shared reference to the wrapped window
     pub fn inner(&self) -> &winit::window::Window {
-        &self.0
+        &self.window
     }
 
     /// Returns the width of the window
     pub fn width(&self) -> u32 {
-        self.0.inner_size().width
+        self.window.inner_size().width
     }
 
     /// Returns the height of the window
     pub fn height(&self) -> u32 {
-        self.0.inner_size().height
+        self.window.inner_size().height
     }
 }


### PR DESCRIPTION
Relaxes the internal interface of `fj-viewer` making it easier to implement alternative input/windowing backends for platforms like web/mobile or for testing / CI.