### PR TITLE
Fix warning; fail CI build, if any warnings are present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions-rs/clippy-check@9d09632661e31982c0be8af59aeb96b680641bc4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features -- -D warnings
 
   export:
     name: Validate 3MF Export

--- a/crates/fj-export/src/lib.rs
+++ b/crates/fj-export/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! [Fornjot]: https://www.fornjot.app/
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 use std::{fs::File, path::Path};
 

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! [Fornjot]: https://www.fornjot.app/
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 mod platform;
 

--- a/crates/fj-interop/src/lib.rs
+++ b/crates/fj-interop/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! [Fornjot]: https://www.fornjot.app/
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 pub mod debug;
 pub mod mesh;

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -85,7 +85,7 @@
 //!
 //! [Fornjot]: https://www.fornjot.app/
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 pub mod algorithms;
 pub mod geometry;

--- a/crates/fj-math/src/lib.rs
+++ b/crates/fj-math/src/lib.rs
@@ -33,7 +33,7 @@
 //! [nalgebra]: https://nalgebra.org/
 //! [Parry]: https://www.parry.rs/
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 mod aabb;
 mod circle;

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -14,7 +14,7 @@
 //! [Fornjot]: https://www.fornjot.app/
 //! [`fj`]: https://crates.io/crates/fj
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 pub mod shape_processor;
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::{sweep_shape, Tolerance},
     shape::Shape,
 };
-use fj_math::{Aabb, Point, Vector};
+use fj_math::{Aabb, Vector};
 
 use super::ToShape;
 

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -16,7 +16,7 @@
 //! [Fornjot]: https://www.fornjot.app/
 //! [Fornjot repository]: https://github.com/hannobraun/Fornjot
 
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 pub mod syntax;
 


### PR DESCRIPTION
Also relaxed the requirement for API documentation: It will just warn, if some is missing. This should still result in a failure in the CI build.