### PR TITLE
Clean up sweep algorithm

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -21,10 +21,10 @@ pub fn sweep_shape(
 
     let (mut bottom, source_to_bottom) = source.clone_shape();
     let (mut top, source_to_top) = source.clone_shape();
-    let sweep_along_negative_direction =
+    let is_sweep_along_negative_direction =
         path.dot(&Vector::from([0., 0., 1.])) < Scalar::ZERO;
 
-    if sweep_along_negative_direction {
+    if is_sweep_along_negative_direction {
         reverse_surfaces(&mut top)?;
     } else {
         reverse_surfaces(&mut bottom)?;
@@ -150,7 +150,7 @@ pub fn sweep_shape(
                     curve: bottom_edge.get().curve(),
                     path,
                 });
-                if sweep_along_negative_direction {
+                if is_sweep_along_negative_direction {
                     surface = surface.reverse();
                 }
                 let surface = target.insert(surface)?;

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -25,14 +25,9 @@ pub fn sweep_shape(
         path.dot(&Vector::from([0., 0., 1.])) < Scalar::ZERO;
 
     if sweep_along_negative_direction {
-        top.update()
-            .update_all(|surface: &mut Surface| *surface = surface.reverse())
-            .validate()?;
+        reverse_surfaces(&mut top)?;
     } else {
-        bottom
-            .update()
-            .update_all(|surface: &mut Surface| *surface = surface.reverse())
-            .validate()?;
+        reverse_surfaces(&mut bottom)?;
     }
     transform_shape(&mut top, &translation)?;
 
@@ -178,6 +173,13 @@ pub fn sweep_shape(
     }
 
     Ok(target)
+}
+
+fn reverse_surfaces(shape: &mut Shape) -> Result<(), ValidationError> {
+    shape
+        .update()
+        .update_all(|surface: &mut Surface| *surface = surface.reverse())
+        .validate()
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -21,6 +21,8 @@ pub fn sweep_shape(
         path.dot(&Vector::from([0., 0., 1.])) < Scalar::ZERO;
     let translation = Transform::translation(path);
 
+    let mut target = Shape::new();
+
     let (mut bottom, source_to_bottom) = source.clone_shape();
     let (mut top, source_to_top) = source.clone_shape();
 
@@ -31,7 +33,6 @@ pub fn sweep_shape(
     }
     transform_shape(&mut top, &translation)?;
 
-    let mut target = Shape::new();
     target.merge_shape(&bottom)?;
     target.merge_shape(&top)?;
 

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use fj_math::{Transform, Triangle, Vector};
+use fj_math::{Scalar, Transform, Triangle, Vector};
 
 use crate::{
     geometry::{Surface, SweptCurve},
@@ -22,7 +22,7 @@ pub fn sweep_shape(
     let (mut bottom, source_to_bottom) = source.clone_shape();
     let (mut top, source_to_top) = source.clone_shape();
     let sweep_along_negative_direction =
-        path.dot(&Vector::from([0., 0., 1.])) < fj_math::Scalar::ZERO;
+        path.dot(&Vector::from([0., 0., 1.])) < Scalar::ZERO;
 
     if sweep_along_negative_direction {
         top.update()

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -17,12 +17,12 @@ pub fn sweep_shape(
     tolerance: Tolerance,
     color: [u8; 4],
 ) -> Result<Shape, ValidationError> {
+    let is_sweep_along_negative_direction =
+        path.dot(&Vector::from([0., 0., 1.])) < Scalar::ZERO;
     let translation = Transform::translation(path);
 
     let (mut bottom, source_to_bottom) = source.clone_shape();
     let (mut top, source_to_top) = source.clone_shape();
-    let is_sweep_along_negative_direction =
-        path.dot(&Vector::from([0., 0., 1.])) < Scalar::ZERO;
 
     if is_sweep_along_negative_direction {
         reverse_surfaces(&mut top)?;


### PR DESCRIPTION
This is a series of changes that separate the various parts of the sweep algorithm into dedicated functions, making the high-level logic more clear. This is preparation for changes to the sweep algorithm, that are going to be required to make progress on #568.