### PR TITLE
Provides two macros to make model creation more convenient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/fj-math",
     "crates/fj-operations",
     "crates/fj-viewer",
+    "crates/fj-proc",
 
     "crates/fj-window",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "models/cuboid",
     "models/spacer",
     "models/star",
+    "models/star_attributed_arguments",
     "models/test",
 
     "tools/export-validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,11 @@ members = [
     "crates/fj-math",
     "crates/fj-operations",
     "crates/fj-viewer",
+
     "crates/fj-window",
+
+    "crates/fj-proc",
+
 
     "models/cuboid",
     "models/spacer",

--- a/crates/fj-proc/Cargo.toml
+++ b/crates/fj-proc/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fj-proc"
+version = "0.6.0"
+edition = "2021"
+
+description = "The world needs another CAD program."
+readme = "../../README.md"
+homepage = "https://www.fornjot.app/"
+repository = "https://github.com/hannobraun/fornjot"
+license = "0BSD"
+keywords = ["cad", "programmatic", "code-cad"]
+categories = ["encoding", "mathematics", "rendering"]
+
+
+[lib]
+proc-macro = true
+
+[dependencies]
+serde = { version = "1.0.7", optional = true }
+syn={version="1.0",features=["full", "extra-traits"]}
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/crates/fj-proc/src/attributed_arguments.rs
+++ b/crates/fj-proc/src/attributed_arguments.rs
@@ -52,6 +52,11 @@ pub fn attributed_arguments(_: TokenStream, input: TokenStream) -> TokenStream {
         }.into()
 }
 
+/// Represents one parameter given to the `model`
+/// `#[value(default=3, min=4)] num_points: u64`
+/// `^^^^^^^^^^^^^^^^^^^^^^^^^^ ~~~~~~~~~~  ^^^-- ty`
+/// `           |                    |`
+/// `         attr                 ident`
 #[derive(Debug, Clone)]
 struct Argument {
     pub attr: HelperAttribute,
@@ -65,8 +70,8 @@ impl Parse for Argument {
         let ident: proc_macro2::Ident = input.parse()?;
 
         let _: syn::token::Colon = input.parse()?;
+
         let ty: proc_macro2::Ident = input.parse()?;
-        println!("attr: {:?}, ident: {:?}, ty: {:?}\n", attr, ident, ty);
         Ok(Self { attr, ident, ty })
     }
 }

