### PR TITLE
Add gnome builder build configuration to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /target
 
 # IDE Configurations
-**/.vs/
-**/.idea/
+**/.vs/ # Visual Studio
+**/.idea/ # Intellij
+**/.buildconfig # Gnome Builder


### PR DESCRIPTION
Eases fornjot development while using Gnome Builder.

I'm experimenting with this editor and having to be careful not to add this file annoys me.