### PR TITLE
Embed the git commit in fj-app's version number

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Continuous Deployment
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,6 +10,10 @@ env:
   # Name of the crate from Cargo.toml
   # used to rename and upload the binaries
   PROJ_NAME: fj-app
+
+  # This lets our app know it's an "official" release. Otherwise we would get
+  # a version number like "fj-app 0.8.0 (8cb928bb, unreleased)"
+  FJ_OFFICIAL_RELEASE: 1
 
 defaults:
   run:

--- a/crates/fj-app/Cargo.toml
+++ b/crates/fj-app/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/hannobraun/fornjot"
 license = "0BSD"
 keywords = ["cad", "programmatic", "code-cad"]
 categories = ["encoding", "mathematics", "rendering"]
-build = "build.rs"
 
 
 [dependencies]

--- a/crates/fj-app/Cargo.toml
+++ b/crates/fj-app/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/hannobraun/fornjot"
 license = "0BSD"
 keywords = ["cad", "programmatic", "code-cad"]
 categories = ["encoding", "mathematics", "rendering"]
+build = "build.rs"
 
 
 [dependencies]

--- a/crates/fj-app/build.rs
+++ b/crates/fj-app/build.rs
@@ -63,11 +63,15 @@ fn git_description() -> Option<String> {
     println!("cargo:rerun-if-changed={}", head_file.display());
 
     if let Ok(contents) = std::fs::read_to_string(&head_file) {
-        let (_, branch) = contents
-            .split_once(' ')
-            .expect(".git/HEAD should point to a valid head file");
-        let commit_hash_file = project_root.join(".git").join(branch.trim());
-        println!("cargo:rerun-if-changed={}", commit_hash_file.display());
+        // Most of the time the HEAD file will be `ref: refs/heads/$branch`, but
+        // when it's a detached head we'll only get the commit hash and can skip
+        // the rerun-if-changed logic.
+
+        if let Some((_, branch)) = contents.split_once(' ') {
+            let commit_hash_file =
+                project_root.join(".git").join(branch.trim());
+            println!("cargo:rerun-if-changed={}", commit_hash_file.display());
+        }
     }
 
     Some(stdout.trim().to_string())

--- a/crates/fj-app/build.rs
+++ b/crates/fj-app/build.rs
@@ -11,7 +11,8 @@ fn version_string() -> String {
     let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap();
     let commit = git_description();
 
-    let official_release = std::env::var("FJ_OFFICIAL_RELEASE").is_ok();
+    let official_release =
+        std::env::var("FJ_OFFICIAL_RELEASE").as_deref() == Ok("1");
     println!("cargo:rerun-if-env-changed=FJ_OFFICIAL_RELEASE");
 
     match (commit, official_release) {

--- a/crates/fj-app/build.rs
+++ b/crates/fj-app/build.rs
@@ -1,0 +1,44 @@
+use std::process::{Command, Output, Stdio};
+
+fn main() {
+    let pkg_version = std::env::var("CARGO_PKG_VERSION")
+        .expect("The $CARGO_PKG_VERSION variable wasn't set");
+    let commit = git_description();
+
+    let version_string = match commit {
+        Some(commit) => format!("{pkg_version} ({commit})"),
+        None => pkg_version,
+    };
+
+    println!("cargo:rustc-env=VERSION_STRING={version_string}");
+}
+
+fn git_description() -> Option<String> {
+    // Note: it's okay for this to fail to start if git isn't installed (e.g.
+    // because we're building in a docker container), but any errors returned by
+    // git itself should fail the build.
+
+    let Output {
+        status,
+        stdout,
+        stderr,
+    } = Command::new("git")
+        .args(["describe", "--always", "--dirty=-modified"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&stdout);
+
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        eprintln!("---- Stdout ----");
+        eprintln!("{stdout}");
+        eprintln!("---- Stderr ----");
+        eprintln!("{stderr}");
+        panic!("Git exited unsuccessfully");
+    }
+
+    Some(stdout.trim().to_string())
+}

--- a/crates/fj-app/build.rs
+++ b/crates/fj-app/build.rs
@@ -1,12 +1,14 @@
-use std::process::{Command, Output, Stdio};
+use std::{
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+};
 
 fn main() {
     println!("cargo:rustc-env=FJ_VERSION_STRING={}", version_string());
 }
 
 fn version_string() -> String {
-    let pkg_version = std::env::var("CARGO_PKG_VERSION")
-        .expect("The $CARGO_PKG_VERSION variable wasn't set");
+    let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap();
     let commit = git_description();
 
     let official_release = std::env::var("FJ_OFFICIAL_RELEASE").is_ok();
@@ -22,31 +24,50 @@ fn version_string() -> String {
     }
 }
 
+/// Try to get the current git commit.
+///
+/// This may fail if `git` isn't installed (unlikely) or if the `.git/` folder
+/// isn't accessible (more likely than you think). This typically happens when
+/// we're building just the `fj-app` crate in a Docker container or when
+/// someone is installing from crates.io via `cargo install`.
 fn git_description() -> Option<String> {
-    // Note: it's okay for this to fail to start if git isn't installed (e.g.
-    // because we're building in a docker container), but any errors returned by
-    // git itself should fail the build.
+    let mut cmd = Command::new("git");
+    cmd.args(["describe", "--always", "--dirty=-modified"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
     let Output {
         status,
         stdout,
         stderr,
-    } = Command::new("git")
-        .args(["describe", "--always", "--dirty=-modified"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .ok()?;
+    } = cmd.output().ok()?;
 
     let stdout = String::from_utf8_lossy(&stdout);
 
     if !status.success() {
+        // Not sure if anyone will ever see this, but it could be helpful for
+        // troubleshooting.
+        eprintln!("Command failed: {cmd:?}");
         let stderr = String::from_utf8_lossy(&stderr);
         eprintln!("---- Stdout ----");
         eprintln!("{stdout}");
         eprintln!("---- Stderr ----");
         eprintln!("{stderr}");
-        panic!("Git exited unsuccessfully");
+        return None;
+    }
+
+    // Make sure we re-run whenever the current commit changes
+    let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let project_root = crate_dir.ancestors().nth(2).unwrap();
+    let head_file = project_root.join(".git").join("HEAD");
+    println!("cargo:rerun-if-changed={}", head_file.display());
+
+    if let Ok(contents) = std::fs::read_to_string(&head_file) {
+        let (_, branch) = contents
+            .split_once(' ')
+            .expect(".git/HEAD should point to a valid head file");
+        let commit_hash_file = project_root.join(".git").join(branch.trim());
+        println!("cargo:rerun-if-changed={}", commit_hash_file.display());
     }
 
     Some(stdout.trim().to_string())

--- a/crates/fj-app/build.rs
+++ b/crates/fj-app/build.rs
@@ -32,10 +32,13 @@ fn version_string() -> String {
 /// we're building just the `fj-app` crate in a Docker container or when
 /// someone is installing from crates.io via `cargo install`.
 fn git_description() -> Option<String> {
+    let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+
     let mut cmd = Command::new("git");
     cmd.args(["describe", "--always", "--dirty=-modified"])
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::piped())
+        .current_dir(&crate_dir);
 
     let Output {
         status,
@@ -58,7 +61,6 @@ fn git_description() -> Option<String> {
     }
 
     // Make sure we re-run whenever the current commit changes
-    let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     let project_root = crate_dir.ancestors().nth(2).unwrap();
     let head_file = project_root.join(".git").join("HEAD");
     println!("cargo:rerun-if-changed={}", head_file.display());

--- a/crates/fj-app/src/args.rs
+++ b/crates/fj-app/src/args.rs
@@ -7,6 +7,7 @@ use fj_math::Scalar;
 
 /// Fornjot - Experimental CAD System
 #[derive(clap::Parser)]
+#[clap(version = env!("VERSION_STRING"))]
 pub struct Args {
     /// The model to open
     #[clap(short, long)]

--- a/crates/fj-app/src/args.rs
+++ b/crates/fj-app/src/args.rs
@@ -7,7 +7,7 @@ use fj_math::Scalar;
 
 /// Fornjot - Experimental CAD System
 #[derive(clap::Parser)]
-#[clap(version = env!("VERSION_STRING"))]
+#[clap(version = env!("FJ_VERSION_STRING"))]
 pub struct Args {
     /// The model to open
     #[clap(short, long)]


### PR DESCRIPTION
Fixes #850.

The version number for an official build will look something like this:

```console
$ FJ_OFFICIAL_RELEASE=1 cargo run --quiet -- --version
fj-app 0.8.0 (66de87d0)
```

Not having the `$FJ_OFFICIAL_RELEASE` variable set will add `unreleased` to the version number, and having a dirty git tree will add a `-modified` suffix to the commit hash.

```console
$ cargo run --quiet -- --version
fj-app 0.8.0 (4ef5109e-modified, unreleased)
```

When `git` doesn't start (i.e. because it's not installed), we silently leave out the commit hash. This is a bit of an edge case, but I've found it often happens when you are building an app inside a Docker container or a `cargo install` from crates.io because you typically don't have access to the repo's `.git/` folder.

We could use something like [`vergen`](https://docs.rs/vergen) or [`build_info`](https://docs.rs/build_info) to get more comprehensive output similar to `rustc --version --verbose`, but that felt like overkill and would have an impact on compile times.