### PR TITLE
Make `fj_math::Transform` more flexible

### DIFF
--- a/crates/fj-kernel/src/geometry/curves/line.rs
+++ b/crates/fj-kernel/src/geometry/curves/line.rs
@@ -87,12 +87,8 @@ impl approx::AbsDiffEq for Line {
 
 #[cfg(test)]
 mod tests {
-    use std::f64::consts::FRAC_PI_2;
-
     use approx::assert_abs_diff_eq;
-    use fj_math::{Point, Vector};
-    use nalgebra::UnitQuaternion;
-    use parry3d_f64::math::{Isometry, Translation};
+    use fj_math::{Point, Scalar, Transform, Vector};
 
     use super::Line;
 
@@ -103,16 +99,9 @@ mod tests {
             direction: Vector::from([0., 1., 0.]),
         };
 
-        let line = line.transform(
-            &Isometry::from_parts(
-                Translation::from([1., 2., 3.]),
-                UnitQuaternion::from_axis_angle(
-                    &nalgebra::Vector::z_axis(),
-                    FRAC_PI_2,
-                ),
-            )
-            .into(),
-        );
+        let transform = Transform::translation([1., 2., 3.])
+            * Transform::rotation(Vector::unit_z() * (Scalar::PI / 2.));
+        let line = line.transform(&transform);
 
         assert_abs_diff_eq!(
             line,

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -1,3 +1,5 @@
+use std::ops;
+
 use super::{Aabb, Point, Segment, Triangle, Vector};
 
 /// A transform
@@ -76,5 +78,13 @@ impl From<Transform> for parry3d_f64::math::Isometry<f64> {
 impl<'r> From<&'r Transform> for parry3d_f64::math::Isometry<f64> {
     fn from(transform: &Transform) -> Self {
         transform.0
+    }
+}
+
+impl ops::Mul<Self> for Transform {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0.mul(rhs.0))
     }
 }

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -4,17 +4,15 @@ use super::{Aabb, Point, Segment, Triangle, Vector};
 
 /// A transform
 #[repr(C)]
-pub struct Transform(parry3d_f64::math::Isometry<f64>);
+pub struct Transform(nalgebra::Transform<f64, nalgebra::TGeneral, 3>);
 
 impl Transform {
     /// Construct a translation
     pub fn translation(vector: impl Into<Vector<3>>) -> Self {
         let vector = vector.into();
 
-        Self(parry3d_f64::math::Isometry::translation(
-            vector.x.into_f64(),
-            vector.y.into_f64(),
-            vector.z.into_f64(),
+        Self(nalgebra::Transform::from_matrix_unchecked(
+            nalgebra::OMatrix::new_translation(&vector.to_na()),
         ))
     }
 
@@ -23,8 +21,12 @@ impl Transform {
     /// The direction of the vector defines the rotation axis. Its length
     /// defines the angle of the rotation.
     pub fn rotation(axis_angle: impl Into<Vector<3>>) -> Self {
-        Self(parry3d_f64::math::Isometry::rotation(
-            axis_angle.into().to_na(),
+        let axis_angle = axis_angle.into();
+
+        Self(nalgebra::Transform::from_matrix_unchecked(
+            nalgebra::OMatrix::<_, nalgebra::Const<4>, _>::new_rotation(
+                axis_angle.to_na(),
+            ),
         ))
     }
 

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -63,24 +63,6 @@ impl Transform {
     }
 }
 
-impl From<parry3d_f64::math::Isometry<f64>> for Transform {
-    fn from(isometry: parry3d_f64::math::Isometry<f64>) -> Self {
-        Self(isometry)
-    }
-}
-
-impl From<Transform> for parry3d_f64::math::Isometry<f64> {
-    fn from(transform: Transform) -> Self {
-        transform.0
-    }
-}
-
-impl<'r> From<&'r Transform> for parry3d_f64::math::Isometry<f64> {
-    fn from(transform: &Transform) -> Self {
-        transform.0
-    }
-}
-
 impl ops::Mul<Self> for Transform {
     type Output = Self;
 

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -16,6 +16,16 @@ impl Transform {
         ))
     }
 
+    /// Construct a rotation
+    ///
+    /// The direction of the vector defines the rotation axis. Its length
+    /// defines the angle of the rotation.
+    pub fn rotation(axis_angle: impl Into<Vector<3>>) -> Self {
+        Self(parry3d_f64::math::Isometry::rotation(
+            axis_angle.into().to_na(),
+        ))
+    }
+
     /// Transform the given point
     pub fn transform_point(&self, point: &Point<3>) -> Point<3> {
         Point::from(self.0.transform_point(&point.to_na()))

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -6,7 +6,9 @@ pub struct Transform(parry3d_f64::math::Isometry<f64>);
 
 impl Transform {
     /// Construct a translation
-    pub fn translation(vector: Vector<3>) -> Self {
+    pub fn translation(vector: impl Into<Vector<3>>) -> Self {
+        let vector = vector.into();
+
         Self(parry3d_f64::math::Isometry::translation(
             vector.x.into_f64(),
             vector.y.into_f64(),

--- a/crates/fj-math/src/vector.rs
+++ b/crates/fj-math/src/vector.rs
@@ -252,19 +252,25 @@ impl<const D: usize> ops::Add<Self> for Vector<D> {
     }
 }
 
-impl<const D: usize> ops::Mul<Scalar> for Vector<D> {
+impl<S, const D: usize> ops::Mul<S> for Vector<D>
+where
+    S: Into<Scalar>,
+{
     type Output = Self;
 
-    fn mul(self, rhs: Scalar) -> Self::Output {
-        self.to_na().mul(rhs.into_f64()).into()
+    fn mul(self, rhs: S) -> Self::Output {
+        self.to_na().mul(rhs.into().into_f64()).into()
     }
 }
 
-impl<const D: usize> ops::Div<Scalar> for Vector<D> {
+impl<S, const D: usize> ops::Div<S> for Vector<D>
+where
+    S: Into<Scalar>,
+{
     type Output = Self;
 
-    fn div(self, rhs: Scalar) -> Self::Output {
-        self.to_na().div(rhs.into_f64()).into()
+    fn div(self, rhs: S) -> Self::Output {
+        self.to_na().div(rhs.into().into_f64()).into()
     }
 }
 

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -1,7 +1,6 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{algorithms::Tolerance, shape::Shape};
-use fj_math::{Aabb, Transform};
-use parry3d_f64::math::Isometry;
+use fj_math::{Aabb, Transform, Vector};
 
 use super::ToShape;
 
@@ -25,10 +24,7 @@ impl ToShape for fj::Transform {
 }
 
 fn transform(transform: &fj::Transform) -> Transform {
-    let axis = nalgebra::Vector::from(transform.axis).normalize();
-    Isometry::new(
-        nalgebra::Vector::from(transform.offset),
-        axis * transform.angle,
-    )
-    .into()
+    let axis = Vector::from(transform.axis).normalize();
+    Transform::translation(transform.offset)
+        * Transform::rotation(axis * transform.angle)
 }


### PR DESCRIPTION
Adds support for arbitrary transforms to `fj_math::Transform`, alongside some other additions to the API in assistance to that. I also snuck in an additional commit, that makes multiplication and division of `Vector` more flexible. All details in the commits!

This is a step towards addressing #101.