### PR TITLE
Followup on PR #682

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,9 @@ jobs:
         uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: build
+          args: --all-features
       - name: Run `cargo test`
         uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: test
+          args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "tools/release-operator",
 ]
 default-members = [
+    "crates/fj",
     "crates/fj-app",
     "crates/fj-export",
     "crates/fj-host",
@@ -29,6 +30,7 @@ default-members = [
     "crates/fj-kernel",
     "crates/fj-math",
     "crates/fj-operations",
+    "crates/fj-proc",
     "crates/fj-viewer",
     "crates/fj-window",
 ]

--- a/crates/fj/Cargo.toml
+++ b/crates/fj/Cargo.toml
@@ -18,8 +18,8 @@ serialization = ["serde"]
 [dependencies]
 serde = { version = "1.0.7", features = ["derive"], optional = true }
 
-[dev-dependencies]
-serde_json = "1.0.81"
-
 [dependencies.fj-proc]
 path = "../../crates/fj-proc"
+
+[dev-dependencies]
+serde_json = "1.0.81"

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
 build:
-    cargo clippy
-    cargo test
+    cargo clippy --all-features
+    cargo test --all-features
     cargo fmt --check


### PR DESCRIPTION
1. Address the ordering of dependencies in `fj`
2. Add `fj` and `fj-proc` to `default-members` so that `just build` takes them into account
3. Make sure that the tests use `--all-features`

Besides cleaning up #682, this addresses #683 and #684.

I've verified the changes, other than the CI. I'll check the results for this PR to make sure that it works as intended.