### PR TITLE
Add serde serialization to `fj`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,9 @@ dependencies = [
 [[package]]
 name = "fj"
 version = "0.6.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "fj-app"

--- a/crates/fj/Cargo.toml
+++ b/crates/fj/Cargo.toml
@@ -10,3 +10,10 @@ repository = "https://github.com/hannobraun/fornjot"
 license = "0BSD"
 keywords = ["cad", "programmatic", "code-cad"]
 categories = ["encoding", "mathematics", "rendering"]
+
+[features]
+default = []
+serialization = ["serde"]
+
+[dependencies]
+serde = { version = "1.0.7", optional = true }

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::{shape_2d::*, shape_3d::*};
 
 /// A shape
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub enum Shape {
     /// A 2D shape

--- a/crates/fj/src/shape_2d.rs
+++ b/crates/fj/src/shape_2d.rs
@@ -4,6 +4,7 @@ use crate::Shape;
 
 /// A 2-dimensional shape
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub enum Shape2d {
     /// A circle
@@ -29,6 +30,7 @@ impl Shape2d {
 
 /// A circle
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Circle {
     /// The radius of the circle
@@ -82,6 +84,7 @@ impl From<Circle> for Shape2d {
 
 /// A difference between two shapes
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Difference2d {
     shapes: [Shape2d; 2],
@@ -126,6 +129,7 @@ impl From<Difference2d> for Shape2d {
 /// that the edges are non-overlapping. If you create a `Sketch` with
 /// overlapping edges, you're on your own.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Sketch {
     // The fields are the raw parts of a `Vec`. `Sketch` needs to be FFI-safe,

--- a/crates/fj/src/shape_3d.rs
+++ b/crates/fj/src/shape_3d.rs
@@ -2,6 +2,7 @@ use crate::{Shape, Shape2d};
 
 /// A 3-dimensional shape
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub enum Shape3d {
     /// A group of two 3-dimensional shapes
@@ -29,6 +30,7 @@ impl From<Shape3d> for Shape {
 ///
 /// Whether the shapes in the group touch or overlap is not currently checked.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Group {
     /// The first of the shapes
@@ -60,6 +62,7 @@ impl From<Group> for Shape3d {
 /// See issue:
 /// <https://github.com/hannobraun/Fornjot/issues/101>
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Transform {
     /// The shape being transformed
@@ -89,6 +92,7 @@ impl From<Transform> for Shape3d {
 
 /// A sweep of a 2-dimensional shape along straight path
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Sweep {
     /// The 2-dimensional shape being swept


### PR DESCRIPTION
Adds serde as an optional dependency to `fj`.

I ran into the need this for while marshaling `Shape`s between javascript and rust for the wasm32-unknown-unknown platform.

I believe implementing serde on crates like this is also considered idiomatic. I'm not sure if this implementation is the exact idiomatic way to accomplish that.