### PR TITLE
Release operator: Wait for crate version to appear upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/tools/release-operator/Cargo.toml
+++ b/tools/release-operator/Cargo.toml
@@ -16,6 +16,7 @@ regex = "1.6.0"
 secstr = "0.5.0"
 semver = "1.0.12"
 serde_json = "1.0.82"
+thiserror = "1.0.31"
 
 [dependencies.reqwest]
 version = "0.11.11"

--- a/tools/release-operator/src/registry.rs
+++ b/tools/release-operator/src/registry.rs
@@ -212,9 +212,15 @@ impl Crate {
 
             let theirs = self.get_upstream_version()?;
 
-            if theirs == ours {
-                log::info!("{self} appeared as {ours} on the registry");
-                break;
+            match theirs.cmp(&ours) {
+                std::cmp::Ordering::Less => (),
+                std::cmp::Ordering::Equal => {
+                    log::info!("{self} appeared as {ours} on the registry");
+                    break;
+                }
+                std::cmp::Ordering::Greater => {
+                    return Err(anyhow!("{self} appeared as {theirs} on the registry which is newer than the current release ({ours})"))
+                },
             }
 
             log::info!("{self} waiting for {ours}...");

--- a/tools/release-operator/src/registry.rs
+++ b/tools/release-operator/src/registry.rs
@@ -157,17 +157,17 @@ impl Crate {
 
         let ours = self.get_local_version()?;
 
-        if ours == theirs {
-            log::info!("{self} has already been published as {ours}");
-            return Ok(CrateState::Published);
+        match theirs.cmp(&ours) {
+            std::cmp::Ordering::Less => Ok(CrateState::Ahead),
+            std::cmp::Ordering::Equal => {
+                log::info!("{self} has already been published as {ours}");
+                Ok(CrateState::Published)
+            }
+            std::cmp::Ordering::Greater => {
+                log::warn!("{self} has already been published as {ours}, which is a newer version");
+                Ok(CrateState::Behind)
+            }
         }
-
-        if ours < theirs {
-            log::warn!("{self} has already been published as {ours}, which is a newer version");
-            return Ok(CrateState::Behind);
-        }
-
-        Ok(CrateState::Ahead)
     }
 
     fn submit(&self, token: &SecUtf8, dry_run: bool) -> anyhow::Result<()> {


### PR DESCRIPTION
This change-set introduces a simple wait loop, with a timeout of 10 minutes, after the submission of each crate. Hence the operator will only move to the next crate in the list of crates to publish once the current one has fully populated.

Fixes #788 