### PR TITLE
Fix mistake in `Angle::wrap`

### DIFF
--- a/crates/fj/src/angle.rs
+++ b/crates/fj/src/angle.rs
@@ -32,7 +32,7 @@ impl Angle {
     fn wrap(rad: f64) -> f64 {
         let modulo = rad % (2. * PI);
         if modulo < 0. {
-            modulo * -1.
+            2. * PI + modulo
         } else {
             modulo
         }


### PR DESCRIPTION
Sorry for the inconvenience, but I made a mistake in the wrapping function, where it previously simply flipped the sign of a negative angle. Now it should properly "overflow" from 2*pi