### PR TITLE
Fix model README run instructions

### DIFF
--- a/models/cuboid/README.md
+++ b/models/cuboid/README.md
@@ -4,7 +4,7 @@ A model of a simple cuboid that demonstrates sweeping a 3D shape from a primitiv
 
 To display this model, run the following from the repository root (model parameters are optional):
 ``` sh
-cargo run -- --model cuboid --parameters x=3.0 y=2.0 z=1.0
+cargo run -- --model cuboid --parameters x=3.0,y=2.0,z=1.0
 ```
 
 ![Screenshot of the cuboid model](cuboid.png)

--- a/models/spacer/README.md
+++ b/models/spacer/README.md
@@ -4,7 +4,7 @@ A simple spacer model that demonstrates the circle primitive, the difference ope
 
 To display this model, run the following from the repository root (model parameters are optional):
 ``` sh
-cargo run -- --model spacer --parameters outer=1.0 inner=0.5 height=1.0
+cargo run -- --model spacer --parameters outer=1.0,inner=0.5,height=1.0
 ```
 
 ![Screenshot of the spacer model](spacer.png)

--- a/models/star/README.md
+++ b/models/star/README.md
@@ -4,7 +4,7 @@ A model of a star that demonstrates sweeping a sketch to create a 3D shape, conc
 
 To display this model, run the following from the repository root (model parameters are optional):
 ``` sh
-cargo run -- --model star --parameters num_points=5 r1=1.0 r2=2.0 h=1.0
+cargo run -- --model star --parameters num_points=5,r1=1.0,r2=2.0,h=1.0
 ```
 
 ![Screenshot of the star model](star.png)


### PR DESCRIPTION
I noticed that the README instructions were generating the following errors for me -

```
% cargo run -- --model cuboid --parameters x=3.0 y=2.0 z=1.0

    Blocking waiting for file lock on build directory
    Finished dev [unoptimized + debuginfo] target(s) in 11.50s
     Running `target/debug/fj-app --model cuboid --parameters x=3.0 y=2.0 z=1.0`
error: Found argument 'y=2.0' which wasn't expected, or isn't valid in this context

USAGE:
    fj-app [OPTIONS]

For more information try --help
```

Looking at the code, I believe this PR updates the instructions to the correct syntax. Certainly the models now load for me -

```
% cargo run -- --model cuboid --parameters x=3.0,y=2.0,z=1.0

    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/fj-app --model cuboid --parameters x=3.0,y=2.0,z=1.0`
  2022-05-09T19:22:00.015053Z  WARN wgpu_core::device: Surface does not support present mode: Mailbox, falling back to FIFO
    at /.../mod.rs:4674

    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
```