### PR TITLE
Clean up coherence validation infrastructure

### DIFF
--- a/crates/fj-kernel/src/shape/mod.rs
+++ b/crates/fj-kernel/src/shape/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     stores::{Handle, Iter},
     update::Update,
     validate::{
-        CoherenceIssues, DuplicateEdge, EdgeVertexMismatch, StructuralIssues,
+        CoherenceIssues, CoherenceMismatch, DuplicateEdge, StructuralIssues,
         UniquenessIssues, ValidationError, ValidationResult,
     },
 };

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -94,7 +94,8 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "local: {:?} (in 3D: {:?}), canonical: {:?}, distance: {}",
+            "local: {:?} (converted to canonical: {:?}), canonical: {:?},\
+            distance: {}",
             self.local, self.local_as_canonical, self.canonical, self.distance
         )
     }

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -49,7 +49,7 @@ pub fn validate_edge(
 #[derive(Debug, Default, thiserror::Error)]
 pub struct CoherenceIssues {
     /// Mismatches between the local and canonical forms of edge vertices
-    pub edge_vertex_mismatches: Vec<CoherenceMismatch>,
+    pub edge_vertex_mismatches: Vec<CoherenceMismatch<Point<1>, Point<3>>>,
 }
 
 impl fmt::Display for CoherenceIssues {
@@ -72,21 +72,25 @@ impl fmt::Display for CoherenceIssues {
 ///
 /// Used in [`CoherenceIssues`].
 #[derive(Debug)]
-pub struct CoherenceMismatch {
+pub struct CoherenceMismatch<Local, Canonical> {
     /// The local form of the vertex
-    pub local: Point<1>,
+    pub local: Local,
 
     /// The local form of the vertex, converted to 3D
-    pub local_3d: Point<3>,
+    pub local_3d: Canonical,
 
     /// The canonical form of the vertex
-    pub canonical: Point<3>,
+    pub canonical: Canonical,
 
     /// The distance between the local and canonical forms
     pub distance: Scalar,
 }
 
-impl fmt::Display for CoherenceMismatch {
+impl<Local, Canonical> fmt::Display for CoherenceMismatch<Local, Canonical>
+where
+    Local: fmt::Debug,
+    Canonical: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -23,7 +23,7 @@ pub fn validate_edge(
         let distance = (local_3d - canonical).magnitude();
 
         if distance > max_distance {
-            edge_vertex_mismatches.push(EdgeVertexMismatch {
+            edge_vertex_mismatches.push(CoherenceMismatch {
                 local,
                 local_3d,
                 canonical,
@@ -49,7 +49,7 @@ pub fn validate_edge(
 #[derive(Debug, Default, thiserror::Error)]
 pub struct CoherenceIssues {
     /// Mismatches between the local and canonical forms of edge vertices
-    pub edge_vertex_mismatches: Vec<EdgeVertexMismatch>,
+    pub edge_vertex_mismatches: Vec<CoherenceMismatch>,
 }
 
 impl fmt::Display for CoherenceIssues {
@@ -72,7 +72,7 @@ impl fmt::Display for CoherenceIssues {
 ///
 /// Used in [`CoherenceIssues`].
 #[derive(Debug)]
-pub struct EdgeVertexMismatch {
+pub struct CoherenceMismatch {
     /// The local form of the vertex
     pub local: Point<1>,
 
@@ -86,7 +86,7 @@ pub struct EdgeVertexMismatch {
     pub distance: Scalar,
 }
 
-impl fmt::Display for EdgeVertexMismatch {
+impl fmt::Display for CoherenceMismatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -27,7 +27,6 @@ pub fn validate_edge(
                 local,
                 local_as_canonical,
                 canonical,
-                distance,
             });
         }
     }
@@ -81,9 +80,6 @@ pub struct CoherenceMismatch<Local, Canonical> {
 
     /// The canonical form of the object
     pub canonical: Canonical,
-
-    /// The distance between the local and canonical forms
-    pub distance: Scalar,
 }
 
 impl<Local, Canonical> fmt::Display for CoherenceMismatch<Local, Canonical>
@@ -94,9 +90,8 @@ where
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "local: {:?} (converted to canonical: {:?}), canonical: {:?},\
-            distance: {}",
-            self.local, self.local_as_canonical, self.canonical, self.distance
+            "local: {:?} (converted to canonical: {:?}), canonical: {:?},",
+            self.local, self.local_as_canonical, self.canonical,
         )
     }
 }

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -70,7 +70,7 @@ impl fmt::Display for CoherenceIssues {
 
 /// A mismatch between the local and canonical forms of an edge vertex
 ///
-/// Used in [`GeometricIssues`].
+/// Used in [`CoherenceIssues`].
 #[derive(Debug)]
 pub struct EdgeVertexMismatch {
     /// The local form of the vertex

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -68,18 +68,18 @@ impl fmt::Display for CoherenceIssues {
     }
 }
 
-/// A mismatch between the local and canonical forms of an edge vertex
+/// A mismatch between the local and canonical forms of an object
 ///
 /// Used in [`CoherenceIssues`].
 #[derive(Debug)]
 pub struct CoherenceMismatch<Local, Canonical> {
-    /// The local form of the vertex
+    /// The local form of the object
     pub local: Local,
 
-    /// The local form of the vertex, converted to 3D
+    /// The local form of the object, converted into the canonical form
     pub local_as_canonical: Canonical,
 
-    /// The canonical form of the vertex
+    /// The canonical form of the object
     pub canonical: Canonical,
 
     /// The distance between the local and canonical forms

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -18,14 +18,14 @@ pub fn validate_edge(
 
     for vertex in edge.vertices.iter() {
         let local = *vertex.local();
-        let local_3d = edge.curve().point_from_curve_coords(local);
+        let local_as_canonical = edge.curve().point_from_curve_coords(local);
         let canonical = vertex.canonical().get().point;
-        let distance = (local_3d - canonical).magnitude();
+        let distance = (local_as_canonical - canonical).magnitude();
 
         if distance > max_distance {
             edge_vertex_mismatches.push(CoherenceMismatch {
                 local,
-                local_as_canonical: local_3d,
+                local_as_canonical,
                 canonical,
                 distance,
             });

--- a/crates/fj-kernel/src/shape/validate/coherence.rs
+++ b/crates/fj-kernel/src/shape/validate/coherence.rs
@@ -25,7 +25,7 @@ pub fn validate_edge(
         if distance > max_distance {
             edge_vertex_mismatches.push(CoherenceMismatch {
                 local,
-                local_3d,
+                local_as_canonical: local_3d,
                 canonical,
                 distance,
             });
@@ -77,7 +77,7 @@ pub struct CoherenceMismatch<Local, Canonical> {
     pub local: Local,
 
     /// The local form of the vertex, converted to 3D
-    pub local_3d: Canonical,
+    pub local_as_canonical: Canonical,
 
     /// The canonical form of the vertex
     pub canonical: Canonical,
@@ -95,7 +95,7 @@ where
         write!(
             f,
             "local: {:?} (in 3D: {:?}), canonical: {:?}, distance: {}",
-            self.local, self.local_3d, self.canonical, self.distance
+            self.local, self.local_as_canonical, self.canonical, self.distance
         )
     }
 }

--- a/crates/fj-kernel/src/shape/validate/mod.rs
+++ b/crates/fj-kernel/src/shape/validate/mod.rs
@@ -3,7 +3,7 @@ mod structural;
 mod uniqueness;
 
 pub use self::{
-    coherence::{CoherenceIssues, EdgeVertexMismatch},
+    coherence::{CoherenceIssues, CoherenceMismatch},
     structural::StructuralIssues,
     uniqueness::{DuplicateEdge, UniquenessIssues},
 };


### PR DESCRIPTION
This is a prelude to extending the coherence validation infrastructure. I plan to do that, but I have some ideas in mind that might make that easier. I'd like to try those ideas first, so I'm merging these cleanups now, instead of letting them sit in a local branch.