### PR TITLE
Close down `LocalForm`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edges.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edges.rs
@@ -12,7 +12,8 @@ pub fn approximate_edge(
     // would lead to bugs in the approximation, as points that should refer to
     // the same vertex would be understood to refer to very close, but distinct
     // vertices.
-    let vertices = vertices.map(|vertices| vertices.map(|vertex| vertex.local));
+    let vertices =
+        vertices.map(|vertices| vertices.map(|vertex| *vertex.local()));
     if let Some([a, b]) = vertices {
         points.insert(0, a);
         points.push(b);

--- a/crates/fj-kernel/src/algorithms/approx/edges.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edges.rs
@@ -53,14 +53,8 @@ mod test {
         let v2 = Vertex::builder(&mut shape).build_from_point(d)?;
 
         let vertices = [
-            LocalForm {
-                local: geometry::Point::new([0.], a),
-                canonical: v1,
-            },
-            LocalForm {
-                local: geometry::Point::new([1.], d),
-                canonical: v2,
-            },
+            LocalForm::new(geometry::Point::new([0.], a), v1),
+            LocalForm::new(geometry::Point::new([1.], d), v2),
         ];
 
         let a = geometry::Point::new([0.0], a);

--- a/crates/fj-kernel/src/algorithms/approx/edges.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edges.rs
@@ -49,24 +49,24 @@ mod test {
         let c = Point::from([3., 5., 8.]);
         let d = Point::from([5., 8., 13.]);
 
+        let v1 = Vertex::builder(&mut shape).build_from_point(a)?;
+        let v2 = Vertex::builder(&mut shape).build_from_point(d)?;
+
+        let vertices = [
+            LocalForm {
+                local: geometry::Point::new([0.], a),
+                canonical: v1,
+            },
+            LocalForm {
+                local: geometry::Point::new([1.], d),
+                canonical: v2,
+            },
+        ];
+
         let a = geometry::Point::new([0.0], a);
         let b = geometry::Point::new([0.25], b);
         let c = geometry::Point::new([0.75], c);
         let d = geometry::Point::new([1.0], d);
-
-        let v1 = Vertex::builder(&mut shape).build_from_point(a.canonical())?;
-        let v2 = Vertex::builder(&mut shape).build_from_point(d.canonical())?;
-
-        let vertices = [
-            LocalForm {
-                local: geometry::Point::new([0.], a.canonical()),
-                canonical: v1,
-            },
-            LocalForm {
-                local: geometry::Point::new([1.], d.canonical()),
-                canonical: v2,
-            },
-        ];
 
         // Regular edge
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -163,7 +163,7 @@ pub fn sweep_shape(
                     vertices_source.map(|vertex_source| {
                         let vertex_bottom = source_to_bottom
                             .vertices
-                            .get(&vertex_source.canonical)
+                            .get(vertex_source.canonical())
                             .unwrap()
                             .clone();
 
@@ -176,7 +176,7 @@ pub fn sweep_shape(
 
                                 let vertex_top = source_to_top
                                     .vertices
-                                    .get(&vertex_source.canonical)
+                                    .get(vertex_source.canonical())
                                     .unwrap()
                                     .clone();
 
@@ -252,7 +252,7 @@ impl Relation {
     ) -> Option<[Handle<Vertex<3>>; 2]> {
         edge.get().vertices.map(|vertices| {
             vertices.map(|vertex| {
-                self.vertices.get(&vertex.canonical).unwrap().clone()
+                self.vertices.get(vertex.canonical()).unwrap().clone()
             })
         })
     }

--- a/crates/fj-kernel/src/shape/local.rs
+++ b/crates/fj-kernel/src/shape/local.rs
@@ -28,6 +28,16 @@ impl<Local, Canonical: Object> LocalForm<Local, Canonical> {
     pub fn new(local: Local, canonical: Handle<Canonical>) -> Self {
         Self { local, canonical }
     }
+
+    /// Access the local form of the referenced object
+    pub fn local(&self) -> &Local {
+        &self.local
+    }
+
+    /// Access the canonical form of the referenced object
+    pub fn canonical(&self) -> &Handle<Canonical> {
+        &self.canonical
+    }
 }
 
 impl<Local, Canonical: Object> PartialEq for LocalForm<Local, Canonical>

--- a/crates/fj-kernel/src/shape/local.rs
+++ b/crates/fj-kernel/src/shape/local.rs
@@ -23,6 +23,13 @@ pub struct LocalForm<Local, Canonical: Object> {
     pub canonical: Handle<Canonical>,
 }
 
+impl<Local, Canonical: Object> LocalForm<Local, Canonical> {
+    /// Construct a new instance of `LocalForm`
+    pub fn new(local: Local, canonical: Handle<Canonical>) -> Self {
+        Self { local, canonical }
+    }
+}
+
 impl<Local, Canonical: Object> PartialEq for LocalForm<Local, Canonical>
 where
     Local: PartialEq,

--- a/crates/fj-kernel/src/shape/local.rs
+++ b/crates/fj-kernel/src/shape/local.rs
@@ -22,6 +22,9 @@ pub struct LocalForm<Local, Canonical: Object> {
 
 impl<Local, Canonical: Object> LocalForm<Local, Canonical> {
     /// Construct a new instance of `LocalForm`
+    ///
+    /// It is the caller's responsibility to make sure that the local and
+    /// canonical forms passed to this method actually match.
     pub fn new(local: Local, canonical: Handle<Canonical>) -> Self {
         Self { local, canonical }
     }

--- a/crates/fj-kernel/src/shape/local.rs
+++ b/crates/fj-kernel/src/shape/local.rs
@@ -16,11 +16,8 @@ use super::{Handle, Object};
 /// the handle that refers to the canonical form is disregarded.
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct LocalForm<Local, Canonical: Object> {
-    /// The local form of the referenced object
-    pub local: Local,
-
-    /// The canonical form of the referenced object
-    pub canonical: Handle<Canonical>,
+    local: Local,
+    canonical: Handle<Canonical>,
 }
 
 impl<Local, Canonical: Object> LocalForm<Local, Canonical> {

--- a/crates/fj-kernel/src/shape/validate.rs
+++ b/crates/fj-kernel/src/shape/validate.rs
@@ -47,7 +47,7 @@ impl Validate for Vertex<3> {
         min_distance: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
-        if !stores.points.contains(&self.point.canonical) {
+        if !stores.points.contains(self.point.canonical()) {
             return Err(StructuralIssues::default().into());
         }
         for existing in stores.vertices.iter() {
@@ -76,8 +76,8 @@ impl Validate for Edge {
         }
         for vertices in &self.vertices {
             for vertex in vertices {
-                if !stores.vertices.contains(&vertex.canonical) {
-                    missing_vertices.insert(vertex.canonical.clone());
+                if !stores.vertices.contains(vertex.canonical()) {
+                    missing_vertices.insert(vertex.canonical().clone());
                 }
             }
         }

--- a/crates/fj-kernel/src/topology/edges.rs
+++ b/crates/fj-kernel/src/topology/edges.rs
@@ -64,7 +64,7 @@ impl Edge {
             vertices.map(|canonical| {
                 let local =
                     curve.get().point_to_curve_coords(canonical.get().point());
-                LocalForm { local, canonical }
+                LocalForm::new(local, canonical)
             })
         });
 

--- a/crates/fj-kernel/src/topology/edges.rs
+++ b/crates/fj-kernel/src/topology/edges.rs
@@ -91,7 +91,7 @@ impl Edge {
     pub fn vertices(&self) -> Option<[Vertex<3>; 2]> {
         self.vertices
             .as_ref()
-            .map(|[a, b]| [a.canonical.get(), b.canonical.get()])
+            .map(|[a, b]| [a.canonical().get(), b.canonical().get()])
     }
 }
 

--- a/crates/fj-kernel/src/topology/vertices.rs
+++ b/crates/fj-kernel/src/topology/vertices.rs
@@ -40,10 +40,7 @@ impl Vertex<3> {
     /// Construct a new instance of `Vertex`
     pub fn new(point: Handle<Point<3>>) -> Self {
         Self {
-            point: LocalForm {
-                local: point.get(),
-                canonical: point,
-            },
+            point: LocalForm::new(point.get(), point),
         }
     }
 

--- a/crates/fj-kernel/src/topology/vertices.rs
+++ b/crates/fj-kernel/src/topology/vertices.rs
@@ -54,7 +54,7 @@ impl Vertex<3> {
     /// This is a convenience method that saves the caller from dealing with the
     /// [`Handle`].
     pub fn point(&self) -> Point<3> {
-        self.point.canonical.get()
+        self.point.canonical().get()
     }
 }
 

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -58,14 +58,15 @@ fn copy_shape(orig: Shape, target: &mut Shape) {
     }
 
     for vertex_orig in orig.vertices() {
-        let point = points[&vertex_orig.get().point.canonical].clone();
+        let point = points[vertex_orig.get().point.canonical()].clone();
         let vertex = target.insert(Vertex::new(point)).unwrap();
         vertices.insert(vertex_orig, vertex);
     }
     for edge_orig in orig.edges() {
         let curve = curves[&edge_orig.get().curve].clone();
         let vertices = edge_orig.get().vertices.as_ref().map(|vs| {
-            vs.clone().map(|vertex| vertices[&vertex.canonical].clone())
+            vs.clone()
+                .map(|vertex| vertices[vertex.canonical()].clone())
         });
 
         let edge = target.insert(Edge::new(curve, vertices)).unwrap();


### PR DESCRIPTION
This is a cleanup I extracted from a local branch. I believe having the fields of `LocalForm` be private is a bit less error-prone. The local and canonical forms need to match, so having the fields be public gives the wrong impression.