### PR TITLE
Math fixes

### DIFF
--- a/crates/fj-kernel/src/algorithms/triangulation/delaunay.rs
+++ b/crates/fj-kernel/src/algorithms/triangulation/delaunay.rs
@@ -22,12 +22,6 @@ pub fn triangulate(
         let triangle = match orientation {
             Winding::Ccw => [v0, v1, v2],
             Winding::Cw => [v0, v2, v1],
-            Winding::None => {
-                panic!(
-                    "Triangle returned from triangulation isn't actually a \
-                    triangle"
-                );
-            }
         };
 
         triangles.push(triangle);

--- a/crates/fj-math/src/point.rs
+++ b/crates/fj-math/src/point.rs
@@ -59,7 +59,7 @@ impl<const D: usize> Point<D> {
         }
     }
 
-    /// Gives the distance between two Points.
+    /// Gives the distance between two points.
     pub fn distance(p1: &Point<D>, p2: &Point<D>) -> Scalar {
         (p1.coords - p2.coords).magnitude()
     }

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -2,6 +2,8 @@ use std::ops;
 
 use nalgebra::Perspective3;
 
+use crate::Scalar;
+
 use super::{Aabb, Point, Segment, Triangle, Vector};
 
 /// An affine transform
@@ -89,13 +91,16 @@ impl Transform {
         fovy: f64,
         znear: f64,
         zfar: f64,
-    ) -> [f64; 16] {
+    ) -> [Scalar; 16] {
         let projection = Perspective3::new(aspect_ratio, fovy, znear, zfar);
-        let mut res = [0f64; 16];
-        res.copy_from_slice(
-            (projection.to_projective() * self.0).matrix().as_slice(),
-        );
-        res
+        (projection.to_projective() * self.0)
+            .matrix()
+            .as_slice()
+            .iter()
+            .map(|f| Scalar::from(*f))
+            .collect::<Vec<Scalar>>()
+            .try_into()
+            .unwrap()
     }
 
     /// Transform the given axis-aligned bounding box

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -4,7 +4,7 @@ use nalgebra::Perspective3;
 
 use super::{Aabb, Point, Segment, Triangle, Vector};
 
-/// A transform
+/// An affine transform
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct Transform(nalgebra::Transform<f64, nalgebra::TAffine, 3>);
@@ -81,9 +81,9 @@ impl Transform {
         ))
     }
 
-    /// Project transform according to camera specfication, return data as a slice.
+    /// Project transform according to camera specfication, return data as an array.
     /// Used primarily for graphics code.
-    pub fn project_to_slice(
+    pub fn project_to_array(
         &self,
         aspect_ratio: f64,
         fovy: f64,

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -1,29 +1,9 @@
-use crate::Vector;
-
-use super::{Point, Scalar};
-
 use parry2d_f64::utils::point_in_triangle::{corner_direction, Orientation};
 use parry3d_f64::query::{Ray, RayCast as _};
 
-/// Winding direction of a triangle.
-pub enum Winding {
-    /// Counter-clockwise
-    Ccw,
-    /// Clockwise
-    Cw,
-    /// Neither (straight lines)
-    None,
-}
+use crate::Vector;
 
-impl From<Orientation> for Winding {
-    fn from(o: Orientation) -> Self {
-        match o {
-            Orientation::Ccw => Winding::Ccw,
-            Orientation::Cw => Winding::Cw,
-            Orientation::None => Winding::None,
-        }
-    }
-}
+use super::{Point, Scalar};
 
 /// A triangle
 ///
@@ -113,6 +93,24 @@ where
 {
     fn from(points: [P; 3]) -> Self {
         Self::from_points(points)
+    }
+}
+
+/// Winding direction of a triangle.
+pub enum Winding {
+    /// Counter-clockwise
+    Ccw,
+    /// Clockwise
+    Cw,
+}
+
+impl From<Orientation> for Winding {
+    fn from(o: Orientation) -> Self {
+        match o {
+            Orientation::Ccw => Winding::Ccw,
+            Orientation::Cw => Winding::Cw,
+            Orientation::None => unreachable!("not a triangle"),
+        }
     }
 }
 

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -77,13 +77,15 @@ impl Triangle<3> {
         dir: Vector<3>,
         max_toi: f64,
         solid: bool,
-    ) -> Option<f64> {
+    ) -> Option<Scalar> {
         let ray = Ray {
             origin: origin.to_na(),
             dir: dir.to_na(),
         };
 
-        self.to_parry().cast_local_ray(&ray, max_toi, solid)
+        self.to_parry()
+            .cast_local_ray(&ray, max_toi, solid)
+            .map(|f| f.into())
     }
 }
 

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -59,8 +59,8 @@ impl<const D: usize> Triangle<D> {
 impl Triangle<2> {
     /// Returns the direction of the line through the points of the triangle.
     pub fn winding_direction(&self) -> Winding {
-        let [v0, v1, v2] = self.points;
-        corner_direction(&v0.to_na(), &v1.to_na(), &v2.to_na()).into()
+        let [v0, v1, v2] = self.points.map(|point| point.to_na());
+        corner_direction(&v0, &v1, &v2).into()
     }
 }
 

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -76,11 +76,11 @@ impl Camera {
             far_plane: Self::DEFAULT_FAR_PLANE,
 
             rotation: Transform::identity(),
-            translation: Transform::translation(Vector::from_components_f64([
-                initial_offset.x.into_f64(),
-                initial_offset.y.into_f64(),
-                -initial_distance.into_f64(),
-            ])),
+            translation: Transform::translation([
+                initial_offset.x,
+                initial_offset.y,
+                -initial_distance,
+            ]),
         }
     }
 

--- a/crates/fj-viewer/src/graphics/transform.rs
+++ b/crates/fj-viewer/src/graphics/transform.rs
@@ -25,7 +25,7 @@ impl Transform {
             camera.far_plane(),
         );
 
-        Self(transform.map(|val| val as f32))
+        Self(transform.map(|scalar| scalar.into_f32()))
     }
 
     /// Compute transform used for normals

