### PR TITLE
Don't use RUSTFLAGS to deny clippy warnings

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,8 +1,7 @@
-export RUSTFLAGS := "-D warnings"
 export RUSTDOCFLAGS := "-D warnings"
 
 build:
-    cargo clippy --all-features
+    cargo clippy --all-features -- -D warnings
     cargo test --all-features
     cargo fmt --check
     cargo doc --no-deps --document-private-items --all-features --workspace


### PR DESCRIPTION
This fixes a bug where cargo wouldn't use the existing artifacts from a previous variable-less build, meaning a `just build` after a regular build would trigger a full rebuild. 

See https://github.com/hannobraun/Fornjot/issues/773#issuecomment-1173957536