--- a/crates/fj-proc/src/attributed_arguments.rs
+++ b/crates/fj-proc/src/attributed_arguments.rs
@@ -1,0 +1,212 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    bracketed, parenthesized, parse::Parse, parse_macro_input, parse_quote,
+};
+
+pub fn attributed_arguments(
+    _default_values: TokenStream,
+    input: TokenStream,
+) -> TokenStream {
+    let item = parse_macro_input!(input as syn::ItemFn);
+    let inputs = item.clone().sig.inputs;
+    let args: Vec<Argument> =
+        inputs.iter().map(|inp| parse_quote!(#inp)).collect();
+    let mut defaults = Vec::new();
+    let mut mins = Vec::new();
+    let mut maxs = Vec::new();
+    let mut names = Vec::new();
+    let mut types = Vec::new();
+    for arg in args {
+        let mut default = None;
+        let mut min = None;
+        let mut max = None;
+        names.push(arg.ident);
+        types.push(arg.ty);
+        for value in arg.attr.values.clone() {
+            if let Some(ident) = value.ident.clone() {
+                match ident.to_string().as_str() {
+                    "default" => default = Some(value.val.clone()),
+                    "min" => min = Some(value.val.clone()),
+                    "max" => max = Some(value.val.clone()),
+                    _ => {}
+                }
+            } else {
+                default = Some(value.val.clone());
+            }
+        }
+        let attr_param = AttributeParameter::new(default, min, max);
+        defaults.push(attr_param.default);
+        mins.push(attr_param.min);
+        maxs.push(attr_param.max);
+    }
+    let block = item.block;
+    println!(
+        "{}",
+        quote! {
+            #[no_mangle]
+            pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
+                #(
+                    let #names: #types = args.get(stringify!(#names)).map(|arg| arg.parse().unwrap()).unwrap_or(#defaults);
+                )*
+                #block
+            }
+        }
+    );
+    quote! {
+            #[no_mangle]
+            pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
+                #(
+                    let #names: #types = args.get(stringify!(#names)).map(|arg| arg.parse().unwrap()).unwrap_or(#defaults);
+                )*
+                #block
+            }
+        }.into()
+}
+
+#[derive(Debug, Clone)]
+struct Argument {
+    pub attr: HelperAttribute,
+    pub ident: proc_macro2::Ident,
+    pub ty: proc_macro2::Ident,
+}
+
+impl Parse for Argument {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let attr: HelperAttribute = input.parse()?;
+        let ident: proc_macro2::Ident = input.parse()?;
+
+        let _: syn::token::Colon = input.parse()?;
+        let ty: proc_macro2::Ident = input.parse()?;
+        println!("attr: {:?}, ident: {:?}, ty: {:?}\n", attr, ident, ty);
+        Ok(Self { attr, ident, ty })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HelperAttribute {
+    pub values: syn::punctuated::Punctuated<DefaultParam, syn::Token![,]>,
+}
+
+impl Parse for HelperAttribute {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let attr_content;
+        let value_content;
+        let _: syn::token::Pound = input.parse()?;
+        bracketed!(attr_content in input);
+        let ident: proc_macro2::Ident = attr_content.parse()?;
+        if ident.to_string() != *"value" {
+            return Err(syn::Error::new_spanned(
+                ident.clone(),
+                format!(
+                    "Unknown attribute \"{}\" found, expected \"value\"",
+                    ident
+                ),
+            ));
+        }
+        parenthesized!(value_content in attr_content);
+
+        Ok(Self {
+            values: syn::punctuated::Punctuated::parse_separated_nonempty_with(
+                &value_content,
+                DefaultParam::parse,
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DefaultParam {
+    pub ident: Option<proc_macro2::Ident>,
+    pub val: syn::Expr,
+}
+
+impl Parse for DefaultParam {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        if input.peek(syn::Ident) {
+            let ident: Option<proc_macro2::Ident> = Some(input.parse()?);
+            let _: syn::token::Eq = input.parse()?;
+            Ok(Self {
+                ident,
+                val: input.parse()?,
+            })
+        } else {
+            Ok(Self {
+                ident: None,
+                val: input.parse()?,
+            })
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AttributeParameter {
+    pub default: Option<syn::Expr>,
+    pub min: Option<syn::Expr>,
+    pub max: Option<syn::Expr>,
+}
+
+impl AttributeParameter {
+    // TODO: Checking the Options is quite ugly
+    pub fn new(
+        default: Option<syn::Expr>,
+        min: Option<syn::Expr>,
+        max: Option<syn::Expr>,
+    ) -> Self {
+        if let Some(default) = default {
+            let min = if min.is_some() { min } else { None };
+            let max = if max.is_some() { max } else { None };
+            Self {
+                default: Some(default),
+                min,
+                max,
+            }
+        } else {
+            let mut default = None;
+            let max = if max.is_some() {
+                default = max.clone();
+                max
+            } else {
+                None
+            };
+
+            let min = if min.is_some() {
+                default = min.clone();
+                min
+            } else {
+                None
+            };
+
+            Self { default, min, max }
+        }
+    }
+}
+
+// #[fj::model]
+// pub fn model(
+//     #[default(5)] num_points: u64,
+//     #[default(1.0)] r1: f64,
+//     #[default(2.0)] r2: f64,
+//     #[default(1.0)] h: f64,
+// ) -> fj::Shape
+
+// #[no_mangle]
+// pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
+//     let num_points: u64 = args
+//         .get("num_points")
+//         .map(|arg| arg.parse().unwrap())
+//         .unwrap_or(5);
+
+//     let r1: f64 = args
+//         .get("r1")
+//         .map(|arg| arg.parse().unwrap())
+//         .unwrap_or(1.0);
+
+//     let r2: f64 = args
+//         .get("r2")
+//         .map(|arg| arg.parse().unwrap())
+//         .unwrap_or(2.0);
+
+//     let h: f64 = args.get("h").map(|arg| arg.parse().unwrap()).unwrap_or(1.0);
+
+// }

--- a/crates/fj-proc/src/lib.rs
+++ b/crates/fj-proc/src/lib.rs
@@ -2,6 +2,8 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse_macro_input;
 
+mod attributed_arguments;
+
 #[proc_macro_attribute]
 pub fn model(default_values: TokenStream, input: TokenStream) -> TokenStream {
     let vals: Vec<String> = default_values
@@ -38,6 +40,14 @@ pub fn model(default_values: TokenStream, input: TokenStream) -> TokenStream {
                 #block
             }
         }.into()
+}
+
+#[proc_macro_attribute]
+pub fn attributed_arguments(
+    default_values: TokenStream,
+    input: TokenStream,
+) -> TokenStream {
+    attributed_arguments::attributed_arguments(default_values, input)
 }
 
 // #[fj_proc::model(5, 1.0, 2.0, 1.0)]

--- a/crates/fj-proc/src/lib.rs
+++ b/crates/fj-proc/src/lib.rs
@@ -1,0 +1,66 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+
+#[proc_macro_attribute]
+pub fn model(default_values: TokenStream, input: TokenStream) -> TokenStream {
+    let vals: Vec<String> = default_values
+        .into_iter()
+        .filter_map(|tree| {
+            if let proc_macro::TokenTree::Literal(lit) = tree {
+                Some(lit.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let item = parse_macro_input!(input as syn::ItemFn);
+
+    let inputs = item.sig.inputs;
+    let mut names = Vec::new();
+    let mut types = Vec::new();
+    for f in inputs.iter() {
+        if let syn::FnArg::Typed(meep) = f {
+            if let syn::Pat::Ident(ident) = *meep.clone().pat {
+                names.push(ident.ident);
+            }
+            if let syn::Type::Path(path) = *meep.clone().ty {
+                types.push(path.path.get_ident().unwrap().clone());
+            }
+        }
+    }
+    let block = item.block;
+
+    quote! {
+            #[no_mangle]
+            pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
+                #(let #names: #types = args.get(stringify!(#names)).map(|arg| arg.parse().unwrap()).unwrap_or(#vals.parse::<#types>().unwrap());)*
+                #block
+            }
+        }.into()
+}
+
+// #[fj_proc::model(5, 1.0, 2.0, 1.0)]
+// pub fn model(num_points: u64, r1: f64, r2: f64, h: f64) -> fj::Shape {
+// }
+
+// #[no_mangle]
+// pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
+//     let num_points: u64 = args
+//         .get("num_points")
+//         .map(|arg| arg.parse().unwrap())
+//         .unwrap_or(5);
+
+//     let r1: f64 = args
+//         .get("r1")
+//         .map(|arg| arg.parse().unwrap())
+//         .unwrap_or(1.0);
+
+//     let r2: f64 = args
+//         .get("r2")
+//         .map(|arg| arg.parse().unwrap())
+//         .unwrap_or(2.0);
+
+//     let h: f64 = args.get("h").map(|arg| arg.parse().unwrap()).unwrap_or(1.0);
+
+// }

--- a/models/star/Cargo.toml
+++ b/models/star/Cargo.toml
@@ -8,3 +8,6 @@ crate-type = ["cdylib"]
 
 [dependencies.fj]
 path = "../../crates/fj"
+
+[dependencies.fj-proc]
+path = "../../crates/fj-proc"

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -1,38 +1,9 @@
 use fj::Angle;
 use std::{collections::HashMap, f64::consts::PI};
+extern crate fj_proc;
 
-#[no_mangle]
-pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
-    // Number of points of the star
-    //
-    // "Points" in the sense of "pointy ends", not in the sense of geometrical
-    // points, or vertices.
-    let num_points: u64 = args
-        .get("num_points")
-        .map(|arg| arg.parse().expect("Could not parse parameter `num_points`"))
-        .unwrap_or(5);
-
-    // Radius of the circle that all the vertices between the pointy ends are on
-    let r1: f64 = args
-        .get("r1")
-        .map(|arg| arg.parse().expect("Could not parse parameter `r1`"))
-        .unwrap_or(1.0);
-
-    // Radius of the circle that all the pointy ends are on
-    let r2: f64 = args
-        .get("r2")
-        .map(|arg| arg.parse().expect("Could not parse parameter `r2`"))
-        .unwrap_or(2.0);
-
-    // The height of the star
-    let h: f64 = args
-        .get("h")
-        .map(|arg| arg.parse().expect("Could not parse parameter `height`"))
-        .unwrap_or(1.0);
-
-    // We need to figure out where to generate vertices, depending on the number
-    // of points the star is supposed to have. Let's generate an iterator that
-    // gives us the angle and radius for each vertex.
+#[fj_proc::model(5, 1.0, 2.0, 1.0)]
+pub fn model(num_points: u64, r1: f64, r2: f64, h: f64) -> fj::Shape {
     let num_vertices = num_points * 2;
     let vertex_iter = (0..num_vertices).map(|i| {
         let angle = Angle::from_rad(2. * PI / num_vertices as f64 * i as f64);
@@ -59,7 +30,7 @@ pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
 
     let footprint = fj::Difference2d::from_shapes([outer.into(), inner.into()]);
 
-    let star = fj::Sweep::from_path(footprint.into(), [0., 0., h]);
+    let star = fj::Sweep::from_path(footprint.into(), [0., 0., -h]);
 
     star.into()
 }

--- a/models/star_attributed_arguments/Cargo.toml
+++ b/models/star_attributed_arguments/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "star_attributed_arguments"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies.fj]
+path = "../../crates/fj"
+
+[dependencies.fj-proc]
+path = "../../crates/fj-proc"

--- a/models/star_attributed_arguments/src/lib.rs
+++ b/models/star_attributed_arguments/src/lib.rs
@@ -1,0 +1,41 @@
+use fj::Angle;
+use std::{collections::HashMap, f64::consts::PI};
+extern crate fj_proc;
+
+#[fj_proc::attributed_arguments]
+pub fn model(
+    #[value(default = 5, min = 3, max = 100)] num_points: u64,
+    #[value(default = 1.0, min = 1.0)] r1: f64,
+    #[value(min = 2.0)] r2: f64,
+    #[value(1.0)] h: f64,
+) -> fj::Shape {
+    let num_vertices = num_points * 2;
+    let vertex_iter = (0..num_vertices).map(|i| {
+        let angle = Angle::from_rad(2. * PI / num_vertices as f64 * i as f64);
+        let radius = if i % 2 == 0 { r1 } else { r2 };
+        (angle, radius)
+    });
+
+    // Now that we got that iterator prepared, generating the vertices is just a
+    // bit of trigonometry.
+    let mut outer = Vec::new();
+    let mut inner = Vec::new();
+    for (angle, radius) in vertex_iter {
+        let (sin, cos) = angle.rad().sin_cos();
+
+        let x = cos * radius;
+        let y = sin * radius;
+
+        outer.push([x, y]);
+        inner.push([x / 2., y / 2.]);
+    }
+
+    let outer = fj::Sketch::from_points(outer);
+    let inner = fj::Sketch::from_points(inner);
+
+    let footprint = fj::Difference2d::from_shapes([outer.into(), inner.into()]);
+
+    let star = fj::Sweep::from_path(footprint.into(), [0., 0., -h]);
+
+    star.into()
+}


### PR DESCRIPTION
An initial PR to get this rolling.

This PR deals with #72. Where `attributed_arguments` is a crude implementation of an idea https://github.com/hannobraun/Fornjot/issues/72#issuecomment-1138387203

The attribute `#[value()]` is required for each parameter the user wants to pass to the model it accepts different forms
- `#[value(3)]` sets default value to 3
- `#[value(default=3)]` same as above
min and max can additionally be supplied like this:
`#[value(min=1, max=2)]`
As long as either one of the three values is supplied a default will be set, min and max are currently only used if no default is provided to set it. Where min takes precedence over max.
Later on a doc comment containing the provided min and max values should be introduced.