### PR TITLE
Fix `PartialEq`/`Hash` impls of `Edge`

### DIFF
--- a/crates/fj-kernel/src/topology/edges.rs
+++ b/crates/fj-kernel/src/topology/edges.rs
@@ -100,13 +100,13 @@ impl Edge {
 
 impl PartialEq for Edge {
     fn eq(&self, other: &Self) -> bool {
-        self.curve() == other.curve() && self.vertices() == other.vertices()
+        self.curve() == other.curve() && self.vertices == other.vertices
     }
 }
 
 impl Hash for Edge {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.curve().hash(state);
-        self.vertices().hash(state);
+        self.vertices.hash(state);
     }
 }


### PR DESCRIPTION
They didn't take the local form of the vertices into account.