### PR TITLE
Add new builder API

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/faces.rs
+++ b/crates/fj-kernel/src/algorithms/approx/faces.rs
@@ -85,7 +85,7 @@ mod tests {
 
     use crate::{
         local::Local,
-        objects::{Cycle, Face, Surface},
+        objects::{Face, Surface},
     };
 
     use super::{CycleApprox, FaceApprox, Tolerance};
@@ -109,11 +109,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let face = Face::build(surface)
             .polygon_from_points([a, b, c, d])
-            .into_face()
-            .with_interiors([Cycle::polygon_from_points(
-                &surface,
-                [e, f, g, h],
-            )]);
+            .with_hole([e, f, g, h]);
 
         let a = Local::new(a, a.to_xyz());
         let b = Local::new(b, b.to_xyz());

--- a/crates/fj-kernel/src/algorithms/approx/faces.rs
+++ b/crates/fj-kernel/src/algorithms/approx/faces.rs
@@ -107,11 +107,8 @@ mod tests {
         let h = Point::from([1., 2.]);
 
         let surface = Surface::xy_plane();
-        let face = Face::new(surface)
-            .with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [a, b, c, d],
-            )])
+        let face = Face::build(surface)
+            .polygon_from_points([a, b, c, d])
             .with_interiors([Cycle::polygon_from_points(
                 &surface,
                 [e, f, g, h],

--- a/crates/fj-kernel/src/algorithms/approx/faces.rs
+++ b/crates/fj-kernel/src/algorithms/approx/faces.rs
@@ -109,6 +109,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let face = Face::build(surface)
             .polygon_from_points([a, b, c, d])
+            .into_face()
             .with_interiors([Cycle::polygon_from_points(
                 &surface,
                 [e, f, g, h],

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -213,6 +213,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let face = Face::build(surface)
             .polygon_from_points(exterior)
+            .into_face()
             .with_interiors([Cycle::polygon_from_points(&surface, interior)]);
 
         let expected =

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -184,7 +184,7 @@ pub type CurveFaceIntersection = [Scalar; 2];
 mod tests {
     use fj_math::{Line, Point, Vector};
 
-    use crate::objects::{Curve, Cycle, Face, Surface};
+    use crate::objects::{Curve, Face, Surface};
 
     use super::CurveFaceIntersectionList;
 
@@ -213,8 +213,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let face = Face::build(surface)
             .polygon_from_points(exterior)
-            .into_face()
-            .with_interiors([Cycle::polygon_from_points(&surface, interior)]);
+            .with_hole(interior);
 
         let expected =
             CurveFaceIntersectionList::from_intervals([[1., 2.], [4., 5.]]);

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -211,8 +211,8 @@ mod tests {
         ];
 
         let surface = Surface::xy_plane();
-        let face = Face::new(surface)
-            .with_exteriors([Cycle::polygon_from_points(&surface, exterior)])
+        let face = Face::build(surface)
+            .polygon_from_points(exterior)
             .with_interiors([Cycle::polygon_from_points(&surface, interior)]);
 
         let expected =

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -60,25 +60,25 @@ fn reverse_local_coordinates_in_cycle<'r>(
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use crate::objects::{Cycle, Face, Surface};
+    use crate::objects::{Face, Surface};
 
     #[test]
     fn reverse_face() {
         let surface = Surface::xy_plane();
-        let original =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )]);
+        let original = Face::build(surface).polygon_from_points([
+            [0., 0.],
+            [1., 0.],
+            [0., 1.],
+        ]);
 
         let reversed = super::reverse_face(&original);
 
         let surface = Surface::xy_plane().reverse();
-        let expected =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [[0., 0.], [1., 0.], [0., -1.]],
-            )]);
+        let expected = Face::build(surface).polygon_from_points([
+            [0., 0.],
+            [1., 0.],
+            [0., -1.],
+        ]);
 
         assert_eq!(expected, reversed);
     }

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -74,11 +74,9 @@ mod tests {
         let reversed = super::reverse_face(&original);
 
         let surface = Surface::xy_plane().reverse();
-        let expected = Face::build(surface).polygon_from_points([
-            [0., 0.],
-            [1., 0.],
-            [0., -1.],
-        ]);
+        let expected = Face::build(surface)
+            .polygon_from_points([[0., 0.], [1., 0.], [0., -1.]])
+            .into_face();
 
         assert_eq!(expected, reversed);
     }

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -313,7 +313,9 @@ mod tests {
         let faces = expected_surfaces.into_iter().map(|surface| {
             let surface = Surface::plane_from_points(surface);
 
-            Face::build(surface).polygon_from_points(expected_vertices.clone())
+            Face::build(surface)
+                .polygon_from_points(expected_vertices.clone())
+                .into_face()
         });
 
         for face in faces {

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -205,7 +205,7 @@ mod tests {
     use crate::{
         algorithms::Tolerance,
         iter::ObjectIters,
-        objects::{Cycle, Face, Sketch, Surface},
+        objects::{Face, Sketch, Surface},
     };
 
     #[test]
@@ -295,11 +295,11 @@ mod tests {
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let surface = Surface::xy_plane();
-        let face =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )]);
+        let face = Face::build(surface).polygon_from_points([
+            [0., 0.],
+            [1., 0.],
+            [0., 1.],
+        ]);
         let sketch = Sketch::from_faces([face]);
 
         let solid =
@@ -313,10 +313,7 @@ mod tests {
         let faces = expected_surfaces.into_iter().map(|surface| {
             let surface = Surface::plane_from_points(surface);
 
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                expected_vertices.clone(),
-            )])
+            Face::build(surface).polygon_from_points(expected_vertices.clone())
         });
 
         for face in faces {

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -110,6 +110,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let face = Face::build(surface)
             .polygon_from_points([a, b, c, d])
+            .into_face()
             .with_interiors([Cycle::polygon_from_points(
                 &surface,
                 [e, f, g, h],

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -180,10 +180,14 @@ mod tests {
         Ok(())
     }
 
-    fn triangulate(face: Face) -> anyhow::Result<Mesh<Point<3>>> {
+    fn triangulate(face: impl Into<Face>) -> anyhow::Result<Mesh<Point<3>>> {
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let mut debug_info = DebugInfo::new();
-        Ok(super::triangulate(vec![face], tolerance, &mut debug_info))
+        Ok(super::triangulate(
+            vec![face.into()],
+            tolerance,
+            &mut debug_info,
+        ))
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -78,11 +78,7 @@ mod tests {
         let d = [0., 1.];
 
         let surface = Surface::xy_plane();
-        let face =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [a, b, c, d],
-            )]);
+        let face = Face::build(surface).polygon_from_points([a, b, c, d]);
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
@@ -112,11 +108,8 @@ mod tests {
         let h = [1., 2.];
 
         let surface = Surface::xy_plane();
-        let face = Face::new(surface)
-            .with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [a, b, c, d],
-            )])
+        let face = Face::build(surface)
+            .polygon_from_points([a, b, c, d])
             .with_interiors([Cycle::polygon_from_points(
                 &surface,
                 [e, f, g, h],
@@ -168,11 +161,7 @@ mod tests {
         let e = Point::from([0., 0.8]);
 
         let surface = Surface::xy_plane();
-        let face =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [a, b, c, d, e],
-            )]);
+        let face = Face::build(surface).polygon_from_points([a, b, c, d, e]);
 
         let triangles = triangulate(face)?;
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -67,7 +67,7 @@ mod tests {
 
     use crate::{
         algorithms::Tolerance,
-        objects::{Cycle, Face, Surface},
+        objects::{Face, Surface},
     };
 
     #[test]
@@ -110,11 +110,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let face = Face::build(surface)
             .polygon_from_points([a, b, c, d])
-            .into_face()
-            .with_interiors([Cycle::polygon_from_points(
-                &surface,
-                [e, f, g, h],
-            )]);
+            .with_hole([e, f, g, h]);
 
         let triangles = triangulate(face)?;
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -35,7 +35,9 @@ impl CycleBuilder {
             // Can be cleaned up, once `array_windows` is stable.
             let points = [points[0], points[1]];
 
-            edges.push(Edge::line_segment_from_points(&self.surface, points));
+            edges.push(
+                Edge::build().line_segment_from_points(&self.surface, points),
+            );
         }
 
         Cycle::new().with_edges(edges)

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -1,0 +1,43 @@
+use fj_math::Point;
+
+use crate::objects::{Cycle, Edge, Surface};
+
+/// API for building a [`Cycle`]
+pub struct CycleBuilder {
+    surface: Surface,
+}
+
+impl CycleBuilder {
+    /// Construct an instance of `CycleBuilder`
+    ///
+    /// Also see [`Cycle::build`].
+    pub fn new(surface: Surface) -> Self {
+        Self { surface }
+    }
+
+    /// Create a polygon from a list of points
+    pub fn polygon_from_points(
+        &self,
+        points: impl IntoIterator<Item = impl Into<Point<2>>>,
+    ) -> Cycle {
+        let mut points: Vec<_> = points.into_iter().map(Into::into).collect();
+
+        // A polygon is closed, so we need to add the first point at the end
+        // again, for the next step.
+        if let Some(point) = points.first().cloned() {
+            points.push(point);
+        }
+
+        let mut edges = Vec::new();
+        for points in points.windows(2) {
+            // Can't panic, as we passed `2` to `windows`.
+            //
+            // Can be cleaned up, once `array_windows` is stable.
+            let points = [points[0], points[1]];
+
+            edges.push(Edge::line_segment_from_points(&self.surface, points));
+        }
+
+        Cycle::new().with_edges(edges)
+    }
+}

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -1,0 +1,64 @@
+use fj_math::{Circle, Line, Point, Scalar, Vector};
+
+use crate::{
+    local::Local,
+    objects::{Curve, Edge, GlobalVertex, Surface, Vertex, VerticesOfEdge},
+};
+
+/// API for building an [`Edge`]
+pub struct EdgeBuilder;
+
+impl EdgeBuilder {
+    /// Create a circle from the given radius
+    pub fn circle_from_radius(&self, radius: Scalar) -> Edge {
+        let curve_local = Curve::Circle(Circle {
+            center: Point::origin(),
+            a: Vector::from([radius, Scalar::ZERO]),
+            b: Vector::from([Scalar::ZERO, radius]),
+        });
+        let curve_canonical = Curve::Circle(Circle {
+            center: Point::origin(),
+            a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
+            b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
+        });
+
+        Edge::new(
+            Local::new(curve_local, curve_canonical),
+            VerticesOfEdge::none(),
+        )
+    }
+
+    /// Create a line segment from two points
+    pub fn line_segment_from_points(
+        &self,
+        surface: &Surface,
+        points: [impl Into<Point<2>>; 2],
+    ) -> Edge {
+        let points = points.map(Into::into);
+
+        let global_vertices = points.map(|position| {
+            let position = surface.point_from_surface_coords(position);
+            GlobalVertex::from_position(position)
+        });
+
+        let curve_local = Curve::Line(Line::from_points(points));
+        let curve_canonical = {
+            let points =
+                global_vertices.map(|global_vertex| global_vertex.position());
+            Curve::Line(Line::from_points(points))
+        };
+
+        let vertices = {
+            let [a, b] = global_vertices;
+            [
+                Vertex::new(Point::from([0.]), a),
+                Vertex::new(Point::from([1.]), b),
+            ]
+        };
+
+        Edge::new(
+            Local::new(curve_local, curve_canonical),
+            VerticesOfEdge::from_vertices(vertices),
+        )
+    }
+}

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,0 +1,26 @@
+use fj_math::Point;
+
+use crate::objects::{Cycle, Face, Surface};
+
+/// API for building a [`Face`]
+pub struct FaceBuilder {
+    surface: Surface,
+}
+
+impl FaceBuilder {
+    /// Construct an instance of `FaceBuilder`
+    ///
+    /// Also see [`Face::build`].
+    pub fn new(surface: Surface) -> Self {
+        Self { surface }
+    }
+
+    /// Construct a polygon from a list of points
+    pub fn polygon_from_points(
+        &self,
+        points: impl IntoIterator<Item = impl Into<Point<2>>>,
+    ) -> Face {
+        Face::new(self.surface)
+            .with_exteriors([Cycle::polygon_from_points(&self.surface, points)])
+    }
+}

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use fj_math::Point;
 
 use crate::objects::{Cycle, Face, Surface};
@@ -19,8 +21,38 @@ impl FaceBuilder {
     pub fn polygon_from_points(
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Face {
-        Face::new(self.surface)
-            .with_exteriors([Cycle::polygon_from_points(&self.surface, points)])
+    ) -> FacePolygon {
+        let face = Face::new(self.surface).with_exteriors([
+            Cycle::polygon_from_points(&self.surface, points),
+        ]);
+
+        FacePolygon { face }
+    }
+}
+
+/// A polygon
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct FacePolygon {
+    face: Face,
+}
+
+impl FacePolygon {
+    /// Consume the `Polygon` and return the [`Face`] it wraps
+    pub fn into_face(self) -> Face {
+        self.face
+    }
+}
+
+impl From<FacePolygon> for Face {
+    fn from(polygon: FacePolygon) -> Self {
+        polygon.into_face()
+    }
+}
+
+impl Deref for FacePolygon {
+    type Target = Face;
+
+    fn deref(&self) -> &Self::Target {
+        &self.face
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -37,6 +37,19 @@ pub struct FacePolygon {
 }
 
 impl FacePolygon {
+    /// Add a hole to the polygon
+    pub fn with_hole(
+        mut self,
+        points: impl IntoIterator<Item = impl Into<Point<2>>>,
+    ) -> Self {
+        let surface = *self.face.surface();
+        self.face = self
+            .face
+            .with_interiors([Cycle::polygon_from_points(&surface, points)]);
+
+        self
+    }
+
     /// Consume the `Polygon` and return the [`Face`] it wraps
     pub fn into_face(self) -> Face {
         self.face

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -22,9 +22,10 @@ impl FaceBuilder {
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> FacePolygon {
-        let face = Face::new(self.surface).with_exteriors([
-            Cycle::polygon_from_points(&self.surface, points),
-        ]);
+        let face = Face::new(self.surface)
+            .with_exteriors([
+                Cycle::build(self.surface).polygon_from_points(points)
+            ]);
 
         FacePolygon { face }
     }
@@ -43,9 +44,9 @@ impl FacePolygon {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         let surface = *self.face.surface();
-        self.face = self
-            .face
-            .with_interiors([Cycle::polygon_from_points(&surface, points)]);
+        self.face = self.face.with_interiors([
+            Cycle::build(surface).polygon_from_points(points)
+        ]);
 
         self
     }

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -2,4 +2,4 @@
 
 mod face;
 
-pub use self::face::FaceBuilder;
+pub use self::face::{FaceBuilder, FacePolygon};

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -3,9 +3,11 @@
 mod cycle;
 mod edge;
 mod face;
+mod solid;
 
 pub use self::{
     cycle::CycleBuilder,
     edge::EdgeBuilder,
     face::{FaceBuilder, FacePolygon},
+    solid::SolidBuilder,
 };

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -1,0 +1,5 @@
+//! API for building objects
+
+mod face;
+
+pub use self::face::FaceBuilder;

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -1,5 +1,9 @@
 //! API for building objects
 
+mod cycle;
 mod face;
 
-pub use self::face::{FaceBuilder, FacePolygon};
+pub use self::{
+    cycle::CycleBuilder,
+    face::{FaceBuilder, FacePolygon},
+};

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -1,9 +1,11 @@
 //! API for building objects
 
 mod cycle;
+mod edge;
 mod face;
 
 pub use self::{
     cycle::CycleBuilder,
+    edge::EdgeBuilder,
     face::{FaceBuilder, FacePolygon},
 };

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -1,0 +1,38 @@
+use fj_math::Scalar;
+
+use crate::{
+    algorithms::TransformObject,
+    objects::{Face, Solid, Surface},
+};
+
+/// API for building a [`Solid`]
+pub struct SolidBuilder;
+
+impl SolidBuilder {
+    /// Create a cube from the length of its edges
+    pub fn cube_from_edge_length(
+        &self,
+        edge_length: impl Into<Scalar>,
+    ) -> Solid {
+        // Let's define a short-hand for half the edge length. We're going to
+        // need it a lot.
+        let h = edge_length.into() / 2.;
+
+        let points = [[-h, -h], [h, -h], [h, h], [-h, h]];
+
+        const Z: Scalar = Scalar::ZERO;
+        let planes = [
+            Surface::xy_plane().translate([Z, Z, -h]), // bottom
+            Surface::xy_plane().translate([Z, Z, h]),  // top
+            Surface::xz_plane().translate([Z, -h, Z]), // front
+            Surface::xz_plane().translate([Z, h, Z]),  // back
+            Surface::yz_plane().translate([-h, Z, Z]), // left
+            Surface::yz_plane().translate([h, Z, Z]),  // right
+        ];
+
+        let faces =
+            planes.map(|plane| Face::build(plane).polygon_from_points(points));
+
+        Solid::from_faces(faces)
+    }
+}

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn solid() {
-        let object = Solid::cube_from_edge_length(1.);
+        let object = Solid::build().cube_from_edge_length(1.);
 
         assert_eq!(18, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -319,10 +319,11 @@ mod tests {
 
     #[test]
     fn cycle() {
-        let object = Cycle::polygon_from_points(
-            &Surface::xy_plane(),
-            [[0., 0.], [1., 0.], [0., 1.]],
-        );
+        let object = Cycle::build(Surface::xy_plane()).polygon_from_points([
+            [0., 0.],
+            [1., 0.],
+            [0., 1.],
+        ]);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -356,11 +356,11 @@ mod tests {
     #[test]
     fn face() {
         let surface = Surface::xy_plane();
-        let object =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )]);
+        let object = Face::build(surface).polygon_from_points([
+            [0., 0.],
+            [1., 0.],
+            [0., 1.],
+        ]);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
@@ -391,11 +391,11 @@ mod tests {
     #[test]
     fn sketch() {
         let surface = Surface::xy_plane();
-        let face =
-            Face::new(surface).with_exteriors([Cycle::polygon_from_points(
-                &surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )]);
+        let face = Face::build(surface).polygon_from_points([
+            [0., 0.],
+            [1., 0.],
+            [0., 1.],
+        ]);
         let object = Sketch::from_faces([face]);
 
         assert_eq!(3, object.curve_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn edge() {
-        let object = Edge::line_segment_from_points(
+        let object = Edge::build().line_segment_from_points(
             &Surface::xy_plane(),
             [[0., 0.], [1., 0.]],
         );

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -88,6 +88,7 @@
 #![warn(missing_docs)]
 
 pub mod algorithms;
+pub mod builder;
 pub mod iter;
 pub mod local;
 pub mod objects;

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -1,4 +1,4 @@
-use fj_math::Point;
+use crate::builder::CycleBuilder;
 
 use super::{Edge, Surface};
 
@@ -33,30 +33,9 @@ impl Cycle {
         self
     }
 
-    /// Create a polygon from a list of points
-    pub fn polygon_from_points(
-        surface: &Surface,
-        points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Cycle {
-        let mut points: Vec<_> = points.into_iter().map(Into::into).collect();
-
-        // A polygon is closed, so we need to add the first point at the end
-        // again, for the next step.
-        if let Some(point) = points.first().cloned() {
-            points.push(point);
-        }
-
-        let mut edges = Vec::new();
-        for points in points.windows(2) {
-            // Can't panic, as we passed `2` to `windows`.
-            //
-            // Can be cleaned up, once `array_windows` is stable.
-            let points = [points[0], points[1]];
-
-            edges.push(Edge::line_segment_from_points(surface, points));
-        }
-
-        Cycle { edges }
+    /// Build a cycle using [`CycleBuilder`]
+    pub fn build(surface: Surface) -> CycleBuilder {
+        CycleBuilder::new(surface)
     }
 
     /// Access edges that make up the cycle

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,10 +1,8 @@
 use std::fmt;
 
-use fj_math::{Circle, Line, Point, Scalar, Vector};
+use crate::{builder::EdgeBuilder, local::Local};
 
-use crate::local::Local;
-
-use super::{Curve, GlobalVertex, Surface, Vertex};
+use super::{Curve, Vertex};
 
 /// An edge of a shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -19,56 +17,9 @@ impl Edge {
         Self { curve, vertices }
     }
 
-    /// Create a circle from the given radius
-    pub fn circle_from_radius(radius: Scalar) -> Self {
-        let curve_local = Curve::Circle(Circle {
-            center: Point::origin(),
-            a: Vector::from([radius, Scalar::ZERO]),
-            b: Vector::from([Scalar::ZERO, radius]),
-        });
-        let curve_canonical = Curve::Circle(Circle {
-            center: Point::origin(),
-            a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
-            b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
-        });
-
-        Edge {
-            curve: Local::new(curve_local, curve_canonical),
-            vertices: VerticesOfEdge::none(),
-        }
-    }
-
-    /// Create a line segment from two points
-    pub fn line_segment_from_points(
-        surface: &Surface,
-        points: [impl Into<Point<2>>; 2],
-    ) -> Self {
-        let points = points.map(Into::into);
-
-        let global_vertices = points.map(|position| {
-            let position = surface.point_from_surface_coords(position);
-            GlobalVertex::from_position(position)
-        });
-
-        let curve_local = Curve::Line(Line::from_points(points));
-        let curve_canonical = {
-            let points =
-                global_vertices.map(|global_vertex| global_vertex.position());
-            Curve::Line(Line::from_points(points))
-        };
-
-        let vertices = {
-            let [a, b] = global_vertices;
-            [
-                Vertex::new(Point::from([0.]), a),
-                Vertex::new(Point::from([1.]), b),
-            ]
-        };
-
-        Self {
-            curve: Local::new(curve_local, curve_canonical),
-            vertices: VerticesOfEdge::from_vertices(vertices),
-        }
+    /// Build an edge using [`EdgeBuilder`]
+    pub fn build() -> EdgeBuilder {
+        EdgeBuilder
     }
 
     /// Access the curve that defines the edge's geometry

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -1,6 +1,8 @@
 use fj_interop::mesh::Color;
 use fj_math::Triangle;
 
+use crate::builder::FaceBuilder;
+
 use super::{Cycle, Surface};
 
 /// A face of a shape
@@ -66,6 +68,11 @@ impl Face {
     pub fn with_color(mut self, color: Color) -> Self {
         self.brep_mut().color = color;
         self
+    }
+
+    /// Build a face using [`FaceBuilder`]
+    pub fn build(surface: Surface) -> FaceBuilder {
+        FaceBuilder::new(surface)
     }
 
     /// Access this face's surface

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -32,6 +32,42 @@ impl Face {
         }
     }
 
+    /// Add exterior cycles to the face
+    ///
+    /// Consumes the face and returns the updated instance.
+    pub fn with_exteriors(
+        mut self,
+        exteriors: impl IntoIterator<Item = Cycle>,
+    ) -> Self {
+        for exterior in exteriors.into_iter() {
+            self.brep_mut().exteriors.push(exterior);
+        }
+
+        self
+    }
+
+    /// Add interior cycles to the face
+    ///
+    /// Consumes the face and returns the updated instance.
+    pub fn with_interiors(
+        mut self,
+        interiors: impl IntoIterator<Item = Cycle>,
+    ) -> Self {
+        for interior in interiors.into_iter() {
+            self.brep_mut().interiors.push(interior);
+        }
+
+        self
+    }
+
+    /// Update the color of the face
+    ///
+    /// Consumes the face and returns the updated instance.
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.brep_mut().color = color;
+        self
+    }
+
     /// Access this face's surface
     pub fn surface(&self) -> &Surface {
         &self.brep().surface
@@ -73,42 +109,6 @@ impl Face {
         }
 
         None
-    }
-
-    /// Add exterior cycles to the face
-    ///
-    /// Consumes the face and returns the updated instance.
-    pub fn with_exteriors(
-        mut self,
-        exteriors: impl IntoIterator<Item = Cycle>,
-    ) -> Self {
-        for exterior in exteriors.into_iter() {
-            self.brep_mut().exteriors.push(exterior);
-        }
-
-        self
-    }
-
-    /// Add interior cycles to the face
-    ///
-    /// Consumes the face and returns the updated instance.
-    pub fn with_interiors(
-        mut self,
-        interiors: impl IntoIterator<Item = Cycle>,
-    ) -> Self {
-        for interior in interiors.into_iter() {
-            self.brep_mut().interiors.push(interior);
-        }
-
-        self
-    }
-
-    /// Update the color of the face
-    ///
-    /// Consumes the face and returns the updated instance.
-    pub fn with_color(mut self, color: Color) -> Self {
-        self.brep_mut().color = color;
-        self
     }
 
     /// Access the boundary representation of the face

--- a/crates/fj-kernel/src/objects/sketch.rs
+++ b/crates/fj-kernel/src/objects/sketch.rs
@@ -15,8 +15,10 @@ pub struct Sketch {
 
 impl Sketch {
     /// Construct a sketch from faces
-    pub fn from_faces(faces: impl IntoIterator<Item = Face>) -> Self {
-        let faces = faces.into_iter().collect();
+    pub fn from_faces(
+        faces: impl IntoIterator<Item = impl Into<Face>>,
+    ) -> Self {
+        let faces = faces.into_iter().map(Into::into).collect();
         Self { faces }
     }
 

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -25,8 +25,10 @@ pub struct Solid {
 
 impl Solid {
     /// Construct a solid from faces
-    pub fn from_faces(faces: impl IntoIterator<Item = Face>) -> Self {
-        let faces = faces.into_iter().collect();
+    pub fn from_faces(
+        faces: impl IntoIterator<Item = impl Into<Face>>,
+    ) -> Self {
+        let faces = faces.into_iter().map(Into::into).collect();
         Self { faces }
     }
 

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use fj_math::Scalar;
 
-use crate::{algorithms::TransformObject, objects::Cycle};
+use crate::algorithms::TransformObject;
 
 use super::{Face, Surface};
 
@@ -48,10 +48,8 @@ impl Solid {
             Surface::yz_plane().translate([h, Z, Z]),  // right
         ];
 
-        let faces = planes.map(|plane| {
-            Face::new(plane)
-                .with_exteriors([Cycle::polygon_from_points(&plane, points)])
-        });
+        let faces =
+            planes.map(|plane| Face::build(plane).polygon_from_points(points));
 
         Solid::from_faces(faces)
     }

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -1,10 +1,8 @@
 use std::collections::BTreeSet;
 
-use fj_math::Scalar;
+use crate::builder::SolidBuilder;
 
-use crate::algorithms::TransformObject;
-
-use super::{Face, Surface};
+use super::Face;
 
 /// A 3-dimensional shape
 ///
@@ -32,28 +30,9 @@ impl Solid {
         Self { faces }
     }
 
-    /// Create a cube from the length of its edges
-    pub fn cube_from_edge_length(edge_length: impl Into<Scalar>) -> Self {
-        // Let's define a short-hand for half the edge length. We're going to
-        // need it a lot.
-        let h = edge_length.into() / 2.;
-
-        let points = [[-h, -h], [h, -h], [h, h], [-h, h]];
-
-        const Z: Scalar = Scalar::ZERO;
-        let planes = [
-            Surface::xy_plane().translate([Z, Z, -h]), // bottom
-            Surface::xy_plane().translate([Z, Z, h]),  // top
-            Surface::xz_plane().translate([Z, -h, Z]), // front
-            Surface::xz_plane().translate([Z, h, Z]),  // back
-            Surface::yz_plane().translate([-h, Z, Z]), // left
-            Surface::yz_plane().translate([h, Z, Z]),  // right
-        ];
-
-        let faces =
-            planes.map(|plane| Face::build(plane).polygon_from_points(points));
-
-        Solid::from_faces(faces)
+    /// Build a solid using [`SolidBuilder`]
+    pub fn build() -> SolidBuilder {
+        SolidBuilder
     }
 
     /// Access the solid's faces

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -24,8 +24,8 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let edge =
-                    Edge::circle_from_radius(Scalar::from_f64(circle.radius()));
+                let edge = Edge::build()
+                    .circle_from_radius(Scalar::from_f64(circle.radius()));
                 let cycle = Cycle::new().with_edges([edge]);
 
                 Face::new(surface)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -36,10 +36,9 @@ impl Shape for fj::Sketch {
                 let points =
                     poly_chain.to_points().into_iter().map(Point::from);
 
-                Face::new(surface)
-                    .with_exteriors([Cycle::polygon_from_points(
-                        &surface, points,
-                    )])
+                Face::build(surface)
+                    .polygon_from_points(points)
+                    .into_face()
                     .with_color(Color(self.color()))
             }
         };


### PR DESCRIPTION
This is a new builder API to replace the previous one, which had been removed. This new builder API provides two immediate advantages:
- It adds back the convenience that was lost when the remnants of the previous builder API were removed.
- It lightens the object modules, by moving anything non-essential out of them again.

The main feature, however, are the new wrapper structs that this new style of API enables, represented here by `FacePolygon`. This aspect isn't fully formed yet, but eventually, there will be more such wrapper objects, and they will provide services beyond just building the object.  For example, I'm currently working on a `Cube` wrapper struct, that provides methods like `bottom_face`, `top_face`, etc.

This is going to mesh well with the object update API I'm currently working on (no issue open yet; still exploring the design space). With this update API and the new builder API, you will be able to create a cube, select one of its faces, and make modifications there. This is going to be highly useful for test code.