--- a/crates/fj-viewer/src/graphics/transform.rs
+++ b/crates/fj-viewer/src/graphics/transform.rs
@@ -18,7 +18,7 @@ impl Transform {
     pub fn for_vertices(camera: &Camera, aspect_ratio: f64) -> Self {
         let field_of_view_in_y = camera.field_of_view_in_x() / aspect_ratio;
 
-        let transform = camera.camera_to_model().project_to_slice(
+        let transform = camera.camera_to_model().project_to_array(
             aspect_ratio,
             field_of_view_in_y,
             camera.near_plane(),

--- a/crates/fj-viewer/src/graphics/transform.rs
+++ b/crates/fj-viewer/src/graphics/transform.rs
@@ -1,7 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 
 use crate::camera::Camera;
-use fj_math::Transform as fjTransform;
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(transparent)]
@@ -9,7 +8,7 @@ pub struct Transform(pub [f32; 16]);
 
 impl Transform {
     pub fn identity() -> Self {
-        Self::from(&fjTransform::identity())
+        Self::from(&fj_math::Transform::identity())
     }
 
     /// Compute transform used for vertices
@@ -39,8 +38,8 @@ impl Transform {
     }
 }
 
-impl From<&fjTransform> for Transform {
-    fn from(other: &fjTransform) -> Self {
+impl From<&fj_math::Transform> for Transform {
+    fn from(other: &fj_math::Transform) -> Self {
         let mut native = [0.0; 16];
         native.copy_from_slice(other.data());
 

--- a/crates/fj-viewer/src/graphics/vertices.rs
+++ b/crates/fj-viewer/src/graphics/vertices.rs
@@ -34,11 +34,7 @@ impl Vertices {
         color: [f32; 4],
     ) {
         let line = line.into_iter().map(|point| Vertex {
-            position: [
-                point.x.into_f32(),
-                point.y.into_f32(),
-                point.z.into_f32(),
-            ],
+            position: point.coords.components.map(|scalar| scalar.into_f32()),
             normal,
             color,
         });

--- a/crates/fj-viewer/src/input/movement.rs
+++ b/crates/fj-viewer/src/input/movement.rs
@@ -1,4 +1,4 @@
-use fj_math::{Point, Transform, Vector};
+use fj_math::{Point, Scalar, Transform, Vector};
 use winit::dpi::PhysicalPosition;
 
 use crate::{
@@ -49,11 +49,12 @@ impl Movement {
                 let diff = (cursor - previous) * d2 / d1;
                 let offset = camera.camera_to_model().transform_vector(&diff);
 
-                camera.translation =
-                    camera.translation
-                        * Transform::translation(Vector::from_components_f64(
-                            [offset.x.into(), offset.y.into(), 0.0],
-                        ));
+                camera.translation = camera.translation
+                    * Transform::translation(Vector::from([
+                        offset.x,
+                        offset.y,
+                        Scalar::ZERO,
+                    ]));
             }
         }
 


### PR DESCRIPTION
Addresses several of the minor comments from my last PR.

A few of the changes mentioned there are not implemented here: namely the switch of the Point::Distance function (this is still an associated function taking in two references) and the shortening of Point calculation when pushing lines (subtracting a Vector from a Point gives a Vector, but adding a Vector to a Point gives a Point - this discrepancy is strange and how it is handled changes how things will be condensed).