### PR TITLE
Rename `validation::Config` to `ValidationConfig`

### DIFF
--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -40,7 +40,7 @@ use crate::{
 /// Validate the given [`Shape`]
 pub fn validate(
     shape: Shape,
-    config: &Config,
+    config: &ValidationConfig,
 ) -> Result<Validated<Shape>, ValidationError> {
     for edge in shape.edges() {
         coherence::validate_edge(&edge.get(), config.identical_max_distance)?;
@@ -51,7 +51,7 @@ pub fn validate(
 
 /// Configuration required for the validation process
 #[derive(Debug, Clone, Copy)]
-pub struct Config {
+pub struct ValidationConfig {
     /// The minimum distance between distinct objects
     ///
     /// Objects whose distance is less than the value defined in this field, are
@@ -67,7 +67,7 @@ pub struct Config {
     pub identical_max_distance: Scalar,
 }
 
-impl Default for Config {
+impl Default for ValidationConfig {
     fn default() -> Self {
         Self {
             distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
@@ -183,7 +183,7 @@ mod tests {
     use crate::{
         objects::Edge,
         shape::{LocalForm, Shape},
-        validation::Config,
+        validation::ValidationConfig,
     };
 
     #[test]
@@ -213,18 +213,18 @@ mod tests {
 
         let result = super::validate(
             shape.clone(),
-            &Config {
+            &ValidationConfig {
                 identical_max_distance: deviation * 2.,
-                ..Config::default()
+                ..ValidationConfig::default()
             },
         );
         assert!(result.is_ok());
 
         let result = super::validate(
             shape,
-            &Config {
+            &ValidationConfig {
                 identical_max_distance: deviation / 2.,
-                ..Config::default()
+                ..ValidationConfig::default()
             },
         );
         assert!(result.is_err());

--- a/crates/fj-operations/src/circle.rs
+++ b/crates/fj-operations/src/circle.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::Tolerance,
     objects::{Cycle, Edge, Face, Surface},
     shape::{LocalForm, Shape},
-    validation::{self, validate, Validated, ValidationError},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Point, Scalar};
 
@@ -12,7 +12,7 @@ use super::ToShape;
 impl ToShape for fj::Circle {
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         _: Tolerance,
         _: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/circle.rs
+++ b/crates/fj-operations/src/circle.rs
@@ -12,7 +12,7 @@ use super::ToShape;
 impl ToShape for fj::Circle {
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         _: Tolerance,
         _: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -12,7 +12,7 @@ use super::ToShape;
 impl ToShape for fj::Difference2d {
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::Tolerance,
     objects::{Cycle, Edge, Face},
     shape::{LocalForm, Shape},
-    validation::{self, validate, Validated, ValidationError},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
 
@@ -12,7 +12,7 @@ use super::ToShape;
 impl ToShape for fj::Difference2d {
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -11,7 +11,7 @@ use super::ToShape;
 impl ToShape for fj::Group {
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -2,7 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
     shape::Shape,
-    validation::{self, validate, Validated, ValidationError},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
 
@@ -11,7 +11,7 @@ use super::ToShape;
 impl ToShape for fj::Group {
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -38,7 +38,7 @@ pub trait ToShape {
     /// Compute the boundary representation of the shape
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError>;
@@ -91,7 +91,7 @@ macro_rules! dispatch {
 
 dispatch! {
     to_shape(
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError>;

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -29,7 +29,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
     shape::Shape,
-    validation::{self, Validated, ValidationError},
+    validation::{Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
 
@@ -38,7 +38,7 @@ pub trait ToShape {
     /// Compute the boundary representation of the shape
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError>;
@@ -91,7 +91,7 @@ macro_rules! dispatch {
 
 dispatch! {
     to_shape(
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError>;

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -38,7 +38,7 @@ impl ShapeProcessor {
             Some(user_defined_tolerance) => user_defined_tolerance,
         };
 
-        let config = validation::Config::default();
+        let config = validation::ValidationConfig::default();
         let mut debug_info = DebugInfo::new();
         let shape = shape.to_shape(&config, tolerance, &mut debug_info)?;
         let mesh = triangulate(shape.into_inner(), tolerance, &mut debug_info);

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -3,7 +3,7 @@
 use fj_interop::{debug::DebugInfo, mesh::Mesh};
 use fj_kernel::{
     algorithms::{triangulate, InvalidTolerance, Tolerance},
-    validation::{self, ValidationError},
+    validation::{ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Point, Scalar};
 
@@ -38,7 +38,7 @@ impl ShapeProcessor {
             Some(user_defined_tolerance) => user_defined_tolerance,
         };
 
-        let config = validation::ValidationConfig::default();
+        let config = ValidationConfig::default();
         let mut debug_info = DebugInfo::new();
         let shape = shape.to_shape(&config, tolerance, &mut debug_info)?;
         let mesh = triangulate(shape.into_inner(), tolerance, &mut debug_info);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -12,7 +12,7 @@ use super::ToShape;
 impl ToShape for fj::Sketch {
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         _: Tolerance,
         _: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::Tolerance,
     objects::{Face, Surface},
     shape::Shape,
-    validation::{self, validate, Validated, ValidationError},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Point};
 
@@ -12,7 +12,7 @@ use super::ToShape;
 impl ToShape for fj::Sketch {
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         _: Tolerance,
         _: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -2,7 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::{sweep_shape, Tolerance},
     shape::Shape,
-    validation::{self, validate, Validated, ValidationError},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Vector};
 
@@ -11,7 +11,7 @@ use super::ToShape;
 impl ToShape for fj::Sweep {
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -11,7 +11,7 @@ use super::ToShape;
 impl ToShape for fj::Sweep {
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -2,7 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::{transform_shape, Tolerance},
     shape::Shape,
-    validation::{self, validate, Validated, ValidationError},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Transform, Vector};
 
@@ -11,7 +11,7 @@ use super::ToShape;
 impl ToShape for fj::Transform {
     fn to_shape(
         &self,
-        config: &validation::ValidationConfig,
+        config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -11,7 +11,7 @@ use super::ToShape;
 impl ToShape for fj::Transform {
     fn to_shape(
         &self,
-        config: &validation::Config,
+        config: &validation::ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Shape>, ValidationError> {


### PR DESCRIPTION
Just a small cleanup of previously added code. See commit message for justification.