### PR TITLE
Improve --parameters usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The file type is based on the supplied extension. Both 3MF and STL are supported
 Some models have parameters that can be overridden. For example, to override the inner and outer radii of the spacer model:
 
 ``` sh
-cargo run -- -m spacer --parameters outer=8.0 --parameters inner=5.0
+cargo run -- -m spacer --parameters "outer=8.0,inner=5.0"
 ```
 
 

--- a/crates/fj-app/src/args.rs
+++ b/crates/fj-app/src/args.rs
@@ -44,10 +44,12 @@ fn parse_parameters(input: &str) -> anyhow::Result<Parameters> {
         let key = parameter
             .next()
             .ok_or_else(|| anyhow!("Expected model parameter key"))?
+            .trim()
             .to_owned();
         let value = parameter
             .next()
             .ok_or_else(|| anyhow!("Expected model parameter value"))?
+            .trim()
             .to_owned();
 
         parameters.0.insert(key, value);


### PR DESCRIPTION
The example command in the readme didn't work so I fixed it. Also added trimming of white-space to allow spaces before/after commas and equal signs.