### PR TITLE
Move uniqueness validation to new infrastructure

### DIFF
--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -264,7 +264,6 @@ mod tests {
     use crate::{
         objects::{Curve, Cycle, Edge, Face, Surface, Vertex, VerticesOfEdge},
         shape::{LocalForm, Shape},
-        validation::{validate, ValidationConfig, ValidationError},
     };
 
     #[test]
@@ -311,49 +310,6 @@ mod tests {
 
         let face = shape.insert(face)?;
         assert!(shape.get_handle(&face.get()).as_ref() == Some(&face));
-
-        Ok(())
-    }
-
-    #[test]
-    fn add_vertex() -> anyhow::Result<()> {
-        let mut shape = Shape::new();
-
-        let point = Point::from([0., 0., 0.]);
-
-        // Adding a vertex should work.
-        shape.insert(Vertex { point })?;
-        validate(shape.clone(), &ValidationConfig::default())?;
-
-        // Adding a second vertex with the same point should fail.
-        shape.insert(Vertex { point })?;
-        let result = validate(shape, &ValidationConfig::default());
-        assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
-
-        Ok(())
-    }
-
-    #[test]
-    fn add_edge_uniqueness() -> anyhow::Result<()> {
-        let mut shape = Shape::new();
-
-        let a = Vertex::builder(&mut shape).build_from_point([0., 0., 0.])?;
-        let b = Vertex::builder(&mut shape).build_from_point([1., 0., 0.])?;
-
-        Edge::builder(&mut shape)
-            .build_line_segment_from_vertices([a.clone(), b.clone()])?;
-
-        // Should fail. An edge with the same vertices has already been added.
-        Edge::builder(&mut shape)
-            .build_line_segment_from_vertices([a.clone(), b.clone()])?;
-        let result = validate(shape.clone(), &ValidationConfig::default());
-        assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
-
-        // Should fail. An edge with the same vertices has already been added,
-        // just the order is different.
-        Edge::builder(&mut shape).build_line_segment_from_vertices([b, a])?;
-        let result = validate(shape, &ValidationConfig::default());
-        assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
 
         Ok(())
     }

--- a/crates/fj-kernel/src/shape/api.rs
+++ b/crates/fj-kernel/src/shape/api.rs
@@ -264,7 +264,7 @@ mod tests {
     use crate::{
         objects::{Curve, Cycle, Edge, Face, Surface, Vertex, VerticesOfEdge},
         shape::{LocalForm, Shape},
-        validation::ValidationError,
+        validation::{validate, ValidationConfig, ValidationError},
     };
 
     #[test]
@@ -323,9 +323,11 @@ mod tests {
 
         // Adding a vertex should work.
         shape.insert(Vertex { point })?;
+        validate(shape.clone(), &ValidationConfig::default())?;
 
         // Adding a second vertex with the same point should fail.
-        let result = shape.insert(Vertex { point });
+        shape.insert(Vertex { point })?;
+        let result = validate(shape, &ValidationConfig::default());
         assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
 
         Ok(())
@@ -342,14 +344,15 @@ mod tests {
             .build_line_segment_from_vertices([a.clone(), b.clone()])?;
 
         // Should fail. An edge with the same vertices has already been added.
-        let result = Edge::builder(&mut shape)
-            .build_line_segment_from_vertices([a.clone(), b.clone()]);
+        Edge::builder(&mut shape)
+            .build_line_segment_from_vertices([a.clone(), b.clone()])?;
+        let result = validate(shape.clone(), &ValidationConfig::default());
         assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
 
         // Should fail. An edge with the same vertices has already been added,
         // just the order is different.
-        let result =
-            Edge::builder(&mut shape).build_line_segment_from_vertices([b, a]);
+        Edge::builder(&mut shape).build_line_segment_from_vertices([b, a])?;
+        let result = validate(shape, &ValidationConfig::default());
         assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
 
         Ok(())

--- a/crates/fj-kernel/src/shape/mod.rs
+++ b/crates/fj-kernel/src/shape/mod.rs
@@ -17,5 +17,5 @@ pub use self::{
     object::Object,
     stores::{Handle, Iter},
     update::Update,
-    validate::{DuplicateEdge, UniquenessIssues, ValidationResult},
+    validate::ValidationResult,
 };

--- a/crates/fj-kernel/src/shape/validate/mod.rs
+++ b/crates/fj-kernel/src/shape/validate/mod.rs
@@ -1,7 +1,3 @@
-mod uniqueness;
-
-pub use self::uniqueness::{DuplicateEdge, UniquenessIssues};
-
 use fj_math::Scalar;
 
 use crate::{
@@ -53,12 +49,10 @@ impl Validate for Vertex {
     /// does. See documentation of [`crate::kernel`] for some context on that.
     fn validate(
         &self,
-        handle: Option<&Handle<Self>>,
+        _: Option<&Handle<Self>>,
         _: Scalar,
-        stores: &Stores,
+        _: &Stores,
     ) -> Result<(), ValidationError> {
-        uniqueness::validate_vertex(self, handle, &stores.vertices)?;
-
         Ok(())
     }
 }
@@ -66,12 +60,10 @@ impl Validate for Vertex {
 impl Validate for Edge<3> {
     fn validate(
         &self,
-        handle: Option<&Handle<Self>>,
+        _: Option<&Handle<Self>>,
         _: Scalar,
-        stores: &Stores,
+        _: &Stores,
     ) -> Result<(), ValidationError> {
-        uniqueness::validate_edge(self, handle, &stores.edges)?;
-
         Ok(())
     }
 }

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -26,10 +26,12 @@
 
 mod coherence;
 mod structural;
+mod uniqueness;
 
 pub use self::{
     coherence::{CoherenceIssues, CoherenceMismatch},
     structural::StructuralIssues,
+    uniqueness::{DuplicateEdge, UniquenessIssues},
 };
 
 use std::{collections::HashSet, ops::Deref};
@@ -38,7 +40,7 @@ use fj_math::Scalar;
 
 use crate::{
     objects::{Curve, Cycle, Edge, Surface, Vertex},
-    shape::{Handle, Shape, UniquenessIssues},
+    shape::{Handle, Shape},
 };
 
 /// Validate the given [`Shape`]
@@ -56,11 +58,14 @@ pub fn validate(
         curves.insert(curve);
     }
     for vertex in shape.vertices() {
+        uniqueness::validate_vertex(&vertex.get(), &vertices)?;
+
         vertices.insert(vertex);
     }
     for edge in shape.edges() {
         coherence::validate_edge(&edge.get(), config.identical_max_distance)?;
         structural::validate_edge(&edge.get(), &curves, &vertices)?;
+        uniqueness::validate_edge(&edge.get(), &edges)?;
 
         edges.insert(edge);
     }

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -367,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn add_edge_uniqueness() -> anyhow::Result<()> {
+    fn uniqueness_edge() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
         let a = Vertex::builder(&mut shape).build_from_point([0., 0., 0.])?;
@@ -392,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn add_vertex() -> anyhow::Result<()> {
+    fn uniqueness_vertex() -> anyhow::Result<()> {
         let mut shape = Shape::new();
 
         let point = Point::from([0., 0., 0.]);

--- a/crates/fj-kernel/src/validation/uniqueness.rs
+++ b/crates/fj-kernel/src/validation/uniqueness.rs
@@ -1,23 +1,18 @@
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
 use crate::{
     objects::{Edge, Vertex},
-    shape::{stores::Store, Handle},
+    shape::Handle,
 };
 
 pub fn validate_vertex(
     vertex: &Vertex,
-    handle: Option<&Handle<Vertex>>,
-    vertices: &Store<Vertex>,
+    vertices: &HashSet<Handle<Vertex>>,
 ) -> Result<(), UniquenessIssues> {
-    for existing in vertices.iter() {
-        if Some(&existing) == handle {
-            continue;
-        }
-
+    for existing in vertices {
         if &existing.get() == vertex {
             return Err(UniquenessIssues {
-                duplicate_vertex: Some(existing),
+                duplicate_vertex: Some(existing.clone()),
                 ..UniquenessIssues::default()
             });
         }
@@ -35,14 +30,9 @@ pub fn validate_vertex(
 /// this code will have to be updated.
 pub fn validate_edge(
     edge: &Edge<3>,
-    handle: Option<&Handle<Edge<3>>>,
-    edges: &Store<Edge<3>>,
+    edges: &HashSet<Handle<Edge<3>>>,
 ) -> Result<(), UniquenessIssues> {
-    for existing in edges.iter() {
-        if Some(&existing) == handle {
-            continue;
-        }
-
+    for existing in edges {
         if existing.get().vertices.are_same(&edge.vertices) {
             return Err(UniquenessIssues {
                 duplicate_edge: Some(DuplicateEdge {


### PR DESCRIPTION
This is more progress towards #696 (step 1). This pull request leaves the old validation infrastructure an empty shell, which can now be removed.