### PR TITLE
Only calculate focus point when needed

### DIFF
--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -4,7 +4,7 @@ use fj_interop::mesh::Mesh;
 use fj_math::{Point, Transform, Vector};
 
 use crate::{
-    camera::{Camera, FocusPoint},
+    camera::Camera,
     screen::{Position, Size},
 };
 
@@ -53,8 +53,8 @@ impl Handler {
         &mut self,
         event: Event,
         screen_size: Size,
-        focus_point: FocusPoint,
         now: Instant,
+        mesh: &Mesh<Point<3>>,
         camera: &mut Camera,
         actions: &mut Actions,
     ) {
@@ -83,12 +83,18 @@ impl Handler {
             }
 
             Event::Key(Key::MouseLeft, KeyState::Pressed) => {
+                let focus_point =
+                    camera.focus_point(screen_size, self.cursor(), mesh);
+
                 self.rotation.start(focus_point);
             }
             Event::Key(Key::MouseLeft, KeyState::Released) => {
                 self.rotation.stop();
             }
             Event::Key(Key::MouseRight, KeyState::Pressed) => {
+                let focus_point =
+                    camera.focus_point(screen_size, self.cursor(), mesh);
+
                 self.movement.start(focus_point, self.cursor);
             }
             Event::Key(Key::MouseRight, KeyState::Released) => {

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -210,17 +210,11 @@ pub fn run(
         if let (Some(event), Some(shape), Some(camera)) =
             (event, &shape, &mut camera)
         {
-            let focus_point = camera.focus_point(
-                window.size(),
-                input_handler.cursor(),
-                &shape.mesh,
-            );
-
             input_handler.handle_event(
                 event,
                 window.size(),
-                focus_point,
                 now,
+                &shape.mesh,
                 camera,
                 &mut actions,
             );


### PR DESCRIPTION
Currently, on every type of input event (include mouse movement), the focus point is calculated. This can be an expensive operation for complex meshes.

If the mouse is moved just right (try small circular motions), many mouse movement events will be triggered, each causing a focus point recalculation. All of these mouse movement events must be handled before a new frame is rendered.

This PR just moves focus point calculation into the mouse click events which need it, preventing the much more frequent mouse movement events from triggering the calculations.