### PR TITLE
Add `Shape::update`

### DIFF
--- a/crates/fj-kernel/src/algorithms/mod.rs
+++ b/crates/fj-kernel/src/algorithms/mod.rs
@@ -5,6 +5,7 @@
 
 mod approx;
 mod sweep;
+mod transform;
 mod triangulation;
 
 pub mod intersection;
@@ -12,5 +13,6 @@ pub mod intersection;
 pub use self::{
     approx::{CycleApprox, FaceApprox, Tolerance},
     sweep::sweep_shape,
+    transform::transform_shape,
     triangulation::triangulate,
 };

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -1,0 +1,31 @@
+use fj_math::Transform;
+
+use crate::{
+    geometry::{Curve, Surface},
+    shape::Shape,
+    topology::Face,
+};
+
+/// Transform the geometry of the shape
+///
+/// Since the topological types refer to geometry, and don't contain any
+/// geometry themselves, this transforms the whole shape.
+pub fn transform_shape(shape: &mut Shape, transform: &Transform) {
+    shape
+        .update()
+        .update_all(|point| *point = transform.transform_point(point))
+        .update_all(|curve: &mut Curve<3>| *curve = curve.transform(transform))
+        .update_all(|surface: &mut Surface| {
+            *surface = surface.transform(transform)
+        })
+        .update_all(|mut face: &mut Face| {
+            use std::ops::DerefMut as _;
+            if let Face::Triangles(triangles) = face.deref_mut() {
+                for (triangle, _) in triangles {
+                    *triangle = transform.transform_triangle(triangle);
+                }
+            }
+        })
+        .validate()
+        .unwrap();
+}

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -61,7 +61,7 @@ impl Shape {
     /// Validates the object, and returns an error if it is not valid. See the
     /// documentation of each object for validation requirements.
     pub fn insert<T: Object>(&mut self, object: T) -> ValidationResult<T> {
-        object.validate(self.min_distance, &self.stores)?;
+        object.validate(None, self.min_distance, &self.stores)?;
         let handle = self.stores.get::<T>().insert(object);
         Ok(handle)
     }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     stores::{Store, Stores},
-    Handle, Iter, Object, ValidationResult,
+    Handle, Iter, Object, Update, ValidationResult,
 };
 
 /// The boundary representation of a shape
