### PR TITLE
Fix color of sketches being ignored

### DIFF
--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -155,6 +155,7 @@ pub struct FaceBuilder<'r> {
     surface: Surface,
     exterior: Option<Vec<Point<2>>>,
     interiors: Vec<Vec<Point<2>>>,
+    color: Option<[u8; 4]>,
 
     shape: &'r mut Shape,
 }
@@ -166,6 +167,7 @@ impl<'r> FaceBuilder<'r> {
             surface,
             exterior: None,
             interiors: Vec::new(),
+            color: None,
 
             shape,
         }
@@ -197,6 +199,12 @@ impl<'r> FaceBuilder<'r> {
         Self { interiors, ..self }
     }
 
+    /// Define the color of the face
+    pub fn with_color(mut self, color: [u8; 4]) -> Self {
+        self.color = Some(color);
+        self
+    }
+
     /// Build the face
     pub fn build(self) -> ValidationResult<Face> {
         let surface = self.shape.insert(self.surface)?;
@@ -215,11 +223,9 @@ impl<'r> FaceBuilder<'r> {
             interiors.push(cycle);
         }
 
-        self.shape.insert(Face::new(
-            surface,
-            exteriors,
-            interiors,
-            [255, 0, 0, 255],
-        ))
+        let color = self.color.unwrap_or([255, 0, 0, 255]);
+
+        self.shape
+            .insert(Face::new(surface, exteriors, interiors, color))
     }
 }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -22,6 +22,7 @@ impl ToShape for fj::Sketch {
 
         Face::builder(surface, &mut shape)
             .with_exterior_polygon(points)
+            .with_color(self.color())
             .build()?;
 
         Ok(shape)


### PR DESCRIPTION
This is a bug that snuck in during some cleanup recently: The color of
an `fj::Sketch` was being ignored in some circumstances.

Before:
![Screenshot from 2022-06-08 15-27-37](https://user-images.githubusercontent.com/85732/172628473-d5b9f81d-5eec-4531-aa8a-15eb9a4fe967.png)

After:
![Screenshot from 2022-06-08 15-28-18](https://user-images.githubusercontent.com/85732/172628499-7d21613f-4792-4881-8a94-512b4108047d.png)
