### PR TITLE
Improve handling of panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         .get("outer")
         .unwrap_or(&"1.0".to_owned())
         .parse()
-        .unwrap();
+        .expect("Could not parse parameter `outer`");
     let inner = args
         .get("inner")
         .unwrap_or(&"0.5".to_owned())
         .parse()
-        .unwrap();
+        .expect("Could not parse parameter `inner`");
     let height = args
         .get("height")
         .unwrap_or(&"1.0".to_owned())
         .parse()
-        .unwrap();
+        .expect("Could not parse parameter `height`");
 
     let outer_edge = fj::Circle::from_radius(outer);
     let inner_edge = fj::Circle::from_radius(inner);

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -53,7 +53,9 @@ impl Model {
             // Can't panic. It only would, if the path ends with "..", and we
             // are canonicalizing it here to prevent that.
             let canonical = path.canonicalize()?;
-            let file_name = canonical.file_name().unwrap();
+            let file_name = canonical
+                .file_name()
+                .expect("Expected path to be canonical");
 
             file_name.to_string_lossy().replace('-', "_")
         };
@@ -181,9 +183,8 @@ impl Model {
                     // is probably the result of a panic on that thread, or the
                     // application is being shut down.
                     //
-                    // Either way, not much we can do about it here, except
-                    // maybe to provide a better error message in the future.
-                    tx.send(()).unwrap();
+                    // Either way, not much we can do about it here.
+                    tx.send(()).expect("Channel is disconnected");
                 }
             },
         )?;
