### PR TITLE
Remove `Edge::new`

### DIFF
--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -319,7 +319,8 @@ mod tests {
         assert!(shape.get_handle(&surface.get()).as_ref() == Some(&surface));
 
         let vertex = Vertex { point };
-        let edge = Edge::new(curve, VerticesOfEdge::none());
+        let edge =
+            Edge::new(LocalForm::canonical_only(curve), VerticesOfEdge::none());
 
         assert!(shape.get_handle(&vertex).is_none());
         assert!(shape.get_handle(&edge).is_none());
@@ -376,7 +377,7 @@ mod tests {
         // Shouldn't work. Nothing has been added to `shape`.
         let err = shape
             .insert(Edge::new(
-                curve.clone(),
+                LocalForm::canonical_only(curve.clone()),
                 VerticesOfEdge::from_vertices([a.clone(), b.clone()]),
             ))
             .unwrap_err();
@@ -392,8 +393,10 @@ mod tests {
         let b = LocalForm::new(Point::from([2.]), b);
 
         // Everything has been added to `shape` now. Should work!
-        shape
-            .insert(Edge::new(curve, VerticesOfEdge::from_vertices([a, b])))?;
+        shape.insert(Edge::new(
+            LocalForm::canonical_only(curve),
+            VerticesOfEdge::from_vertices([a, b]),
+        ))?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -319,8 +319,10 @@ mod tests {
         assert!(shape.get_handle(&surface.get()).as_ref() == Some(&surface));
 
         let vertex = Vertex { point };
-        let edge =
-            Edge::new(LocalForm::canonical_only(curve), VerticesOfEdge::none());
+        let edge = Edge {
+            curve: LocalForm::canonical_only(curve),
+            vertices: VerticesOfEdge::none(),
+        };
 
         assert!(shape.get_handle(&vertex).is_none());
         assert!(shape.get_handle(&edge).is_none());
@@ -376,10 +378,10 @@ mod tests {
 
         // Shouldn't work. Nothing has been added to `shape`.
         let err = shape
-            .insert(Edge::new(
-                LocalForm::canonical_only(curve.clone()),
-                VerticesOfEdge::from_vertices([a.clone(), b.clone()]),
-            ))
+            .insert(Edge {
+                curve: LocalForm::canonical_only(curve.clone()),
+                vertices: VerticesOfEdge::from_vertices([a.clone(), b.clone()]),
+            })
             .unwrap_err();
         assert!(err.missing_curve(&curve));
         assert!(err.missing_vertex(&a.canonical()));
@@ -393,10 +395,10 @@ mod tests {
         let b = LocalForm::new(Point::from([2.]), b);
 
         // Everything has been added to `shape` now. Should work!
-        shape.insert(Edge::new(
-            LocalForm::canonical_only(curve),
-            VerticesOfEdge::from_vertices([a, b]),
-        ))?;
+        shape.insert(Edge {
+            curve: LocalForm::canonical_only(curve),
+            vertices: VerticesOfEdge::from_vertices([a, b]),
+        })?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -108,10 +108,10 @@ impl Object for Edge<3> {
                     Ok(LocalForm::new(*vertex.local(), canonical))
                 })?;
 
-        let merged = shape.get_handle_or_insert(Edge::new(
-            LocalForm::canonical_only(curve),
-            VerticesOfEdge::new(vertices),
-        ))?;
+        let merged = shape.get_handle_or_insert(Edge {
+            curve: LocalForm::canonical_only(curve),
+            vertices: VerticesOfEdge::new(vertices),
+        })?;
 
         if let Some(handle) = handle {
             mapping.edges.insert(handle, merged.clone());

--- a/crates/fj-kernel/src/shape/object.rs
+++ b/crates/fj-kernel/src/shape/object.rs
@@ -109,7 +109,7 @@ impl Object for Edge<3> {
                 })?;
 
         let merged = shape.get_handle_or_insert(Edge::new(
-            curve,
+            LocalForm::canonical_only(curve),
             VerticesOfEdge::new(vertices),
         ))?;
 

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -66,9 +66,10 @@ impl<'r> EdgeBuilder<'r> {
             curve: LocalForm::new(curve_local, curve_canonical.clone()),
             vertices: VerticesOfEdge::none(),
         };
-        let edge_canonical = self
-            .shape
-            .insert(Edge::new(curve_canonical, VerticesOfEdge::none()))?;
+        let edge_canonical = self.shape.insert(Edge::new(
+            LocalForm::canonical_only(curve_canonical),
+            VerticesOfEdge::none(),
+        ))?;
 
         Ok(LocalForm::new(edge_local, edge_canonical))
     }
@@ -109,7 +110,7 @@ impl<'r> EdgeBuilder<'r> {
         ];
 
         let edge = self.shape.insert(Edge::new(
-            curve,
+            LocalForm::canonical_only(curve),
             VerticesOfEdge::from_vertices(vertices),
         ))?;
 

--- a/crates/fj-kernel/src/topology/builder.rs
+++ b/crates/fj-kernel/src/topology/builder.rs
@@ -66,10 +66,10 @@ impl<'r> EdgeBuilder<'r> {
             curve: LocalForm::new(curve_local, curve_canonical.clone()),
             vertices: VerticesOfEdge::none(),
         };
-        let edge_canonical = self.shape.insert(Edge::new(
-            LocalForm::canonical_only(curve_canonical),
-            VerticesOfEdge::none(),
-        ))?;
+        let edge_canonical = self.shape.insert(Edge {
+            curve: LocalForm::canonical_only(curve_canonical),
+            vertices: VerticesOfEdge::none(),
+        })?;
 
         Ok(LocalForm::new(edge_local, edge_canonical))
     }
@@ -109,10 +109,10 @@ impl<'r> EdgeBuilder<'r> {
             LocalForm::new(Point::from([1.]), b),
         ];
 
-        let edge = self.shape.insert(Edge::new(
-            LocalForm::canonical_only(curve),
-            VerticesOfEdge::from_vertices(vertices),
-        ))?;
+        let edge = self.shape.insert(Edge {
+            curve: LocalForm::canonical_only(curve),
+            vertices: VerticesOfEdge::from_vertices(vertices),
+        })?;
 
         Ok(edge)
     }

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -37,19 +37,6 @@ pub struct Edge<const D: usize> {
     pub vertices: VerticesOfEdge,
 }
 
-impl Edge<3> {
-    /// Construct an instance of `Edge`
-    pub fn new(curve: Handle<Curve<3>>, vertices: VerticesOfEdge) -> Self {
-        let curve = LocalForm::canonical_only(curve);
-        Self { curve, vertices }
-    }
-
-    /// Build an edge using the [`EdgeBuilder`] API
-    pub fn builder(shape: &mut Shape) -> EdgeBuilder {
-        EdgeBuilder::new(shape)
-    }
-}
-
 impl<const D: usize> Edge<D> {
     /// Access the curve that the edge refers to
     ///
@@ -68,6 +55,19 @@ impl<const D: usize> Edge<D> {
             .0
             .as_ref()
             .map(|[a, b]| [a.canonical().get(), b.canonical().get()])
+    }
+}
+
+impl Edge<3> {
+    /// Construct an instance of `Edge`
+    pub fn new(curve: Handle<Curve<3>>, vertices: VerticesOfEdge) -> Self {
+        let curve = LocalForm::canonical_only(curve);
+        Self { curve, vertices }
+    }
+
+    /// Build an edge using the [`EdgeBuilder`] API
+    pub fn builder(shape: &mut Shape) -> EdgeBuilder {
+        EdgeBuilder::new(shape)
     }
 }
 

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -4,7 +4,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::Curve,
-    shape::{Handle, LocalForm, Shape},
+    shape::{LocalForm, Shape},
 };
 
 use super::{EdgeBuilder, Vertex};
@@ -38,6 +38,14 @@ pub struct Edge<const D: usize> {
 }
 
 impl<const D: usize> Edge<D> {
+    /// Construct an instance of `Edge`
+    pub fn new(
+        curve: LocalForm<Curve<D>, Curve<3>>,
+        vertices: VerticesOfEdge,
+    ) -> Self {
+        Self { curve, vertices }
+    }
+
     /// Access the curve that the edge refers to
     ///
     /// This is a convenience method that saves the caller from dealing with the
@@ -59,12 +67,6 @@ impl<const D: usize> Edge<D> {
 }
 
 impl Edge<3> {
-    /// Construct an instance of `Edge`
-    pub fn new(curve: Handle<Curve<3>>, vertices: VerticesOfEdge) -> Self {
-        let curve = LocalForm::canonical_only(curve);
-        Self { curve, vertices }
-    }
-
     /// Build an edge using the [`EdgeBuilder`] API
     pub fn builder(shape: &mut Shape) -> EdgeBuilder {
         EdgeBuilder::new(shape)

--- a/crates/fj-kernel/src/topology/edge.rs
+++ b/crates/fj-kernel/src/topology/edge.rs
@@ -38,14 +38,6 @@ pub struct Edge<const D: usize> {
 }
 
 impl<const D: usize> Edge<D> {
-    /// Construct an instance of `Edge`
-    pub fn new(
-        curve: LocalForm<Curve<D>, Curve<3>>,
-        vertices: VerticesOfEdge,
-    ) -> Self {
-        Self { curve, vertices }
-    }
-
     /// Access the curve that the edge refers to
     ///
     /// This is a convenience method that saves the caller from dealing with the

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -121,10 +121,10 @@ fn add_cycle(
             curve: LocalForm::new(curve_local, curve_canonical.clone()),
             vertices: vertices.clone(),
         };
-        let edge_canonical = shape.merge(Edge::new(
-            LocalForm::canonical_only(curve_canonical),
+        let edge_canonical = shape.merge(Edge {
+            curve: LocalForm::canonical_only(curve_canonical),
             vertices,
-        ))?;
+        })?;
 
         edges.push(LocalForm::new(edge_local, edge_canonical));
     }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -121,8 +121,10 @@ fn add_cycle(
             curve: LocalForm::new(curve_local, curve_canonical.clone()),
             vertices: vertices.clone(),
         };
-        let edge_canonical =
-            shape.merge(Edge::new(curve_canonical, vertices))?;
+        let edge_canonical = shape.merge(Edge::new(
+            LocalForm::canonical_only(curve_canonical),
+            vertices,
+        ))?;
 
         edges.push(LocalForm::new(edge_local, edge_canonical));
     }


### PR DESCRIPTION
These are some first steps towards #691. I intended to take this branch further, largely simplifying `Edge` and making it non-generic, but I now think it's the wrong place to start. I'll re-try with another starting point, and in the meantime, it doesn't hurt to already get these commits merged.