### PR TITLE
Rename custom `#[value]` attribute to `#[param]`

### DIFF
--- a/crates/fj-proc/src/lib.rs
+++ b/crates/fj-proc/src/lib.rs
@@ -86,7 +86,7 @@ pub fn model(_: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// Represents one parameter given to the `model`
-/// `#[value(default=3, min=4)] num_points: u64`
+/// `#[param(default=3, min=4)] num_points: u64`
 /// `^^^^^^^^^^^^^^^^^^^^^^^^^^ ~~~~~~~~~~  ^^^-- ty`
 /// `           |                    |`
 /// `         attr                 ident`
@@ -112,8 +112,8 @@ impl Parse for Argument {
     }
 }
 
-/// Represents all arguments given to the `#[value]` attribute eg:
-/// `#[value(default=3, min=4)]`
+/// Represents all arguments given to the `#[param]` attribute eg:
+/// `#[param(default=3, min=4)]`
 /// `        ^^^^^^^^^^^^^^^^`
 #[derive(Debug, Clone)]
 struct HelperAttribute {
@@ -128,11 +128,11 @@ impl Parse for HelperAttribute {
         let _: syn::token::Pound = input.parse()?;
         bracketed!(attr_content in input);
         let ident: proc_macro2::Ident = attr_content.parse()?;
-        if ident != *"value" {
+        if ident != *"param" {
             return Err(syn::Error::new_spanned(
                 ident.clone(),
                 format!(
-                    "Unknown attribute \"{}\" found, expected \"value\"",
+                    "Unknown attribute \"{}\" found, expected \"param\"",
                     ident
                 ),
             ));
@@ -180,8 +180,8 @@ impl HelperAttribute {
     }
 }
 
-/// Represents one argument given to the `#[value]` attribute eg:
-/// `#[value(default=3)]`
+/// Represents one argument given to the `#[param]` attribute eg:
+/// `#[param(default=3)]`
 /// `        ^^^^^^^^^----- is parsed as DefaultParam{ ident: Some(default), val: 3 }`
 #[derive(Debug, Clone)]
 struct DefaultParam {

--- a/crates/fj-proc/src/lib.rs
+++ b/crates/fj-proc/src/lib.rs
@@ -117,7 +117,7 @@ impl Parse for Argument {
 /// `        ^^^^^^^^^^^^^^^^`
 #[derive(Debug, Clone)]
 struct HelperAttribute {
-    pub values:
+    pub param:
         Option<syn::punctuated::Punctuated<DefaultParam, syn::Token![,]>>,
 }
 
@@ -141,10 +141,10 @@ impl Parse for HelperAttribute {
         if attr_content.peek(syn::token::Paren) {
             parenthesized!(param_content in attr_content);
             if param_content.is_empty() {
-                Ok(Self { values: None })
+                Ok(Self { param: None })
             } else {
                 Ok(Self {
-                values: Some(
+                param: Some(
                     syn::punctuated::Punctuated::parse_separated_nonempty_with(
                         &param_content,
                         DefaultParam::parse,
@@ -153,14 +153,14 @@ impl Parse for HelperAttribute {
             })
             }
         } else {
-            Ok(Self { values: None })
+            Ok(Self { param: None })
         }
     }
 }
 
 impl HelperAttribute {
     fn get_parameter(&self, parameter_name: &str) -> Option<DefaultParam> {
-        if let Some(values) = self.values.clone() {
+        if let Some(values) = self.param.clone() {
             values.into_iter().find(|val| val.ident == *parameter_name)
         } else {
             None

--- a/crates/fj-proc/src/lib.rs
+++ b/crates/fj-proc/src/lib.rs
@@ -124,7 +124,7 @@ struct HelperAttribute {
 impl Parse for HelperAttribute {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let attr_content;
-        let value_content;
+        let param_content;
         let _: syn::token::Pound = input.parse()?;
         bracketed!(attr_content in input);
         let ident: proc_macro2::Ident = attr_content.parse()?;
@@ -139,14 +139,14 @@ impl Parse for HelperAttribute {
         }
 
         if attr_content.peek(syn::token::Paren) {
-            parenthesized!(value_content in attr_content);
-            if value_content.is_empty() {
+            parenthesized!(param_content in attr_content);
+            if param_content.is_empty() {
                 Ok(Self { values: None })
             } else {
                 Ok(Self {
                 values: Some(
                     syn::punctuated::Punctuated::parse_separated_nonempty_with(
-                        &value_content,
+                        &param_content,
                         DefaultParam::parse,
                     )?,
                 ),

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -1,8 +1,8 @@
 #[fj::model]
 pub fn model(
-    #[value(default = 3.0)] x: f64,
-    #[value(default = 2.0)] y: f64,
-    #[value(default = 1.0)] z: f64,
+    #[param(default = 3.0)] x: f64,
+    #[param(default = 2.0)] y: f64,
+    #[param(default = 1.0)] z: f64,
 ) -> fj::Shape {
     #[rustfmt::skip]
     let rectangle = fj::Sketch::from_points(vec![

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -2,9 +2,9 @@ use fj::syntax::*;
 
 #[fj::model]
 pub fn model(
-    #[value(default = 1.0, min = inner * 1.01)] outer: f64,
-    #[value(default = 0.5, max = outer * 0.99)] inner: f64,
-    #[value(default = 1.0)] height: f64,
+    #[param(default = 1.0, min = inner * 1.01)] outer: f64,
+    #[param(default = 0.5, max = outer * 0.99)] inner: f64,
+    #[param(default = 1.0)] height: f64,
 ) -> fj::Shape {
     let outer_edge = fj::Sketch::from_circle(fj::Circle::from_radius(outer));
     let inner_edge = fj::Sketch::from_circle(fj::Circle::from_radius(inner));

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -2,10 +2,10 @@ use std::f64::consts::PI;
 
 #[fj::model]
 pub fn model(
-    #[value(default = 5, min = 3)] num_points: u64,
-    #[value(default = 1.0, min = 1.0)] r1: f64,
-    #[value(default = 2.0, min = 2.0)] r2: f64,
-    #[value(default = 1.0)] h: f64,
+    #[param(default = 5, min = 3)] num_points: u64,
+    #[param(default = 1.0, min = 1.0)] r1: f64,
+    #[param(default = 2.0, min = 2.0)] r2: f64,
+    #[param(default = 1.0)] h: f64,
 ) -> fj::Shape {
     let num_vertices = num_points * 2;
     let vertex_iter = (0..num_vertices).map(|i| {


### PR DESCRIPTION
The new name is more descriptive.