### PR TITLE
Derive `Copy` for `Vertex`

### DIFF
--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -25,7 +25,7 @@ use crate::{builder::VertexBuilder, shape::Shape};
 /// are close to each other are considered identical. The minimum distance
 /// between distinct vertices can be configured using
 /// [`Shape::with_minimum_distance`].
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     /// The point that defines the location of the vertex
     pub point: Point<3>,


### PR DESCRIPTION
This has become possible due to a recent simplification of `Vertex`.