### PR TITLE
Add additional building blocks to `Shape` API

### DIFF
--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     stores::{Store, Stores},
-    Handle, Iter, Object, Update, ValidationResult,
+    Handle, Iter, Mapping, Object, Update, ValidationError, ValidationResult,
 };
 
 /// The boundary representation of a shape
@@ -120,6 +120,51 @@ impl Shape {
     /// shape.
     pub fn update(&mut self) -> Update {
         Update::new(self.min_distance, &mut self.stores)
+    }
+
+    /// Clone the shape
+    ///
+    /// Returns a [`Mapping`] that maps each object from the original shape to
+    /// the respective object in the cloned shape.
+    pub fn clone_shape(&self) -> (Shape, Mapping) {
+        self.clone_shape_inner()
+            .expect("Clone of valid shape can't be invalid")
+    }
+
+    fn clone_shape_inner(&self) -> Result<(Shape, Mapping), ValidationError> {
+        let mut target = Shape::new();
+        let mut mapping = Mapping::new();
+
+        for original in self.points() {
+            let cloned = target.merge(original.get())?;
+            mapping.points.insert(original, cloned);
+        }
+        for original in self.curves() {
+            let cloned = target.merge(original.get())?;
+            mapping.curves.insert(original, cloned);
+        }
+        for original in self.surfaces() {
+            let cloned = target.merge(original.get())?;
+            mapping.surfaces.insert(original, cloned);
+        }
+        for original in self.vertices() {
+            let cloned = target.merge(original.get())?;
+            mapping.vertices.insert(original, cloned);
+        }
+        for original in self.edges() {
+            let cloned = target.merge(original.get())?;
+            mapping.edges.insert(original, cloned);
+        }
+        for original in self.cycles() {
+            let cloned = target.merge(original.get())?;
+            mapping.cycles.insert(original, cloned);
+        }
+        for original in self.faces() {
+            let cloned = target.merge(original.get())?;
+            mapping.faces.insert(original, cloned);
+        }
+
+        Ok((target, mapping))
     }
 
     /// Access an iterator over all points

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -111,7 +111,7 @@ impl Shape {
     ///
     /// This is done recursively.
     pub fn merge<T: Object>(&mut self, object: T) -> ValidationResult<T> {
-        object.merge_into(self)
+        object.merge_into(None, self)
     }
 
     /// Update objects in the shape

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -111,7 +111,7 @@ impl Shape {
     ///
     /// This is done recursively.
     pub fn merge<T: Object>(&mut self, object: T) -> ValidationResult<T> {
-        object.merge_into(None, self)
+        object.merge_into(None, self, &mut Mapping::new())
     }
 
     /// Update objects in the shape

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -114,6 +114,41 @@ impl Shape {
         object.merge_into(None, self, &mut Mapping::new())
     }
 
+    /// Merge the provided shape into this one
+    ///
+    /// Returns a [`Mapping`] that maps each object from the merged shape to the
+    /// merged objects in this shape.
+    pub fn merge_shape(
+        &mut self,
+        other: &Shape,
+    ) -> Result<Mapping, ValidationError> {
+        let mut mapping = Mapping::new();
+
+        for object in other.points() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+        for object in other.curves() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+        for object in other.surfaces() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+        for object in other.vertices() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+        for object in other.edges() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+        for object in other.cycles() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+        for object in other.faces() {
+            object.get().merge_into(Some(object), self, &mut mapping)?;
+        }
+
+        Ok(mapping)
+    }
+
     /// Update objects in the shape
     ///
     /// Returns [`Update`], and API that can be used to update objects in the

--- a/crates/fj-kernel/src/shape/mapping.rs
+++ b/crates/fj-kernel/src/shape/mapping.rs
@@ -21,6 +21,18 @@ pub struct Mapping {
 }
 
 impl Mapping {
+    pub(super) fn new() -> Self {
+        Self {
+            points: OneMapping::new(),
+            curves: OneMapping::new(),
+            surfaces: OneMapping::new(),
+            vertices: OneMapping::new(),
+            edges: OneMapping::new(),
+            cycles: OneMapping::new(),
+            faces: OneMapping::new(),
+        }
+    }
+
     /// Access iterator over the mapped points
     pub fn points(&self) -> &OneMapping<Point<3>> {
         &self.points

--- a/crates/fj-kernel/src/shape/mapping.rs
+++ b/crates/fj-kernel/src/shape/mapping.rs
@@ -1,0 +1,60 @@
+use std::collections::HashMap;
+
+use fj_math::Point;
+
+use crate::{
+    geometry::{Curve, Surface},
+    topology::{Cycle, Edge, Face, Vertex},
+};
+
+use super::Handle;
+
+/// A mapping between objects in different shapes
+pub struct Mapping {
+    pub(super) points: OneMapping<Point<3>>,
+    pub(super) curves: OneMapping<Curve<3>>,
+    pub(super) surfaces: OneMapping<Surface>,
+    pub(super) vertices: OneMapping<Vertex<3>>,
+    pub(super) edges: OneMapping<Edge<3>>,
+    pub(super) cycles: OneMapping<Cycle<3>>,
+    pub(super) faces: OneMapping<Face>,
+}
+
+impl Mapping {
+    /// Access iterator over the mapped points
+    pub fn points(&self) -> &OneMapping<Point<3>> {
+        &self.points
+    }
+
+    /// Access iterator over the mapped curves
+    pub fn curves(&self) -> &OneMapping<Curve<3>> {
+        &self.curves
+    }
+
+    /// Access iterator over the mapped surfaces
+    pub fn surfaces(&self) -> &OneMapping<Surface> {
+        &self.surfaces
+    }
+
+    /// Access iterator over the mapped vertices
+    pub fn vertices(&self) -> &OneMapping<Vertex<3>> {
+        &self.vertices
+    }
+
+    /// Access iterator over the mapped edges
+    pub fn edges(&self) -> &OneMapping<Edge<3>> {
+        &self.edges
+    }
+
+    /// Access iterator over the mapped cycles
+    pub fn cycles(&self) -> &OneMapping<Cycle<3>> {
+        &self.cycles
+    }
+
+    /// Access iterator over the mapped faces
+    pub fn faces(&self) -> &OneMapping<Face> {
+        &self.faces
+    }
+}
+
+pub type OneMapping<T> = HashMap<Handle<T>, Handle<T>>;

--- a/crates/fj-kernel/src/shape/mod.rs
+++ b/crates/fj-kernel/src/shape/mod.rs
@@ -4,6 +4,7 @@
 
 mod api;
 mod local;
+mod mapping;
 mod object;
 mod stores;
 mod update;
@@ -12,6 +13,7 @@ mod validate;
 pub use self::{
     api::Shape,
     local::LocalForm,
+    mapping::Mapping,
     object::Object,
     stores::{Handle, Iter},
     update::Update,

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -5,7 +5,7 @@ use crate::{
     topology::{Cycle, Edge, Face, Vertex},
 };
 
-use super::{validate::Validate, Shape, ValidationResult};
+use super::{validate::Validate, Handle, Shape, ValidationResult};
 
 /// Marker trait for geometric and topological objects
 pub trait Object:
@@ -14,7 +14,11 @@ pub trait Object:
     /// Internal function
     ///
     /// Please consider using [`Shape::merge`] instead.
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self>;
+    fn merge_into(
+        self,
+        handle: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self>;
 }
 
 impl private::Sealed for Point<3> {}
@@ -27,39 +31,66 @@ impl private::Sealed for Cycle<3> {}
 impl private::Sealed for Face {}
 
 impl Object for Point<3> {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
         shape.get_handle_or_insert(self)
     }
 }
 
 impl Object for Curve<3> {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
         shape.get_handle_or_insert(self)
     }
 }
 
 impl Object for Surface {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
         shape.get_handle_or_insert(self)
     }
 }
 
 impl Object for Vertex<3> {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
-        let point = self.point().merge_into(shape)?;
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
+        let point = self
+            .point()
+            .merge_into(Some(self.point.canonical()), shape)?;
         shape.get_handle_or_insert(Vertex::new(point))
     }
 }
 
 impl Object for Edge<3> {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
-        let curve = self.curve().merge_into(shape)?;
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
+        let curve = self
+            .curve()
+            .merge_into(Some(self.curve.canonical()), shape)?;
 
         // Can be cleaned up using `try_map`, once that is stable:
         // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
-        let vertices = self
-            .vertices()
-            .map(|vertices| vertices.map(|vertex| vertex.merge_into(shape)));
+        let vertices = self.vertices.map(|vertices| {
+            vertices.map(|vertex| {
+                let vertex = vertex.canonical();
+                vertex.get().merge_into(Some(vertex), shape)
+            })
+        });
         let vertices = match vertices {
             Some([a, b]) => Some([a?, b?]),
             None => None,
@@ -70,10 +101,15 @@ impl Object for Edge<3> {
 }
 
 impl Object for Cycle<3> {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
         let mut edges = Vec::new();
-        for edge in self.edges() {
-            let edge = edge.merge_into(shape)?;
+        for edge in self.edges {
+            let edge = edge.canonical();
+            let edge = edge.get().merge_into(Some(edge), shape)?;
             edges.push(edge);
         }
 
@@ -82,20 +118,25 @@ impl Object for Cycle<3> {
 }
 
 impl Object for Face {
-    fn merge_into(self, shape: &mut Shape) -> ValidationResult<Self> {
+    fn merge_into(
+        self,
+        _: Option<Handle<Self>>,
+        shape: &mut Shape,
+    ) -> ValidationResult<Self> {
         match self {
             Face::Face(face) => {
-                let surface = face.surface.get().merge_into(shape)?;
+                let surface =
+                    face.surface.get().merge_into(Some(face.surface), shape)?;
 
                 let mut exts = Vec::new();
-                for cycle in face.exteriors.as_canonical() {
-                    let cycle = cycle.merge_into(shape)?;
+                for cycle in face.exteriors.as_handle() {
+                    let cycle = cycle.get().merge_into(Some(cycle), shape)?;
                     exts.push(cycle);
                 }
 
                 let mut ints = Vec::new();
-                for cycle in face.interiors.as_canonical() {
-                    let cycle = cycle.merge_into(shape)?;
+                for cycle in face.interiors.as_handle() {
+                    let cycle = cycle.get().merge_into(Some(cycle), shape)?;
                     ints.push(cycle);
                 }
 


### PR DESCRIPTION
The new building blocks will be useful for cleaning up the sweep operation (#602).