### PR TITLE
Prefer returning cloned `Handle`s

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -156,7 +156,7 @@ pub fn sweep_shape(
                     vertices_source.map(|vertex_source| {
                         let vertex_bottom = source_to_bottom
                             .vertices
-                            .get(vertex_source.canonical())
+                            .get(&vertex_source.canonical())
                             .unwrap()
                             .clone();
 
@@ -169,7 +169,7 @@ pub fn sweep_shape(
 
                                 let vertex_top = source_to_top
                                     .vertices
-                                    .get(vertex_source.canonical())
+                                    .get(&vertex_source.canonical())
                                     .unwrap()
                                     .clone();
 
@@ -187,9 +187,9 @@ pub fn sweep_shape(
                 // this source/bottom edge.
 
                 let bottom_edge =
-                    source_to_bottom.edges.get(edge_source).unwrap().clone();
+                    source_to_bottom.edges.get(&edge_source).unwrap().clone();
                 let top_edge =
-                    source_to_top.edges.get(edge_source).unwrap().clone();
+                    source_to_top.edges.get(&edge_source).unwrap().clone();
 
                 let surface = target
                     .insert(Surface::SweptCurve(SweptCurve {
@@ -238,7 +238,7 @@ impl Relation {
     ) -> Option<[Handle<Vertex<3>>; 2]> {
         edge.get().vertices.map(|vertices| {
             vertices.map(|vertex| {
-                self.vertices.get(vertex.canonical()).unwrap().clone()
+                self.vertices.get(&vertex.canonical()).unwrap().clone()
             })
         })
     }
@@ -251,7 +251,7 @@ impl Relation {
             .get()
             .edges
             .iter()
-            .map(|edge| self.edges.get(edge.canonical()).unwrap().clone())
+            .map(|edge| self.edges.get(&edge.canonical()).unwrap().clone())
             .collect()
     }
 

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -259,7 +259,7 @@ impl Relation {
         face.brep()
             .exteriors
             .as_handle()
-            .map(|cycle| self.cycles.get(cycle).unwrap().clone())
+            .map(|cycle| self.cycles.get(&cycle).unwrap().clone())
             .collect()
     }
 
@@ -267,7 +267,7 @@ impl Relation {
         face.brep()
             .interiors
             .as_handle()
-            .map(|cycle| self.cycles.get(cycle).unwrap().clone())
+            .map(|cycle| self.cycles.get(&cycle).unwrap().clone())
             .collect()
     }
 }

--- a/crates/fj-kernel/src/shape/local.rs
+++ b/crates/fj-kernel/src/shape/local.rs
@@ -35,8 +35,8 @@ impl<Local, Canonical: Object> LocalForm<Local, Canonical> {
     }
 
     /// Access the canonical form of the referenced object
-    pub fn canonical(&self) -> &Handle<Canonical> {
-        &self.canonical
+    pub fn canonical(&self) -> Handle<Canonical> {
+        self.canonical.clone()
     }
 }
 

--- a/crates/fj-kernel/src/shape/validate.rs
+++ b/crates/fj-kernel/src/shape/validate.rs
@@ -172,8 +172,8 @@ impl Validate for Face {
             for cycle in
                 face.exteriors.as_handle().chain(face.interiors.as_handle())
             {
-                if !stores.cycles.contains(cycle) {
-                    missing_cycles.insert(cycle.clone());
+                if !stores.cycles.contains(&cycle) {
+                    missing_cycles.insert(cycle);
                 }
             }
 

--- a/crates/fj-kernel/src/shape/validate.rs
+++ b/crates/fj-kernel/src/shape/validate.rs
@@ -66,7 +66,7 @@ impl Validate for Vertex<3> {
         min_distance: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
-        if !stores.points.contains(self.point.canonical()) {
+        if !stores.points.contains(&self.point.canonical()) {
             return Err(StructuralIssues::default().into());
         }
         for existing in stores.vertices.iter() {
@@ -95,12 +95,12 @@ impl Validate for Edge<3> {
         let mut missing_curve = None;
         let mut missing_vertices = HashSet::new();
 
-        if !stores.curves.contains(self.curve.canonical()) {
-            missing_curve = Some(self.curve.canonical().clone());
+        if !stores.curves.contains(&self.curve.canonical()) {
+            missing_curve = Some(self.curve.canonical());
         }
         for vertices in &self.vertices {
             for vertex in vertices {
-                if !stores.vertices.contains(vertex.canonical()) {
+                if !stores.vertices.contains(&vertex.canonical()) {
                     missing_vertices.insert(vertex.canonical().clone());
                 }
             }
@@ -138,7 +138,7 @@ impl Validate for Cycle<3> {
         for edge in &self.edges {
             let edge = edge.canonical();
 
-            if !stores.edges.contains(edge) {
+            if !stores.edges.contains(&edge) {
                 missing_edges.insert(edge.clone());
             }
         }

--- a/crates/fj-kernel/src/topology/face.rs
+++ b/crates/fj-kernel/src/topology/face.rs
@@ -209,7 +209,7 @@ impl CyclesInFace {
     }
 
     /// Access an iterator over handles to the cycles
-    pub fn as_handle(&self) -> impl Iterator<Item = &'_ Handle<Cycle<3>>> + '_ {
-        self.0.iter()
+    pub fn as_handle(&self) -> impl Iterator<Item = Handle<Cycle<3>>> + '_ {
+        self.0.iter().cloned()
     }
 }

--- a/crates/fj-kernel/src/topology/vertex.rs
+++ b/crates/fj-kernel/src/topology/vertex.rs
@@ -63,7 +63,7 @@ impl Vertex<3> {
         local: impl Into<Point<D>>,
     ) -> Vertex<D> {
         Vertex {
-            point: LocalForm::new(local.into(), self.point.canonical().clone()),
+            point: LocalForm::new(local.into(), self.point.canonical()),
         }
     }
 }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -97,7 +97,7 @@ fn add_cycle(
         let curve = shape.insert(curve).unwrap();
 
         let vertices = edge.vertices.clone().map(|vs| {
-            let mut vs = vs.map(|vertex| vertex.canonical().clone());
+            let mut vs = vs.map(|vertex| vertex.canonical());
 
             if reverse {
                 vs.reverse();


### PR DESCRIPTION
Updates some APIs tor returned cloned `Handle`s instead of `&Handle`. This is easy to do with handles, and I think it is an ergonomics win, overall.