### PR TITLE
Fix bounding volume issue for swept shapes

### DIFF
--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -24,6 +24,13 @@ impl ToShape for fj::Sweep {
 
     fn bounding_volume(&self) -> Aabb<3> {
         let target = Point::origin() + self.path();
-        self.shape().bounding_volume().include_point(&target)
+        self.shape()
+            .bounding_volume()
+            .merged(&Aabb::<3>::from_points(
+                self.shape()
+                    .bounding_volume()
+                    .vertices()
+                    .map(|v| v + self.path()),
+            ))
     }
 }

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -23,7 +23,6 @@ impl ToShape for fj::Sweep {
     }
 
     fn bounding_volume(&self) -> Aabb<3> {
-        let target = Point::origin() + self.path();
         self.shape()
             .bounding_volume()
             .merged(&Aabb::<3>::from_points(


### PR DESCRIPTION
This addresses #566

This solution is probably less than ideal,
since the bounding volume gets split up into its vertices,
which then get individually translated.

Signed-off-by: gabsi26 <gabriel.seebach@gmx.at>

edit (by @hannobraun):
Close #566 (to make sure the issue is closed automatically when this is merged)