### PR TITLE
Add local forms of cycles to `Face`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use fj_math::{Scalar, Transform, Triangle, Vector};
+use fj_math::{Line, Scalar, Transform, Triangle, Vector};
 
 use crate::{
-    geometry::{Surface, SweptCurve},
-    shape::{Handle, Mapping, Shape, ValidationError, ValidationResult},
+    geometry::{Curve, Surface, SweptCurve},
+    shape::{Handle, LocalForm, Mapping, Shape, ValidationError},
     topology::{Cycle, Edge, Face, Vertex},
 };
 
@@ -93,8 +93,16 @@ impl Sweep {
 
     fn create_side_faces(&mut self) -> Result<(), ValidationError> {
         for face_source in self.source.faces() {
-            for cycle_source in face_source.get().all_cycles() {
-                if cycle_source.edges.len() == 1 {
+            let face_source = face_source.get();
+            let face_source = face_source.brep();
+
+            let cycles_source = face_source
+                .exteriors
+                .as_local_form()
+                .chain(face_source.interiors.as_local_form());
+
+            for cycle_source in cycles_source {
+                if cycle_source.canonical().get().edges.len() == 1 {
                     // If there's only one edge in the cycle, it must be a
                     // continuous edge that connects to itself. By sweeping
                     // that, we create a continuous face.
@@ -107,7 +115,7 @@ impl Sweep {
                     // This is the last piece of code that still uses the
                     // triangle representation.
                     create_continuous_side_face_fallback(
-                        &cycle_source,
+                        &cycle_source.canonical().get(),
                         &self.translation,
                         self.tolerance,
                         self.color,
@@ -122,7 +130,7 @@ impl Sweep {
 
                 let mut vertex_bottom_to_edge = HashMap::new();
 
-                for edge_source in &cycle_source.edges {
+                for edge_source in &cycle_source.local().edges {
                     let edge_bottom =
                         self.source_to_bottom.edge(&edge_source.canonical());
                     let edge_top =
@@ -130,8 +138,24 @@ impl Sweep {
 
                     let surface = create_side_surface(self, &edge_bottom);
 
+                    let edge_bottom = LocalForm::new(
+                        Edge {
+                            curve: edge_source.local().curve.clone(),
+                            vertices: edge_bottom.get().vertices,
+                        },
+                        edge_bottom,
+                    );
+                    let edge_top = LocalForm::new(
+                        Edge {
+                            curve: edge_source.local().curve.clone(),
+                            vertices: edge_top.get().vertices,
+                        },
+                        edge_top,
+                    );
+
                     let cycle = create_side_cycle(
                         &mut self.target,
+                        self.path,
                         edge_bottom,
                         edge_top,
                         &mut vertex_bottom_to_edge,
@@ -202,14 +226,15 @@ fn create_side_surface(
 
 fn create_side_cycle(
     target: &mut Shape,
-    edge_bottom: Handle<Edge<3>>,
-    edge_top: Handle<Edge<3>>,
+    path: Vector<3>,
+    edge_bottom: LocalForm<Edge<2>, Edge<3>>,
+    edge_top: LocalForm<Edge<2>, Edge<3>>,
     vertex_bottom_to_edge: &mut HashMap<Handle<Vertex>, Handle<Edge<3>>>,
-) -> ValidationResult<Cycle<3>> {
+) -> Result<LocalForm<Cycle<2>, Cycle<3>>, ValidationError> {
     // Can't panic. We already ruled out the "continuous edge" case above, so
     // these edges must have vertices.
     let [vertices_bottom, vertices_top] = [&edge_bottom, &edge_top]
-        .map(|edge| edge.get().vertices.expect_vertices());
+        .map(|edge| edge.local().vertices.clone().expect_vertices());
 
     // Can be simplified, once `zip` is stabilized:
     // https://doc.rust-lang.org/std/primitive.array.html#method.zip
@@ -223,42 +248,68 @@ fn create_side_cycle(
     // Can be cleaned up, once `try_map` is stable:
     // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
     let side_edges = vertices.map(|[vertex_bottom, vertex_top]| {
-        // We only need to create the edge, if it hasn't already been created
-        // for a neighboring side face. Let's check our cache, to see if that's
-        // the case.
-        let edge = vertex_bottom_to_edge
-            .get(&vertex_bottom.canonical())
-            .cloned();
-        if let Some(edge) = edge {
-            return Ok(edge);
-        }
+        let edge_canonical = {
+            // We only need to create the edge, if it hasn't already been
+            // created for a neighboring side face. Let's check our cache, to
+            // see if that's the case.
+            let edge = vertex_bottom_to_edge
+                .get(&vertex_bottom.canonical())
+                .cloned();
+            if let Some(edge) = edge {
+                edge
+            } else {
+                let points_canonical =
+                    [vertex_bottom.clone(), vertex_top.clone()]
+                        .map(|vertex| vertex.canonical().get().point);
 
-        let points_canonical = [vertex_bottom.clone(), vertex_top]
-            .map(|vertex| vertex.canonical().get().point);
+                Edge::builder(target)
+                    .build_line_segment_from_points(points_canonical)?
+            }
+        };
 
-        let edge_canonical = Edge::builder(target)
-            .build_line_segment_from_points(points_canonical)?;
+        let vertices = [vertex_bottom.clone(), vertex_top];
+        let mut points_local =
+            vertices.map(|vertex| [vertex.local().t, Scalar::ZERO]);
+        points_local[1][1] = path.magnitude();
+
+        let edge_local = Edge {
+            curve: LocalForm::new(
+                Curve::Line(Line::from_points(points_local)),
+                edge_canonical.get().curve.canonical(),
+            ),
+            vertices: edge_canonical.get().vertices,
+        };
 
         vertex_bottom_to_edge
             .insert(vertex_bottom.canonical(), edge_canonical.clone());
 
-        Ok(edge_canonical)
+        Ok(LocalForm::new(edge_local, edge_canonical))
     });
     let [a, b]: [Result<_, ValidationError>; 2] = side_edges;
     let [edge_side_a, edge_side_b] = [a?, b?];
 
-    target.merge(Cycle::new([
-        edge_bottom,
-        edge_top,
-        edge_side_a,
-        edge_side_b,
-    ]))
+    let local = Cycle {
+        edges: vec![
+            edge_bottom.clone(),
+            edge_top.clone(),
+            edge_side_a.clone(),
+            edge_side_b.clone(),
+        ],
+    };
+    let canonical = target.merge(Cycle::new([
+        edge_bottom.canonical(),
+        edge_top.canonical(),
+        edge_side_a.canonical(),
+        edge_side_b.canonical(),
+    ]))?;
+
+    Ok(LocalForm::new(local, canonical))
 }
 
 fn create_side_face(
     sweep: &mut Sweep,
     surface: Surface,
-    cycle: Handle<Cycle<3>>,
+    cycle: LocalForm<Cycle<2>, Cycle<3>>,
 ) -> Result<(), ValidationError> {
     let surface = sweep.target.insert(surface)?;
 

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -233,11 +233,11 @@ fn create_side_cycle(
             return Ok(edge);
         }
 
-        let points = [vertex_bottom.clone(), vertex_top]
+        let points_canonical = [vertex_bottom.clone(), vertex_top]
             .map(|vertex| vertex.canonical().get().point);
 
-        let edge_canonical =
-            Edge::builder(target).build_line_segment_from_points(points)?;
+        let edge_canonical = Edge::builder(target)
+            .build_line_segment_from_points(points_canonical)?;
 
         vertex_bottom_to_edge
             .insert(vertex_bottom.canonical(), edge_canonical.clone());

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -236,12 +236,13 @@ fn create_side_cycle(
         let points = [vertex_bottom.clone(), vertex_top]
             .map(|vertex| vertex.canonical().get().point);
 
-        let edge =
+        let edge_canonical =
             Edge::builder(target).build_line_segment_from_points(points)?;
 
-        vertex_bottom_to_edge.insert(vertex_bottom.canonical(), edge.clone());
+        vertex_bottom_to_edge
+            .insert(vertex_bottom.canonical(), edge_canonical.clone());
 
-        Ok(edge)
+        Ok(edge_canonical)
     });
     let [a, b]: [Result<_, ValidationError>; 2] = side_edges;
     let [edge_side_a, edge_side_b] = [a?, b?];

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -213,9 +213,9 @@ fn create_side_cycle(
 
     // Can be simplified, once `zip` is stabilized:
     // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-    let [b_a, b_b] = vertices_bottom;
-    let [t_a, t_b] = vertices_top;
-    let vertices = [(b_a, t_a), (b_b, t_b)];
+    let [bot_a, bot_b] = vertices_bottom;
+    let [top_a, top_b] = vertices_top;
+    let vertices = [(bot_a, top_a), (bot_b, top_b)];
 
     // Create (or retrieve from the cache, `vertex_bottom_to_edge`) side edges
     // from the vertices of this source/bottom edge.

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -215,14 +215,14 @@ fn create_side_cycle(
     // https://doc.rust-lang.org/std/primitive.array.html#method.zip
     let [bot_a, bot_b] = vertices_bottom;
     let [top_a, top_b] = vertices_top;
-    let vertices = [(bot_a, top_a), (bot_b, top_b)];
+    let vertices = [[bot_a, top_a], [bot_b, top_b]];
 
     // Create (or retrieve from the cache, `vertex_bottom_to_edge`) side edges
     // from the vertices of this source/bottom edge.
     //
     // Can be cleaned up, once `try_map` is stable:
     // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
-    let side_edges = vertices.map(|(vertex_bottom, vertex_top)| {
+    let side_edges = vertices.map(|[vertex_bottom, vertex_top]| {
         // We only need to create the edge, if it hasn't already been created
         // for a neighboring side face. Let's check our cache, to see if that's
         // the case.

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -122,9 +122,10 @@ impl Sweep {
             let mut vertex_bottom_to_edge = HashMap::new();
 
             for edge_source in &cycle_source.get().edges {
-                let edge_source = edge_source.canonical();
-                let edge_bottom = self.source_to_bottom.edge(&edge_source);
-                let edge_top = self.source_to_top.edge(&edge_source);
+                let edge_bottom =
+                    self.source_to_bottom.edge(&edge_source.canonical());
+                let edge_top =
+                    self.source_to_top.edge(&edge_source.canonical());
 
                 let surface = create_side_surface(self, &edge_bottom);
 

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -454,7 +454,7 @@ mod tests {
         let err = shape
             .insert(Face::new(
                 surface.clone(),
-                vec![cycle.canonical()],
+                vec![cycle.clone()],
                 Vec::new(),
                 [255, 0, 0, 255],
             ))
@@ -469,7 +469,7 @@ mod tests {
         // Everything has been added to `shape` now. Should work!
         shape.insert(Face::new(
             surface,
-            vec![cycle.canonical()],
+            vec![cycle],
             Vec::new(),
             [255, 0, 0, 255],
         ))?;

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -161,17 +161,23 @@ impl Object for Face {
                 )?;
 
                 let mut exts = Vec::new();
-                for cycle in face.exteriors.as_handle() {
-                    let merged =
-                        cycle.get().merge_into(Some(cycle), shape, mapping)?;
-                    exts.push(merged);
+                for cycle in face.exteriors.as_local_form() {
+                    let merged = cycle.canonical().get().merge_into(
+                        Some(cycle.canonical()),
+                        shape,
+                        mapping,
+                    )?;
+                    exts.push(LocalForm::new(cycle.local().clone(), merged));
                 }
 
                 let mut ints = Vec::new();
-                for cycle in face.interiors.as_handle() {
-                    let merged =
-                        cycle.get().merge_into(Some(cycle), shape, mapping)?;
-                    ints.push(merged);
+                for cycle in face.interiors.as_local_form() {
+                    let merged = cycle.canonical().get().merge_into(
+                        Some(cycle.canonical()),
+                        shape,
+                        mapping,
+                    )?;
+                    ints.push(LocalForm::new(cycle.local().clone(), merged));
                 }
 
                 shape.get_handle_or_insert(Face::new(

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -47,17 +47,30 @@ impl<'r> EdgeBuilder<'r> {
     }
 
     /// Build a circle from a radius
-    pub fn build_circle(self, radius: Scalar) -> ValidationResult<Edge<3>> {
+    pub fn build_circle(
+        self,
+        radius: Scalar,
+    ) -> Result<LocalForm<Edge<2>, Edge<3>>, ValidationError> {
+        let curve_local = Curve::Circle(Circle {
+            center: Point::origin(),
+            a: Vector::from([radius, Scalar::ZERO]),
+            b: Vector::from([Scalar::ZERO, radius]),
+        });
         let curve_canonical = self.shape.insert(Curve::Circle(Circle {
             center: Point::origin(),
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
         }))?;
+
+        let edge_local = Edge {
+            curve: LocalForm::new(curve_local, curve_canonical.clone()),
+            vertices: VerticesOfEdge::none(),
+        };
         let edge_canonical = self
             .shape
             .insert(Edge::new(curve_canonical, VerticesOfEdge::none()))?;
 
-        Ok(edge_canonical)
+        Ok(LocalForm::new(edge_local, edge_canonical))
     }
 
     /// Build a line segment from two points

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -53,11 +53,11 @@ impl<'r> EdgeBuilder<'r> {
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
         }))?;
-        let edge = self
+        let edge_canonical = self
             .shape
             .insert(Edge::new(curve_canonical, VerticesOfEdge::none()))?;
 
-        Ok(edge)
+        Ok(edge_canonical)
     }
 
     /// Build a line segment from two points

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -48,14 +48,14 @@ impl<'r> EdgeBuilder<'r> {
 
     /// Build a circle from a radius
     pub fn build_circle(self, radius: Scalar) -> ValidationResult<Edge<3>> {
-        let curve = self.shape.insert(Curve::Circle(Circle {
+        let curve_canonical = self.shape.insert(Curve::Circle(Circle {
             center: Point::origin(),
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
         }))?;
         let edge = self
             .shape
-            .insert(Edge::new(curve, VerticesOfEdge::none()))?;
+            .insert(Edge::new(curve_canonical, VerticesOfEdge::none()))?;
 
         Ok(edge)
     }

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -241,14 +241,14 @@ impl<'r> FaceBuilder<'r> {
         if let Some(points) = self.exterior {
             let cycle = Cycle::builder(self.surface, self.shape)
                 .build_polygon(points)?;
-            exteriors.push(cycle.canonical());
+            exteriors.push(cycle);
         }
 
         let mut interiors = Vec::new();
         for points in self.interiors {
             let cycle = Cycle::builder(self.surface, self.shape)
                 .build_polygon(points)?;
-            interiors.push(cycle.canonical());
+            interiors.push(cycle);
         }
 
         let color = self.color.unwrap_or([255, 0, 0, 255]);

--- a/crates/fj-kernel/src/topology/face.rs
+++ b/crates/fj-kernel/src/topology/face.rs
@@ -5,7 +5,7 @@ use fj_math::Triangle;
 
 use crate::{
     geometry::Surface,
-    shape::{Handle, Shape},
+    shape::{Handle, LocalForm, Shape},
 };
 
 use super::{Cycle, FaceBuilder};
@@ -42,8 +42,8 @@ impl Face {
     /// Construct a new instance of `Face`
     pub fn new(
         surface: Handle<Surface>,
-        exteriors: impl IntoIterator<Item = Handle<Cycle<3>>>,
-        interiors: impl IntoIterator<Item = Handle<Cycle<3>>>,
+        exteriors: impl IntoIterator<Item = LocalForm<Cycle<2>, Cycle<3>>>,
+        interiors: impl IntoIterator<Item = LocalForm<Cycle<2>, Cycle<3>>>,
         color: [u8; 4],
     ) -> Self {
         let exteriors = CyclesInFace::new(exteriors);
@@ -194,10 +194,12 @@ impl Hash for FaceBRep {
 
 /// A list of cycles, as they are stored in `Face`
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct CyclesInFace(Vec<Handle<Cycle<3>>>);
+pub struct CyclesInFace(Vec<LocalForm<Cycle<2>, Cycle<3>>>);
 
 impl CyclesInFace {
-    fn new(cycles: impl IntoIterator<Item = Handle<Cycle<3>>>) -> Self {
+    fn new(
+        cycles: impl IntoIterator<Item = LocalForm<Cycle<2>, Cycle<3>>>,
+    ) -> Self {
         Self(cycles.into_iter().collect())
     }
 
@@ -208,6 +210,13 @@ impl CyclesInFace {
 
     /// Access an iterator over handles to the cycles
     pub fn as_handle(&self) -> impl Iterator<Item = Handle<Cycle<3>>> + '_ {
-        self.0.iter().cloned()
+        self.0.iter().map(|cycle| cycle.canonical())
+    }
+
+    /// Access an iterator over local forms of the cycles
+    pub fn as_local_form(
+        &self,
+    ) -> impl Iterator<Item = &'_ LocalForm<Cycle<2>, Cycle<3>>> {
+        self.0.iter()
     }
 }

--- a/crates/fj-math/src/line.rs
+++ b/crates/fj-math/src/line.rs
@@ -24,7 +24,9 @@ pub struct Line<const D: usize> {
 
 impl<const D: usize> Line<D> {
     /// Create a line from two points
-    pub fn from_points([a, b]: [Point<D>; 2]) -> Self {
+    pub fn from_points(points: [impl Into<Point<D>>; 2]) -> Self {
+        let [a, b] = points.map(Into::into);
+
         Self {
             origin: a,
             direction: b - a,

--- a/crates/fj-operations/src/circle.rs
+++ b/crates/fj-operations/src/circle.rs
@@ -22,7 +22,8 @@ impl ToShape for fj::Circle {
 
         let edge = Edge::builder(&mut shape)
             .build_circle(Scalar::from_f64(self.radius()))?;
-        let cycle_canonical = shape.insert(Cycle::new(vec![edge]))?;
+        let cycle_canonical =
+            shape.insert(Cycle::new(vec![edge.canonical()]))?;
 
         let surface = shape.insert(Surface::xy_plane())?;
         shape.insert(Face::new(

--- a/crates/fj-operations/src/circle.rs
+++ b/crates/fj-operations/src/circle.rs
@@ -22,12 +22,12 @@ impl ToShape for fj::Circle {
 
         let edge = Edge::builder(&mut shape)
             .build_circle(Scalar::from_f64(self.radius()))?;
-        let cycle = shape.insert(Cycle::new(vec![edge]))?;
+        let cycle_canonical = shape.insert(Cycle::new(vec![edge]))?;
 
         let surface = shape.insert(Surface::xy_plane())?;
         shape.insert(Face::new(
             surface,
-            vec![cycle],
+            vec![cycle_canonical],
             Vec::new(),
             self.color(),
         ))?;

--- a/crates/fj-operations/src/circle.rs
+++ b/crates/fj-operations/src/circle.rs
@@ -22,11 +22,15 @@ impl ToShape for fj::Circle {
 
         let edge = Edge::builder(&mut shape)
             .build_circle(Scalar::from_f64(self.radius()))?;
-        shape.insert(Cycle::new(vec![edge]))?;
+        let cycle = shape.insert(Cycle::new(vec![edge]))?;
 
-        let cycles = shape.cycles();
         let surface = shape.insert(Surface::xy_plane())?;
-        shape.insert(Face::new(surface, cycles, Vec::new(), self.color()))?;
+        shape.insert(Face::new(
+            surface,
+            vec![cycle],
+            Vec::new(),
+            self.color(),
+        ))?;
 
         Ok(shape)
     }

--- a/crates/fj-operations/src/circle.rs
+++ b/crates/fj-operations/src/circle.rs
@@ -2,7 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
     geometry::Surface,
-    shape::{Shape, ValidationError},
+    shape::{LocalForm, Shape, ValidationError},
     topology::{Cycle, Edge, Face},
 };
 use fj_math::{Aabb, Point, Scalar};
@@ -22,13 +22,17 @@ impl ToShape for fj::Circle {
 
         let edge = Edge::builder(&mut shape)
             .build_circle(Scalar::from_f64(self.radius()))?;
+
+        let cycle_local = Cycle {
+            edges: vec![edge.clone()],
+        };
         let cycle_canonical =
             shape.insert(Cycle::new(vec![edge.canonical()]))?;
 
         let surface = shape.insert(Surface::xy_plane())?;
         shape.insert(Face::new(
             surface,
-            vec![cycle_canonical],
+            vec![LocalForm::new(cycle_local, cycle_canonical)],
             Vec::new(),
             self.color(),
         ))?;

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
-    shape::{Handle, Shape, ValidationError, ValidationResult},
+    shape::{LocalForm, Shape, ValidationError},
     topology::{Cycle, Edge, Face},
 };
 use fj_math::Aabb;
@@ -44,14 +44,12 @@ impl ToShape for fj::Difference2d {
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                for cycle in face.exteriors.as_handle() {
-                    let cycle =
-                        add_cycle(cycle.clone(), &mut difference, false)?;
+                for cycle in face.exteriors.as_local_form().cloned() {
+                    let cycle = add_cycle(cycle, &mut difference, false)?;
                     exteriors.push(cycle);
                 }
-                for cycle in face.interiors.as_handle() {
-                    let cycle =
-                        add_cycle(cycle.clone(), &mut difference, true)?;
+                for cycle in face.interiors.as_local_form().cloned() {
+                    let cycle = add_cycle(cycle, &mut difference, true)?;
                     interiors.push(cycle);
                 }
             }
@@ -66,9 +64,8 @@ impl ToShape for fj::Difference2d {
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                for cycle in face.exteriors.as_handle() {
-                    let cycle =
-                        add_cycle(cycle.clone(), &mut difference, true)?;
+                for cycle in face.exteriors.as_local_form().cloned() {
+                    let cycle = add_cycle(cycle, &mut difference, true)?;
                     interiors.push(cycle);
                 }
             }
@@ -93,13 +90,20 @@ impl ToShape for fj::Difference2d {
 }
 
 fn add_cycle(
-    cycle: Handle<Cycle<3>>,
+    cycle: LocalForm<Cycle<2>, Cycle<3>>,
     shape: &mut Shape,
     reverse: bool,
-) -> ValidationResult<Cycle<3>> {
+) -> Result<LocalForm<Cycle<2>, Cycle<3>>, ValidationError> {
     let mut edges = Vec::new();
-    for edge in cycle.get().edges() {
-        let curve_canonical = edge.curve();
+    for edge in cycle.local().edges.clone() {
+        let curve_local = *edge.local().curve.local();
+        let curve_local = if reverse {
+            curve_local.reverse()
+        } else {
+            curve_local
+        };
+
+        let curve_canonical = edge.canonical().get().curve();
         let curve_canonical = if reverse {
             curve_canonical.reverse()
         } else {
@@ -108,21 +112,30 @@ fn add_cycle(
         let curve_canonical = shape.insert(curve_canonical)?;
 
         let vertices = if reverse {
-            edge.vertices.reverse()
+            edge.local().vertices.clone().reverse()
         } else {
-            edge.vertices
+            edge.local().vertices.clone()
         };
 
+        let edge_local = Edge {
+            curve: LocalForm::new(curve_local, curve_canonical.clone()),
+            vertices: vertices.clone(),
+        };
         let edge_canonical =
             shape.merge(Edge::new(curve_canonical, vertices))?;
-        edges.push(edge_canonical);
+
+        edges.push(LocalForm::new(edge_local, edge_canonical));
     }
 
     if reverse {
         edges.reverse();
     }
 
-    let cycle_canonical = shape.insert(Cycle::new(edges))?;
+    let cycle_local = Cycle {
+        edges: edges.clone(),
+    };
+    let cycle_canonical = shape
+        .insert(Cycle::new(edges.into_iter().map(|edge| edge.canonical())))?;
 
-    Ok(cycle_canonical)
+    Ok(LocalForm::new(cycle_local, cycle_canonical))
 }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -117,7 +117,7 @@ fn add_cycle(
         edges.reverse();
     }
 
-    let cycle = shape.insert(Cycle::new(edges))?;
+    let cycle_canonical = shape.insert(Cycle::new(edges))?;
 
-    Ok(cycle)
+    Ok(cycle_canonical)
 }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -109,8 +109,8 @@ fn add_cycle(
             edge.vertices
         };
 
-        let edge = shape.merge(Edge::new(curve, vertices))?;
-        edges.push(edge);
+        let edge_canonical = shape.merge(Edge::new(curve, vertices))?;
+        edges.push(edge_canonical);
     }
 
     if reverse {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -99,9 +99,13 @@ fn add_cycle(
 ) -> ValidationResult<Cycle<3>> {
     let mut edges = Vec::new();
     for edge in cycle.get().edges() {
-        let curve = edge.curve();
-        let curve = if reverse { curve.reverse() } else { curve };
-        let curve = shape.insert(curve)?;
+        let curve_canonical = edge.curve();
+        let curve_canonical = if reverse {
+            curve_canonical.reverse()
+        } else {
+            curve_canonical
+        };
+        let curve_canonical = shape.insert(curve_canonical)?;
 
         let vertices = if reverse {
             edge.vertices.reverse()
@@ -109,7 +113,8 @@ fn add_cycle(
             edge.vertices
         };
 
-        let edge_canonical = shape.merge(Edge::new(curve, vertices))?;
+        let edge_canonical =
+            shape.merge(Edge::new(curve_canonical, vertices))?;
         edges.push(edge_canonical);
     }
 


### PR DESCRIPTION
As the title says, this adds the local forms of cycles, in addition to the canonical forms, to `Face`. This is a huge step towards #568, and also a bit of a breakthrough, as I've been struggling with this for a while.