### PR TITLE
Make names of `Local` methods more explicit

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/cycles.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycles.rs
@@ -27,8 +27,8 @@ impl CycleApprox {
             points.extend(edge_points.into_iter().map(|point| {
                 let local = edge
                     .curve()
-                    .local()
-                    .point_from_curve_coords(*point.local());
+                    .local_form()
+                    .point_from_curve_coords(*point.local_form());
                 Local::new(local, *point.global())
             }));
         }

--- a/crates/fj-kernel/src/algorithms/approx/cycles.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycles.rs
@@ -21,7 +21,11 @@ impl CycleApprox {
 
         for edge in &cycle.edges {
             let mut edge_points = Vec::new();
-            approx_curve(edge.curve().global(), tolerance, &mut edge_points);
+            approx_curve(
+                edge.curve().global_form(),
+                tolerance,
+                &mut edge_points,
+            );
             approx_edge(*edge.vertices(), &mut edge_points);
 
             points.extend(edge_points.into_iter().map(|point| {
@@ -29,13 +33,13 @@ impl CycleApprox {
                     .curve()
                     .local_form()
                     .point_from_curve_coords(*point.local_form());
-                Local::new(local, *point.global())
+                Local::new(local, *point.global_form())
             }));
         }
 
         // Can't just rely on `dedup`, as the conversion from curve coordinates
         // could lead to subtly different surface coordinates.
-        points.dedup_by(|a, b| a.global() == b.global());
+        points.dedup_by(|a, b| a.global_form() == b.global_form());
 
         Self { points }
     }
@@ -49,7 +53,8 @@ impl CycleApprox {
             // up, once `array_windows` is stable.
             let segment = [segment[0], segment[1]];
 
-            segments.push(Segment::from(segment.map(|point| *point.global())));
+            segments
+                .push(Segment::from(segment.map(|point| *point.global_form())));
         }
 
         segments

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -40,7 +40,7 @@ impl CurveFaceIntersectionList {
                 edges
             })
             .map(|edge| {
-                let line = match edge.curve().local() {
+                let line = match edge.curve().local_form() {
                     Curve::Line(line) => line,
                     _ => {
                         todo!("Curve-face intersection only supports polygons")

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -28,7 +28,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
             .iter()
             .map(|edge| {
                 let curve = {
-                    let local = match edge.curve().local() {
+                    let local = match edge.curve().local_form() {
                         Curve::Circle(Circle { center, a, b }) => {
                             let center = Point::from([center.u, -center.v]);
 

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -46,7 +46,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
                         }
                     };
 
-                    Local::new(local, *edge.curve().global())
+                    Local::new(local, *edge.curve().global_form())
                 };
 
                 Edge::new(curve, *edge.vertices())

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -59,7 +59,7 @@ impl TransformObject for Edge {
     fn transform(self, transform: &Transform) -> Self {
         let curve = Local::new(
             *self.curve().local_form(),
-            self.curve().global().transform(transform),
+            self.curve().global_form().transform(transform),
         );
 
         let vertices =

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -58,7 +58,7 @@ impl TransformObject for Cycle {
 impl TransformObject for Edge {
     fn transform(self, transform: &Transform) -> Self {
         let curve = Local::new(
-            *self.curve().local(),
+            *self.curve().local_form(),
             self.curve().global().transform(transform),
         );
 

--- a/crates/fj-kernel/src/algorithms/triangulate/delaunay.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/delaunay.rs
@@ -13,9 +13,12 @@ pub fn triangulate(points: Vec<Local<Point<2>>>) -> Vec<[Local<Point<2>>; 3]> {
     let mut triangles = Vec::new();
     for triangle in triangulation.inner_faces() {
         let [v0, v1, v2] = triangle.vertices().map(|vertex| *vertex.data());
-        let orientation =
-            Triangle::<2>::from_points([*v0.local(), *v1.local(), *v2.local()])
-                .winding_direction();
+        let orientation = Triangle::<2>::from_points([
+            *v0.local_form(),
+            *v1.local_form(),
+            *v2.local_form(),
+        ])
+        .winding_direction();
 
         let triangle = match orientation {
             Winding::Ccw => [v0, v1, v2],
@@ -34,8 +37,8 @@ impl HasPosition for Local<Point<2>> {
 
     fn position(&self) -> spade::Point2<Self::Scalar> {
         spade::Point2 {
-            x: self.local().u,
-            y: self.local().v,
+            x: self.local_form().u,
+            y: self.local_form().v,
         }
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -37,16 +37,16 @@ pub fn triangulate(
                     .exterior
                     .points
                     .into_iter()
-                    .map(|point| *point.local()),
+                    .map(|point| *point.local_form()),
             )
             .with_interiors(approx.interiors.into_iter().map(|interior| {
-                interior.points.into_iter().map(|point| *point.local())
+                interior.points.into_iter().map(|point| *point.local_form())
             }));
 
         let mut triangles = delaunay::triangulate(points);
         triangles.retain(|triangle| {
             face_as_polygon.contains_triangle(
-                triangle.map(|point| *point.local()),
+                triangle.map(|point| *point.local_form()),
                 debug_info,
             )
         });

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -52,7 +52,7 @@ pub fn triangulate(
         });
 
         for triangle in triangles {
-            let points = triangle.map(|point| *point.global());
+            let points = triangle.map(|point| *point.global_form());
             mesh.push_triangle(points, face.color());
         }
     }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -142,7 +142,7 @@ impl<'r> ObjectIters<'r> for Cycle {
 
 impl<'r> ObjectIters<'r> for Edge {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
-        let mut objects = vec![self.curve().global() as &dyn ObjectIters];
+        let mut objects = vec![self.curve().global_form() as &dyn ObjectIters];
 
         for vertex in self.vertices().iter() {
             objects.push(vertex);

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -37,7 +37,7 @@ impl<T: LocalForm> Local<T> {
     }
 
     /// Access the global form of the value
-    pub fn global(&self) -> &T::GlobalForm {
+    pub fn global_form(&self) -> &T::GlobalForm {
         &self.global
     }
 }

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -32,7 +32,7 @@ impl<T: LocalForm> Local<T> {
     }
 
     /// Access the local form of the value
-    pub fn local(&self) -> &T {
+    pub fn local_form(&self) -> &T {
         &self.local
     }
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -100,7 +100,7 @@ impl fmt::Display for Edge {
             None => write!(f, "continuous edge")?,
         }
 
-        write!(f, " on {}", self.curve().global())?;
+        write!(f, " on {}", self.curve().global_form())?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/validation/coherence.rs
+++ b/crates/fj-kernel/src/validation/coherence.rs
@@ -19,7 +19,7 @@ pub fn validate_edge(
     for vertex in edge.vertices().iter() {
         let local = vertex.position();
         let local_as_global =
-            edge.curve().global().point_from_curve_coords(local);
+            edge.curve().global_form().point_from_curve_coords(local);
         let global = vertex.global().position();
         let distance = (local_as_global - global).magnitude();
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -95,9 +95,9 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
         };
 
         let curve_global = if reverse {
-            edge.curve().global().reverse()
+            edge.curve().global_form().reverse()
         } else {
-            *edge.curve().global()
+            *edge.curve().global_form()
         };
 
         let vertices = if reverse {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -89,9 +89,9 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
     let mut edges = Vec::new();
     for edge in cycle.edges {
         let curve_local = if reverse {
-            edge.curve().local().reverse()
+            edge.curve().local_form().reverse()
         } else {
-            *edge.curve().local()
+            *edge.curve().local_form()
         };
 
         let curve_global = if reverse {


### PR DESCRIPTION
I think those names were a bit too short for their own good. The new names are more explicit, and match the trait and associated type names the methods are associated with.