### PR TITLE
Make use of `Sketch` and `Solid` in `fj-operations`

### DIFF
--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -11,12 +11,14 @@ use fj_math::Aabb;
 use super::Shape;
 
 impl Shape for fj::Difference2d {
+    type Brep = Vec<Face>;
+
     fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError> {
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
         // This method assumes that `b` is fully contained within `a`:
         // https://github.com/hannobraun/Fornjot/issues/92
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -22,7 +22,7 @@ impl Shape for fj::Difference2d {
         // This method assumes that `b` is fully contained within `a`:
         // https://github.com/hannobraun/Fornjot/issues/92
 
-        let mut difference = Vec::new();
+        let mut faces = Vec::new();
 
         let mut exteriors = Vec::new();
         let mut interiors = Vec::new();
@@ -74,15 +74,10 @@ impl Shape for fj::Difference2d {
                 }
             }
 
-            difference.push(Face::new(
-                surface,
-                exteriors,
-                interiors,
-                self.color(),
-            ));
+            faces.push(Face::new(surface, exteriors, interiors, self.color()));
         }
 
-        let difference = Sketch::from_faces(difference);
+        let difference = Sketch::from_faces(faces);
         validate(difference, config)
     }
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::Tolerance,
     iter::ObjectIters,
     local::Local,
-    objects::{Cycle, Edge, Face},
+    objects::{Cycle, Edge, Face, Sketch},
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
@@ -11,7 +11,7 @@ use fj_math::Aabb;
 use super::Shape;
 
 impl Shape for fj::Difference2d {
-    type Brep = Vec<Face>;
+    type Brep = Sketch;
 
     fn compute_brep(
         &self,
@@ -82,6 +82,7 @@ impl Shape for fj::Difference2d {
             ));
         }
 
