### PR TITLE
Remove support for overriding `target/` directory

### DIFF
--- a/crates/fj-app/src/config.rs
+++ b/crates/fj-app/src/config.rs
@@ -11,7 +11,6 @@ use serde::Deserialize;
 pub struct Config {
     pub default_path: Option<PathBuf>,
     pub default_model: Option<PathBuf>,
-    pub target_dir: Option<PathBuf>,
 }
 
 impl Config {

--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> anyhow::Result<()> {
     })?;
     path.push(model);
 
-    let model = Model::from_path(path.clone(), config.target_dir)
+    let model = Model::from_path(path.clone())
         .with_context(|| format!("Failed to load model: {}", path.display()))?;
     let parameters = args.parameters.unwrap_or_else(Parameters::empty);
 

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -47,10 +47,7 @@ impl Model {
     /// Optionally, the target directory where plugin files are compiled to can
     /// be provided. If it is not provided, the target directory is assumed to
     /// be located within the model path.
-    pub fn from_path(
-        path: PathBuf,
-        target_dir: Option<PathBuf>,
-    ) -> Result<Self, Error> {
+    pub fn from_path(path: PathBuf) -> Result<Self, Error> {
         let crate_dir = path.canonicalize()?;
 
         let metadata = cargo_metadata::MetadataCommand::new()
@@ -63,8 +60,8 @@ impl Model {
         let lib_path = {
             let name = pkg.name.replace('-', "_");
             let file = HostPlatform::lib_file_name(&name);
-            let target_dir = target_dir
-                .unwrap_or_else(|| metadata.target_directory.clone().into());
+            let target_dir =
+                metadata.target_directory.clone().into_std_path_buf();
             target_dir.join("debug").join(file)
         };
 

--- a/fj.toml
+++ b/fj.toml
@@ -5,7 +5,3 @@ default_path = "models"
 # The default models that is loaded, if none is specified. If this is a relative
 # path, it should be relative to `default_path`.
 default_model = "test"
-
-# The `target/` directory, where compiled model libraries are located. By
-# default, this is expected to be in the model directory.
-target_dir = "target"


### PR DESCRIPTION
This is no longer required. See commits for details.