### PR TITLE
Add `Solid` object

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -4,7 +4,7 @@ use crate::{
     iter::ObjectIters,
     local::Local,
     objects::{
-        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Surface, Vertex,
+        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
         VerticesOfEdge,
     },
 };
@@ -17,7 +17,7 @@ pub fn sweep(
     path: impl Into<Vector<3>>,
     tolerance: Tolerance,
     color: [u8; 4],
-) -> Vec<Face> {
+) -> Solid {
     let path = path.into();
 
     let is_sweep_along_negative_direction =
@@ -62,7 +62,7 @@ pub fn sweep(
         }
     }
 
-    target
+    Solid::from_faces(target)
 }
 
 fn create_bottom_faces(

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -4,7 +4,7 @@ use crate::{
     local::Local,
     objects::{
         Curve, Cycle, CyclesInFace, Edge, Face, FaceBRep, GlobalVertex, Sketch,
-        Surface, Vertex,
+        Solid, Surface, Vertex,
     },
 };
 
@@ -109,6 +109,14 @@ impl TransformObject for GlobalVertex {
 }
 
 impl TransformObject for Sketch {
+    fn transform(self, transform: &Transform) -> Self {
+        let mut faces = self.into_faces();
+        transform_faces(&mut faces, transform);
+        Self::from_faces(faces)
+    }
+}
+
+impl TransformObject for Solid {
     fn transform(self, transform: &Transform) -> Self {
         let mut faces = self.into_faces();
         transform_faces(&mut faces, transform);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 
 use crate::objects::{
-    Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Surface, Vertex,
+    Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
 };
 
 /// Access iterators over all objects of a shape, or part of it
@@ -28,6 +28,9 @@ pub trait ObjectIters {
 
     /// Iterate over all sketches
     fn sketch_iter(&self) -> Iter<Sketch>;
+
+    /// Iterate over all solids
+    fn solid_iter(&self) -> Iter<Solid>;
 
     /// Iterate over all surfaces
     fn surface_iter(&self) -> Iter<Surface>;
@@ -58,6 +61,10 @@ impl ObjectIters for Curve<3> {
     }
 
     fn sketch_iter(&self) -> Iter<Sketch> {
+        Iter::empty()
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
         Iter::empty()
     }
 
@@ -120,6 +127,16 @@ impl ObjectIters for Cycle {
 
         for edge in self.edges() {
             iter = iter.with(edge.sketch_iter());
+        }
+
+        iter
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
+        let mut iter = Iter::empty();
+
+        for edge in self.edges() {
+            iter = iter.with(edge.solid_iter());
         }
 
         iter
@@ -196,6 +213,16 @@ impl ObjectIters for Edge {
 
         for vertex in self.vertices().into_iter().flatten() {
             iter = iter.with(vertex.sketch_iter());
+        }
+
+        iter
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
+        let mut iter = Iter::empty().with(self.curve().solid_iter());
+
+        for vertex in self.vertices().into_iter().flatten() {
+            iter = iter.with(vertex.solid_iter());
         }
 
         iter
@@ -298,6 +325,20 @@ impl ObjectIters for Face {
         Iter::empty()
     }
 
+    fn solid_iter(&self) -> Iter<Solid> {
+        if let Face::Face(face) = self {
+            let mut iter = Iter::empty().with(face.surface().solid_iter());
+
+            for cycle in face.all_cycles() {
+                iter = iter.with(cycle.solid_iter());
+            }
+
+            return iter;
+        }
+
+        Iter::empty()
+    }
+
     fn surface_iter(&self) -> Iter<Surface> {
         if let Face::Face(face) = self {
             let mut iter = Iter::empty().with(face.surface().surface_iter());
@@ -349,6 +390,10 @@ impl ObjectIters for GlobalVertex {
     }
 
     fn sketch_iter(&self) -> Iter<Sketch> {
+        Iter::empty()
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
         Iter::empty()
     }
 
@@ -416,6 +461,16 @@ impl ObjectIters for Sketch {
         Iter::from_object(self.clone())
     }
 
+    fn solid_iter(&self) -> Iter<Solid> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.solid_iter());
+        }
+
+        iter
+    }
+
     fn surface_iter(&self) -> Iter<Surface> {
         let mut iter = Iter::empty();
 
@@ -462,6 +517,10 @@ impl ObjectIters for Surface {
         Iter::empty()
     }
 
+    fn solid_iter(&self) -> Iter<Solid> {
+        Iter::empty()
+    }
+
     fn surface_iter(&self) -> Iter<Surface> {
         Iter::from_object(*self)
     }
@@ -494,6 +553,10 @@ impl ObjectIters for Vertex {
 
     fn sketch_iter(&self) -> Iter<Sketch> {
         self.global().sketch_iter()
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
+        self.global().solid_iter()
     }
 
     fn surface_iter(&self) -> Iter<Surface> {
@@ -570,6 +633,16 @@ where
 
         for object in self.into_iter() {
             iter = iter.with(object.sketch_iter());
+        }
+
+        iter
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
+        let mut iter = Iter::empty();
+
+        for object in self.into_iter() {
+            iter = iter.with(object.solid_iter());
         }
 
         iter
@@ -652,6 +725,7 @@ mod tests {
         assert_eq!(0, object.face_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
     }
@@ -669,6 +743,7 @@ mod tests {
         assert_eq!(0, object.face_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
     }
@@ -686,6 +761,7 @@ mod tests {
         assert_eq!(0, object.face_iter().count());
         assert_eq!(2, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(2, object.vertex_iter().count());
     }
@@ -702,6 +778,7 @@ mod tests {
         assert_eq!(1, object.face_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(1, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
     }
@@ -716,6 +793,7 @@ mod tests {
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
     }
@@ -733,6 +811,7 @@ mod tests {
         assert_eq!(1, object.face_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
         assert_eq!(1, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(1, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
     }
@@ -747,6 +826,7 @@ mod tests {
         assert_eq!(0, object.face_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(1, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
     }
@@ -762,6 +842,7 @@ mod tests {
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());
         assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(1, object.vertex_iter().count());
     }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -492,6 +492,92 @@ impl ObjectIters for Sketch {
     }
 }
 
+impl ObjectIters for Solid {
+    fn curve_iter(&self) -> Iter<Curve<3>> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.curve_iter());
+        }
+
+        iter
+    }
+
+    fn cycle_iter(&self) -> Iter<Cycle> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.cycle_iter());
+        }
+
+        iter
+    }
+
+    fn edge_iter(&self) -> Iter<Edge> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.edge_iter());
+        }
+
+        iter
+    }
+
+    fn face_iter(&self) -> Iter<Face> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.face_iter());
+        }
+
+        iter
+    }
+
+    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.global_vertex_iter());
+        }
+
+        iter
+    }
+
+    fn sketch_iter(&self) -> Iter<Sketch> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.sketch_iter());
+        }
+
+        iter
+    }
+
+    fn solid_iter(&self) -> Iter<Solid> {
+        Iter::from_object(self.clone())
+    }
+
+    fn surface_iter(&self) -> Iter<Surface> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.surface_iter());
+        }
+
+        iter
+    }
+
+    fn vertex_iter(&self) -> Iter<Vertex> {
+        let mut iter = Iter::empty();
+
+        for edge in self.faces() {
+            iter = iter.with(edge.vertex_iter());
+        }
+
+        iter
+    }
+}
+
 impl ObjectIters for Surface {
     fn curve_iter(&self) -> Iter<Curve<3>> {
         Iter::empty()
@@ -710,7 +796,7 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::objects::{
-        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Surface, Vertex,
+        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
     };
 
     use super::ObjectIters as _;
@@ -814,6 +900,21 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(1, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
+    }
+
+    #[test]
+    fn solid() {
+        let object = Solid::cube_from_edge_length(1.);
+
+        assert_eq!(18, object.curve_iter().count());
+        assert_eq!(6, object.cycle_iter().count());
+        assert_eq!(20, object.edge_iter().count());
+        assert_eq!(6, object.face_iter().count());
+        assert_eq!(8, object.global_vertex_iter().count());
+        assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(1, object.solid_iter().count());
+        assert_eq!(6, object.surface_iter().count());
+        assert_eq!(16, object.vertex_iter().count());
     }
 
     #[test]

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -10,6 +10,7 @@ mod edge;
 mod face;
 mod global_vertex;
 mod sketch;
+mod solid;
 mod surface;
 mod vertex;
 
@@ -20,6 +21,7 @@ pub use self::{
     face::{CyclesInFace, Face, FaceBRep},
     global_vertex::GlobalVertex,
     sketch::Sketch,
+    solid::Solid,
     surface::{Surface, SweptCurve},
     vertex::Vertex,
 };

--- a/crates/fj-kernel/src/objects/sketch.rs
+++ b/crates/fj-kernel/src/objects/sketch.rs
@@ -12,7 +12,7 @@ pub struct Sketch {
 }
 
 impl Sketch {
-    /// Construct a sketch from a number of faces
+    /// Construct a sketch from faces
     pub fn from_faces(faces: impl IntoIterator<Item = Face>) -> Self {
         let faces = faces.into_iter().collect();
         Self { faces }

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -1,0 +1,30 @@
+use super::Face;
+
+/// A 3-dimensional shape
+///
+/// # Implementation Note
+///
+/// The faces that make up the solid must form a closed shape. This is not
+/// currently validated.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Solid {
+    faces: Vec<Face>,
+}
+
+impl Solid {
+    /// Construct a solid from faces
+    pub fn from_faces(faces: impl IntoIterator<Item = Face>) -> Self {
+        let faces = faces.into_iter().collect();
+        Self { faces }
+    }
+
+    /// Access the solid's faces
+    pub fn faces(&self) -> impl Iterator<Item = &Face> {
+        self.faces.iter()
+    }
+
+    /// Convert the solid into a list of faces
+    pub fn into_faces(self) -> Vec<Face> {
+        self.faces
+    }
+}

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -1,4 +1,8 @@
-use super::Face;
+use fj_math::Scalar;
+
+use crate::algorithms::TransformObject;
+
+use super::{Face, Surface};
 
 /// A 3-dimensional shape
 ///
@@ -16,6 +20,31 @@ impl Solid {
     pub fn from_faces(faces: impl IntoIterator<Item = Face>) -> Self {
         let faces = faces.into_iter().collect();
         Self { faces }
+    }
+
+    /// Create a cube from the length of its edges
+    pub fn cube_from_edge_length(edge_length: impl Into<Scalar>) -> Self {
+        // Let's define a short-hand for half the edge length. We're going to
+        // need it a lot.
+        let h = edge_length.into() / 2.;
+
+        let points = [[-h, -h], [h, -h], [h, h], [-h, h]];
+
+        const Z: Scalar = Scalar::ZERO;
+        let planes = [
+            Surface::xy_plane().translate([Z, Z, -h]), // bottom
+            Surface::xy_plane().translate([Z, Z, h]),  // top
+            Surface::xz_plane().translate([Z, -h, Z]), // front
+            Surface::xz_plane().translate([Z, h, Z]),  // back
+            Surface::yz_plane().translate([-h, Z, Z]), // left
+            Surface::yz_plane().translate([h, Z, Z]),  // right
+        ];
+
+        let faces = planes.map(|plane| {
+            Face::builder(plane).with_exterior_polygon(points).build()
+        });
+
+        Solid::from_faces(faces)
     }
 
     /// Access the solid's faces

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -27,7 +27,7 @@ impl Shape for fj::Sweep {
             color,
         );
 
-        validate(solid, config)
+        validate(solid.into_faces(), config)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {


### PR DESCRIPTION
This extends what the addition of `Sketch` started: Improving type safety by helping distinguish between 2D and 3D shapes.