+        let difference = Sketch::from_faces(difference);
         validate(difference, config)
     }
 

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
-    objects::Face,
+    objects::Solid,
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
@@ -9,7 +9,7 @@ use fj_math::Aabb;
 use super::Shape;
 
 impl Shape for fj::Group {
-    type Brep = Vec<Face>;
+    type Brep = Solid;
 
     fn compute_brep(
         &self,
@@ -22,10 +22,11 @@ impl Shape for fj::Group {
         let a = self.a.compute_brep(config, tolerance, debug_info)?;
         let b = self.b.compute_brep(config, tolerance, debug_info)?;
 
-        shape.extend(a.into_inner());
-        shape.extend(b.into_inner());
+        shape.extend(a.into_inner().into_faces());
+        shape.extend(b.into_inner().into_faces());
 
-        validate(shape, config)
+        let group = Solid::from_faces(shape);
+        validate(group, config)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -9,12 +9,14 @@ use fj_math::Aabb;
 use super::Shape;
 
 impl Shape for fj::Group {
+    type Brep = Vec<Face>;
+
     fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError> {
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
         let mut shape = Vec::new();
 
         let a = self.a.compute_brep(config, tolerance, debug_info)?;

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -17,15 +17,15 @@ impl Shape for fj::Group {
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Self::Brep>, ValidationError> {
-        let mut shape = Vec::new();
+        let mut faces = Vec::new();
 
         let a = self.a.compute_brep(config, tolerance, debug_info)?;
         let b = self.b.compute_brep(config, tolerance, debug_info)?;
 
-        shape.extend(a.into_inner().into_faces());
-        shape.extend(b.into_inner().into_faces());
+        faces.extend(a.into_inner().into_faces());
+        faces.extend(b.into_inner().into_faces());
 
-        let group = Solid::from_faces(shape);
+        let group = Solid::from_faces(faces);
         validate(group, config)
     }
 

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -27,7 +27,7 @@ mod transform;
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
-    objects::{Face, Sketch},
+    objects::{Face, Sketch, Solid},
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
@@ -69,9 +69,13 @@ impl Shape for fj::Shape {
                     .into_faces(),
                 config,
             ),
-            Self::Shape3d(shape) => {
-                shape.compute_brep(config, tolerance, debug_info)
-            }
+            Self::Shape3d(shape) => validate(
+                shape
+                    .compute_brep(config, tolerance, debug_info)?
+                    .into_inner()
+                    .into_faces(),
+                config,
+            ),
         }
     }
 
@@ -111,7 +115,7 @@ impl Shape for fj::Shape2d {
 }
 
 impl Shape for fj::Shape3d {
-    type Brep = Vec<Face>;
+    type Brep = Solid;
 
     fn compute_brep(
         &self,

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -52,55 +52,87 @@ pub trait Shape {
     fn bounding_volume(&self) -> Aabb<3>;
 }
 
-macro_rules! dispatch {
-    ($($method:ident($($arg_name:ident: $arg_ty:ty,)*) -> $ret:ty;)*) => {
-        impl Shape for fj::Shape {
-            type Brep = Vec<Face>;
+impl Shape for fj::Shape {
+    type Brep = Vec<Face>;
 
-            $(
-                fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
-                    match self {
-                        Self::Shape2d(shape) => shape.$method($($arg_name,)*),
-                        Self::Shape3d(shape) => shape.$method($($arg_name,)*),
-                    }
-                }
-            )*
-        }
-
-        impl Shape for fj::Shape2d {
-            type Brep = Vec<Face>;
-
-            $(
-                fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
-                    match self {
-                        Self::Difference(shape) => shape.$method($($arg_name,)*),
-                        Self::Sketch(shape) => shape.$method($($arg_name,)*),
-                    }
-                }
-            )*
-        }
-
-        impl Shape for fj::Shape3d {
-            type Brep = Vec<Face>;
-
-            $(
-                fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
-                    match self {
-                        Self::Group(shape) => shape.$method($($arg_name,)*),
-                        Self::Sweep(shape) => shape.$method($($arg_name,)*),
-                        Self::Transform(shape) => shape.$method($($arg_name,)*),
-                    }
-                }
-            )*
-        }
-    };
-}
-
-dispatch! {
-    compute_brep(
+    fn compute_brep(
+        &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Self::Brep>, ValidationError>;
-    bounding_volume() -> Aabb<3>;
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
+        match self {
+            Self::Shape2d(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+            Self::Shape3d(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+        }
+    }
+
+    fn bounding_volume(&self) -> Aabb<3> {
+        match self {
+            Self::Shape2d(shape) => shape.bounding_volume(),
+            Self::Shape3d(shape) => shape.bounding_volume(),
+        }
+    }
+}
+
+impl Shape for fj::Shape2d {
+    type Brep = Vec<Face>;
+
+    fn compute_brep(
+        &self,
+        config: &ValidationConfig,
+        tolerance: Tolerance,
+        debug_info: &mut DebugInfo,
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
+        match self {
+            Self::Difference(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+            Self::Sketch(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+        }
+    }
+
+    fn bounding_volume(&self) -> Aabb<3> {
+        match self {
+            Self::Difference(shape) => shape.bounding_volume(),
+            Self::Sketch(shape) => shape.bounding_volume(),
+        }
+    }
+}
+
+impl Shape for fj::Shape3d {
+    type Brep = Vec<Face>;
+
+    fn compute_brep(
+        &self,
+        config: &ValidationConfig,
+        tolerance: Tolerance,
+        debug_info: &mut DebugInfo,
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
+        match self {
+            Self::Group(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+            Self::Sweep(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+            Self::Transform(shape) => {
+                shape.compute_brep(config, tolerance, debug_info)
+            }
+        }
+    }
+
+    fn bounding_volume(&self) -> Aabb<3> {
+        match self {
+            Self::Group(shape) => shape.bounding_volume(),
+            Self::Sweep(shape) => shape.bounding_volume(),
+            Self::Transform(shape) => shape.bounding_volume(),
+        }
+    }
 }

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -34,13 +34,16 @@ use fj_math::Aabb;
 
 /// Implemented for all operations from the [`fj`] crate
 pub trait Shape {
+    /// The type that is used for the shape's boundary representation
+    type Brep;
+
     /// Compute the boundary representation of the shape
     fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError>;
+    ) -> Result<Validated<Self::Brep>, ValidationError>;
 
     /// Access the axis-aligned bounding box of a shape
     ///
@@ -52,6 +55,8 @@ pub trait Shape {
 macro_rules! dispatch {
     ($($method:ident($($arg_name:ident: $arg_ty:ty,)*) -> $ret:ty;)*) => {
         impl Shape for fj::Shape {
+            type Brep = Vec<Face>;
+
             $(
                 fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
                     match self {
@@ -63,6 +68,8 @@ macro_rules! dispatch {
         }
 
         impl Shape for fj::Shape2d {
+            type Brep = Vec<Face>;
+
             $(
                 fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
                     match self {
@@ -74,6 +81,8 @@ macro_rules! dispatch {
         }
 
         impl Shape for fj::Shape3d {
+            type Brep = Vec<Face>;
+
             $(
                 fn $method(&self, $($arg_name: $arg_ty,)*) -> $ret {
                     match self {
@@ -92,6 +101,6 @@ dispatch! {
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError>;
+    ) -> Result<Validated<Self::Brep>, ValidationError>;
     bounding_volume() -> Aabb<3>;
 }

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -27,8 +27,8 @@ mod transform;
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
-    objects::Face,
-    validation::{Validated, ValidationConfig, ValidationError},
+    objects::{Face, Sketch},
+    validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
 
@@ -62,9 +62,13 @@ impl Shape for fj::Shape {
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Self::Brep>, ValidationError> {
         match self {
-            Self::Shape2d(shape) => {
-                shape.compute_brep(config, tolerance, debug_info)
-            }
+            Self::Shape2d(shape) => validate(
+                shape
+                    .compute_brep(config, tolerance, debug_info)?
+                    .into_inner()
+                    .into_faces(),
+                config,
+            ),
             Self::Shape3d(shape) => {
                 shape.compute_brep(config, tolerance, debug_info)
             }
@@ -80,7 +84,7 @@ impl Shape for fj::Shape {
 }
 
 impl Shape for fj::Shape2d {
-    type Brep = Vec<Face>;
+    type Brep = Sketch;
 
     fn compute_brep(
         &self,

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::Tolerance,
-    objects::{Cycle, Edge, Face, Surface},
+    objects::{Cycle, Edge, Face, Sketch, Surface},
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Point, Scalar};
@@ -9,7 +9,7 @@ use fj_math::{Aabb, Point, Scalar};
 use super::Shape;
 
 impl Shape for fj::Sketch {
-    type Brep = Vec<Face>;
+    type Brep = Sketch;
 
     fn compute_brep(
         &self,
@@ -41,7 +41,8 @@ impl Shape for fj::Sketch {
             }
         };
 
-        validate(vec![sketch], config)
+        let sketch = Sketch::from_faces([sketch]);
+        validate(sketch, config)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -9,12 +9,14 @@ use fj_math::{Aabb, Point, Scalar};
 use super::Shape;
 
 impl Shape for fj::Sketch {
+    type Brep = Vec<Face>;
+
     fn compute_brep(
         &self,
         config: &ValidationConfig,
         _: Tolerance,
         _: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError> {
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
         let surface = Surface::xy_plane();
 
         let sketch = match self.chain() {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -19,7 +19,7 @@ impl Shape for fj::Sketch {
     ) -> Result<Validated<Self::Brep>, ValidationError> {
         let surface = Surface::xy_plane();
 
-        let sketch = match self.chain() {
+        let face = match self.chain() {
             fj::Chain::Circle(circle) => {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
@@ -41,7 +41,7 @@ impl Shape for fj::Sketch {
             }
         };
 
-        let sketch = Sketch::from_faces([sketch]);
+        let sketch = Sketch::from_faces([face]);
         validate(sketch, config)
     }
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -9,12 +9,14 @@ use fj_math::{Aabb, Vector};
 use super::Shape;
 
 impl Shape for fj::Sweep {
+    type Brep = Vec<Face>;
+
     fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError> {
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
         let sketch =
             self.shape().compute_brep(config, tolerance, debug_info)?;
         let path = Vector::from(self.path());

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::{sweep, Tolerance},
-    objects::Face,
+    objects::Solid,
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Vector};
@@ -9,7 +9,7 @@ use fj_math::{Aabb, Vector};
 use super::Shape;
 
 impl Shape for fj::Sweep {
-    type Brep = Vec<Face>;
+    type Brep = Solid;
 
     fn compute_brep(
         &self,
@@ -23,8 +23,7 @@ impl Shape for fj::Sweep {
         let color = self.shape().color();
 
         let solid = sweep(sketch.into_inner(), path, tolerance, color);
-
-        validate(solid.into_faces(), config)
+        validate(solid, config)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::{sweep, Tolerance},
-    objects::{Face, Sketch},
+    objects::Face,
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Vector};
@@ -22,12 +22,7 @@ impl Shape for fj::Sweep {
         let path = Vector::from(self.path());
         let color = self.shape().color();
 
-        let solid = sweep(
-            Sketch::from_faces(sketch.into_inner()),
-            path,
-            tolerance,
-            color,
-        );
+        let solid = sweep(sketch.into_inner(), path, tolerance, color);
 
         validate(solid.into_faces(), config)
     }

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
-    algorithms::{transform_faces, Tolerance},
-    objects::Face,
+    algorithms::{Tolerance, TransformObject},
+    objects::Solid,
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Transform, Vector};
@@ -9,7 +9,7 @@ use fj_math::{Aabb, Transform, Vector};
 use super::Shape;
 
 impl Shape for fj::Transform {
-    type Brep = Vec<Face>;
+    type Brep = Solid;
 
     fn compute_brep(
         &self,
@@ -17,14 +17,13 @@ impl Shape for fj::Transform {
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Self::Brep>, ValidationError> {
-        let mut shape = self
+        let shape = self
             .shape
             .compute_brep(config, tolerance, debug_info)?
             .into_inner();
 
-        transform_faces(&mut shape, &make_transform(self));
-
-        validate(shape, config)
+        let transformed = shape.transform(&make_transform(self));
+        validate(transformed, config)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -9,12 +9,14 @@ use fj_math::{Aabb, Transform, Vector};
 use super::Shape;
 
 impl Shape for fj::Transform {
+    type Brep = Vec<Face>;
+
     fn compute_brep(
         &self,
         config: &ValidationConfig,
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Vec<Face>>, ValidationError> {
+    ) -> Result<Validated<Self::Brep>, ValidationError> {
         let mut shape = self
             .shape
             .compute_brep(config, tolerance, debug_info)?

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -17,12 +17,12 @@ impl Shape for fj::Transform {
         tolerance: Tolerance,
         debug_info: &mut DebugInfo,
     ) -> Result<Validated<Self::Brep>, ValidationError> {
-        let shape = self
+        let original = self
             .shape
             .compute_brep(config, tolerance, debug_info)?
             .into_inner();
 
-        let transformed = shape.transform(&make_transform(self));
+        let transformed = original.transform(&make_transform(self));
         validate(transformed, config)
     }
 


### PR DESCRIPTION
This is a follow-up to #819 and #823, adding support for these objects to `fj-operations`.