### PR TITLE
Make it possible to assign labels to `Shape`s

### DIFF
--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -51,6 +51,26 @@ impl Shape {
         }
     }
 
+    /// Assign a label to the shape
+    ///
+    /// The assigned label will be part of the `Debug` representation of
+    /// `Handle`s, making it way easier to understand which `Handle`s belong to
+    /// which `Shape`.
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        let label = label.into();
+
+        self.stores.points.label = Some(label.clone());
+        self.stores.curves.label = Some(label.clone());
+        self.stores.surfaces.label = Some(label.clone());
+
+        self.stores.vertices.label = Some(label.clone());
+        self.stores.edges.label = Some(label.clone());
+        self.stores.cycles.label = Some(label.clone());
+        self.stores.faces.label = Some(label);
+
+        self
+    }
+
     /// Override the minimum distance between distinct objects
     ///
     /// Used for vertex validation, to determine whether vertices are unique.

--- a/crates/fj-kernel/src/shape/stores.rs
+++ b/crates/fj-kernel/src/shape/stores.rs
@@ -214,7 +214,10 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Handle").field(&self.get()).finish()
+        f.debug_struct("Handle")
+            .field("shape", &self.store.label.as_deref().unwrap_or("unnamed"))
+            .field("object", &self.get())
+            .finish()
     }
 }
 

--- a/crates/fj-kernel/src/shape/stores.rs
+++ b/crates/fj-kernel/src/shape/stores.rs
@@ -51,12 +51,14 @@ impl Stores {
 
 #[derive(Debug)]
 pub struct Store<T: Object> {
+    pub(super) label: Option<String>,
     objects: Arc<RwLock<Objects<T>>>,
 }
 
 impl<T: Object> Store<T> {
     pub fn new() -> Self {
         Self {
+            label: None,
             objects: Arc::new(RwLock::new(SlotMap::new())),
         }
     }
@@ -109,6 +111,7 @@ impl<T: Object> Store<T> {
 impl<T: Object> Clone for Store<T> {
     fn clone(&self) -> Self {
         Self {
+            label: self.label.clone().map(|label| format!("{} (clone)", label)),
             objects: self.objects.clone(),
         }
     }

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -76,6 +76,6 @@ pub enum Error {
     ToShape(#[from] ValidationError),
 
     /// Model has zero size
-    #[error("Model has an zero size")]
+    #[error("Model has zero size")]
     Extent(#[from] InvalidTolerance),
 }

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -68,6 +68,7 @@ pub struct ProcessedShape {
 }
 
 /// A shape processing error
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error converting to shape


### PR DESCRIPTION
This capability isn't yet used anywhere in the code base. It's a debugging feature, that allows for better insight into which `Handle`s belong to which `Shape`s.