@@ -196,7 +197,7 @@ impl Model {
         //
         // Will panic, if the receiving end has panicked. Not much we can do
         // about that, if it happened.
-        thread::spawn(move || tx2.send(()).unwrap());
+        thread::spawn(move || tx2.send(()).expect("Channel is disconnected"));
 
         Ok(Watcher {
             _watcher: Box::new(watcher),

--- a/crates/fj-kernel/src/algorithms/approx/faces.rs
+++ b/crates/fj-kernel/src/algorithms/approx/faces.rs
@@ -93,7 +93,7 @@ mod tests {
     fn for_face_closed() -> anyhow::Result<()> {
         // Test a closed face, i.e. one that is completely encircled by edges.
 
-        let tolerance = Tolerance::from_scalar(Scalar::ONE).unwrap();
+        let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let mut shape = Shape::new();
 

--- a/crates/fj-kernel/src/algorithms/approx/tolerance.rs
+++ b/crates/fj-kernel/src/algorithms/approx/tolerance.rs
@@ -47,7 +47,8 @@ where
     S: Into<Scalar>,
 {
     fn from(scalar: S) -> Self {
-        Self::from_scalar(scalar).unwrap()
+        Self::from_scalar(scalar)
+            .expect("Tried to create `Tolerance` from invalid value")
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn sweep() -> anyhow::Result<()> {
-        let tolerance = Tolerance::from_scalar(Scalar::ONE).unwrap();
+        let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let sketch =
             Triangle::new([[0., 0., 0.], [1., 0., 0.], [0., 1., 0.]], false)?;

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -86,26 +86,40 @@ pub fn sweep_shape(
 
                 // Can't panic. We already ruled out the continuous edge case
                 // above, so this edge must have vertices.
-                let vertices_source =
-                    edge_source.get().vertices.clone().unwrap();
+                let vertices_source = edge_source
+                    .get()
+                    .vertices
+                    .clone()
+                    .expect("Expected edge to have vertices");
 
                 // Create (or retrieve from the cache, `vertex_bottom_to_edge`)
                 // side edges from the vertices of this source/bottom edge.
                 let [side_edge_a, side_edge_b] =
                     vertices_source.map(|vertex_source| {
+                        // Can't panic, unless this isn't actually a vertex from
+                        // `source`, we're using the wrong mapping, or the
+                        // mapping doesn't contain this vertex.
+                        //
+                        // All of these would be a bug.
                         let vertex_bottom = source_to_bottom
                             .vertices()
                             .get(&vertex_source.canonical())
-                            .unwrap()
+                            .expect("Could not find vertex in mapping")
                             .clone();
 
                         vertex_bottom_to_edge
                             .entry(vertex_bottom.clone())
                             .or_insert_with(|| {
+                                // Can't panic, unless this isn't actually a
+                                // vertex from `source`, we're using the wrong
+                                // mapping, or the mapping doesn't contain this
+                                // vertex.
+                                //
+                                // All of these would be a bug.
                                 let vertex_top = source_to_top
                                     .vertices()
                                     .get(&vertex_source.canonical())
-                                    .unwrap()
+                                    .expect("Could not find vertex in mapping")
                                     .clone();
 
                                 let points = [vertex_bottom, vertex_top]
@@ -121,10 +135,21 @@ pub fn sweep_shape(
                 // Now we have everything we need to create the side face from
                 // this source/bottom edge.
 
-                let bottom_edge =
-                    source_to_bottom.edges().get(&edge_source).unwrap().clone();
-                let top_edge =
-                    source_to_top.edges().get(&edge_source).unwrap().clone();
+                // Can't panic, unless this isn't actually an edge from
+                // `source`, we're using the wrong mappings, or the mappings
+                // don't contain this edge.
+                //
+                // All of these would be a bug.
+                let bottom_edge = source_to_bottom
+                    .edges()
+                    .get(&edge_source)
+                    .expect("Couldn't find edge in mapping")
+                    .clone();
+                let top_edge = source_to_top
+                    .edges()
+                    .get(&edge_source)
+                    .expect("Couldn't find edge in mapping")
+                    .clone();
 
                 let mut surface = Surface::SweptCurve(SweptCurve {
                     curve: bottom_edge.get().curve(),

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -34,7 +34,7 @@ pub fn sweep_shape(
             .update_all(|surface: &mut Surface| *surface = surface.reverse())
             .validate()?;
     }
-    transform_shape(&mut top, &translation);
+    transform_shape(&mut top, &translation)?;
 
     let mut target = Shape::new();
     target.merge_shape(&bottom)?;

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     geometry::{Curve, Surface},
-    shape::Shape,
+    shape::{Shape, ValidationError},
     topology::Face,
 };
 
@@ -10,7 +10,10 @@ use crate::{
 ///
 /// Since the topological types refer to geometry, and don't contain any
 /// geometry themselves, this transforms the whole shape.
-pub fn transform_shape(shape: &mut Shape, transform: &Transform) {
+pub fn transform_shape(
+    shape: &mut Shape,
+    transform: &Transform,
+) -> Result<(), ValidationError> {
     shape
         .update()
         .update_all(|point| *point = transform.transform_point(point))
@@ -26,6 +29,7 @@ pub fn transform_shape(shape: &mut Shape, transform: &Transform) {
                 }
             }
         })
-        .validate()
-        .unwrap();
+        .validate()?;
+
+    Ok(())
 }

--- a/crates/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -104,7 +104,7 @@ mod tests {
             .with_exterior_polygon([a, b, c, d])
             .build()?;
 
-        let triangles = triangulate(shape);
+        let triangles = triangulate(shape)?;
         assert!(triangles.contains_triangle([a, b, d]));
         assert!(triangles.contains_triangle([b, c, d]));
         assert!(!triangles.contains_triangle([a, b, c]));
@@ -132,7 +132,7 @@ mod tests {
             .with_interior_polygon([e, f, g, h])
             .build()?;
 
-        let triangles = triangulate(shape);
+        let triangles = triangulate(shape)?;
 
         // Should contain some triangles from the polygon. Don't need to test
         // them all.
@@ -148,10 +148,10 @@ mod tests {
         Ok(())
     }
 
-    fn triangulate(shape: Shape) -> Mesh<Point<3>> {
-        let tolerance = Tolerance::from_scalar(Scalar::ONE).unwrap();
+    fn triangulate(shape: Shape) -> anyhow::Result<Mesh<Point<3>>> {
+        let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let mut debug_info = DebugInfo::new();
-        super::triangulate(shape, tolerance, &mut debug_info)
+        Ok(super::triangulate(shape, tolerance, &mut debug_info))
     }
 }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -292,7 +292,7 @@ mod tests {
 
     use crate::{
         geometry::{Curve, Surface},
-        shape::{Handle, Shape, ValidationError},
+        shape::{Handle, Shape, ValidationError, ValidationResult},
         topology::{Cycle, Edge, Face, Vertex},
     };
 
@@ -378,7 +378,7 @@ mod tests {
         let mut shape = TestShape::new();
         let mut other = TestShape::new();
 
-        let curve = other.add_curve();
+        let curve = other.add_curve()?;
         let a = Vertex::builder(&mut other).build_from_point([1., 0., 0.])?;
         let b = Vertex::builder(&mut other).build_from_point([2., 0., 0.])?;
 
@@ -390,7 +390,7 @@ mod tests {
         assert!(err.missing_vertex(&a));
         assert!(err.missing_vertex(&b));
 
-        let curve = shape.add_curve();
+        let curve = shape.add_curve()?;
         let a = Vertex::builder(&mut shape).build_from_point([1., 0., 0.])?;
         let b = Vertex::builder(&mut shape).build_from_point([2., 0., 0.])?;
 
@@ -422,7 +422,7 @@ mod tests {
         let mut shape = TestShape::new();
         let mut other = TestShape::new();
 
-        let surface = other.add_surface();
+        let surface = other.add_surface()?;
         let cycle = other.add_cycle()?;
 
         // Nothing has been added to `shape`. Should fail.
@@ -437,7 +437,7 @@ mod tests {
         assert!(err.missing_surface(&surface));
         assert!(err.missing_cycle(&cycle));
 
-        let surface = shape.add_surface();
+        let surface = shape.add_surface()?;
         let cycle = shape.add_cycle()?;
 
         // Everything has been added to `shape` now. Should work!
@@ -464,12 +464,12 @@ mod tests {
             }
         }
 
-        fn add_curve(&mut self) -> Handle<Curve<3>> {
-            self.insert(Curve::x_axis()).unwrap()
+        fn add_curve(&mut self) -> ValidationResult<Curve<3>> {
+            self.insert(Curve::x_axis())
         }
 
-        fn add_surface(&mut self) -> Handle<Surface> {
-            self.insert(Surface::xy_plane()).unwrap()
+        fn add_surface(&mut self) -> ValidationResult<Surface> {
+            self.insert(Surface::xy_plane())
         }
 
         fn add_edge(&mut self) -> anyhow::Result<Handle<Edge<3>>> {

--- a/crates/fj-kernel/src/shape/stores.rs
+++ b/crates/fj-kernel/src/shape/stores.rs
@@ -201,7 +201,7 @@ impl<T: Object> Handle<T> {
             // Can't panic, unless the handle was invalid in the first place.
             // Objects are never removed from `Store`, so if we have a handle
             // pointing to it, it should be there.
-            .unwrap()
+            .expect("Invalid handle")
             .clone()
     }
 }

--- a/crates/fj-kernel/src/shape/update.rs
+++ b/crates/fj-kernel/src/shape/update.rs
@@ -112,6 +112,6 @@ impl<'r> Update<'r> {
 
 impl Drop for Update<'_> {
     fn drop(&mut self) {
-        self.validate_inner().unwrap();
+        self.validate_inner().expect("Dropped invalid update");
     }
 }

--- a/crates/fj-math/src/scalar.rs
+++ b/crates/fj-math/src/scalar.rs
@@ -115,7 +115,7 @@ impl Ord for Scalar {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         // Should never panic, as `from_f64` checks that the wrapped value is
         // finite.
-        self.partial_cmp(other).unwrap()
+        self.partial_cmp(other).expect("Invalid `Scalar`")
     }
 }
 

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -16,7 +16,7 @@ impl ToShape for fj::Transform {
         let mut shape = self.shape.to_shape(tolerance, debug_info)?;
         let transform = transform(self);
 
-        transform_shape(&mut shape, &transform);
+        transform_shape(&mut shape, &transform)?;
 
         Ok(shape)
     }

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -50,7 +50,7 @@ impl Camera {
                     // `reduce` can only return `None`, if there are no items in
                     // the iterator. And since we're creating an array full of
                     // items above, we know this can't panic.
-                    .unwrap();
+                    .expect("Array should have contained items");
 
             // The actual furthest point is not far enough. We don't want the
             // model to fill the whole screen.

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -2,9 +2,21 @@ use std::collections::HashMap;
 
 #[no_mangle]
 pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
-    let x: f64 = args.get("x").unwrap_or(&"3.0".to_owned()).parse().unwrap();
-    let y: f64 = args.get("y").unwrap_or(&"2.0".to_owned()).parse().unwrap();
-    let z: f64 = args.get("z").unwrap_or(&"1.0".to_owned()).parse().unwrap();
+    let x: f64 = args
+        .get("x")
+        .unwrap_or(&"3.0".to_owned())
+        .parse()
+        .expect("Could not parse parameter `x`");
+    let y: f64 = args
+        .get("y")
+        .unwrap_or(&"2.0".to_owned())
+        .parse()
+        .expect("Could not parse parameter `y`");
+    let z: f64 = args
+        .get("z")
+        .unwrap_or(&"1.0".to_owned())
+        .parse()
+        .expect("Could not parse parameter `z`");
 
     #[rustfmt::skip]
     let rectangle = fj::Sketch::from_points(vec![

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -8,17 +8,17 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
         .get("outer")
         .unwrap_or(&"1.0".to_owned())
         .parse()
-        .unwrap();
+        .expect("Could not parse parameter `outer`");
     let inner = args
         .get("inner")
         .unwrap_or(&"0.5".to_owned())
         .parse()
-        .unwrap();
+        .expect("Could not parse parameter `inner`");
     let height: f64 = args
         .get("height")
         .unwrap_or(&"1.0".to_owned())
         .parse()
-        .unwrap();
+        .expect("Could not parse parameter `height`");
 
     let outer_edge =
         fj::Circle::from_radius(outer).with_color([0, 0, 255, 255]);

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -9,23 +9,26 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
     // points, or vertices.
     let num_points: u64 = args
         .get("num_points")
-        .map(|arg| arg.parse().unwrap())
+        .map(|arg| arg.parse().expect("Could not parse parameter `num_points`"))
         .unwrap_or(5);
 
     // Radius of the circle that all the vertices between the pointy ends are on
     let r1: f64 = args
         .get("r1")
-        .map(|arg| arg.parse().unwrap())
+        .map(|arg| arg.parse().expect("Could not parse parameter `r1`"))
         .unwrap_or(1.0);
 
     // Radius of the circle that all the pointy ends are on
     let r2: f64 = args
         .get("r2")
-        .map(|arg| arg.parse().unwrap())
+        .map(|arg| arg.parse().expect("Could not parse parameter `r2`"))
         .unwrap_or(2.0);
 
     // The height of the star
-    let h: f64 = args.get("h").map(|arg| arg.parse().unwrap()).unwrap_or(1.0);
+    let h: f64 = args
+        .get("h")
+        .map(|arg| arg.parse().expect("Could not parse parameter `height`"))
+        .unwrap_or(1.0);
 
     // We need to figure out where to generate vertices, depending on the number
     // of points the star is supposed to have. Let's generate an iterator that


### PR DESCRIPTION
Improves the handling of panics all over the code base, by replacing some panics with errors, where that is practical, adding more documentations where panics should never happen, and replacing `unwrap` with `expect` for all such panics.