@@ -112,6 +112,14 @@ impl Shape {
     /// This is done recursively.
     pub fn merge<T: Object>(&mut self, object: T) -> ValidationResult<T> {
         object.merge_into(self)
+    }
+
+    /// Update objects in the shape
+    ///
+    /// Returns [`Update`], and API that can be used to update objects in the
+    /// shape.
+    pub fn update(&mut self) -> Update {
+        Update::new(self.min_distance, &mut self.stores)
     }
 
     /// Transform the geometry of the shape

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -1,4 +1,4 @@
-use fj_math::{Point, Scalar, Transform};
+use fj_math::{Point, Scalar};
 
 use crate::{
     geometry::{Curve, Surface},
@@ -120,31 +120,6 @@ impl Shape {
     /// shape.
     pub fn update(&mut self) -> Update {
         Update::new(self.min_distance, &mut self.stores)
-    }
-
-    /// Transform the geometry of the shape
-    ///
-    /// Since the topological types refer to geometry, and don't contain any
-    /// geometry themselves, this transforms the whole shape.
-    pub fn transform(&mut self, transform: &Transform) {
-        self.update()
-            .update_all(|point| *point = transform.transform_point(point))
-            .update_all(|curve: &mut Curve<3>| {
-                *curve = curve.transform(transform)
-            })
-            .update_all(|surface: &mut Surface| {
-                *surface = surface.transform(transform)
-            })
-            .update_all(|mut face: &mut Face| {
-                use std::ops::DerefMut as _;
-                if let Face::Triangles(triangles) = face.deref_mut() {
-                    for (triangle, _) in triangles {
-                        *triangle = transform.transform_triangle(triangle);
-                    }
-                }
-            })
-            .validate()
-            .unwrap();
     }
 
     /// Access an iterator over all points

--- a/crates/fj-kernel/src/shape/mod.rs
+++ b/crates/fj-kernel/src/shape/mod.rs
@@ -6,6 +6,7 @@ mod api;
 mod local;
 mod object;
 mod stores;
+mod update;
 mod validate;
 
 pub use self::{
@@ -13,5 +14,6 @@ pub use self::{
     local::LocalForm,
     object::Object,
     stores::{Handle, Iter},
+    update::Update,
     validate::{StructuralIssues, ValidationError, ValidationResult},
 };

--- a/crates/fj-kernel/src/shape/update.rs
+++ b/crates/fj-kernel/src/shape/update.rs
@@ -1,0 +1,104 @@
+use fj_math::Scalar;
+
+use super::{stores::Stores, validate::Validate as _, Object, ValidationError};
+
+/// API to update a `Shape`
+///
+/// See [`Shape::update`].
+#[must_use]
+pub struct Update<'r> {
+    min_distance: Scalar,
+    stores: &'r mut Stores,
+    executed: bool,
+}
+
+impl<'r> Update<'r> {
+    pub(super) fn new(min_distance: Scalar, stores: &'r mut Stores) -> Self {
+        Self {
+            min_distance,
+            stores,
+            executed: false,
+        }
+    }
+
+    /// Update all objects of a specific type
+    pub fn update_all<T: Object>(self, f: impl FnMut(&mut T)) -> Self {
+        self.stores.get::<T>().update(f);
+        self
+    }
+
+    /// Validate the update
+    ///
+    /// The update is validated automatically, when this `Update` instance is
+    /// dropped. It is recommended to validate by calling this method though, as
+    /// no [`ValidationError`] will be available otherwise.
+    pub fn validate(mut self) -> Result<(), ValidationError> {
+        self.validate_inner()
+    }
+
+    fn validate_inner(&mut self) -> Result<(), ValidationError> {
+        if !self.executed {
+            self.executed = true;
+
+            // Validating every single object is certainly not ideal from a
+            // performance perspective, but it will do for now.
+            for object in self.stores.points.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+            for object in self.stores.curves.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+            for object in self.stores.surfaces.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+            for object in self.stores.vertices.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+            for object in self.stores.edges.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+            for object in self.stores.cycles.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+            for object in self.stores.faces.iter() {
+                object.get().validate(
+                    Some(&object),
+                    self.min_distance,
+                    self.stores,
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for Update<'_> {
+    fn drop(&mut self) {
+        self.validate_inner().unwrap();
+    }
+}

--- a/crates/fj-kernel/src/shape/validate.rs
+++ b/crates/fj-kernel/src/shape/validate.rs
@@ -62,7 +62,7 @@ impl Validate for Vertex<3> {
     /// does. See documentation of [`crate::kernel`] for some context on that.
     fn validate(
         &self,
-        _: Option<&Handle<Self>>,
+        handle: Option<&Handle<Self>>,
         min_distance: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
@@ -70,6 +70,10 @@ impl Validate for Vertex<3> {
             return Err(StructuralIssues::default().into());
         }
         for existing in stores.vertices.iter() {
+            if Some(&existing) == handle {
+                continue;
+            }
+
             let distance = (existing.get().point() - self.point()).magnitude();
 
             if distance < min_distance {

--- a/crates/fj-kernel/src/shape/validate.rs
+++ b/crates/fj-kernel/src/shape/validate.rs
@@ -7,30 +7,48 @@ use crate::{
     topology::{Cycle, Edge, Face, Vertex},
 };
 
-use super::{stores::Stores, Handle};
+use super::{stores::Stores, Handle, Object};
 
 pub trait Validate {
     fn validate(
         &self,
+        handle: Option<&Handle<Self>>,
         min_distance: Scalar,
         stores: &Stores,
-    ) -> Result<(), ValidationError>;
+    ) -> Result<(), ValidationError>
+    where
+        Self: Object;
 }
 
 impl Validate for Point<3> {
-    fn validate(&self, _: Scalar, _: &Stores) -> Result<(), ValidationError> {
+    fn validate(
+        &self,
+        _: Option<&Handle<Self>>,
+        _: Scalar,
+        _: &Stores,
+    ) -> Result<(), ValidationError> {
         Ok(())
     }
 }
 
 impl Validate for Curve<3> {
-    fn validate(&self, _: Scalar, _: &Stores) -> Result<(), ValidationError> {
+    fn validate(
+        &self,
+        _: Option<&Handle<Self>>,
+        _: Scalar,
+        _: &Stores,
+    ) -> Result<(), ValidationError> {
         Ok(())
     }
 }
 
 impl Validate for Surface {
-    fn validate(&self, _: Scalar, _: &Stores) -> Result<(), ValidationError> {
+    fn validate(
+        &self,
+        _: Option<&Handle<Self>>,
+        _: Scalar,
+        _: &Stores,
+    ) -> Result<(), ValidationError> {
         Ok(())
     }
 }
@@ -44,6 +62,7 @@ impl Validate for Vertex<3> {
     /// does. See documentation of [`crate::kernel`] for some context on that.
     fn validate(
         &self,
+        _: Option<&Handle<Self>>,
         min_distance: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
@@ -65,6 +84,7 @@ impl Validate for Vertex<3> {
 impl Validate for Edge<3> {
     fn validate(
         &self,
+        _: Option<&Handle<Self>>,
         _: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
@@ -106,6 +126,7 @@ impl Validate for Cycle<3> {
     /// - That there exists no duplicate cycle, with the same edges.
     fn validate(
         &self,
+        _: Option<&Handle<Self>>,
         _: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
@@ -133,6 +154,7 @@ impl Validate for Cycle<3> {
 impl Validate for Face {
     fn validate(
         &self,
+        _: Option<&Handle<Self>>,
         _: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -1,5 +1,8 @@
 use fj_interop::debug::DebugInfo;
-use fj_kernel::{algorithms::Tolerance, shape::Shape};
+use fj_kernel::{
+    algorithms::{transform_shape, Tolerance},
+    shape::Shape,
+};
 use fj_math::{Aabb, Transform, Vector};
 
 use super::ToShape;
@@ -13,7 +16,7 @@ impl ToShape for fj::Transform {
         let mut shape = self.shape.to_shape(tolerance, debug_info);
         let transform = transform(self);
 
-        shape.transform(&transform);
+        transform_shape(&mut shape, &transform);
 
         shape
     }


### PR DESCRIPTION
This pull request adds a new method `Shape::update`, implements `Shape::transform` in terms of the new method, and moves it out of the `Shape` API (it no longer requires privileged access to `Shape` internals).

Having a new general-purpose shape update API will also pave the way for more cleanups. Specifically, it should help with #602.

Close #601