### PR TITLE
Clean up `Face`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/faces.rs
+++ b/crates/fj-kernel/src/algorithms/approx/faces.rs
@@ -46,13 +46,13 @@ impl FaceApprox {
         let mut interiors = HashSet::new();
 
         for cycle in face.exteriors() {
-            let cycle = CycleApprox::new(&cycle, tolerance);
+            let cycle = CycleApprox::new(cycle, tolerance);
 
             points.extend(cycle.points.iter().copied());
             exteriors.push(cycle);
         }
         for cycle in face.interiors() {
-            let cycle = CycleApprox::new(&cycle, tolerance);
+            let cycle = CycleApprox::new(cycle, tolerance);
 
             points.extend(cycle.points.iter().copied());
             interiors.insert(cycle);

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -7,19 +7,16 @@ use crate::{
 
 /// Reverse the direction of a face
 pub fn reverse_face(face: &Face) -> Face {
-    let face = match face {
-        Face::Face(face) => face,
-        Face::Triangles(_) => {
-            panic!("Reversing tri-rep faces is not supported")
-        }
-    };
+    if let Face::Triangles(_) = face {
+        panic!("Reversing tri-rep faces is not supported");
+    }
 
     let surface = face.surface().reverse();
 
     let exteriors = reverse_local_coordinates_in_cycle(face.exteriors());
     let interiors = reverse_local_coordinates_in_cycle(face.interiors());
 
-    Face::new(surface, exteriors, interiors, face.color)
+    Face::new(surface, exteriors, interiors, face.color())
 }
 
 fn reverse_local_coordinates_in_cycle<'r>(

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Reverse the direction of a face
 pub fn reverse_face(face: &Face) -> Face {
-    if let Face::Triangles(_) = face {
+    if face.triangles().is_some() {
         panic!("Reversing tri-rep faces is not supported");
     }
 

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -2,7 +2,7 @@ use fj_math::{Circle, Line, Point, Vector};
 
 use crate::{
     local::Local,
-    objects::{Curve, Cycle, CyclesInFace, Edge, Face},
+    objects::{Curve, Cycle, Edge, Face},
 };
 
 /// Reverse the direction of a face
@@ -16,16 +16,16 @@ pub fn reverse_face(face: &Face) -> Face {
 
     let surface = face.surface().reverse();
 
-    let exteriors = reverse_local_coordinates_in_cycle(&face.exteriors);
-    let interiors = reverse_local_coordinates_in_cycle(&face.interiors);
+    let exteriors = reverse_local_coordinates_in_cycle(face.exteriors());
+    let interiors = reverse_local_coordinates_in_cycle(face.interiors());
 
     Face::new(surface, exteriors, interiors, face.color)
 }
 
-fn reverse_local_coordinates_in_cycle(
-    cycles: &CyclesInFace,
-) -> impl Iterator<Item = Cycle> + '_ {
-    cycles.as_local().map(|cycle| {
+fn reverse_local_coordinates_in_cycle<'r>(
+    cycles: impl IntoIterator<Item = &'r Cycle> + 'r,
+) -> impl Iterator<Item = Cycle> + 'r {
+    cycles.into_iter().map(|cycle| {
         let edges = cycle
             .edges
             .iter()

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -25,7 +25,7 @@ pub fn reverse_face(face: &Face) -> Face {
 fn reverse_local_coordinates_in_cycle(
     cycles: &CyclesInFace,
 ) -> impl Iterator<Item = Cycle> + '_ {
-    let cycles = cycles.as_local().map(|cycle| {
+    cycles.as_local().map(|cycle| {
         let edges = cycle
             .edges
             .iter()
@@ -57,9 +57,7 @@ fn reverse_local_coordinates_in_cycle(
             .collect();
 
         Cycle { edges }
-    });
-
-    cycles
+    })
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -193,7 +193,7 @@ fn create_continuous_side_face(
         side_face.push(([v0, v2, v3].into(), color));
     }
 
-    target.push(Face::Triangles(side_face));
+    target.push(Face::from_triangles(side_face));
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -39,7 +39,7 @@ pub fn sweep(
         );
 
         for cycle in face.all_cycles() {
-            for edge in cycle.edges {
+            for edge in &cycle.edges {
                 if let Some(vertices) = edge.vertices().get() {
                     create_non_continuous_side_face(
                         path,
@@ -52,7 +52,7 @@ pub fn sweep(
                 }
 
                 create_continuous_side_face(
-                    edge,
+                    *edge,
                     path,
                     tolerance,
                     color,

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -3,8 +3,7 @@ use fj_math::{Transform, Vector};
 use crate::{
     local::Local,
     objects::{
-        Curve, Cycle, CyclesInFace, Edge, Face, FaceBRep, GlobalVertex, Sketch,
-        Solid, Surface, Vertex,
+        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
     },
 };
 
@@ -76,17 +75,12 @@ impl TransformObject for Face {
             Self::Face(face) => {
                 let surface = face.surface.transform(transform);
 
-                let exteriors = transform_cycles(&face.exteriors, transform);
-                let interiors = transform_cycles(&face.interiors, transform);
+                let exteriors = transform_cycles(face.exteriors(), transform);
+                let interiors = transform_cycles(face.interiors(), transform);
 
                 let color = face.color;
 
-                Self::Face(FaceBRep {
-                    surface,
-                    exteriors,
-                    interiors,
-                    color,
-                })
+                Face::new(surface, exteriors, interiors, color)
             }
             Self::Triangles(triangles) => {
                 let mut target = Vec::new();
@@ -152,13 +146,11 @@ pub fn transform_faces(faces: &mut Vec<Face>, transform: &Transform) {
     }
 }
 
-fn transform_cycles(
-    cycles: &CyclesInFace,
-    transform: &Transform,
-) -> CyclesInFace {
-    let cycles = cycles
-        .as_local()
-        .map(|cycle| cycle.clone().transform(transform));
-
-    CyclesInFace::new(cycles)
+fn transform_cycles<'a>(
+    cycles: impl IntoIterator<Item = &'a Cycle> + 'a,
+    transform: &'a Transform,
+) -> impl Iterator<Item = Cycle> + 'a {
+    cycles
+        .into_iter()
+        .map(|cycle| cycle.clone().transform(transform))
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -79,7 +79,7 @@ impl TransformObject for Face {
                 target.push((triangle, color));
             }
 
-            return Self::Triangles(target);
+            return Self::from_triangles(target);
         }
 
         let surface = self.surface().transform(transform);

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -156,7 +156,9 @@ fn transform_cycles(
     cycles: &CyclesInFace,
     transform: &Transform,
 ) -> CyclesInFace {
-    let cycles = cycles.as_local().map(|cycle| cycle.transform(transform));
+    let cycles = cycles
+        .as_local()
+        .map(|cycle| cycle.clone().transform(transform));
 
     CyclesInFace::new(cycles)
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -71,28 +71,25 @@ impl TransformObject for Edge {
 
 impl TransformObject for Face {
     fn transform(self, transform: &Transform) -> Self {
-        match self {
-            Self::Face(face) => {
-                let surface = face.surface.transform(transform);
+        if let Self::Triangles(triangles) = self {
+            let mut target = Vec::new();
 
-                let exteriors = transform_cycles(face.exteriors(), transform);
-                let interiors = transform_cycles(face.interiors(), transform);
-
-                let color = face.color;
-
-                Face::new(surface, exteriors, interiors, color)
+            for (triangle, color) in triangles {
+                let triangle = transform.transform_triangle(&triangle);
+                target.push((triangle, color));
             }
-            Self::Triangles(triangles) => {
-                let mut target = Vec::new();
 
-                for (triangle, color) in triangles {
-                    let triangle = transform.transform_triangle(&triangle);
-                    target.push((triangle, color));
-                }
-
-                Self::Triangles(target)
-            }
+            return Self::Triangles(target);
         }
+
+        let surface = self.surface().transform(transform);
+
+        let exteriors = transform_cycles(self.exteriors(), transform);
+        let interiors = transform_cycles(self.interiors(), transform);
+
+        let color = self.color();
+
+        Face::new(surface, exteriors, interiors, color)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -71,10 +71,10 @@ impl TransformObject for Edge {
 
 impl TransformObject for Face {
     fn transform(self, transform: &Transform) -> Self {
-        if let Self::Triangles(triangles) = self {
+        if let Some(triangles) = self.triangles() {
             let mut target = Vec::new();
 
-            for (triangle, color) in triangles {
+            for (triangle, color) in triangles.clone() {
                 let triangle = transform.transform_triangle(&triangle);
                 target.push((triangle, color));
             }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -20,7 +20,7 @@ pub fn triangulate(
     let mut mesh = Mesh::new();
 
     for face in faces {
-        if let Face::Triangles(triangles) = &face {
+        if let Some(triangles) = face.triangles() {
             for &(triangle, color) in triangles {
                 mesh.push_triangle(triangle.points(), color);
             }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -252,45 +252,45 @@ impl ObjectIters for Edge {
 
 impl ObjectIters for Face {
     fn curve_iter(&self) -> Iter<Curve<3>> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().curve_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.curve_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().curve_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.curve_iter());
+        }
+
+        iter
     }
 
     fn cycle_iter(&self) -> Iter<Cycle> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().cycle_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.cycle_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().cycle_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.cycle_iter());
+        }
+
+        iter
     }
 
     fn edge_iter(&self) -> Iter<Edge> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().edge_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.edge_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().edge_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.edge_iter());
+        }
+
+        iter
     }
 
     fn face_iter(&self) -> Iter<Face> {
@@ -298,74 +298,73 @@ impl ObjectIters for Face {
     }
 
     fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
-        if let Face::Face(face) = self {
-            let mut iter =
-                Iter::empty().with(face.surface().global_vertex_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.global_vertex_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().global_vertex_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.global_vertex_iter());
+        }
+
+        iter
     }
 
     fn sketch_iter(&self) -> Iter<Sketch> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().sketch_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.sketch_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().sketch_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.sketch_iter());
+        }
+
+        iter
     }
 
     fn solid_iter(&self) -> Iter<Solid> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().solid_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.solid_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().solid_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.solid_iter());
+        }
+
+        iter
     }
 
     fn surface_iter(&self) -> Iter<Surface> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().surface_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.surface_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().surface_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.surface_iter());
+        }
+
+        iter
     }
 
     fn vertex_iter(&self) -> Iter<Vertex> {
-        if let Face::Face(face) = self {
-            let mut iter = Iter::empty().with(face.surface().vertex_iter());
-
-            for cycle in face.all_cycles() {
-                iter = iter.with(cycle.vertex_iter());
-            }
-
-            return iter;
+        if let Face::Triangles(_) = self {
+            return Iter::empty();
         }
 
-        Iter::empty()
+        let mut iter = Iter::empty().with(self.surface().vertex_iter());
+
+        for cycle in self.all_cycles() {
+            iter = iter.with(cycle.vertex_iter());
+        }
+
+        iter
     }
 }
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -252,7 +252,7 @@ impl ObjectIters for Edge {
 
 impl ObjectIters for Face {
     fn curve_iter(&self) -> Iter<Curve<3>> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -266,7 +266,7 @@ impl ObjectIters for Face {
     }
 
     fn cycle_iter(&self) -> Iter<Cycle> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -280,7 +280,7 @@ impl ObjectIters for Face {
     }
 
     fn edge_iter(&self) -> Iter<Edge> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -298,7 +298,7 @@ impl ObjectIters for Face {
     }
 
     fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -312,7 +312,7 @@ impl ObjectIters for Face {
     }
 
     fn sketch_iter(&self) -> Iter<Sketch> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -326,7 +326,7 @@ impl ObjectIters for Face {
     }
 
     fn solid_iter(&self) -> Iter<Solid> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -340,7 +340,7 @@ impl ObjectIters for Face {
     }
 
     fn surface_iter(&self) -> Iter<Surface> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 
@@ -354,7 +354,7 @@ impl ObjectIters for Face {
     }
 
     fn vertex_iter(&self) -> Iter<Vertex> {
-        if let Face::Triangles(_) = self {
+        if self.triangles().is_some() {
             return Iter::empty();
         }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -12,7 +12,7 @@ pub enum Face {
     ///
     /// A face is defined by a surface, and is bounded by edges that lie in that
     /// surface.
-    Face(FaceBRep),
+    BRep(FaceBRep),
 
     /// The triangles of the face
     ///
@@ -34,7 +34,7 @@ impl Face {
         let exteriors = exteriors.into_iter().collect();
         let interiors = interiors.into_iter().collect();
 
-        Self::Face(FaceBRep {
+        Self::BRep(FaceBRep {
             surface,
             exteriors,
             interiors,
@@ -78,7 +78,7 @@ impl Face {
 
     /// Access the boundary representation of the face
     fn brep(&self) -> &FaceBRep {
-        if let Self::Face(face) = self {
+        if let Self::BRep(face) = self {
             return face;
         }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -51,12 +51,14 @@ impl Face {
         self.brep().surface()
     }
 
-    /// Access this face's exterior cycles
+    /// Access the cycles that bound the face on the outside
     pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.brep().exteriors()
     }
 
-    /// Access this face's interior cycles
+    /// Access the cycles that bound the face on the inside
+    ///
+    /// Each of these cycles defines a hole in the face.
     pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.brep().interiors()
     }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -48,19 +48,19 @@ impl Face {
 
     /// Access this face's surface
     pub fn surface(&self) -> &Surface {
-        self.brep().surface()
+        &self.brep().surface
     }
 
     /// Access the cycles that bound the face on the outside
     pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().exteriors()
+        self.brep().exteriors.as_local()
     }
 
     /// Access the cycles that bound the face on the inside
     ///
     /// Each of these cycles defines a hole in the face.
     pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().interiors()
+        self.brep().interiors.as_local()
     }
 
     /// Access all cycles of this face
@@ -68,7 +68,7 @@ impl Face {
     /// This is equivalent to chaining the iterators returned by
     /// [`Face::exteriors`] and [`Face::interiors`].
     pub fn all_cycles(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().all_cycles()
+        self.exteriors().chain(self.interiors())
     }
 
     /// Access the color of the face
@@ -99,31 +99,6 @@ pub struct FaceBRep {
     exteriors: CyclesInFace,
     interiors: CyclesInFace,
     color: [u8; 4],
-}
-
-impl FaceBRep {
-    /// Access this face's surface
-    pub fn surface(&self) -> &Surface {
-        &self.surface
-    }
-
-    /// Access this face's exterior cycles
-    pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.exteriors.as_local()
-    }
-
-    /// Access this face's interior cycles
-    pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.interiors.as_local()
-    }
-
-    /// Access all cycles of this face
-    ///
-    /// This is equivalent to chaining the iterators returned by
-    /// [`Face::exteriors`] and [`Face::interiors`].
-    pub fn all_cycles(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.exteriors().chain(self.interiors())
-    }
 }
 
 /// A list of cycles, as they are stored in `Face`

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -41,6 +41,12 @@ impl Face {
             color,
         })
     }
+
+    /// Contact an instance that uses triangle representation
+    pub fn from_triangles(triangles: TriRep) -> Self {
+        Self::Triangles(triangles)
+    }
+
     /// Build a face using the [`FaceBuilder`] API
     pub fn builder(surface: Surface) -> FaceBuilder {
         FaceBuilder::new(surface)

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -63,12 +63,12 @@ impl Face {
     }
 
     /// Access this face's exterior cycles
-    pub fn exteriors(&self) -> impl Iterator<Item = Cycle> + '_ {
+    pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.brep().exteriors()
     }
 
     /// Access this face's interior cycles
-    pub fn interiors(&self) -> impl Iterator<Item = Cycle> + '_ {
+    pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.brep().interiors()
     }
 
@@ -76,7 +76,7 @@ impl Face {
     ///
     /// This is equivalent to chaining the iterators returned by
     /// [`Face::exteriors`] and [`Face::interiors`].
-    pub fn all_cycles(&self) -> impl Iterator<Item = Cycle> + '_ {
+    pub fn all_cycles(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.brep().all_cycles()
     }
 
@@ -128,12 +128,12 @@ impl FaceBRep {
     }
 
     /// Access this face's exterior cycles
-    pub fn exteriors(&self) -> impl Iterator<Item = Cycle> + '_ {
+    pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.exteriors.as_local()
     }
 
     /// Access this face's interior cycles
-    pub fn interiors(&self) -> impl Iterator<Item = Cycle> + '_ {
+    pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.interiors.as_local()
     }
 
@@ -141,7 +141,7 @@ impl FaceBRep {
     ///
     /// This is equivalent to chaining the iterators returned by
     /// [`Face::exteriors`] and [`Face::interiors`].
-    pub fn all_cycles(&self) -> impl Iterator<Item = Cycle> + '_ {
+    pub fn all_cycles(&self) -> impl Iterator<Item = &Cycle> + '_ {
         self.exteriors().chain(self.interiors())
     }
 }
@@ -157,7 +157,7 @@ impl CyclesInFace {
     }
 
     /// Access an iterator over the canonical forms of the cycles
-    pub fn as_local(&self) -> impl Iterator<Item = Cycle> + '_ {
-        self.0.iter().cloned()
+    pub fn as_local(&self) -> impl Iterator<Item = &Cycle> + '_ {
+        self.0.iter()
     }
 }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -97,24 +97,11 @@ pub struct FaceBRep {
     pub surface: Surface,
 
     /// The cycles that bound the face on the outside
-    ///
-    /// # Implementation Note
-    ///
-    /// Since these cycles bound the face, the edges they consist of must
-    /// lie in the surface. The data we're using here is 3-dimensional
-    /// though, so no such limitation is enforced.
-    ///
-    /// It might be less error-prone to specify the cycles in surface
-    /// coordinates.
     pub exteriors: CyclesInFace,
 
     /// The cycles that bound the face on the inside
     ///
     /// Each of these cycles defines a hole in the face.
-    ///
-    /// # Implementation note
-    ///
-    /// See note on `exterior` field.
     pub interiors: CyclesInFace,
 
     /// The color of the face

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -20,7 +20,7 @@ pub enum Face {
     /// The plan is to eventually represent faces as a geometric surface,
     /// bounded by edges. While the transition is being made, this variant is
     /// still required.
-    Triangles(Vec<(Triangle<3>, Color)>),
+    Triangles(TriRep),
 }
 
 impl Face {
@@ -100,3 +100,5 @@ pub struct FaceBRep {
     interiors: Vec<Cycle>,
     color: [u8; 4],
 }
+
+type TriRep = Vec<(Triangle<3>, Color)>;

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -31,8 +31,8 @@ impl Face {
         interiors: impl IntoIterator<Item = Cycle>,
         color: [u8; 4],
     ) -> Self {
-        let exteriors = CyclesInFace::new(exteriors);
-        let interiors = CyclesInFace::new(interiors);
+        let exteriors = exteriors.into_iter().collect();
+        let interiors = interiors.into_iter().collect();
 
         Self::Face(FaceBRep {
             surface,
@@ -53,14 +53,14 @@ impl Face {
 
     /// Access the cycles that bound the face on the outside
     pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().exteriors.as_local()
+        self.brep().exteriors.iter()
     }
 
     /// Access the cycles that bound the face on the inside
     ///
     /// Each of these cycles defines a hole in the face.
     pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().interiors.as_local()
+        self.brep().interiors.iter()
     }
 
     /// Access all cycles of this face
@@ -96,23 +96,7 @@ impl Face {
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct FaceBRep {
     surface: Surface,
-    exteriors: CyclesInFace,
-    interiors: CyclesInFace,
+    exteriors: Vec<Cycle>,
+    interiors: Vec<Cycle>,
     color: [u8; 4],
-}
-
-/// A list of cycles, as they are stored in `Face`
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct CyclesInFace(Vec<Cycle>);
-
-impl CyclesInFace {
-    /// Create a new instance of `CyclesInFace`
-    pub fn new(cycles: impl IntoIterator<Item = Cycle>) -> Self {
-        Self(cycles.into_iter().collect())
-    }
-
-    /// Access an iterator over the canonical forms of the cycles
-    pub fn as_local(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.0.iter()
-    }
 }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -76,6 +76,19 @@ impl Face {
         self.brep().color
     }
 
+    /// Access triangles, if this face uses triangle representation
+    ///
+    /// Only some faces still use triangle representation. At some point, none
+    /// will. This method exists as a workaround, while the transition is still
+    /// in progress.
+    pub fn triangles(&self) -> Option<&TriRep> {
+        if let Self::Triangles(triangles) = self {
+            return Some(triangles);
+        }
+
+        None
+    }
+
     /// Access the boundary representation of the face
     fn brep(&self) -> &FaceBRep {
         if let Self::BRep(face) = self {

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -105,13 +105,8 @@ enum Representation {
     TriRep(TriRep),
 }
 
-/// The boundary representation of a face
-///
-/// This type exists to ease the handling of faces that use boundary
-/// representation. It will eventually be merged into `Face`, once
-/// `Face::Triangles` can finally be removed.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct FaceBRep {
+struct FaceBRep {
     surface: Surface,
     exteriors: Vec<Cycle>,
     interiors: Vec<Cycle>,

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -58,7 +58,7 @@ impl Face {
     }
 
     /// Access this face's surface
-    pub fn surface(&self) -> Surface {
+    pub fn surface(&self) -> &Surface {
         self.brep().surface()
     }
 
@@ -123,8 +123,8 @@ pub struct FaceBRep {
 
 impl FaceBRep {
     /// Access this face's surface
-    pub fn surface(&self) -> Surface {
-        self.surface
+    pub fn surface(&self) -> &Surface {
+        &self.surface
     }
 
     /// Access this face's exterior cycles

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -95,19 +95,10 @@ impl Face {
 /// `Face::Triangles` can finally be removed.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct FaceBRep {
-    /// The surface that defines this face
-    pub surface: Surface,
-
-    /// The cycles that bound the face on the outside
-    pub exteriors: CyclesInFace,
-
-    /// The cycles that bound the face on the inside
-    ///
-    /// Each of these cycles defines a hole in the face.
-    pub interiors: CyclesInFace,
-
-    /// The color of the face
-    pub color: [u8; 4],
+    surface: Surface,
+    exteriors: CyclesInFace,
+    interiors: CyclesInFace,
+    color: [u8; 4],
 }
 
 impl FaceBRep {

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -48,14 +48,13 @@ impl Face {
 
     /// Access the boundary representation of the face
     pub fn brep(&self) -> &FaceBRep {
-        match self {
-            Self::Face(face) => face,
-            _ => {
-                // No code that still uses triangle representation is calling
-                // this method.
-                unreachable!()
-            }
+        if let Self::Face(face) = self {
+            return face;
         }
+
+        // No code that still uses triangle representation is calling this
+        // method.
+        unreachable!()
     }
 
     /// Access this face's surface

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -7,20 +7,8 @@ use super::{Cycle, Surface};
 
 /// A face of a shape
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum Face {
-    /// A face of a shape
-    ///
-    /// A face is defined by a surface, and is bounded by edges that lie in that
-    /// surface.
-    BRep(FaceBRep),
-
-    /// The triangles of the face
-    ///
-    /// Representing faces as a collection of triangles is a temporary state.
-    /// The plan is to eventually represent faces as a geometric surface,
-    /// bounded by edges. While the transition is being made, this variant is
-    /// still required.
-    TriRep(TriRep),
+pub struct Face {
+    representation: Representation,
 }
 
 impl Face {
@@ -34,17 +22,21 @@ impl Face {
         let exteriors = exteriors.into_iter().collect();
         let interiors = interiors.into_iter().collect();
 
-        Self::BRep(FaceBRep {
-            surface,
-            exteriors,
-            interiors,
-            color,
-        })
+        Self {
+            representation: Representation::BRep(FaceBRep {
+                surface,
+                exteriors,
+                interiors,
+                color,
+            }),
+        }
     }
 
     /// Contact an instance that uses triangle representation
     pub fn from_triangles(triangles: TriRep) -> Self {
-        Self::TriRep(triangles)
+        Self {
+            representation: Representation::TriRep(triangles),
+        }
     }
 
     /// Build a face using the [`FaceBuilder`] API
@@ -88,7 +80,7 @@ impl Face {
     /// will. This method exists as a workaround, while the transition is still
     /// in progress.
     pub fn triangles(&self) -> Option<&TriRep> {
-        if let Self::TriRep(triangles) = self {
+        if let Representation::TriRep(triangles) = &self.representation {
             return Some(triangles);
         }
 
@@ -97,7 +89,7 @@ impl Face {
 
     /// Access the boundary representation of the face
     fn brep(&self) -> &FaceBRep {
-        if let Self::BRep(face) = self {
+        if let Representation::BRep(face) = &self.representation {
             return face;
         }
 
@@ -105,6 +97,12 @@ impl Face {
         // method.
         unreachable!()
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+enum Representation {
+    BRep(FaceBRep),
+    TriRep(TriRep),
 }
 
 /// The boundary representation of a face

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -23,7 +23,7 @@ impl Face {
         let interiors = interiors.into_iter().collect();
 
         Self {
-            representation: Representation::BRep(FaceBRep {
+            representation: Representation::BRep(BRep {
                 surface,
                 exteriors,
                 interiors,
@@ -88,7 +88,7 @@ impl Face {
     }
 
     /// Access the boundary representation of the face
-    fn brep(&self) -> &FaceBRep {
+    fn brep(&self) -> &BRep {
         if let Representation::BRep(face) = &self.representation {
             return face;
         }
@@ -101,12 +101,12 @@ impl Face {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 enum Representation {
-    BRep(FaceBRep),
+    BRep(BRep),
     TriRep(TriRep),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-struct FaceBRep {
+struct BRep {
     surface: Surface,
     exteriors: Vec<Cycle>,
     interiors: Vec<Cycle>,

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -78,7 +78,7 @@ impl Face {
     /// This is equivalent to chaining the iterators returned by
     /// [`Face::exteriors`] and [`Face::interiors`].
     pub fn all_cycles(&self) -> impl Iterator<Item = Cycle> + '_ {
-        self.exteriors().chain(self.interiors())
+        self.brep().all_cycles()
     }
 
     /// Access the color of the face

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -20,7 +20,7 @@ pub enum Face {
     /// The plan is to eventually represent faces as a geometric surface,
     /// bounded by edges. While the transition is being made, this variant is
     /// still required.
-    Triangles(TriRep),
+    TriRep(TriRep),
 }
 
 impl Face {
@@ -44,7 +44,7 @@ impl Face {
 
     /// Contact an instance that uses triangle representation
     pub fn from_triangles(triangles: TriRep) -> Self {
-        Self::Triangles(triangles)
+        Self::TriRep(triangles)
     }
 
     /// Build a face using the [`FaceBuilder`] API
@@ -88,7 +88,7 @@ impl Face {
     /// will. This method exists as a workaround, while the transition is still
     /// in progress.
     pub fn triangles(&self) -> Option<&TriRep> {
-        if let Self::Triangles(triangles) = self {
+        if let Self::TriRep(triangles) = self {
             return Some(triangles);
         }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -46,17 +46,6 @@ impl Face {
         FaceBuilder::new(surface)
     }
 
-    /// Access the boundary representation of the face
-    pub fn brep(&self) -> &FaceBRep {
-        if let Self::Face(face) = self {
-            return face;
-        }
-
-        // No code that still uses triangle representation is calling this
-        // method.
-        unreachable!()
-    }
-
     /// Access this face's surface
     pub fn surface(&self) -> &Surface {
         self.brep().surface()
@@ -83,6 +72,17 @@ impl Face {
     /// Access the color of the face
     pub fn color(&self) -> [u8; 4] {
         self.brep().color
+    }
+
+    /// Access the boundary representation of the face
+    fn brep(&self) -> &FaceBRep {
+        if let Self::Face(face) = self {
+            return face;
+        }
+
+        // No code that still uses triangle representation is calling this
+        // method.
+        unreachable!()
     }
 }
 

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     curve::Curve,
     cycle::Cycle,
     edge::{Edge, VerticesOfEdge},
-    face::{CyclesInFace, Face, FaceBRep},
+    face::{Face, FaceBRep},
     global_vertex::GlobalVertex,
     sketch::Sketch,
     solid::Solid,

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     curve::Curve,
     cycle::Cycle,
     edge::{Edge, VerticesOfEdge},
-    face::{Face, FaceBRep},
+    face::Face,
     global_vertex::GlobalVertex,
     sketch::Sketch,
     solid::Solid,

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -38,43 +38,39 @@ impl Shape for fj::Difference2d {
         if let Some(face) = a.face_iter().next() {
             // If there's at least one face to subtract from, we can proceed.
 
-            let surface = face.brep().surface;
+            let surface = face.surface();
 
             for face in a.face_iter() {
-                let face = face.brep();
-
                 assert_eq!(
                     surface,
-                    *face.surface(),
+                    face.surface(),
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                for cycle in face.exteriors.as_local() {
+                for cycle in face.exteriors() {
                     let cycle = add_cycle(cycle.clone(), false);
                     exteriors.push(cycle);
                 }
-                for cycle in face.interiors.as_local() {
+                for cycle in face.interiors() {
                     let cycle = add_cycle(cycle.clone(), true);
                     interiors.push(cycle);
                 }
             }
 
             for face in b.face_iter() {
-                let face = face.brep();
-
                 assert_eq!(
                     surface,
-                    *face.surface(),
+                    face.surface(),
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                for cycle in face.exteriors.as_local() {
+                for cycle in face.exteriors() {
                     let cycle = add_cycle(cycle.clone(), true);
                     interiors.push(cycle);
                 }
             }
 
-            faces.push(Face::new(surface, exteriors, interiors, self.color()));
+            faces.push(Face::new(*surface, exteriors, interiors, self.color()));
         }
 
         let difference = Sketch::from_faces(faces);

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -50,11 +50,11 @@ impl Shape for fj::Difference2d {
                 );
 
                 for cycle in face.exteriors.as_local() {
-                    let cycle = add_cycle(cycle, false);
+                    let cycle = add_cycle(cycle.clone(), false);
                     exteriors.push(cycle);
                 }
                 for cycle in face.interiors.as_local() {
-                    let cycle = add_cycle(cycle, true);
+                    let cycle = add_cycle(cycle.clone(), true);
                     interiors.push(cycle);
                 }
             }
@@ -69,7 +69,7 @@ impl Shape for fj::Difference2d {
                 );
 
                 for cycle in face.exteriors.as_local() {
-                    let cycle = add_cycle(cycle, true);
+                    let cycle = add_cycle(cycle.clone(), true);
                     interiors.push(cycle);
                 }
             }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -45,7 +45,7 @@ impl Shape for fj::Difference2d {
 
                 assert_eq!(
                     surface,
-                    face.surface(),
+                    *face.surface(),
                     "Trying to subtract faces with different surfaces.",
                 );
 
@@ -64,7 +64,7 @@ impl Shape for fj::Difference2d {
 
                 assert_eq!(
                     surface,
-                    face.surface(),
+                    *face.surface(),
                     "Trying to subtract faces with different surfaces.",
                 );
 


### PR DESCRIPTION
Simplify `Face` and make representation mostly an implementation detail. This eases the use of faces with boundary representation, at the cost of some type safety. I think this is the right trade-off for now. Return references from `Face`'s accessor methods. Clean up other things, as required.