### PR TITLE
High-level fj-viewer interface

### DIFF
--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -4,7 +4,7 @@ use std::f64::consts::FRAC_PI_2;
 use fj_interop::mesh::Mesh;
 use fj_math::{Aabb, Point, Scalar, Transform, Triangle, Vector};
 
-use crate::screen::{Position, Size};
+use crate::screen::{NormalizedPosition, Position, Size};
 
 /// The camera abstraction
 ///
@@ -104,6 +104,19 @@ impl Camera {
             .inverse_transform_point(&Point::<3>::origin())
     }
 
+    /// Transform a normalized cursor position on the near plane to model space.
+    pub fn normalized_cursor_to_model_space(
+        &self,
+        cursor: NormalizedPosition,
+    ) -> Point<3> {
+        // Cursor position in camera space.
+        let f = (self.field_of_view_in_x() / 2.).tan() * self.near_plane();
+        let cursor = Point::origin()
+            + Vector::from([cursor.x * f, cursor.y * f, -self.near_plane()]);
+
+        self.camera_to_model().inverse_transform_point(&cursor)
+    }
+
     /// Transform the position of the cursor on the near plane to model space.
     pub fn cursor_to_model_space(
         &self,
@@ -118,19 +131,13 @@ impl Camera {
         let x = cursor.x / width * 2. - 1.;
         let y = -(cursor.y / height * 2. - 1.) / aspect_ratio;
 
-        // Cursor position in camera space.
-        let f = (self.field_of_view_in_x() / 2.).tan() * self.near_plane();
-        let cursor =
-            Point::origin() + Vector::from([x * f, y * f, -self.near_plane()]);
-
-        self.camera_to_model().inverse_transform_point(&cursor)
+        self.normalized_cursor_to_model_space(NormalizedPosition { x, y })
     }
 
     /// Compute the point on the model, that the cursor currently points to.
     pub fn focus_point(
         &self,
-        size: Size,
-        cursor: Option<Position>,
+        cursor: Option<NormalizedPosition>,
         mesh: &Mesh<fj_math::Point<3>>,
     ) -> FocusPoint {
         let cursor = match cursor {
@@ -140,7 +147,7 @@ impl Camera {
 
         // Transform camera and cursor positions to model space.
         let origin = self.position();
-        let cursor = self.cursor_to_model_space(cursor, size);
+        let cursor = self.normalized_cursor_to_model_space(cursor);
         let dir = (cursor - origin).normalize();
 
         let mut min_t = None;

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -4,7 +4,7 @@ use std::f64::consts::FRAC_PI_2;
 use fj_interop::mesh::Mesh;
 use fj_math::{Aabb, Point, Scalar, Transform, Triangle, Vector};
 
-use crate::screen::{NormalizedPosition, Position, Size};
+use crate::screen::NormalizedPosition;
 
 /// The camera abstraction
 ///
@@ -105,7 +105,7 @@ impl Camera {
     }
 
     /// Transform a normalized cursor position on the near plane to model space.
-    pub fn normalized_cursor_to_model_space(
+    pub fn cursor_to_model_space(
         &self,
         cursor: NormalizedPosition,
     ) -> Point<3> {
@@ -115,23 +115,6 @@ impl Camera {
             + Vector::from([cursor.x * f, cursor.y * f, -self.near_plane()]);
 
         self.camera_to_model().inverse_transform_point(&cursor)
-    }
-
-    /// Transform the position of the cursor on the near plane to model space.
-    pub fn cursor_to_model_space(
-        &self,
-        cursor: Position,
-        size: Size,
-    ) -> Point<3> {
-        let [width, height] = size.as_f64();
-        let aspect_ratio = width / height;
-
-        // Cursor position in normalized coordinates (-1 to +1) with
-        // aspect ratio taken into account.
-        let x = cursor.x / width * 2. - 1.;
-        let y = -(cursor.y / height * 2. - 1.) / aspect_ratio;
-
-        self.normalized_cursor_to_model_space(NormalizedPosition { x, y })
     }
 
     /// Compute the point on the model, that the cursor currently points to.
@@ -147,7 +130,7 @@ impl Camera {
 
         // Transform camera and cursor positions to model space.
         let origin = self.position();
-        let cursor = self.normalized_cursor_to_model_space(cursor);
+        let cursor = self.cursor_to_model_space(cursor);
         let dir = (cursor - origin).normalize();
 
         let mut min_t = None;

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -2,16 +2,16 @@ use crate::screen::NormalizedPosition;
 
 /// An input event
 pub enum Event {
-    /// Move the view up, down, left or right
-    Pan {
+    /// Move the model up, down, left or right
+    Translate {
         /// The normalized position of the cursor before input
         previous: NormalizedPosition,
         /// The normalized position of the cursor after input
         current: NormalizedPosition,
     },
 
-    /// Rotate the view around the focus point
-    Orbit {
+    /// Rotate the model around the focus point
+    Rotation {
         /// The normalized position of the cursor before input
         previous: NormalizedPosition,
         /// The normalized position of the cursor after input
@@ -20,43 +20,4 @@ pub enum Event {
 
     /// Move the view forwards and backwards
     Zoom(f64),
-}
-
-/// Describes a difference in the vertical mouse scroll wheel state.
-/// Positive values indicate movement forward (away from the user).
-pub enum MouseScrollDelta {
-    /// Amount in lines to scroll.
-    Line(f64),
-    /// Amount in pixels to scroll.
-    Pixel(f64),
-}
-
-/// A keyboard or mouse key
-pub enum Key {
-    /// The escape key
-    Escape,
-
-    /// The numerical key `1`
-    Key1,
-
-    /// The numerical key `2`
-    Key2,
-
-    /// The numerical key `3`
-    Key3,
-
-    /// The left mouse key
-    MouseLeft,
-
-    /// The right mouse key
-    MouseRight,
-}
-
-/// Defines the meaning of a key event
-pub enum KeyState {
-    /// A key was pressed
-    Pressed,
-
-    /// A key was released
-    Released,
 }

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -1,10 +1,7 @@
-use crate::{camera::FocusPoint, screen::NormalizedPosition};
+use crate::screen::NormalizedPosition;
 
 /// An input event
 pub enum Event {
-    /// A new focus point was selected.
-    FocusPoint(FocusPoint),
-
     /// Move the view up, down, left or right
     Pan {
         /// The normalized position of the cursor before input
@@ -23,16 +20,6 @@ pub enum Event {
 
     /// Move the view forwards and backwards
     Zoom(f64),
-
-    /// Application should exit
-    Exit,
-
-    /// Toggle the shaded display of the model.
-    ToggleModel,
-    /// Toggle the model's wireframe.
-    ToggleMesh,
-    /// Toggle debug information.
-    ToggleDebug,
 }
 
 /// Describes a difference in the vertical mouse scroll wheel state.

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -12,10 +12,10 @@ pub enum Event {
 
     /// Rotate the model around the focus point
     Rotation {
-        /// The normalized position of the cursor before input
-        previous: NormalizedPosition,
-        /// The normalized position of the cursor after input
-        current: NormalizedPosition,
+        /// The angle around the screen x axis to rotate (in radians)
+        angle_x: f64,
+        /// The angle around the screen y axis to rotate (in radians)
+        angle_y: f64,
     },
 
     /// Move the view forwards and backwards

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -1,15 +1,38 @@
-use crate::screen::Position;
+use crate::{camera::FocusPoint, screen::NormalizedPosition};
 
 /// An input event
 pub enum Event {
-    /// The cursor has moved to another position
-    CursorMoved(Position),
+    /// A new focus point was selected.
+    FocusPoint(FocusPoint),
 
-    /// A key has been pressed or released
-    Key(Key, KeyState),
+    /// Move the view up, down, left or right
+    Pan {
+        /// The normalized position of the cursor before input
+        previous: NormalizedPosition,
+        /// The normalized position of the cursor after input
+        current: NormalizedPosition,
+    },
 
-    /// The user scrolled
-    Scroll(MouseScrollDelta),
+    /// Rotate the view around the focus point
+    Orbit {
+        /// The normalized position of the cursor before input
+        previous: NormalizedPosition,
+        /// The normalized position of the cursor after input
+        current: NormalizedPosition,
+    },
+
+    /// Move the view forwards and backwards
+    Zoom(f64),
+
+    /// Application should exit
+    Exit,
+
+    /// Toggle the shaded display of the model.
+    ToggleModel,
+    /// Toggle the model's wireframe.
+    ToggleMesh,
+    /// Toggle debug information.
+    ToggleDebug,
 }
 
 /// Describes a difference in the vertical mouse scroll wheel state.

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -1,20 +1,11 @@
-use fj_interop::mesh::Mesh;
-use fj_math::Point;
-
-use super::{
-    event::KeyState, movement::Movement, rotation::Rotation, zoom::Zoom, Event,
-    Key,
-};
-use crate::{
-    camera::Camera,
-    screen::{Position, Size},
-};
+use super::{movement::Movement, rotation::Rotation, zoom::Zoom, Event};
+use crate::camera::{Camera, FocusPoint};
 
 /// Input handling abstraction
 ///
 /// Takes user input and applies them to application state.
 pub struct Handler {
-    cursor: Option<Position>,
+    focus_point: FocusPoint,
 
     movement: Movement,
     rotation: Rotation,
@@ -22,92 +13,47 @@ pub struct Handler {
 }
 
 impl Handler {
-    /// Returns the state of the cursor position.
-    pub fn cursor(&self) -> Option<Position> {
-        self.cursor
-    }
-
     /// Handle an input event
     pub fn handle_event(
         &mut self,
         event: Event,
-        screen_size: Size,
-        mesh: &Mesh<Point<3>>,
         camera: &mut Camera,
         actions: &mut Actions,
     ) {
         match event {
-            Event::CursorMoved(position) => {
-                if let Some(previous) = self.cursor {
-                    let diff_x = position.x - previous.x;
-                    let diff_y = position.y - previous.y;
-
-                    self.movement.apply(self.cursor, camera, screen_size);
-                    self.rotation.apply(diff_x, diff_y, camera);
-                }
-
-                self.cursor = Some(position);
+            Event::FocusPoint(focus_point) => self.focus_point = focus_point,
+            Event::Pan { previous, current } => self.movement.apply(
+                previous,
+                current,
+                &self.focus_point,
+                camera,
+            ),
+            Event::Orbit { previous, current } => self.rotation.apply(
+                previous,
+                current,
+                &self.focus_point,
+                camera,
+            ),
+            Event::Zoom(zoom_delta) => {
+                self.zoom
+                    .apply_to_camera(zoom_delta, &self.focus_point, camera)
             }
-            Event::Key(Key::Escape, KeyState::Pressed) => actions.exit = true,
-
-            Event::Key(Key::Key1, KeyState::Pressed) => {
-                actions.toggle_model = true
-            }
-            Event::Key(Key::Key2, KeyState::Pressed) => {
-                actions.toggle_mesh = true
-            }
-            Event::Key(Key::Key3, KeyState::Pressed) => {
-                actions.toggle_debug = true
-            }
-
-            Event::Key(Key::MouseLeft, KeyState::Pressed) => {
-                let focus_point =
-                    camera.focus_point(screen_size, self.cursor(), mesh);
-
-                self.rotation.start(focus_point);
-            }
-            Event::Key(Key::MouseLeft, KeyState::Released) => {
-                self.rotation.stop();
-            }
-            Event::Key(Key::MouseRight, KeyState::Pressed) => {
-                let focus_point =
-                    camera.focus_point(screen_size, self.cursor(), mesh);
-
-                self.movement.start(focus_point, self.cursor);
-            }
-            Event::Key(Key::MouseRight, KeyState::Released) => {
-                self.movement.stop();
-            }
-
-            Event::Scroll(delta) => {
-                self.zoom.push(delta);
-            }
-
-            _ => {}
+            Event::Exit => actions.exit = true,
+            Event::ToggleModel => actions.toggle_model = true,
+            Event::ToggleMesh => actions.toggle_mesh = true,
+            Event::ToggleDebug => actions.toggle_debug = true,
         }
-    }
-
-    /// Update application state from user input.
-    pub fn update(
-        &mut self,
-        delta_t: f64,
-        camera: &mut Camera,
-        screen_size: Size,
-        mesh: &Mesh<Point<3>>,
-    ) {
-        let focus_point = camera.focus_point(screen_size, self.cursor(), mesh);
-        self.zoom.apply_to_camera(delta_t, focus_point, camera);
     }
 }
 
 impl Default for Handler {
     fn default() -> Self {
         Self {
-            cursor: None,
+            focus_point: FocusPoint::none(),
 
-            movement: Movement::new(),
-            rotation: Rotation::new(),
-            zoom: Zoom::new(),
+            movement: Movement,
+            rotation: Rotation,
+            zoom: Zoom,
         }
     }
 }

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -35,8 +35,7 @@ impl Handler {
                 camera,
             ),
             Event::Zoom(zoom_delta) => {
-                self.zoom
-                    .apply_to_camera(zoom_delta, &self.focus_point, camera)
+                self.zoom.apply(zoom_delta, &self.focus_point, camera)
             }
             Event::Exit => actions.exit = true,
             Event::ToggleModel => actions.toggle_model = true,

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -22,12 +22,10 @@ impl Handler {
                 &self.focus_point,
                 camera,
             ),
-            Event::Rotation { previous, current } => self.rotation.apply(
-                previous,
-                current,
-                &self.focus_point,
-                camera,
-            ),
+            Event::Rotation { angle_x, angle_y } => {
+                self.rotation
+                    .apply(angle_x, angle_y, &self.focus_point, camera)
+            }
             Event::Zoom(zoom_delta) => {
                 self.zoom.apply(zoom_delta, &self.focus_point, camera)
             }

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -16,13 +16,13 @@ impl Handler {
     /// Handle an input event
     pub fn handle_event(&mut self, event: Event, camera: &mut Camera) {
         match event {
-            Event::Pan { previous, current } => self.movement.apply(
+            Event::Translate { previous, current } => self.movement.apply(
                 previous,
                 current,
                 &self.focus_point,
                 camera,
             ),
-            Event::Orbit { previous, current } => self.rotation.apply(
+            Event::Rotation { previous, current } => self.rotation.apply(
                 previous,
                 current,
                 &self.focus_point,

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -16,7 +16,6 @@ impl Handler {
     /// Handle an input event
     pub fn handle_event(&mut self, event: Event, camera: &mut Camera) {
         match event {
-            Event::FocusPoint(focus_point) => self.focus_point = focus_point,
             Event::Pan { previous, current } => self.movement.apply(
                 previous,
                 current,
@@ -32,8 +31,12 @@ impl Handler {
             Event::Zoom(zoom_delta) => {
                 self.zoom.apply(zoom_delta, &self.focus_point, camera)
             }
-            _ => {}
         }
+    }
+
+    /// A new focus point was selected (or deselected)
+    pub fn focus(&mut self, focus_point: FocusPoint) {
+        self.focus_point = focus_point;
     }
 }
 

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -14,12 +14,7 @@ pub struct Handler {
 
 impl Handler {
     /// Handle an input event
-    pub fn handle_event(
-        &mut self,
-        event: Event,
-        camera: &mut Camera,
-        actions: &mut Actions,
-    ) {
+    pub fn handle_event(&mut self, event: Event, camera: &mut Camera) {
         match event {
             Event::FocusPoint(focus_point) => self.focus_point = focus_point,
             Event::Pan { previous, current } => self.movement.apply(
@@ -37,10 +32,7 @@ impl Handler {
             Event::Zoom(zoom_delta) => {
                 self.zoom.apply(zoom_delta, &self.focus_point, camera)
             }
-            Event::Exit => actions.exit = true,
-            Event::ToggleModel => actions.toggle_model = true,
-            Event::ToggleMesh => actions.toggle_mesh = true,
-            Event::ToggleDebug => actions.toggle_debug = true,
+            _ => {}
         }
     }
 }
@@ -54,28 +46,5 @@ impl Default for Handler {
             rotation: Rotation,
             zoom: Zoom,
         }
-    }
-}
-
-/// Intermediate input state container
-///
-/// Used as a per frame state container for sending application state to `winit`.
-#[derive(Default)]
-pub struct Actions {
-    /// Application exit state.
-    pub exit: bool,
-
-    /// Toggle for the shaded display of the model.
-    pub toggle_model: bool,
-    /// Toggle for the model's wireframe.
-    pub toggle_mesh: bool,
-    /// Toggle for debug information.
-    pub toggle_debug: bool,
-}
-
-impl Actions {
-    /// Returns a new `Actions`.
-    pub fn new() -> Self {
-        Self::default()
     }
 }

--- a/crates/fj-viewer/src/input/mod.rs
+++ b/crates/fj-viewer/src/input/mod.rs
@@ -6,7 +6,4 @@ mod movement;
 mod rotation;
 mod zoom;
 
-pub use self::{
-    event::{Event, Key, KeyState, MouseScrollDelta},
-    handler::Handler,
-};
+pub use self::{event::Event, handler::Handler};

--- a/crates/fj-viewer/src/input/mod.rs
+++ b/crates/fj-viewer/src/input/mod.rs
@@ -8,5 +8,5 @@ mod zoom;
 
 pub use self::{
     event::{Event, Key, KeyState, MouseScrollDelta},
-    handler::{Actions, Handler},
+    handler::Handler,
 };

--- a/crates/fj-viewer/src/input/movement.rs
+++ b/crates/fj-viewer/src/input/movement.rs
@@ -2,57 +2,35 @@ use fj_math::{Point, Scalar, Transform, Vector};
 
 use crate::{
     camera::{Camera, FocusPoint},
-    screen::{Position, Size},
+    screen::NormalizedPosition,
 };
 
-pub struct Movement {
-    focus_point: FocusPoint,
-    cursor: Option<Position>,
-}
+pub struct Movement;
 
 impl Movement {
-    pub fn new() -> Self {
-        Self {
-            focus_point: FocusPoint::none(),
-            cursor: None,
-        }
-    }
-
-    pub fn start(&mut self, focus_point: FocusPoint, cursor: Option<Position>) {
-        self.focus_point = focus_point;
-        self.cursor = cursor;
-    }
-
-    pub fn stop(&mut self) {
-        self.focus_point = FocusPoint::none();
-    }
-
     pub fn apply(
         &mut self,
-        cursor: Option<Position>,
+        previous: NormalizedPosition,
+        current: NormalizedPosition,
+        focus_point: &FocusPoint,
         camera: &mut Camera,
-        size: Size,
     ) {
-        if let (Some(previous), Some(cursor)) = (self.cursor, cursor) {
-            let previous = camera.cursor_to_model_space(previous, size);
-            let cursor = camera.cursor_to_model_space(cursor, size);
+        let previous = camera.normalized_cursor_to_model_space(previous);
+        let cursor = camera.normalized_cursor_to_model_space(current);
 
-            if let Some(focus_point) = self.focus_point.0 {
-                let d1 = Point::distance(&camera.position(), &cursor);
-                let d2 = Point::distance(&camera.position(), &focus_point);
+        if let Some(focus_point) = focus_point.0 {
+            let d1 = Point::distance(&camera.position(), &cursor);
+            let d2 = Point::distance(&camera.position(), &focus_point);
 
-                let diff = (cursor - previous) * d2 / d1;
-                let offset = camera.camera_to_model().transform_vector(&diff);
+            let diff = (cursor - previous) * d2 / d1;
+            let offset = camera.camera_to_model().transform_vector(&diff);
 
-                camera.translation = camera.translation
-                    * Transform::translation(Vector::from([
-                        offset.x,
-                        offset.y,
-                        Scalar::ZERO,
-                    ]));
-            }
+            camera.translation = camera.translation
+                * Transform::translation(Vector::from([
+                    offset.x,
+                    offset.y,
+                    Scalar::ZERO,
+                ]));
         }
-
-        self.cursor = cursor;
     }
 }

--- a/crates/fj-viewer/src/input/movement.rs
+++ b/crates/fj-viewer/src/input/movement.rs
@@ -15,8 +15,8 @@ impl Movement {
         focus_point: &FocusPoint,
         camera: &mut Camera,
     ) {
-        let previous = camera.normalized_cursor_to_model_space(previous);
-        let cursor = camera.normalized_cursor_to_model_space(current);
+        let previous = camera.cursor_to_model_space(previous);
+        let cursor = camera.cursor_to_model_space(current);
 
         if let Some(focus_point) = focus_point.0 {
             let d1 = Point::distance(&camera.position(), &cursor);

--- a/crates/fj-viewer/src/input/rotation.rs
+++ b/crates/fj-viewer/src/input/rotation.rs
@@ -1,30 +1,19 @@
 use fj_math::{Point, Transform, Vector};
 
-use crate::{
-    camera::{Camera, FocusPoint},
-    screen::NormalizedPosition,
-};
+use crate::camera::{Camera, FocusPoint};
 
 pub struct Rotation;
 
 impl Rotation {
     pub fn apply(
         &self,
-        previous: NormalizedPosition,
-        current: NormalizedPosition,
+        angle_x: f64,
+        angle_y: f64,
         focus_point: &FocusPoint,
         camera: &mut Camera,
     ) {
         let rotate_around: Vector<3> =
             focus_point.0.unwrap_or_else(Point::origin).coords;
-
-        let f = -5.;
-
-        let diff_x = current.x - previous.x;
-        let diff_y = current.y - previous.y;
-        let angle_x = diff_y * f;
-        let angle_y = -diff_x * f;
-
         let rotate_around = Transform::translation(rotate_around);
 
         // the model rotates not the camera, so invert the transform

--- a/crates/fj-viewer/src/input/rotation.rs
+++ b/crates/fj-viewer/src/input/rotation.rs
@@ -1,57 +1,47 @@
 use fj_math::{Point, Transform, Vector};
 
-use crate::camera::{Camera, FocusPoint};
+use crate::{
+    camera::{Camera, FocusPoint},
+    screen::NormalizedPosition,
+};
 
-pub struct Rotation {
-    active: bool,
-    focus_point: FocusPoint,
-}
+pub struct Rotation;
 
 impl Rotation {
-    pub fn new() -> Self {
-        Self {
-            active: false,
-            focus_point: FocusPoint::none(),
-        }
-    }
+    pub fn apply(
+        &self,
+        previous: NormalizedPosition,
+        current: NormalizedPosition,
+        focus_point: &FocusPoint,
+        camera: &mut Camera,
+    ) {
+        let rotate_around: Vector<3> =
+            focus_point.0.unwrap_or_else(Point::origin).coords;
 
-    pub fn start(&mut self, focus_point: FocusPoint) {
-        self.active = true;
-        self.focus_point = focus_point;
-    }
+        let f = -5.;
 
-    pub fn stop(&mut self) {
-        self.active = false;
-    }
+        let diff_x = current.x - previous.x;
+        let diff_y = current.y - previous.y;
+        let angle_x = diff_y * f;
+        let angle_y = -diff_x * f;
 
-    pub fn apply(&self, diff_x: f64, diff_y: f64, camera: &mut Camera) {
-        if self.active {
-            let rotate_around: Vector<3> =
-                self.focus_point.0.unwrap_or_else(Point::origin).coords;
+        let rotate_around = Transform::translation(rotate_around);
 
-            let f = 0.005;
+        // the model rotates not the camera, so invert the transform
+        let camera_rotation = camera.rotation.inverse();
+        let right_vector = right_vector(&camera_rotation);
+        let up_vector = up_vector(&camera_rotation);
 
-            let angle_x = diff_y * f;
-            let angle_y = diff_x * f;
+        let rotation = Transform::rotation(right_vector * angle_x)
+            * Transform::rotation(up_vector * angle_y);
 
-            let rotate_around = Transform::translation(rotate_around);
+        let transform = camera.camera_to_model()
+            * rotate_around
+            * rotation
+            * rotate_around.inverse();
 
-            // the model rotates not the camera, so invert the transform
-            let camera_rotation = camera.rotation.inverse();
-            let right_vector = right_vector(&camera_rotation);
-            let up_vector = up_vector(&camera_rotation);
-
-            let rotation = Transform::rotation(right_vector * angle_x)
-                * Transform::rotation(up_vector * angle_y);
-
-            let transform = camera.camera_to_model()
-                * rotate_around
-                * rotation
-                * rotate_around.inverse();
-
-            camera.rotation = transform.extract_rotation();
-            camera.translation = transform.extract_translation();
-        }
+        camera.rotation = transform.extract_rotation();
+        camera.translation = transform.extract_translation();
     }
 }
 

--- a/crates/fj-viewer/src/input/zoom.rs
+++ b/crates/fj-viewer/src/input/zoom.rs
@@ -2,54 +2,21 @@ use fj_math::{Transform, Vector};
 
 use crate::camera::{Camera, FocusPoint};
 
-use super::event::MouseScrollDelta;
-
-pub struct Zoom {
-    accumulated_delta: f64,
-}
+pub struct Zoom;
 
 impl Zoom {
-    pub fn new() -> Self {
-        Self {
-            accumulated_delta: 0.0,
-        }
-    }
-
-    pub fn push(&mut self, delta: MouseScrollDelta) {
-        // Accumulate all zoom inputs
-        self.accumulated_delta += match delta {
-            MouseScrollDelta::Line(delta) => ZOOM_FACTOR_LINE * delta,
-            MouseScrollDelta::Pixel(delta) => ZOOM_FACTOR_PIXEL * delta,
-        };
-    }
-
     pub fn apply_to_camera(
         &mut self,
-        delta_t: f64,
-        focus_point: FocusPoint,
+        zoom_delta: f64,
+        focus_point: &FocusPoint,
         camera: &mut Camera,
     ) {
         let distance = match focus_point.0 {
             Some(fp) => (fp - camera.position()).magnitude(),
             None => camera.position().coords.magnitude(),
         };
-        let displacement =
-            self.accumulated_delta * delta_t * distance.into_f64();
+        let displacement = zoom_delta * distance.into_f64();
         camera.translation = camera.translation
             * Transform::translation(Vector::from([0.0, 0.0, -displacement]));
-
-        self.accumulated_delta = 0.;
     }
 }
-
-/// Affects the speed of zoom movement given a scroll wheel input in lines.
-///
-/// Smaller values will move the camera less with the same input.
-/// Larger values will move the camera more with the same input.
-const ZOOM_FACTOR_LINE: f64 = 15.0;
-
-/// Affects the speed of zoom movement given a scroll wheel input in pixels.
-///
-/// Smaller values will move the camera less with the same input.
-/// Larger values will move the camera more with the same input.
-const ZOOM_FACTOR_PIXEL: f64 = 1.0;

--- a/crates/fj-viewer/src/input/zoom.rs
+++ b/crates/fj-viewer/src/input/zoom.rs
@@ -5,7 +5,7 @@ use crate::camera::{Camera, FocusPoint};
 pub struct Zoom;
 
 impl Zoom {
-    pub fn apply_to_camera(
+    pub fn apply(
         &mut self,
         zoom_delta: f64,
         focus_point: &FocusPoint,

--- a/crates/fj-viewer/src/screen.rs
+++ b/crates/fj-viewer/src/screen.rs
@@ -14,24 +14,14 @@ pub trait Screen {
     fn window(&self) -> &Self::Window;
 }
 
-/// A position on the screen
-#[derive(Clone, Copy, Debug)]
-pub struct Position {
-    /// The x coordinate of the position
-    pub x: f64,
-
-    /// The y coordinate of the position
-    pub y: f64,
-}
-
 /// Cursor position in normalized coordinates (-1 to +1) with aspect ratio taken into account.
 /// i.e. the center of the screen is at (0, 0)
 #[derive(Clone, Copy, Debug)]
 pub struct NormalizedPosition {
-    /// The x coordinate of the position
+    /// The x coordinate of the position [-1, 1]
     pub x: f64,
 
-    /// The y coordinate of the position
+    /// The y coordinate of the position [-1, 1]
     pub y: f64,
 }
 

--- a/crates/fj-viewer/src/screen.rs
+++ b/crates/fj-viewer/src/screen.rs
@@ -24,6 +24,17 @@ pub struct Position {
     pub y: f64,
 }
 
+/// Cursor position in normalized coordinates (-1 to +1) with aspect ratio taken into account.
+/// i.e. the center of the screen is at (0, 0)
+#[derive(Clone, Copy, Debug)]
+pub struct NormalizedPosition {
+    /// The x coordinate of the position
+    pub x: f64,
+
+    /// The y coordinate of the position
+    pub y: f64,
+}
+
 /// The size of the screen
 #[derive(Clone, Copy, Debug)]
 pub struct Size {

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -223,7 +223,12 @@ fn input_event(
             let event = match (*previous_cursor, held_mouse_button) {
                 (Some(previous), Some(button)) => match button {
                     MouseButton::Left => {
-                        Some(input::Event::Rotation { previous, current })
+                        let diff_x = current.x - previous.x;
+                        let diff_y = current.y - previous.y;
+                        let angle_x = -diff_y * ROTATION_SENSITIVITY;
+                        let angle_y = diff_x * ROTATION_SENSITIVITY;
+
+                        Some(input::Event::Rotation { angle_x, angle_y })
                     }
                     MouseButton::Right => {
                         Some(input::Event::Translate { previous, current })
@@ -302,3 +307,9 @@ const ZOOM_FACTOR_LINE: f64 = 0.075;
 /// Smaller values will move the camera less with the same input.
 /// Larger values will move the camera more with the same input.
 const ZOOM_FACTOR_PIXEL: f64 = 0.005;
+
+/// Affects the speed of rotation given a change in normalized screen position [-1, 1]
+///
+/// Smaller values will move the camera less with the same input.
+/// Larger values will move the camera more with the same input.
+const ROTATION_SENSITIVITY: f64 = 5.;

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -223,10 +223,10 @@ fn input_event(
             let event = match (*previous_cursor, held_mouse_button) {
                 (Some(previous), Some(button)) => match button {
                     MouseButton::Left => {
-                        Some(input::Event::Orbit { previous, current })
+                        Some(input::Event::Rotation { previous, current })
                     }
                     MouseButton::Right => {
-                        Some(input::Event::Pan { previous, current })
+                        Some(input::Event::Translate { previous, current })
                     }
                     _ => None,
                 },


### PR DESCRIPTION
See https://github.com/hannobraun/Fornjot/pull/764#issuecomment-1176245933

Open questions:
1. Does it make sense to pass `Actions` from `fj-window` to `fj-viewer` and back again?
2. `fj-viewer` now uses resolution-independent cursor positions everywhere (normalized to [-1, 1]). This means I had to change the magic number here to feel right. What was the meaning/units of this number? https://github.com/hannobraun/Fornjot/blob/edf7a6636d1d0323d7e56943c3fc96ab4cfd46a3/crates/fj-viewer/src/input/rotation.rs#L32
3. I've introduced a small change in behavior of the "focus point" which might not be desirable. On left and right clicks a new focus point is chosen. There is no way to remove an old focus point, only replacing when clicking again. Zooming now uses the most recently created focus point, instead of the current cursor position. Is this fine, or should I reimplement the old behavior (Mouse down creates focus point, mouse up removes focus point, temporary focus point calculated for each zoom event)?
