### PR TITLE
Improve error handling in `fj-viewer`

### DIFF
--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -100,7 +100,7 @@ impl Transform {
         ))
     }
 
-    /// Project transform according to camera specfication, return data as an array.
+    /// Project transform according to camera specification, return data as an array.
     /// Used primarily for graphics code.
     pub fn project_to_array(
         &self,

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -110,14 +110,13 @@ impl Transform {
         zfar: f64,
     ) -> [Scalar; 16] {
         let projection = Perspective3::new(aspect_ratio, fovy, znear, zfar);
-        (projection.to_projective() * self.0)
-            .matrix()
-            .as_slice()
-            .iter()
-            .map(|f| Scalar::from(*f))
-            .collect::<Vec<Scalar>>()
-            .try_into()
-            .unwrap()
+
+        let mut array = [0.; 16];
+        array.copy_from_slice(
+            (projection.to_projective() * self.0).matrix().as_slice(),
+        );
+
+        array.map(Scalar::from)
     }
 
     /// Transform the given axis-aligned bounding box

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -46,7 +46,7 @@ impl Renderer {
     ///
     /// // Create window
     /// let event_loop = winit::event_loop::EventLoop::new();
-    /// let window = window::Window::new(&event_loop);
+    /// let window = window::Window::new(&event_loop).unwrap();
     ///
     /// // Attach renderer to the window
     /// let mut renderer = graphics::Renderer::new(&window);

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -347,7 +347,7 @@ pub enum InitError {
 
 /// Graphics rendering error
 ///
-/// Describes errors related to non intialization graphics errors.
+/// Describes errors related to non initialization graphics errors.
 #[derive(Error, Debug)]
 pub enum DrawError {
     #[error("Error acquiring output surface: {0}")]

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -47,18 +47,22 @@ pub fn run(
         let now = Instant::now();
 
         if let Some(new_shape) = watcher.receive() {
-            let new_shape = shape_processor.process(&new_shape).unwrap();
-            renderer.update_geometry(
-                (&new_shape.mesh).into(),
-                (&new_shape.debug_info).into(),
-                new_shape.aabb,
-            );
+            match shape_processor.process(&new_shape) {
+                Ok(new_shape) => {
+                    renderer.update_geometry(
+                        (&new_shape.mesh).into(),
+                        (&new_shape.debug_info).into(),
+                        new_shape.aabb,
+                    );
 
-            if camera.is_none() {
-                camera = Some(Camera::new(&new_shape.aabb));
+                    if camera.is_none() {
+                        camera = Some(Camera::new(&new_shape.aabb));
+                    }
+
+                    shape = Some(new_shape);
+                }
+                Err(err) => println!("Shape processing error: {}", err),
             }
-
-            shape = Some(new_shape);
         }
 
         match event {

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -27,7 +27,7 @@ pub fn run(
     shape_processor: ShapeProcessor,
 ) -> Result<(), graphics::InitError> {
     let event_loop = EventLoop::new();
-    let window = Window::new(&event_loop);
+    let window = Window::new(&event_loop).unwrap();
 
     let mut previous_time = Instant::now();
 

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -18,7 +18,7 @@ use crate::{
     camera::Camera,
     graphics::{self, DrawConfig, Renderer},
     input,
-    window::Window,
+    window::{self, Window},
 };
 
 /// Initializes a model viewer for a given model and enters its process loop.
@@ -27,7 +27,7 @@ pub fn run(
     shape_processor: ShapeProcessor,
 ) -> Result<(), Error> {
     let event_loop = EventLoop::new();
-    let window = Window::new(&event_loop).unwrap();
+    let window = Window::new(&event_loop)?;
 
     let mut previous_time = Instant::now();
 
@@ -163,6 +163,10 @@ pub fn run(
 /// Error in main loop
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Error initializing window
+    #[error("Error initializing window")]
+    WindowInit(#[from] window::Error),
+
     /// Error initializing graphics
     #[error("Error initializing graphics")]
     GraphicsInit(#[from] graphics::InitError),

--- a/crates/fj-viewer/src/run.rs
+++ b/crates/fj-viewer/src/run.rs
@@ -25,7 +25,7 @@ use crate::{
 pub fn run(
     watcher: Watcher,
     shape_processor: ShapeProcessor,
-) -> Result<(), graphics::InitError> {
+) -> Result<(), Error> {
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop).unwrap();
 
@@ -158,4 +158,12 @@ pub fn run(
             draw_config.draw_debug = !draw_config.draw_debug;
         }
     });
+}
+
+/// Error in main loop
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error initializing graphics
+    #[error("Error initializing graphics")]
+    GraphicsInit(#[from] graphics::InitError),
 }

--- a/crates/fj-viewer/src/window.rs
+++ b/crates/fj-viewer/src/window.rs
@@ -13,16 +13,15 @@ impl Window {
     /// let event_loop = winit::event_loop::EventLoop::new();
     /// let window = fj_viewer::window::Window::new(&event_loop);
     /// ```
-    pub fn new(event_loop: &EventLoop<()>) -> Self {
+    pub fn new(event_loop: &EventLoop<()>) -> Result<Self, Error> {
         let window = WindowBuilder::new()
             .with_title("Fornjot")
             .with_maximized(true)
             .with_decorations(true)
             .with_transparent(false)
-            .build(event_loop)
-            .unwrap();
+            .build(event_loop)?;
 
-        Self(window)
+        Ok(Self(window))
     }
 
     /// Returns a shared reference to the wrapped window
@@ -40,3 +39,8 @@ impl Window {
         self.0.inner_size().height
     }
 }
+
+/// Error initializing window
+#[derive(Debug, thiserror::Error)]
+#[error("Error initializing window")]
+pub struct Error(#[from] pub winit::error::OsError);


### PR DESCRIPTION
Shape processing errors will no longer cause a panic.