### PR TITLE
Fix camera rotation around focus point

### DIFF
--- a/crates/fj-viewer/src/input/rotation.rs
+++ b/crates/fj-viewer/src/input/rotation.rs
@@ -43,7 +43,7 @@ impl Rotation {
 
             let inv = trans.inverse();
 
-            camera.rotation = trans * rot_y * rot_x * inv * camera.rotation;
+            camera.rotation = camera.rotation * trans * rot_y * rot_x * inv;
         }
     }
 }


### PR DESCRIPTION
This fixes the remaining part of #18.

I've noticed a couple of possible further issues -

* The larger the rotation, the less intuitive the axis of rotation becomes. This is due to it being fixed to x/y axis rather than relative to `Camera` `rotation`.
* Whilst the transform in `Camera` is broken into `rotation` and `translation` matrices, the current implementation of `Rotation` does not guarantee `rotation` is an [orthogonal matrix (under heading Properties of the Transform Matrix)](http://fastgraph.com/makegames/3drotation/). 