### PR TITLE
Return references to objects, where appropriate

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/cycles.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycles.rs
@@ -21,7 +21,7 @@ impl CycleApprox {
 
         for edge in &cycle.edges {
             let mut edge_points = Vec::new();
-            approx_curve(&edge.curve().global(), tolerance, &mut edge_points);
+            approx_curve(edge.curve().global(), tolerance, &mut edge_points);
             approx_edge(*edge.vertices(), &mut edge_points);
 
             points.extend(edge_points.into_iter().map(|point| {
@@ -29,7 +29,7 @@ impl CycleApprox {
                     .curve()
                     .local()
                     .point_from_curve_coords(*point.local());
-                Local::new(local, point.global())
+                Local::new(local, *point.global())
             }));
         }
 
@@ -49,7 +49,7 @@ impl CycleApprox {
             // up, once `array_windows` is stable.
             let segment = [segment[0], segment[1]];
 
-            segments.push(Segment::from(segment.map(|point| point.global())));
+            segments.push(Segment::from(segment.map(|point| *point.global())));
         }
 
         segments

--- a/crates/fj-kernel/src/algorithms/approx/cycles.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycles.rs
@@ -25,8 +25,10 @@ impl CycleApprox {
             approx_edge(*edge.vertices(), &mut edge_points);
 
             points.extend(edge_points.into_iter().map(|point| {
-                let local =
-                    edge.curve().local().point_from_curve_coords(point.local());
+                let local = edge
+                    .curve()
+                    .local()
+                    .point_from_curve_coords(*point.local());
                 Local::new(local, point.global())
             }));
         }

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -55,7 +55,7 @@ impl CurveFaceIntersectionList {
                     ),
                 };
 
-                (line, vertices)
+                (*line, vertices)
             });
 
         let mut intersections = Vec::new();

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -36,7 +36,7 @@ impl CurveFaceIntersectionList {
             .exteriors()
             .chain(face.interiors())
             .flat_map(|cycle| {
-                let edges: Vec<_> = cycle.edges().collect();
+                let edges: Vec<_> = cycle.edges().cloned().collect();
                 edges
             })
             .map(|edge| {

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -46,7 +46,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
                         }
                     };
 
-                    Local::new(local, edge.curve().global())
+                    Local::new(local, *edge.curve().global())
                 };
 
                 Edge::new(curve, *edge.vertices())

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -44,7 +44,7 @@ pub fn sweep(
                     create_non_continuous_side_face(
                         path,
                         is_sweep_along_negative_direction,
-                        vertices.map(|vertex| vertex.global()),
+                        vertices.map(|vertex| *vertex.global()),
                         color,
                         &mut target,
                     );

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -27,7 +27,7 @@ pub fn sweep(
 
     for face in source.face_iter() {
         create_bottom_faces(
-            &face,
+            face,
             is_sweep_along_negative_direction,
             &mut target,
         );
@@ -314,7 +314,7 @@ mod tests {
         });
 
         for face in faces {
-            assert!(solid.face_iter().any(|f| f == face));
+            assert!(solid.face_iter().any(|f| f == &face));
         }
 
         Ok(())

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -58,7 +58,7 @@ impl TransformObject for Cycle {
 impl TransformObject for Edge {
     fn transform(self, transform: &Transform) -> Self {
         let curve = Local::new(
-            self.curve().local(),
+            *self.curve().local(),
             self.curve().global().transform(transform),
         );
 

--- a/crates/fj-kernel/src/algorithms/triangulate/delaunay.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/delaunay.rs
@@ -14,7 +14,7 @@ pub fn triangulate(points: Vec<Local<Point<2>>>) -> Vec<[Local<Point<2>>; 3]> {
     for triangle in triangulation.inner_faces() {
         let [v0, v1, v2] = triangle.vertices().map(|vertex| *vertex.data());
         let orientation =
-            Triangle::<2>::from_points([v0.local(), v1.local(), v2.local()])
+            Triangle::<2>::from_points([*v0.local(), *v1.local(), *v2.local()])
                 .winding_direction();
 
         let triangle = match orientation {

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -52,7 +52,7 @@ pub fn triangulate(
         });
 
         for triangle in triangles {
-            let points = triangle.map(|point| point.global());
+            let points = triangle.map(|point| *point.global());
             mesh.push_triangle(points, face.color());
         }
     }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -37,16 +37,16 @@ pub fn triangulate(
                     .exterior
                     .points
                     .into_iter()
-                    .map(|point| point.local()),
+                    .map(|point| *point.local()),
             )
             .with_interiors(approx.interiors.into_iter().map(|interior| {
-                interior.points.into_iter().map(|point| point.local())
+                interior.points.into_iter().map(|point| *point.local())
             }));
 
         let mut triangles = delaunay::triangulate(points);
         triangles.retain(|triangle| {
             face_as_polygon.contains_triangle(
-                triangle.map(|point| point.local()),
+                triangle.map(|point| *point.local()),
                 debug_info,
             )
         });

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -10,75 +10,75 @@ use crate::objects::{
 ///
 /// Implemented for all object types. An implementation must return itself, in
 /// addition to any other objects it references.
-pub trait ObjectIters {
+pub trait ObjectIters<'r> {
     /// Iterate over all curves
-    fn curve_iter(&self) -> Iter<Curve<3>>;
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>>;
 
     /// Iterate over all cycles
-    fn cycle_iter(&self) -> Iter<Cycle>;
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle>;
 
     /// Iterate over all edges
-    fn edge_iter(&self) -> Iter<Edge>;
+    fn edge_iter(&'r self) -> Iter<&'r Edge>;
 
     /// Iterate over all faces
-    fn face_iter(&self) -> Iter<Face>;
+    fn face_iter(&'r self) -> Iter<&'r Face>;
 
     /// Iterate over all global vertices
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex>;
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex>;
 
     /// Iterate over all sketches
-    fn sketch_iter(&self) -> Iter<Sketch>;
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch>;
 
     /// Iterate over all solids
-    fn solid_iter(&self) -> Iter<Solid>;
+    fn solid_iter(&'r self) -> Iter<&'r Solid>;
 
     /// Iterate over all surfaces
-    fn surface_iter(&self) -> Iter<Surface>;
+    fn surface_iter(&'r self) -> Iter<&'r Surface>;
 
     /// Iterator over all vertices
-    fn vertex_iter(&self) -> Iter<Vertex>;
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex>;
 }
 
-impl ObjectIters for Curve<3> {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
-        Iter::from_object(*self)
+impl<'r> ObjectIters<'r> for Curve<3> {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
+        Iter::from_object(self)
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         Iter::empty()
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         Iter::empty()
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         Iter::empty()
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         Iter::empty()
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         Iter::empty()
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         Iter::empty()
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         Iter::empty()
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         Iter::empty()
     }
 }
 
-impl ObjectIters for Cycle {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Cycle {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -88,11 +88,11 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
-        Iter::from_object(self.clone())
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
+        Iter::from_object(self)
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -102,7 +102,7 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -112,7 +112,7 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -122,7 +122,7 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -132,7 +132,7 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -142,7 +142,7 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -152,7 +152,7 @@ impl ObjectIters for Cycle {
         iter
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         let mut iter = Iter::empty();
 
         for edge in self.edges() {
@@ -163,8 +163,8 @@ impl ObjectIters for Cycle {
     }
 }
 
-impl ObjectIters for Edge {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Edge {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         let mut iter = Iter::empty().with(self.curve().global().curve_iter());
 
         for vertex in self.vertices().iter() {
@@ -174,7 +174,7 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         let mut iter = Iter::empty().with(self.curve().global().cycle_iter());
 
         for vertex in self.vertices().iter() {
@@ -184,11 +184,11 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
-        Iter::from_object(*self)
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
+        Iter::from_object(self)
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         let mut iter = Iter::empty().with(self.curve().global().face_iter());
 
         for vertex in self.vertices().iter() {
@@ -198,7 +198,7 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         let mut iter =
             Iter::empty().with(self.curve().global().global_vertex_iter());
 
@@ -209,7 +209,7 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         let mut iter = Iter::empty().with(self.curve().global().sketch_iter());
 
         for vertex in self.vertices().iter() {
@@ -219,7 +219,7 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         let mut iter = Iter::empty().with(self.curve().global().solid_iter());
 
         for vertex in self.vertices().iter() {
@@ -229,7 +229,7 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         let mut iter = Iter::empty().with(self.curve().global().surface_iter());
 
         for vertex in self.vertices().iter() {
@@ -239,7 +239,7 @@ impl ObjectIters for Edge {
         iter
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         let mut iter = Iter::empty().with(self.curve().global().vertex_iter());
 
         for vertex in self.vertices().iter() {
@@ -250,8 +250,8 @@ impl ObjectIters for Edge {
     }
 }
 
-impl ObjectIters for Face {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Face {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -265,7 +265,7 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -279,7 +279,7 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -293,11 +293,11 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn face_iter(&self) -> Iter<Face> {
-        Iter::from_object(self.clone())
+    fn face_iter(&'r self) -> Iter<&'r Face> {
+        Iter::from_object(self)
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -311,7 +311,7 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -325,7 +325,7 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -339,7 +339,7 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -353,7 +353,7 @@ impl ObjectIters for Face {
         iter
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         if self.triangles().is_some() {
             return Iter::empty();
         }
@@ -368,46 +368,46 @@ impl ObjectIters for Face {
     }
 }
 
-impl ObjectIters for GlobalVertex {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for GlobalVertex {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         Iter::empty()
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         Iter::empty()
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         Iter::empty()
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         Iter::empty()
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
-        Iter::from_object(*self)
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
+        Iter::from_object(self)
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         Iter::empty()
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         Iter::empty()
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         Iter::empty()
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         Iter::empty()
     }
 }
 
-impl ObjectIters for Sketch {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Sketch {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -417,7 +417,7 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -427,7 +427,7 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -437,7 +437,7 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -447,7 +447,7 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -457,11 +457,11 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
-        Iter::from_object(self.clone())
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
+        Iter::from_object(self)
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -471,7 +471,7 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -481,7 +481,7 @@ impl ObjectIters for Sketch {
         iter
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -492,8 +492,8 @@ impl ObjectIters for Sketch {
     }
 }
 
-impl ObjectIters for Solid {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Solid {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -503,7 +503,7 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -513,7 +513,7 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -523,7 +523,7 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -533,7 +533,7 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -543,7 +543,7 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -553,11 +553,11 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
-        Iter::from_object(self.clone())
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
+        Iter::from_object(self)
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -567,7 +567,7 @@ impl ObjectIters for Solid {
         iter
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         let mut iter = Iter::empty();
 
         for edge in self.faces() {
@@ -578,79 +578,79 @@ impl ObjectIters for Solid {
     }
 }
 
-impl ObjectIters for Surface {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Surface {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         Iter::empty()
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         Iter::empty()
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         Iter::empty()
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         Iter::empty()
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         Iter::empty()
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         Iter::empty()
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         Iter::empty()
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
-        Iter::from_object(*self)
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
+        Iter::from_object(self)
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         Iter::empty()
     }
 }
 
-impl ObjectIters for Vertex {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+impl<'r> ObjectIters<'r> for Vertex {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         self.global().curve_iter()
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         self.global().cycle_iter()
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         self.global().edge_iter()
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         self.global().face_iter()
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         self.global().global_vertex_iter()
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         self.global().sketch_iter()
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         self.global().solid_iter()
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         self.global().surface_iter()
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
-        Iter::from_object(*self)
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
+        Iter::from_object(self)
     }
 }
 
@@ -659,12 +659,13 @@ impl ObjectIters for Vertex {
 // `Solid`).
 //
 // It is also very useful in test code.
-impl<T, O> ObjectIters for T
+impl<'r, T, O> ObjectIters<'r> for T
 where
-    for<'r> &'r T: IntoIterator<Item = &'r O>,
-    O: ObjectIters,
+    T: 'r,
+    O: ObjectIters<'r> + 'r,
+    &'r T: IntoIterator<Item = &'r O>,
 {
-    fn curve_iter(&self) -> Iter<Curve<3>> {
+    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -674,7 +675,7 @@ where
         iter
     }
 
-    fn cycle_iter(&self) -> Iter<Cycle> {
+    fn cycle_iter(&'r self) -> Iter<&'r Cycle> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -684,7 +685,7 @@ where
         iter
     }
 
-    fn edge_iter(&self) -> Iter<Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r Edge> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -694,7 +695,7 @@ where
         iter
     }
 
-    fn face_iter(&self) -> Iter<Face> {
+    fn face_iter(&'r self) -> Iter<&'r Face> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -704,7 +705,7 @@ where
         iter
     }
 
-    fn global_vertex_iter(&self) -> Iter<GlobalVertex> {
+    fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -714,7 +715,7 @@ where
         iter
     }
 
-    fn sketch_iter(&self) -> Iter<Sketch> {
+    fn sketch_iter(&'r self) -> Iter<&'r Sketch> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -724,7 +725,7 @@ where
         iter
     }
 
-    fn solid_iter(&self) -> Iter<Solid> {
+    fn solid_iter(&'r self) -> Iter<&'r Solid> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -734,7 +735,7 @@ where
         iter
     }
 
-    fn surface_iter(&self) -> Iter<Surface> {
+    fn surface_iter(&'r self) -> Iter<&'r Surface> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {
@@ -744,7 +745,7 @@ where
         iter
     }
 
-    fn vertex_iter(&self) -> Iter<Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
         let mut iter = Iter::empty();
 
         for object in self.into_iter() {

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -37,8 +37,8 @@ impl<T: LocalForm> Local<T> {
     }
 
     /// Access the global form of the value
-    pub fn global(&self) -> T::GlobalForm {
-        self.global
+    pub fn global(&self) -> &T::GlobalForm {
+        &self.global
     }
 }
 

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -32,8 +32,8 @@ impl<T: LocalForm> Local<T> {
     }
 
     /// Access the local form of the value
-    pub fn local(&self) -> T {
-        self.local
+    pub fn local(&self) -> &T {
+        &self.local
     }
 
     /// Access the global form of the value

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -45,9 +45,9 @@ impl<T: LocalForm> Local<T> {
 /// Implemented for types that are the local form of a global type
 ///
 /// See [`Local`] for more information.
-pub trait LocalForm: Copy {
+pub trait LocalForm {
     /// The global form of the implementing type
-    type GlobalForm: Copy;
+    type GlobalForm;
 }
 
 impl LocalForm for Curve<2> {

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -41,7 +41,7 @@ impl Cycle {
     }
 
     /// Access this cycle's edges
-    pub fn edges(&self) -> impl Iterator<Item = Edge> + '_ {
-        self.edges.iter().cloned()
+    pub fn edges(&self) -> impl Iterator<Item = &Edge> + '_ {
+        self.edges.iter()
     }
 }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -169,8 +169,8 @@ impl VerticesOfEdge {
     pub fn reverse(self) -> Self {
         Self(self.0.map(|[a, b]| {
             [
-                Vertex::new(-b.position(), b.global()),
-                Vertex::new(-a.position(), a.global()),
+                Vertex::new(-b.position(), *b.global()),
+                Vertex::new(-a.position(), *a.global()),
             ]
         }))
     }

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -36,7 +36,7 @@ impl Vertex {
     }
 
     /// The global form of this vertex
-    pub fn global(&self) -> GlobalVertex {
-        self.global
+    pub fn global(&self) -> &GlobalVertex {
+        &self.global
     }
 }

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -34,22 +34,22 @@ pub fn validate<T>(
     config: &ValidationConfig,
 ) -> Result<Validated<T>, ValidationError>
 where
-    T: ObjectIters,
+    T: for<'r> ObjectIters<'r>,
 {
     let mut vertices = HashSet::new();
 
     for vertex in object.global_vertex_iter() {
         uniqueness::validate_vertex(
-            &vertex,
+            vertex,
             &vertices,
             config.distinct_min_distance,
         )?;
 
-        vertices.insert(vertex);
+        vertices.insert(*vertex);
     }
 
     for edge in object.edge_iter() {
-        coherence::validate_edge(&edge, config.identical_max_distance)?;
+        coherence::validate_edge(edge, config.identical_max_distance)?;
     }
 
     Ok(Validated(object))

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -91,7 +91,7 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
         let curve_local = if reverse {
             edge.curve().local().reverse()
         } else {
-            edge.curve().local()
+            *edge.curve().local()
         };
 
         let curve_global = if reverse {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -97,7 +97,7 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
         let curve_global = if reverse {
             edge.curve().global().reverse()
         } else {
-            edge.curve().global()
+            *edge.curve().global()
         };
 
         let vertices = if reverse {


### PR DESCRIPTION
Update the kernel APIs that return objects, to return references to them instead, where appropriate. This has the following advantages:
- It makes the potential cost of copying/cloning the object explicit.
- It avoids the cost of copying/cloning the object, where that's not needed.
- It helps in some use cases, for example when working with trait objects, where your only alternative to using a reference is putting them in a `Box` (or similar).