### PR TITLE
Move ProcessedShape to fj-interop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,6 @@ dependencies = [
  "egui-winit",
  "fj-interop",
  "fj-math",
- "fj-operations",
  "raw-window-handle",
  "thiserror",
  "tracing",

--- a/crates/fj-interop/src/lib.rs
+++ b/crates/fj-interop/src/lib.rs
@@ -16,3 +16,4 @@
 
 pub mod debug;
 pub mod mesh;
+pub mod processed_shape;

--- a/crates/fj-interop/src/processed_shape.rs
+++ b/crates/fj-interop/src/processed_shape.rs
@@ -1,0 +1,17 @@
+//! A processed shape
+
+use fj_math::{Aabb, Point};
+
+use crate::{debug::DebugInfo, mesh::Mesh};
+
+/// A processed shape
+pub struct ProcessedShape {
+    /// The axis-aligned bounding box of the shape
+    pub aabb: Aabb<3>,
+
+    /// The triangle mesh that approximates the original shape
+    pub mesh: Mesh<Point<3>>,
+
+    /// The debug info generated while processing the shape
+    pub debug_info: DebugInfo,
+}

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -1,11 +1,11 @@
 //! API for processing shapes
 
-use fj_interop::{debug::DebugInfo, mesh::Mesh};
+use fj_interop::{debug::DebugInfo, processed_shape::ProcessedShape};
 use fj_kernel::{
     algorithms::{triangulate, InvalidTolerance, Tolerance},
     validation::{ValidationConfig, ValidationError},
 };
-use fj_math::{Aabb, Point, Scalar};
+use fj_math::Scalar;
 
 use crate::ToShape as _;
 
@@ -49,20 +49,6 @@ impl ShapeProcessor {
             debug_info,
         })
     }
-}
-
-/// A processed shape
-///
-/// Created by [`ShapeProcessor::process`].
-pub struct ProcessedShape {
-    /// The axis-aligned bounding box of the shape
-    pub aabb: Aabb<3>,
-
-    /// The triangle mesh that approximates the original shape
-    pub mesh: Mesh<Point<3>>,
-
-    /// The debug info generated while processing the shape
-    pub debug_info: DebugInfo,
 }
 
 /// A shape processing error

--- a/crates/fj-viewer/Cargo.toml
+++ b/crates/fj-viewer/Cargo.toml
@@ -28,10 +28,6 @@ path = "../fj-interop"
 version = "0.7.0"
 path = "../fj-math"
 
-[dependencies.fj-operations]
-version = "0.7.0"
-path = "../fj-operations"
-
 [dependencies.egui]
 version = "0.18.1"
 

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -1,8 +1,8 @@
 //! Viewer camera module
 use std::f64::consts::FRAC_PI_2;
 
+use fj_interop::processed_shape::ProcessedShape;
 use fj_math::{Aabb, Point, Scalar, Transform, Triangle, Vector};
-use fj_operations::shape_processor::ProcessedShape;
 
 use crate::screen::NormalizedPosition;
 


### PR DESCRIPTION
As suggested here: https://github.com/hannobraun/Fornjot/pull/806#discussion_r919934299

Unfortunately, I had to remove the docs link to `ShapeProcessor::process`, as it is not reachable as a dependency of the `fj-interop` crate.