### PR TITLE
Add typechecking to model signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
 name = "fj-proc"
 version = "0.8.0"
 dependencies = [
+ "fj",
  "proc-macro2",
  "quote",
  "serde",

--- a/crates/fj-proc/Cargo.toml
+++ b/crates/fj-proc/Cargo.toml
@@ -26,3 +26,6 @@ optional = true
 [dependencies.syn]
 version = "1.0.98"
 features = ["full", "extra-traits"]
+
+[dev-dependencies]
+fj = { path = "../fj" }


### PR DESCRIPTION
This fixes #849 by placing the original model function inside our generated `extern "C" fn model()`, letting the Rust compiler make sure it type checks. From there, it's simple to call the original function with its parsed arguments and assert that the result is convertible to a `fj::Shape`.

I've also added some examples to the attribute's docs so we can make sure `#[model] fn model() { todo!() }` doesn't compile.