### PR TITLE
Improve proc macro `model`

### DIFF
--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -1,23 +1,11 @@
 use std::collections::HashMap;
 
-#[no_mangle]
-pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
-    let x: f64 = args
-        .get("x")
-        .unwrap_or(&"3.0".to_owned())
-        .parse()
-        .expect("Could not parse parameter `x`");
-    let y: f64 = args
-        .get("y")
-        .unwrap_or(&"2.0".to_owned())
-        .parse()
-        .expect("Could not parse parameter `y`");
-    let z: f64 = args
-        .get("z")
-        .unwrap_or(&"1.0".to_owned())
-        .parse()
-        .expect("Could not parse parameter `z`");
-
+#[fj::model]
+pub fn model(
+    #[value(default = 3.0)] x: f64,
+    #[value(default = 2.0)] y: f64,
+    #[value(default = 1.0)] z: f64,
+) -> fj::Shape {
     #[rustfmt::skip]
     let rectangle = fj::Sketch::from_points(vec![
         [-x / 2., -y / 2.],

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -2,24 +2,12 @@ use std::collections::HashMap;
 
 use fj::syntax::*;
 
-#[no_mangle]
-pub extern "C" fn model(args: &HashMap<String, String>) -> fj::Shape {
-    let outer = args
-        .get("outer")
-        .unwrap_or(&"1.0".to_owned())
-        .parse()
-        .expect("Could not parse parameter `outer`");
-    let inner = args
-        .get("inner")
-        .unwrap_or(&"0.5".to_owned())
-        .parse()
-        .expect("Could not parse parameter `inner`");
-    let height: f64 = args
-        .get("height")
-        .unwrap_or(&"1.0".to_owned())
-        .parse()
-        .expect("Could not parse parameter `height`");
-
+#[fj::model]
+pub fn model(
+    #[value(default = 1.0, min = inner * 1.01)] outer: f64,
+    #[value(default = 0.5, max = outer * 0.99)] inner: f64,
+    #[value(default = 1.0)] height: f64,
+) -> fj::Shape {
     let outer_edge = fj::Circle::from_radius(outer);
     let inner_edge = fj::Circle::from_radius(inner);
 

--- a/models/test/src/lib.rs
+++ b/models/test/src/lib.rs
@@ -2,8 +2,8 @@ use std::{collections::HashMap, f64::consts::PI};
 
 use fj::{syntax::*, Angle};
 
-#[no_mangle]
-pub extern "C" fn model(_: &HashMap<String, String>) -> fj::Shape {
+#[fj::model]
+pub fn model() -> fj::Shape {
     let a = star(4, [0, 255, 0, 200]);
     let b = star(5, [255, 0, 0, 255])
         .rotate([1., 1., 1.], Angle::from_deg(45.))


### PR DESCRIPTION
Make argument annotation optional and use macro for all example models.

(Side note: the arguments can refer to each other in their `min`/`max` attributes, this is due to the order of the generated code.
I think this is a nice feature and should be kept.)