### PR TITLE
Make Anyhow a `dev-dependency` of `fj-kernel`

### DIFF
--- a/crates/fj-kernel/Cargo.toml
+++ b/crates/fj-kernel/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["encoding", "mathematics", "rendering"]
 
 
 [dependencies]
-anyhow = "1.0.58"
 anymap = "1.0.0-beta.2"
 map-macro = "0.2.0"
 parking_lot = "0.12.0"
@@ -29,3 +28,7 @@ path = "../fj-interop"
 [dependencies.fj-math]
 version = "0.6.0"
 path = "../fj-math"
+
+
+[dev-dependencies]
+anyhow = "1.0.58"


### PR DESCRIPTION
It's only used in tests, so it doesn't need to be a full dependency.