### PR TITLE
Remove `Point<3>` objects from `Shape`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edges.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edges.rs
@@ -13,7 +13,7 @@ pub fn approximate_edge(
     // the same vertex would be understood to refer to very close, but distinct
     // vertices.
     let vertices = vertices.convert(|vertex| {
-        geometry::Point::new(*vertex.local(), vertex.canonical().get().point())
+        geometry::Point::new(*vertex.local(), vertex.canonical().get().point)
     });
     if let Some([a, b]) = vertices {
         points.insert(0, a);

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -231,7 +231,7 @@ fn create_side_cycle(
         }
 
         let points = [vertex_bottom.clone(), vertex_top]
-            .map(|vertex| vertex.canonical().get().point());
+            .map(|vertex| vertex.canonical().get().point);
 
         let edge =
             Edge::builder(target).build_line_segment_from_points(points)?;

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -16,7 +16,6 @@ pub fn transform_shape(
 ) -> Result<(), ValidationError> {
     shape
         .update()
-        .update_all(|point| *point = transform.transform_point(point))
         .update_all(|vertex: &mut Vertex| {
             vertex.point = transform.transform_point(&vertex.point)
         })

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -3,7 +3,7 @@ use fj_math::Transform;
 use crate::{
     geometry::{Curve, Surface},
     shape::{Shape, ValidationError},
-    topology::Face,
+    topology::{Face, Vertex},
 };
 
 /// Transform the geometry of the shape
@@ -17,6 +17,9 @@ pub fn transform_shape(
     shape
         .update()
         .update_all(|point| *point = transform.transform_point(point))
+        .update_all(|vertex: &mut Vertex| {
+            vertex.point = transform.transform_point(&vertex.point)
+        })
         .update_all(|curve: &mut Curve<3>| *curve = curve.transform(transform))
         .update_all(|surface: &mut Surface| {
             *surface = surface.transform(transform)

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -346,7 +346,7 @@ mod tests {
     }
 
     #[test]
-    fn add_vertex_uniqueness() -> anyhow::Result<()> {
+    fn add_vertex() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
         let point = Point::from([0., 0., 0.]);

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -1,4 +1,4 @@
-use fj_math::{Point, Scalar};
+use fj_math::Scalar;
 
 use crate::{
     geometry::{Curve, Surface},
@@ -39,7 +39,6 @@ impl Shape {
             identical_max_distance: Scalar::from_f64(5e-14),
 
             stores: Stores {
-                points: Store::new(),
                 curves: Store::new(),
                 surfaces: Store::new(),
 
@@ -59,7 +58,6 @@ impl Shape {
     pub fn with_label(mut self, label: impl Into<String>) -> Self {
         let label = label.into();
 
-        self.stores.points.label = Some(label.clone());
         self.stores.curves.label = Some(label.clone());
         self.stores.surfaces.label = Some(label.clone());
 
@@ -166,9 +164,6 @@ impl Shape {
     ) -> Result<Mapping, ValidationError> {
         let mut mapping = Mapping::new();
 
-        for object in other.points() {
-            object.get().merge_into(Some(object), self, &mut mapping)?;
-        }
         for object in other.curves() {
             object.get().merge_into(Some(object), self, &mut mapping)?;
         }
@@ -216,10 +211,6 @@ impl Shape {
         let mut target = Shape::new();
         let mut mapping = Mapping::new();
 
-        for original in self.points() {
-            let cloned = target.merge(original.get())?;
-            mapping.points.insert(original, cloned);
-        }
         for original in self.curves() {
             let cloned = target.merge(original.get())?;
             mapping.curves.insert(original, cloned);
@@ -246,13 +237,6 @@ impl Shape {
         }
 
         Ok((target, mapping))
-    }
-
-    /// Access an iterator over all points
-    ///
-    /// The caller must not make any assumptions about the order of points.
-    pub fn points(&self) -> Iter<Point<3>> {
-        self.stores.points.iter()
     }
 
     /// Access an iterator over all curves
@@ -316,8 +300,6 @@ mod tests {
         topology::{Cycle, Edge, Face, Vertex, VerticesOfEdge},
     };
 
-    const MIN_DISTANCE: f64 = 5e-7;
-
     #[test]
 
     fn get_handle() -> anyhow::Result<()> {
@@ -327,7 +309,6 @@ mod tests {
         let curve = Curve::x_axis();
         let surface = Surface::xy_plane();
 
-        assert!(shape.get_handle(&point).is_none());
         assert!(shape.get_handle(&curve).is_none());
         assert!(shape.get_handle(&surface).is_none());
 
@@ -360,24 +341,6 @@ mod tests {
 
         let face = shape.insert(face)?;
         assert!(shape.get_handle(&face.get()).as_ref() == Some(&face));
-
-        Ok(())
-    }
-
-    #[test]
-    fn add_point() -> anyhow::Result<()> {
-        let mut shape = Shape::new().with_distinct_min_distance(MIN_DISTANCE);
-
-        // Add the original point.
-        shape.insert(Point::from([0., 0., 0.]))?;
-
-        // `point` is too close to the original point.
-        let result = shape.insert(Point::from([5e-8, 0., 0.]));
-        assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
-
-        // `point` is farther than `MIN_DISTANCE` away from original point.
-        // Should work.
-        shape.insert(Point::from([5e-6, 0., 0.]))?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -331,11 +331,9 @@ mod tests {
         assert!(shape.get_handle(&curve).is_none());
         assert!(shape.get_handle(&surface).is_none());
 
-        let point = shape.insert(point)?;
         let curve = shape.insert(curve)?;
         let surface = shape.insert(surface)?;
 
-        assert!(shape.get_handle(&point.get()).as_ref() == Some(&point));
         assert!(shape.get_handle(&curve.get()).as_ref() == Some(&curve));
         assert!(shape.get_handle(&surface.get()).as_ref() == Some(&surface));
 
@@ -385,28 +383,13 @@ mod tests {
     }
 
     #[test]
-    fn add_vertex_structural() -> anyhow::Result<()> {
-        let mut shape = Shape::new().with_distinct_min_distance(MIN_DISTANCE);
-        let mut other = Shape::new();
-
-        // Should fail, as `point` is not part of the shape.
-        let point = other.insert(Point::from([0., 0., 0.]))?;
-        let result = shape.insert(Vertex { point });
-        assert!(matches!(result, Err(ValidationError::Structural(_))));
-
-        Ok(())
-    }
-
-    #[test]
     fn add_vertex_uniqueness() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
-        let point = shape.insert(Point::from([0., 0., 0.]))?;
+        let point = Point::from([0., 0., 0.]);
 
         // Adding a vertex should work.
-        shape.insert(Vertex {
-            point: point.clone(),
-        })?;
+        shape.insert(Vertex { point })?;
 
         // Adding a second vertex with the same point should fail.
         let result = shape.insert(Vertex { point });

--- a/crates/fj-kernel/src/shape/mapping.rs
+++ b/crates/fj-kernel/src/shape/mapping.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use fj_math::Point;
-
 use crate::{
     geometry::{Curve, Surface},
     topology::{Cycle, Edge, Face, Vertex},
@@ -11,7 +9,6 @@ use super::Handle;
 
 /// A mapping between objects in different shapes
 pub struct Mapping {
-    pub(super) points: OneMapping<Point<3>>,
     pub(super) curves: OneMapping<Curve<3>>,
     pub(super) surfaces: OneMapping<Surface>,
     pub(super) vertices: OneMapping<Vertex>,
@@ -23,7 +20,6 @@ pub struct Mapping {
 impl Mapping {
     pub(super) fn new() -> Self {
         Self {
-            points: OneMapping::new(),
             curves: OneMapping::new(),
             surfaces: OneMapping::new(),
             vertices: OneMapping::new(),
@@ -31,18 +27,6 @@ impl Mapping {
             cycles: OneMapping::new(),
             faces: OneMapping::new(),
         }
-    }
-
-    /// Access the point mapped from the provided point
-    ///
-    /// # Panics
-    ///
-    /// Panics, if `object` can not be found in the mapping.
-    pub fn point(&self, object: &Handle<Point<3>>) -> Handle<Point<3>> {
-        self.points
-            .get(object)
-            .expect("Could not find point in mapping")
-            .clone()
     }
 
     /// Access the curve mapped from the provided curve

--- a/crates/fj-kernel/src/shape/mod.rs
+++ b/crates/fj-kernel/src/shape/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     stores::{Handle, Iter},
     update::Update,
     validate::{
-        DuplicateEdge, DuplicatePoint, EdgeVertexMismatch, GeometricIssues,
-        StructuralIssues, UniquenessIssues, ValidationError, ValidationResult,
+        DuplicateEdge, EdgeVertexMismatch, GeometricIssues, StructuralIssues,
+        UniquenessIssues, ValidationError, ValidationResult,
     },
 };

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -92,9 +92,8 @@ impl Object for Vertex {
         shape: &mut Shape,
         mapping: &mut Mapping,
     ) -> ValidationResult<Self> {
-        let point =
-            self.point().merge_into(Some(self.point), shape, mapping)?;
-        let merged = shape.get_handle_or_insert(Vertex { point })?;
+        let merged =
+            shape.get_handle_or_insert(Vertex { point: self.point })?;
 
         if let Some(handle) = handle {
             mapping.vertices.insert(handle, merged.clone());

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -1,5 +1,3 @@
-use fj_math::Point;
-
 use crate::{
     geometry::{Curve, Surface},
     topology::{Cycle, Edge, Face, Vertex, VerticesOfEdge},
@@ -25,7 +23,6 @@ pub trait Object:
     ) -> ValidationResult<Self>;
 }
 
-impl private::Sealed for Point<3> {}
 impl private::Sealed for Curve<3> {}
 impl private::Sealed for Surface {}
 
@@ -33,23 +30,6 @@ impl private::Sealed for Vertex {}
 impl private::Sealed for Edge<3> {}
 impl private::Sealed for Cycle<3> {}
 impl private::Sealed for Face {}
-
-impl Object for Point<3> {
-    fn merge_into(
-        self,
-        handle: Option<Handle<Self>>,
-        shape: &mut Shape,
-        mapping: &mut Mapping,
-    ) -> ValidationResult<Self> {
-        let merged = shape.get_handle_or_insert(self)?;
-
-        if let Some(handle) = handle {
-            mapping.points.insert(handle, merged.clone());
-        }
-
-        Ok(merged)
-    }
-}
 
 impl Object for Curve<3> {
     fn merge_into(

--- a/crates/fj-kernel/src/shape/stores.rs
+++ b/crates/fj-kernel/src/shape/stores.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use anymap::AnyMap;
-use fj_math::Point;
 use parking_lot::{RwLock, RwLockReadGuard};
 use slotmap::{DefaultKey, SlotMap};
 
@@ -18,7 +17,6 @@ use super::Object;
 
 #[derive(Clone, Debug)]
 pub struct Stores {
-    pub points: Store<Point<3>>,
     pub curves: Store<Curve<3>>,
     pub surfaces: Store<Surface>,
 
@@ -32,7 +30,6 @@ impl Stores {
     pub fn get<T: Object>(&self) -> Store<T> {
         let mut stores = AnyMap::new();
 
-        stores.insert(self.points.clone());
         stores.insert(self.curves.clone());
         stores.insert(self.surfaces.clone());
 

--- a/crates/fj-kernel/src/shape/update.rs
+++ b/crates/fj-kernel/src/shape/update.rs
@@ -48,14 +48,6 @@ impl<'r> Update<'r> {
 
             // Validating every single object is certainly not ideal from a
             // performance perspective, but it will do for now.
-            for object in self.stores.points.iter() {
-                object.get().validate(
-                    Some(&object),
-                    self.min_distance,
-                    self.max_distance,
-                    self.stores,
-                )?;
-            }
             for object in self.stores.curves.iter() {
                 object.get().validate(
                     Some(&object),

--- a/crates/fj-kernel/src/shape/validate/geometric.rs
+++ b/crates/fj-kernel/src/shape/validate/geometric.rs
@@ -19,7 +19,7 @@ pub fn validate_edge(
     for vertex in edge.vertices.iter() {
         let local = *vertex.local();
         let local_3d = edge.curve().point_from_curve_coords(local);
-        let canonical = vertex.canonical().get().point();
+        let canonical = vertex.canonical().get().point;
         let distance = (local_3d - canonical).magnitude();
 
         if distance > max_distance {

--- a/crates/fj-kernel/src/shape/validate/mod.rs
+++ b/crates/fj-kernel/src/shape/validate/mod.rs
@@ -5,10 +5,10 @@ mod uniqueness;
 pub use self::{
     geometric::{EdgeVertexMismatch, GeometricIssues},
     structural::StructuralIssues,
-    uniqueness::{DuplicateEdge, DuplicatePoint, UniquenessIssues},
+    uniqueness::{DuplicateEdge, UniquenessIssues},
 };
 
-use fj_math::{Point, Scalar};
+use fj_math::Scalar;
 
 use crate::{
     geometry::{Curve, Surface},
@@ -27,25 +27,6 @@ pub trait Validate {
     ) -> Result<(), ValidationError>
     where
         Self: Object;
-}
-
-impl Validate for Point<3> {
-    fn validate(
-        &self,
-        handle: Option<&Handle<Self>>,
-        min_distance: Scalar,
-        _: Scalar,
-        stores: &Stores,
-    ) -> Result<(), ValidationError> {
-        uniqueness::validate_point(
-            *self,
-            handle,
-            min_distance,
-            &stores.points,
-        )?;
-
-        Ok(())
-    }
 }
 
 impl Validate for Curve<3> {

--- a/crates/fj-kernel/src/shape/validate/mod.rs
+++ b/crates/fj-kernel/src/shape/validate/mod.rs
@@ -86,7 +86,6 @@ impl Validate for Vertex {
         _: Scalar,
         stores: &Stores,
     ) -> Result<(), ValidationError> {
-        structural::validate_vertex(self, stores)?;
         uniqueness::validate_vertex(self, handle, &stores.vertices)?;
 
         Ok(())

--- a/crates/fj-kernel/src/shape/validate/structural.rs
+++ b/crates/fj-kernel/src/shape/validate/structural.rs
@@ -8,20 +8,6 @@ use crate::{
     topology::{Cycle, Edge, Face, Vertex},
 };
 
-pub fn validate_vertex(
-    vertex: &Vertex,
-    stores: &Stores,
-) -> Result<(), StructuralIssues> {
-    if !stores.points.contains(&vertex.point) {
-        return Err(StructuralIssues {
-            missing_point: Some(vertex.point.clone()),
-            ..StructuralIssues::default()
-        });
-    }
-
-    Ok(())
-}
-
 pub fn validate_edge(
     edge: &Edge<3>,
     stores: &Stores,

--- a/crates/fj-kernel/src/shape/validate/structural.rs
+++ b/crates/fj-kernel/src/shape/validate/structural.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashSet, fmt};
 
-use fj_math::Point;
-
 use crate::{
     geometry::{Curve, Surface},
     shape::{stores::Stores, Handle},
@@ -94,9 +92,6 @@ pub fn validate_face(
 /// Used by [`ValidationError`].
 #[derive(Debug, Default, thiserror::Error)]
 pub struct StructuralIssues {
-    /// Missing point found in vertex validation
-    pub missing_point: Option<Handle<Point<3>>>,
-
     /// Missing curve found in edge validation
     pub missing_curve: Option<Handle<Curve<3>>>,
 
@@ -117,9 +112,6 @@ impl fmt::Display for StructuralIssues {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Structural issues found:")?;
 
-        if let Some(point) = &self.missing_point {
-            writeln!(f, "- Missing point: {:?}", point.get())?;
-        }
         if let Some(curve) = &self.missing_curve {
             writeln!(f, "- Missing curve: {:?}", curve.get())?;
         }

--- a/crates/fj-kernel/src/shape/validate/uniqueness.rs
+++ b/crates/fj-kernel/src/shape/validate/uniqueness.rs
@@ -1,38 +1,9 @@
 use std::fmt;
 
-use fj_math::{Point, Scalar};
-
 use crate::{
     shape::{stores::Store, Handle},
     topology::{Edge, Vertex},
 };
-
-pub fn validate_point(
-    point: Point<3>,
-    handle: Option<&Handle<Point<3>>>,
-    min_distance: Scalar,
-    points: &Store<Point<3>>,
-) -> Result<(), UniquenessIssues> {
-    for existing in points.iter() {
-        if Some(&existing) == handle {
-            continue;
-        }
-
-        let distance = (existing.get() - point).magnitude();
-        if distance < min_distance {
-            return Err(UniquenessIssues {
-                duplicate_point: Some(DuplicatePoint {
-                    existing,
-                    new: point,
-                    distance,
-                }),
-                ..UniquenessIssues::default()
-            });
-        }
-    }
-
-    Ok(())
-}
 
 pub fn validate_vertex(
     vertex: &Vertex,
@@ -99,9 +70,6 @@ pub fn validate_edge(
 /// [`ValidationError`]: super::ValidationError
 #[derive(Debug, Default, thiserror::Error)]
 pub struct UniquenessIssues {
-    /// Duplicate point found
-    pub duplicate_point: Option<DuplicatePoint>,
-
     /// Duplicate vertex found
     pub duplicate_vertex: Option<Handle<Vertex>>,
 
@@ -113,10 +81,6 @@ impl fmt::Display for UniquenessIssues {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Uniqueness issues found:")?;
 
-        if let Some(duplicate_point) = &self.duplicate_point {
-            writeln!(f, "- Duplicate point ({})", duplicate_point)?;
-        }
-
         if let Some(duplicate_vertex) = &self.duplicate_vertex {
             writeln!(f, "- Duplicate vertex ({:?}", duplicate_vertex)?;
         }
@@ -126,31 +90,6 @@ impl fmt::Display for UniquenessIssues {
         }
 
         Ok(())
-    }
-}
-
-/// A duplicate point
-///
-/// Used in [`UniquenessIssues`].
-#[derive(Debug)]
-pub struct DuplicatePoint {
-    /// The existing point
-    pub existing: Handle<Point<3>>,
-
-    /// The new point
-    pub new: Point<3>,
-
-    /// The distance between the vertices
-    pub distance: Scalar,
-}
-
-impl fmt::Display for DuplicatePoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "existing: {:?}, new: {:?}, distance: {}",
-            self.existing, self.new, self.distance
-        )
     }
 }
 

--- a/crates/fj-kernel/src/shape/validate/uniqueness.rs
+++ b/crates/fj-kernel/src/shape/validate/uniqueness.rs
@@ -15,7 +15,7 @@ pub fn validate_vertex(
             continue;
         }
 
-        if existing.get().point == vertex.point {
+        if &existing.get() == vertex {
             return Err(UniquenessIssues {
                 duplicate_vertex: Some(existing),
                 ..UniquenessIssues::default()

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -85,7 +85,7 @@ impl<'r> EdgeBuilder<'r> {
         [a, b]: [Handle<Vertex>; 2],
     ) -> ValidationResult<Edge<3>> {
         let curve = {
-            let points = [&a, &b].map(|vertex| vertex.get().point());
+            let points = [&a, &b].map(|vertex| vertex.get().point);
             let curve = Curve::Line(Line::from_points(points));
             self.shape.insert(curve)?
         };

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -27,7 +27,7 @@ impl<'r> VertexBuilder<'r> {
         self,
         point: impl Into<Point<3>>,
     ) -> ValidationResult<Vertex> {
-        let point = self.shape.get_handle_or_insert(point.into())?;
+        let point = point.into();
         let vertex = self.shape.get_handle_or_insert(Vertex { point })?;
 
         Ok(vertex)

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -75,7 +75,7 @@ impl<const D: usize> fmt::Display for Edge<D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.vertices() {
             Some(vertices) => {
-                let [a, b] = vertices.map(|vertex| vertex.point());
+                let [a, b] = vertices.map(|vertex| vertex.point);
                 write!(f, "edge from {:?} to {:?}", a, b)?
             }
             None => write!(f, "continuous edge")?,

--- a/crates/fj-kernel/src/topology/vertex.rs
+++ b/crates/fj-kernel/src/topology/vertex.rs
@@ -22,9 +22,9 @@ use super::VertexBuilder;
 ///
 /// # Validation
 ///
-/// Vertices must be unique within a shape, meaning another vertex defined by
-/// the same shape must not exist. In the context of vertex uniqueness, points
-/// that are close to each other are considered identical. The minimum distance
+/// Vertices must be unique within a shape, meaning an identical vertex must not
+/// exist in the same shape. In the context of vertex uniqueness, points that
+/// are close to each other are considered identical. The minimum distance
 /// between distinct vertices can be configured using
 /// [`Shape::with_minimum_distance`].
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/crates/fj-kernel/src/topology/vertex.rs
+++ b/crates/fj-kernel/src/topology/vertex.rs
@@ -30,7 +30,7 @@ use super::VertexBuilder;
 /// that are close to each other are considered identical. The minimum distance
 /// between distinct vertices can be configured using
 /// [`Shape::with_minimum_distance`].
-#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     /// The point that defines the location of the vertex
     pub point: Point<3>,
@@ -40,17 +40,5 @@ impl Vertex {
     /// Build a vertex using the [`VertexBuilder`] API
     pub fn builder(shape: &mut Shape) -> VertexBuilder {
         VertexBuilder::new(shape)
-    }
-}
-
-impl PartialEq for Vertex {
-    fn eq(&self, other: &Self) -> bool {
-        self.point == other.point
-    }
-}
-
-impl Hash for Vertex {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.point.hash(state);
     }
 }

--- a/crates/fj-kernel/src/topology/vertex.rs
+++ b/crates/fj-kernel/src/topology/vertex.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use fj_math::Point;
 
-use crate::shape::{Handle, Shape};
+use crate::shape::Shape;
 
 use super::VertexBuilder;
 
@@ -33,7 +33,7 @@ use super::VertexBuilder;
 #[derive(Clone, Debug, Eq, Ord, PartialOrd)]
 pub struct Vertex {
     /// The point that defines the location of the vertex
-    pub point: Handle<Point<3>>,
+    pub point: Point<3>,
 }
 
 impl Vertex {
@@ -47,7 +47,7 @@ impl Vertex {
     /// This is a convenience method that saves the caller from dealing with the
     /// [`Handle`].
     pub fn point(&self) -> Point<3> {
-        self.point.get()
+        self.point
     }
 }
 

--- a/crates/fj-kernel/src/topology/vertex.rs
+++ b/crates/fj-kernel/src/topology/vertex.rs
@@ -41,24 +41,16 @@ impl Vertex {
     pub fn builder(shape: &mut Shape) -> VertexBuilder {
         VertexBuilder::new(shape)
     }
-
-    /// Access the point that the vertex refers to
-    ///
-    /// This is a convenience method that saves the caller from dealing with the
-    /// [`Handle`].
-    pub fn point(&self) -> Point<3> {
-        self.point
-    }
 }
 
 impl PartialEq for Vertex {
     fn eq(&self, other: &Self) -> bool {
-        self.point() == other.point()
+        self.point == other.point
     }
 }
 
 impl Hash for Vertex {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.point().hash(state);
+        self.point.hash(state);
     }
 }

--- a/crates/fj-kernel/src/topology/vertex.rs
+++ b/crates/fj-kernel/src/topology/vertex.rs
@@ -22,9 +22,6 @@ use super::VertexBuilder;
 ///
 /// # Validation
 ///
-/// A vertex that is part of a [`Shape`] must be structurally sound. That means
-/// the point it refers to must be part of the same shape.
-///
 /// Vertices must be unique within a shape, meaning another vertex defined by
 /// the same shape must not exist. In the context of vertex uniqueness, points
 /// that are close to each other are considered identical. The minimum distance


### PR DESCRIPTION
Having the distinction between points and vertices as distinct object within a shape doesn't make any sense in the current structure. This pull request simplifies things, by embedding a point in `Vertex` directly. This makes it possible to remove quite a bit of code.