### PR TITLE
Add `cargo doc` to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,8 @@
+export RUSTDOCFLAGS := "-D warnings"
+
 build:
     cargo clippy --all-features
     cargo test --all-features
     cargo fmt --check
+    cargo doc --no-deps --document-private-items --all-features --workspace
     cargo run -p export-validator

--- a/justfile
+++ b/justfile
@@ -1,3 +1,4 @@
+export RUSTFLAGS := "-D warnings"
 export RUSTDOCFLAGS := "-D warnings"
 
 build:


### PR DESCRIPTION
* `cargo doc` checks will now run when running `just build`.
* Warnings will be treated as errors for `doc` and `clippy` checks.

Close #773.