### PR TITLE
Replace problematic `Edge` constructor with a simpler one

### DIFF
--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -320,7 +320,7 @@ mod tests {
         assert!(shape.get_handle(&surface.get()).as_ref() == Some(&surface));
 
         let vertex = Vertex { point };
-        let edge = Edge::new_obsolete(curve, None);
+        let edge = Edge::new(curve, None);
 
         assert!(shape.get_handle(&vertex).is_none());
         assert!(shape.get_handle(&edge).is_none());

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -320,7 +320,7 @@ mod tests {
         assert!(shape.get_handle(&surface.get()).as_ref() == Some(&surface));
 
         let vertex = Vertex { point };
-        let edge = Edge::new(curve, None);
+        let edge = Edge::new_obsolete(curve, None);
 
         assert!(shape.get_handle(&vertex).is_none());
         assert!(shape.get_handle(&edge).is_none());
@@ -384,7 +384,10 @@ mod tests {
 
         // Shouldn't work. Nothing has been added to `shape`.
         let err = shape
-            .insert(Edge::new(curve.clone(), Some([a.clone(), b.clone()])))
+            .insert(Edge::new_obsolete(
+                curve.clone(),
+                Some([a.clone(), b.clone()]),
+            ))
             .unwrap_err();
         assert!(err.missing_curve(&curve));
         assert!(err.missing_vertex(&a));
@@ -395,7 +398,7 @@ mod tests {
         let b = Vertex::builder(&mut shape).build_from_point([2., 0., 0.])?;
 
         // Everything has been added to `shape` now. Should work!
-        shape.insert(Edge::new(curve, Some([a, b])))?;
+        shape.insert(Edge::new_obsolete(curve, Some([a, b])))?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -292,7 +292,7 @@ mod tests {
 
     use crate::{
         geometry::{Curve, Surface},
-        shape::{Handle, Shape, ValidationError, ValidationResult},
+        shape::{Handle, LocalForm, Shape, ValidationError, ValidationResult},
         topology::{Cycle, Edge, Face, Vertex},
     };
 
@@ -382,23 +382,26 @@ mod tests {
         let a = Vertex::builder(&mut other).build_from_point([1., 0., 0.])?;
         let b = Vertex::builder(&mut other).build_from_point([2., 0., 0.])?;
 
+        let a = LocalForm::new(Point::from([1.]), a);
+        let b = LocalForm::new(Point::from([2.]), b);
+
         // Shouldn't work. Nothing has been added to `shape`.
         let err = shape
-            .insert(Edge::new_obsolete(
-                curve.clone(),
-                Some([a.clone(), b.clone()]),
-            ))
+            .insert(Edge::new(curve.clone(), Some([a.clone(), b.clone()])))
             .unwrap_err();
         assert!(err.missing_curve(&curve));
-        assert!(err.missing_vertex(&a));
-        assert!(err.missing_vertex(&b));
+        assert!(err.missing_vertex(&a.canonical()));
+        assert!(err.missing_vertex(&b.canonical()));
 
         let curve = shape.add_curve()?;
         let a = Vertex::builder(&mut shape).build_from_point([1., 0., 0.])?;
         let b = Vertex::builder(&mut shape).build_from_point([2., 0., 0.])?;
 
+        let a = LocalForm::new(Point::from([1.]), a);
+        let b = LocalForm::new(Point::from([2.]), b);
+
         // Everything has been added to `shape` now. Should work!
-        shape.insert(Edge::new_obsolete(curve, Some([a, b])))?;
+        shape.insert(Edge::new(curve, Some([a, b])))?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -118,8 +118,8 @@ impl Object for Edge<3> {
         // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
         let vertices = self.vertices.map(|vertices| {
             vertices.map(|vertex| {
-                let vertex = vertex.canonical();
-                vertex.get().merge_into(Some(vertex), shape, mapping)
+                let canonical = vertex.canonical();
+                canonical.get().merge_into(Some(canonical), shape, mapping)
             })
         });
         let vertices = match vertices {

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -127,7 +127,8 @@ impl Object for Edge<3> {
             None => None,
         };
 
-        let merged = shape.get_handle_or_insert(Edge::new(curve, vertices))?;
+        let merged =
+            shape.get_handle_or_insert(Edge::new_obsolete(curve, vertices))?;
 
         if let Some(handle) = handle {
             mapping.edges.insert(handle, merged.clone());

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -2,7 +2,7 @@ use fj_math::{Circle, Line, Point, Scalar, Vector};
 
 use crate::{
     geometry::{Curve, Surface},
-    shape::{Handle, Shape, ValidationResult},
+    shape::{Handle, LocalForm, Shape, ValidationResult},
 };
 
 use super::{Cycle, Edge, Face, Vertex};
@@ -85,9 +85,14 @@ impl<'r> EdgeBuilder<'r> {
         let curve = self.shape.insert(Curve::Line(Line::from_points(
             vertices.clone().map(|vertex| vertex.get().point()),
         )))?;
-        let edge = self
-            .shape
-            .insert(Edge::new_obsolete(curve, Some(vertices)))?;
+
+        let [a, b] = vertices;
+        let vertices = [
+            LocalForm::new(Point::from([0.]), a),
+            LocalForm::new(Point::from([1.]), b),
+        ];
+
+        let edge = self.shape.insert(Edge::new(curve, Some(vertices)))?;
 
         Ok(edge)
     }

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -53,7 +53,7 @@ impl<'r> EdgeBuilder<'r> {
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
         }))?;
-        let edge = self.shape.insert(Edge::new_obsolete(curve, None))?;
+        let edge = self.shape.insert(Edge::new(curve, None))?;
 
         Ok(edge)
     }

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -53,7 +53,7 @@ impl<'r> EdgeBuilder<'r> {
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
         }))?;
-        let edge = self.shape.insert(Edge::new(curve, None))?;
+        let edge = self.shape.insert(Edge::new_obsolete(curve, None))?;
 
         Ok(edge)
     }
@@ -85,7 +85,9 @@ impl<'r> EdgeBuilder<'r> {
         let curve = self.shape.insert(Curve::Line(Line::from_points(
             vertices.clone().map(|vertex| vertex.get().point()),
         )))?;
-        let edge = self.shape.insert(Edge::new(curve, Some(vertices)))?;
+        let edge = self
+            .shape
+            .insert(Edge::new_obsolete(curve, Some(vertices)))?;
 
         Ok(edge)
     }

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -58,7 +58,7 @@ impl Edge<3> {
     /// infrastructure. Here's one such piece of infrastructure, for which an
     /// issue already exists:
     /// <https://github.com/hannobraun/Fornjot/issues/399>
-    pub fn new(
+    pub fn new_obsolete(
         curve: Handle<Curve<3>>,
         vertices: Option<[Handle<Vertex>; 2]>,
     ) -> Self {

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -39,6 +39,15 @@ pub struct Edge<const D: usize> {
 
 impl Edge<3> {
     /// Construct an instance of `Edge`
+    pub fn new(
+        curve: Handle<Curve<3>>,
+        vertices: Option<[LocalForm<Point<1>, Vertex>; 2]>,
+    ) -> Self {
+        let curve = LocalForm::canonical_only(curve);
+        Self { curve, vertices }
+    }
+
+    /// Construct an instance of `Edge`
     ///
     /// # Implementation Note
     ///

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -47,46 +47,6 @@ impl Edge<3> {
         Self { curve, vertices }
     }
 
-    /// Construct an instance of `Edge`
-    ///
-    /// # Implementation Note
-    ///
-    /// This method accepts two `Handle<Vertex>`, and projects them onto the
-    /// curve, to create the local representation that is stored in `Edge`. This
-    /// could lead to incorrect results, as the caller could provide vertices
-    /// that don't actually lie on `curve`.
-    ///
-    /// The good news is, that whole thing seems to be unnecessary. Or rather,
-    /// this whole method seems to be unnecessary. I reviewed all the call
-    /// sites, and in all cases, there seems to be a better way to construct the
-    /// `Edge`, without using this constructor.
-    ///
-    /// Ideally, we'd just fix all those call sites and remove this method, to
-    /// completely avoid the potential for any bugs to occur here. Problem is,
-    /// some of those call sites can't be fixed easily, without building further
-    /// infrastructure. Here's one such piece of infrastructure, for which an
-    /// issue already exists:
-    /// <https://github.com/hannobraun/Fornjot/issues/399>
-    pub fn new_obsolete(
-        curve: Handle<Curve<3>>,
-        vertices: Option<[Handle<Vertex>; 2]>,
-    ) -> Self {
-        let curve = LocalForm::canonical_only(curve);
-
-        let vertices = vertices.map(|vertices| {
-            vertices.map(|canonical| {
-                let local = curve
-                    .canonical()
-                    .get()
-                    .point_to_curve_coords(canonical.get().point())
-                    .local();
-                LocalForm::new(local, canonical)
-            })
-        });
-
-        Self { curve, vertices }
-    }
-
     /// Build an edge using the [`EdgeBuilder`] API
     pub fn builder(shape: &mut Shape) -> EdgeBuilder {
         EdgeBuilder::new(shape)

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -113,7 +113,7 @@ fn add_cycle(
             vs
         });
 
-        let edge = shape.merge(Edge::new(curve, vertices))?;
+        let edge = shape.merge(Edge::new_obsolete(curve, vertices))?;
         edges.push(edge);
     }
 


### PR DESCRIPTION
The constructor was problematic, because it projected the edge vertices into the curve to create the local form of the vertices, without checking whether those points lie on the curve. I also had some other concerns regarding floating point accuracy issues in the computation of these surface coordinates, but I'm not sure whether those concerns where well-founded.

In any case, the new constructors accepts the canonical and the local forms of the vertices. It doesn't verify them directly, but geometric validation will later ensure that they match.