### PR TITLE
Update top-level documentation of all crates

### DIFF
--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -1,3 +1,17 @@
+//! # Fornjot Application
+//!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! Together with the [`fj`] library, this application forms the part of Fornjot
+//! that is relevant to end users. Please refer to the [Fornjot repository] for
+//! usage examples.
+//!
+//! [Fornjot]: https://www.fornjot.app/
+//! [`fj`]: https://crates.io/crates/fj
+//! [Fornjot repository]: https://github.com/hannobraun/Fornjot
+
 mod args;
 mod config;
 

--- a/crates/fj-export/src/lib.rs
+++ b/crates/fj-export/src/lib.rs
@@ -1,4 +1,16 @@
-//! Exporting Fornjot models to external files
+//! # Fornjot Exporter
+//!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
+//!
+//! The purpose of this library is to export Fornjot models to external file
+//! formats.
+//!
+//! [Fornjot]: https://www.fornjot.app/
 
 #![deny(missing_docs)]
 

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -1,7 +1,17 @@
-//! Plugin host for Fornjot models
+//! # Fornjot Model Host
 //!
-//! Fornjot models are loaded into the Fornjot application as plugins. This
-//! crate contains the code required to host plugins.
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
+//!
+//! The purpose of this library is to load Fornjot models and watch them for
+//! changes. Fornjot models are basically plugins that can be loaded into a CAD
+//! application. This library is the host for these model plugins.
+//!
+//! [Fornjot]: https://www.fornjot.app/
 
 #![deny(missing_docs)]
 

--- a/crates/fj-interop/src/lib.rs
+++ b/crates/fj-interop/src/lib.rs
@@ -1,4 +1,16 @@
-//! Data types for interoperation within the Fornjot ecosystem
+//! # Fornjot Interop Types
+//!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
+//!
+//! The purpose of this library is to define types that allow other components
+//! of the Fornjot ecosystem to interoperate, without depending on each other.
+//!
+//! [Fornjot]: https://www.fornjot.app/
 
 #![deny(missing_docs)]
 

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -1,5 +1,12 @@
 //! # Fornjot CAD Kernel
 //!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
+//!
 //! The CAD kernel is the core of Fornjot: the geometry, the topology, and the
 //! algorithms that handle them. It is separate from the CAD application, and
 //! could be used in other applications.
@@ -39,7 +46,7 @@
 //!
 //! Choosing an epsilon value that is suitable for *most* use cases is possible,
 //! at the cost of non-standard use cases breaking in unexpected and non-obvious
-//! ways. Fornjot has chosen another approach.
+//! ways. Fornjot has chosen a different approach.
 //!
 //! ### Explicitness
 //!
@@ -50,7 +57,7 @@
 //!
 //! If vertex instances that refer to the same point are used in different
 //! places (for example, in two neighboring edges that share a vertex), then
-//! those vertex instance must be known by the system to refer to the same
+//! those vertex instances must be known by the system to refer to the same
 //! vertex. If a vertex lies on an edge or in a surface, then it must be defined
 //! in terms of its position on that edge or surface.
 //!
@@ -75,6 +82,8 @@
 //! If the user does something non-standard, they can override the epsilon value
 //! on a per-shape basis. Forcing the user to deal with these issues up-front
 //! should lead to less work overall.
+//!
+//! [Fornjot]: https://www.fornjot.app/
 
 #![deny(missing_docs)]
 

--- a/crates/fj-math/src/lib.rs
+++ b/crates/fj-math/src/lib.rs
@@ -1,10 +1,17 @@
-//! Math primitives for the Fornjot ecosystem
+//! # Fornjot Math Library
+//!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
 //!
 //! This crates provides basic math types for the Fornjot ecosystem. It is built
 //! on [nalgebra] and [Parry], but provides an interface that is specifically
 //! tailored to the needs of Fornjot.
 //!
-//! # Failing [`From`]/[`Into`] implementations
+//! ## Failing [`From`]/[`Into`] implementations
 //!
 //! Please note that any [`From`]/[`Into`] implementation that convert floating
 //! point numbers into [`Scalar`] can panic. These conversions call
@@ -22,6 +29,7 @@
 //! [`From`]/[`Into`] documentation fails to provide any reasons for its
 //! mandate.
 //!
+//! [Fornjot]: https://www.fornjot.app/
 //! [nalgebra]: https://nalgebra.org/
 //! [Parry]: https://www.parry.rs/
 

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -1,8 +1,18 @@
-//! Connection between the Fornjot kernel and Fornjot models
+//! # Fornjot CAD Operations
+//!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
 //!
 //! Fornjot models use the [`fj`] crate to define a shape. This crate provides
 //! the connection between [`fj`] and the Fornjot kernel. It translates those
 //! operations into terms the kernel can understand.
+//!
+//! [Fornjot]: https://www.fornjot.app/
+//! [`fj`]: https://crates.io/crates/fj
 
 #![deny(missing_docs)]
 

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -1,6 +1,16 @@
-//! Fornjot Model Viewer
+//! # Fornjot Model Viewer
 //!
-//! A model viewer which allows basic navigation and rendering of generated models.
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
+//!
+//! This library is an internal component of Fornjot. It is not relevant to end
+//! users that just want to create CAD models.
+//!
+//! This library provides a model viewer which allows basic navigation and
+//! rendering of generated models.
+//!
+//! [Fornjot]: https://www.fornjot.app/
 
 #![warn(missing_docs)]
 

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -1,13 +1,19 @@
-//! Fornjot modeling library
+//! # Fornjot Modeling Library
+//!
+//! This library is part of the [Fornjot] ecosystem. Fornjot is an open-source,
+//! code-first CAD application; and collection of libraries that make up the CAD
+//! application, but can be used independently.
 //!
 //! The purpose of this library is to support Fornjot models, which are just
 //! Rust libraries. Models depend on this library and use the primitives defined
-//! here to define a CAD model.
+//! here to define a CAD model. Together with the Fornjot application, this
+//! library forms the part of Fornjot that is relevant to end users.
 //!
-//! To actually display the CAD model, or export it to another file format, you
-//! need the Fornjot app. Please refer to the [Fornjot repository] for usage
-//! examples.
+//! To display the created CAD model, or export it to another file format, you
+//! need the Fornjot application. Please refer to the [Fornjot repository] for
+//! usage examples.
 //!
+//! [Fornjot]: https://www.fornjot.app/
 //! [Fornjot repository]: https://github.com/hannobraun/Fornjot
 
 #![deny(missing_docs)]


### PR DESCRIPTION
Makes sure that all crates have top-level documentation that refers to the Fornjot ecosystem, explains the crate's context within the Fornjot ecosystem, and links to the website.