### PR TITLE
Rename `ToShape` to `Shape`; clean it up

### DIFF
--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -8,9 +8,9 @@ use fj_kernel::{
 };
 use fj_math::Aabb;
 
-use super::ToShape;
+use super::Shape;
 
-impl ToShape for fj::Difference2d {
+impl Shape for fj::Difference2d {
     fn to_shape(
         &self,
         config: &ValidationConfig,

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -11,7 +11,7 @@ use fj_math::Aabb;
 use super::Shape;
 
 impl Shape for fj::Difference2d {
-    fn to_shape(
+    fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
@@ -29,8 +29,8 @@ impl Shape for fj::Difference2d {
         // - https://doc.rust-lang.org/std/primitive.array.html#method.each_ref
         // - https://doc.rust-lang.org/std/primitive.array.html#method.try_map
         let [a, b] = self.shapes();
-        let [a, b] =
-            [a, b].map(|shape| shape.to_shape(config, tolerance, debug_info));
+        let [a, b] = [a, b]
+            .map(|shape| shape.compute_brep(config, tolerance, debug_info));
         let [a, b] = [a?, b?];
 
         if let Some(face) = a.face_iter().next() {

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -6,9 +6,9 @@ use fj_kernel::{
 };
 use fj_math::Aabb;
 
-use super::ToShape;
+use super::Shape;
 
-impl ToShape for fj::Group {
+impl Shape for fj::Group {
     fn to_shape(
         &self,
         config: &ValidationConfig,

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -9,7 +9,7 @@ use fj_math::Aabb;
 use super::Shape;
 
 impl Shape for fj::Group {
-    fn to_shape(
+    fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
@@ -17,8 +17,8 @@ impl Shape for fj::Group {
     ) -> Result<Validated<Vec<Face>>, ValidationError> {
         let mut shape = Vec::new();
 
-        let a = self.a.to_shape(config, tolerance, debug_info)?;
-        let b = self.b.to_shape(config, tolerance, debug_info)?;
+        let a = self.a.compute_brep(config, tolerance, debug_info)?;
+        let b = self.b.compute_brep(config, tolerance, debug_info)?;
 
         shape.extend(a.into_inner());
         shape.extend(b.into_inner());

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -33,7 +33,7 @@ use fj_kernel::{
 use fj_math::Aabb;
 
 /// Implemented for all operations from the [`fj`] crate
-pub trait ToShape {
+pub trait Shape {
     /// Compute the boundary representation of the shape
     fn to_shape(
         &self,
@@ -51,7 +51,7 @@ pub trait ToShape {
 
 macro_rules! dispatch {
     ($($method:ident($($arg_name:ident: $arg_ty:ty,)*) -> $ret:ty;)*) => {
-        impl ToShape for fj::Shape {
+        impl Shape for fj::Shape {
             $(
                 fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
                     match self {
@@ -62,7 +62,7 @@ macro_rules! dispatch {
             )*
         }
 
-        impl ToShape for fj::Shape2d {
+        impl Shape for fj::Shape2d {
             $(
                 fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
                     match self {
@@ -73,7 +73,7 @@ macro_rules! dispatch {
             )*
         }
 
-        impl ToShape for fj::Shape3d {
+        impl Shape for fj::Shape3d {
             $(
                 fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
                     match self {

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -35,7 +35,7 @@ use fj_math::Aabb;
 /// Implemented for all operations from the [`fj`] crate
 pub trait Shape {
     /// Compute the boundary representation of the shape
-    fn to_shape(
+    fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
@@ -88,7 +88,7 @@ macro_rules! dispatch {
 }
 
 dispatch! {
-    to_shape(
+    compute_brep(
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -7,7 +7,7 @@ use fj_kernel::{
 };
 use fj_math::Scalar;
 
-use crate::ToShape as _;
+use crate::Shape as _;
 
 /// Processes an [`fj::Shape`] into a [`ProcessedShape`]
 pub struct ShapeProcessor {

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -40,7 +40,7 @@ impl ShapeProcessor {
 
         let config = ValidationConfig::default();
         let mut debug_info = DebugInfo::new();
-        let shape = shape.to_shape(&config, tolerance, &mut debug_info)?;
+        let shape = shape.compute_brep(&config, tolerance, &mut debug_info)?;
         let mesh = triangulate(shape.into_inner(), tolerance, &mut debug_info);
 
         Ok(ProcessedShape {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -9,7 +9,7 @@ use fj_math::{Aabb, Point, Scalar};
 use super::Shape;
 
 impl Shape for fj::Sketch {
-    fn to_shape(
+    fn compute_brep(
         &self,
         config: &ValidationConfig,
         _: Tolerance,

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -6,9 +6,9 @@ use fj_kernel::{
 };
 use fj_math::{Aabb, Point, Scalar};
 
-use super::ToShape;
+use super::Shape;
 
-impl ToShape for fj::Sketch {
+impl Shape for fj::Sketch {
     fn to_shape(
         &self,
         config: &ValidationConfig,

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -6,9 +6,9 @@ use fj_kernel::{
 };
 use fj_math::{Aabb, Vector};
 
-use super::ToShape;
+use super::Shape;
 
-impl ToShape for fj::Sweep {
+impl Shape for fj::Sweep {
     fn to_shape(
         &self,
         config: &ValidationConfig,

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -9,13 +9,14 @@ use fj_math::{Aabb, Vector};
 use super::Shape;
 
 impl Shape for fj::Sweep {
-    fn to_shape(
+    fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Vec<Face>>, ValidationError> {
-        let sketch = self.shape().to_shape(config, tolerance, debug_info)?;
+        let sketch =
+            self.shape().compute_brep(config, tolerance, debug_info)?;
         let path = Vector::from(self.path());
         let color = self.shape().color();
 

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -9,7 +9,7 @@ use fj_math::{Aabb, Transform, Vector};
 use super::Shape;
 
 impl Shape for fj::Transform {
-    fn to_shape(
+    fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
@@ -17,7 +17,7 @@ impl Shape for fj::Transform {
     ) -> Result<Validated<Vec<Face>>, ValidationError> {
         let mut shape = self
             .shape
-            .to_shape(config, tolerance, debug_info)?
+            .compute_brep(config, tolerance, debug_info)?
             .into_inner();
 
         transform_shape(&mut shape, &make_transform(self));

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -6,9 +6,9 @@ use fj_kernel::{
 };
 use fj_math::{Aabb, Transform, Vector};
 
-use super::ToShape;
+use super::Shape;
 
-impl ToShape for fj::Transform {
+impl Shape for fj::Transform {
     fn to_shape(
         &self,
         config: &ValidationConfig,


### PR DESCRIPTION
The old names didn't make much sense any more. See commits for more details.