### PR TITLE
Clean up `Shape` tests

### DIFF
--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -259,8 +259,6 @@ impl Default for Shape {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::{Deref, DerefMut};
-
     use fj_math::Point;
 
     use crate::{
@@ -335,8 +333,8 @@ mod tests {
 
     #[test]
     fn add_edge() -> anyhow::Result<()> {
-        let mut shape = TestShape::new();
-        let mut other = TestShape::new();
+        let mut shape = Shape::new();
+        let mut other = Shape::new();
 
         let curve = other.insert(Curve::x_axis())?;
         let a = Vertex::builder(&mut other).build_from_point([1., 0., 0.])?;
@@ -398,8 +396,8 @@ mod tests {
 
     #[test]
     fn add_cycle() -> anyhow::Result<()> {
-        let mut shape = TestShape::new();
-        let mut other = TestShape::new();
+        let mut shape = Shape::new();
+        let mut other = Shape::new();
 
         // Trying to refer to edge that is not from the same shape. Should fail.
         let edge = Edge::builder(&mut other)
@@ -417,8 +415,8 @@ mod tests {
 
     #[test]
     fn add_face() -> anyhow::Result<()> {
-        let mut shape = TestShape::new();
-        let mut other = TestShape::new();
+        let mut shape = Shape::new();
+        let mut other = Shape::new();
 
         let triangle = [[0., 0.], [1., 0.], [0., 1.]];
 
@@ -451,31 +449,5 @@ mod tests {
         ))?;
 
         Ok(())
-    }
-
-    struct TestShape {
-        inner: Shape,
-    }
-
-    impl TestShape {
-        fn new() -> Self {
-            Self {
-                inner: Shape::new(),
-            }
-        }
-    }
-
-    impl Deref for TestShape {
-        type Target = Shape;
-
-        fn deref(&self) -> &Self::Target {
-            &self.inner
-        }
-    }
-
-    impl DerefMut for TestShape {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.inner
-        }
     }
 }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -422,7 +422,7 @@ mod tests {
 
         let triangle = [[0., 0.], [1., 0.], [0., 1.]];
 
-        let surface = other.add_surface()?;
+        let surface = other.insert(Surface::xy_plane())?;
         let cycle = Cycle::builder(surface.get(), &mut other)
             .build_polygon(triangle)?;
 
@@ -438,7 +438,7 @@ mod tests {
         assert!(err.missing_surface(&surface));
         assert!(err.missing_cycle(&cycle.canonical()));
 
-        let surface = shape.add_surface()?;
+        let surface = shape.insert(Surface::xy_plane())?;
         let cycle = Cycle::builder(surface.get(), &mut shape)
             .build_polygon(triangle)?;
 
@@ -466,10 +466,6 @@ mod tests {
 
         fn add_curve(&mut self) -> ValidationResult<Curve<3>> {
             self.insert(Curve::x_axis())
-        }
-
-        fn add_surface(&mut self) -> ValidationResult<Surface> {
-            self.insert(Surface::xy_plane())
         }
     }
 

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -265,7 +265,7 @@ mod tests {
 
     use crate::{
         objects::{Curve, Cycle, Edge, Face, Surface, Vertex, VerticesOfEdge},
-        shape::{LocalForm, Shape, ValidationResult},
+        shape::{LocalForm, Shape},
         validation::ValidationError,
     };
 
@@ -338,7 +338,7 @@ mod tests {
         let mut shape = TestShape::new();
         let mut other = TestShape::new();
 
-        let curve = other.add_curve()?;
+        let curve = other.insert(Curve::x_axis())?;
         let a = Vertex::builder(&mut other).build_from_point([1., 0., 0.])?;
         let b = Vertex::builder(&mut other).build_from_point([2., 0., 0.])?;
 
@@ -356,7 +356,7 @@ mod tests {
         assert!(err.missing_vertex(&a.canonical()));
         assert!(err.missing_vertex(&b.canonical()));
 
-        let curve = shape.add_curve()?;
+        let curve = shape.insert(Curve::x_axis())?;
         let a = Vertex::builder(&mut shape).build_from_point([1., 0., 0.])?;
         let b = Vertex::builder(&mut shape).build_from_point([2., 0., 0.])?;
 
@@ -462,10 +462,6 @@ mod tests {
             Self {
                 inner: Shape::new(),
             }
-        }
-
-        fn add_curve(&mut self) -> ValidationResult<Curve<3>> {
-            self.insert(Curve::x_axis())
         }
     }
 


### PR DESCRIPTION
Removes the obsolete test infrastructure that has outlived its use.