### PR TITLE
Include `export-validator` in `just build`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,3 +2,4 @@ build:
     cargo clippy --all-features
     cargo test --all-features
     cargo fmt --check
+    cargo run -p export-validator


### PR DESCRIPTION
`export-validator` verifies that Fornjot produces valid triangle meshes,
by validating exported 3MF files. It is included in the CI build, but
was missing from `just build`.