### PR TITLE
Break `triangulate`'s dependency on `Shape`

### DIFF
--- a/crates/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -5,7 +5,7 @@ mod ray;
 use fj_interop::{debug::DebugInfo, mesh::Mesh};
 use fj_math::Point;
 
-use crate::{objects::Face, shape::Shape};
+use crate::objects::Face;
 
 use self::polygon::Polygon;
 
@@ -13,14 +13,13 @@ use super::{FaceApprox, Tolerance};
 
 /// Triangulate a shape
 pub fn triangulate(
-    shape: Shape,
+    faces: Vec<Face>,
     tolerance: Tolerance,
     debug_info: &mut DebugInfo,
 ) -> Mesh<Point<3>> {
     let mut mesh = Mesh::new();
 
-    for face in shape.faces() {
-        let face = face.get();
+    for face in faces {
         match &face {
             Face::Face(brep) => {
                 let surface = brep.surface.get();
@@ -163,9 +162,11 @@ mod tests {
     }
 
     fn triangulate(shape: Shape) -> anyhow::Result<Mesh<Point<3>>> {
+        let faces = shape.faces().map(|handle| handle.get()).collect();
+
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let mut debug_info = DebugInfo::new();
-        Ok(super::triangulate(shape, tolerance, &mut debug_info))
+        Ok(super::triangulate(faces, tolerance, &mut debug_info))
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -101,16 +101,17 @@ mod tests {
         let c = [2., 2.];
         let d = [0., 1.];
 
-        Face::builder(Surface::xy_plane(), &mut shape)
+        let face = Face::builder(Surface::xy_plane(), &mut shape)
             .with_exterior_polygon([a, b, c, d])
-            .build();
+            .build()
+            .get();
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
         let c = Point::from(c).to_xyz();
         let d = Point::from(d).to_xyz();
 
-        let triangles = triangulate(shape)?;
+        let triangles = triangulate(face)?;
 
         assert!(triangles.contains_triangle([a, b, d]));
         assert!(triangles.contains_triangle([b, c, d]));
@@ -134,12 +135,13 @@ mod tests {
         let g = [3., 3.];
         let h = [1., 2.];
 
-        Face::builder(Surface::xy_plane(), &mut shape)
+        let face = Face::builder(Surface::xy_plane(), &mut shape)
             .with_exterior_polygon([a, b, c, d])
             .with_interior_polygon([e, f, g, h])
-            .build();
+            .build()
+            .get();
 
-        let triangles = triangulate(shape)?;
+        let triangles = triangulate(face)?;
 
         let a = Point::from(a).to_xyz();
         let d = Point::from(d).to_xyz();
@@ -162,12 +164,10 @@ mod tests {
         Ok(())
     }
 
-    fn triangulate(shape: Shape) -> anyhow::Result<Mesh<Point<3>>> {
-        let faces = shape.faces().map(|handle| handle.get()).collect();
-
+    fn triangulate(face: Face) -> anyhow::Result<Mesh<Point<3>>> {
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let mut debug_info = DebugInfo::new();
-        Ok(super::triangulate(faces, tolerance, &mut debug_info))
+        Ok(super::triangulate(vec![face], tolerance, &mut debug_info))
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulation/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulation/mod.rs
@@ -111,6 +111,7 @@ mod tests {
         let d = Point::from(d).to_xyz();
 
         let triangles = triangulate(shape)?;
+
         assert!(triangles.contains_triangle([a, b, d]));
         assert!(triangles.contains_triangle([b, c, d]));
         assert!(!triangles.contains_triangle([a, b, c]));

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -40,8 +40,12 @@ impl ShapeProcessor {
 
         let config = ValidationConfig::default();
         let mut debug_info = DebugInfo::new();
-        let shape = shape.to_shape(&config, tolerance, &mut debug_info)?;
-        let mesh = triangulate(shape.into_inner(), tolerance, &mut debug_info);
+        let shape = shape
+            .to_shape(&config, tolerance, &mut debug_info)?
+            .faces()
+            .map(|handle| handle.get())
+            .collect();
+        let mesh = triangulate(shape, tolerance, &mut debug_info);
 
         Ok(ProcessedShape {
             aabb,


### PR DESCRIPTION
This is another step towards #697.