### PR TITLE
Clean up line/segment intersection, use it in curve/edge intersection

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
@@ -15,11 +15,8 @@ pub enum CurveEdgeIntersection {
 
     /// The edge lies on the curve
     Coincident {
-        /// The first vertex of the edge, in curve coordinates
-        a_on_curve: Point<1>,
-
-        /// The second vertex of the edge, in curve coordinates
-        b_on_curve: Point<1>,
+        /// The end points of the edge, in curve coordinates on the curve
+        points_on_curve: [Point<1>; 2],
     },
 }
 
@@ -62,12 +59,11 @@ impl CurveEdgeIntersection {
             LineSegmentIntersection::Point { point_on_line } => Self::Point {
                 point_on_curve: point_on_line,
             },
-            LineSegmentIntersection::Coincident {
-                points_on_line: [a, b],
-            } => Self::Coincident {
-                a_on_curve: a,
-                b_on_curve: b,
-            },
+            LineSegmentIntersection::Coincident { points_on_line } => {
+                Self::Coincident {
+                    points_on_curve: points_on_line,
+                }
+            }
         };
 
         Some(intersection)
@@ -140,8 +136,7 @@ mod tests {
         assert_eq!(
             intersection,
             Some(CurveEdgeIntersection::Coincident {
-                a_on_curve: Point::from([-1.]),
-                b_on_curve: Point::from([1.]),
+                points_on_curve: [Point::from([-1.]), Point::from([1.]),]
             })
         );
     }

--- a/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
@@ -34,23 +34,25 @@ impl CurveEdgeIntersection {
             _ => todo!("Curve-edge intersection only supports lines"),
         };
 
-        let edge_curve_as_line = match edge.curve().local_form() {
-            Curve::Line(line) => line,
-            _ => {
-                todo!("Curve-edge intersection only supports line segments")
-            }
-        };
+        let edge_as_segment = {
+            let edge_curve_as_line = match edge.curve().local_form() {
+                Curve::Line(line) => line,
+                _ => {
+                    todo!("Curve-edge intersection only supports line segments")
+                }
+            };
 
-        let edge_vertices = match edge.vertices().get() {
-            Some(vertices) => vertices.map(|vertex| {
-                edge_curve_as_line.point_from_line_coords(vertex.position())
-            }),
-            None => todo!(
-                "Curve-edge intersection does not support continuous edges"
-            ),
-        };
+            let edge_vertices = match edge.vertices().get() {
+                Some(vertices) => vertices.map(|vertex| {
+                    edge_curve_as_line.point_from_line_coords(vertex.position())
+                }),
+                None => todo!(
+                    "Curve-edge intersection does not support continuous edges"
+                ),
+            };
 
-        let edge_as_segment = Segment::from_points(edge_vertices);
+            Segment::from_points(edge_vertices)
+        };
 
         let intersection =
             LineSegmentIntersection::compute(curve_as_line, &edge_as_segment)?;

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -44,12 +44,8 @@ impl CurveFaceIntersectionList {
                     CurveEdgeIntersection::Point { point_on_curve } => {
                         intersections.push(point_on_curve);
                     }
-                    CurveEdgeIntersection::Coincident {
-                        a_on_curve,
-                        b_on_curve,
-                    } => {
-                        intersections.push(a_on_curve);
-                        intersections.push(b_on_curve);
+                    CurveEdgeIntersection::Coincident { points_on_curve } => {
+                        intersections.extend(points_on_curve);
                     }
                 }
             }

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -60,13 +60,12 @@ mod tests {
     use crate::algorithms::intersection::LineSegmentIntersection;
 
     #[test]
-    fn line_segment() {
+    fn compute_one_hit() {
         let line = Line {
             origin: Point::origin(),
             direction: Vector::unit_u(),
         };
 
-        // regular hit
         assert_eq!(
             LineSegmentIntersection::compute(
                 &line,
@@ -74,8 +73,15 @@ mod tests {
             ),
             Some(LineSegmentIntersection::PointOnLine(Scalar::ONE)),
         );
+    }
 
-        // hit, where line and segment are parallel
+    #[test]
+    fn compute_coincident() {
+        let line = Line {
+            origin: Point::origin(),
+            direction: Vector::unit_u(),
+        };
+
         assert_eq!(
             LineSegmentIntersection::compute(
                 &line,
@@ -83,8 +89,15 @@ mod tests {
             ),
             Some(LineSegmentIntersection::Coincident),
         );
+    }
 
-        // segment above line
+    #[test]
+    fn compute_no_hit_above() {
+        let line = Line {
+            origin: Point::origin(),
+            direction: Vector::unit_u(),
+        };
+
         assert_eq!(
             LineSegmentIntersection::compute(
                 &line,
@@ -92,8 +105,15 @@ mod tests {
             ),
             None,
         );
+    }
 
-        // segment below line
+    #[test]
+    fn compute_no_hit_below() {
+        let line = Line {
+            origin: Point::origin(),
+            direction: Vector::unit_u(),
+        };
+
         assert_eq!(
             LineSegmentIntersection::compute(
                 &line,
@@ -101,8 +121,15 @@ mod tests {
             ),
             None,
         );
+    }
 
-        // segment parallel to line
+    #[test]
+    fn compute_no_hit_parallel() {
+        let line = Line {
+            origin: Point::origin(),
+            direction: Vector::unit_u(),
+        };
+
         assert_eq!(
             LineSegmentIntersection::compute(
                 &line,

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -3,9 +3,7 @@ use fj_math::{Aabb, Line, Point, Scalar, Segment, Vector};
 /// An intersection between a [`Line`] and a [`Segment`]
 #[derive(Debug, Eq, PartialEq)]
 pub enum LineSegmentIntersection {
-    /// Line and segment intersect on a point
-    ///
-    /// Point is given as a coordinate on the line.
+    /// Line and segment intersect at a point
     Point {
         /// The intersection point, given as a coordinate on the line
         point_on_line: Point<1>,

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -1,5 +1,17 @@
 use fj_math::{Aabb, Line, Scalar, Segment, Vector};
 
+/// An intersection between a [`Line`] and a [`Segment`]
+#[derive(Debug, Eq, PartialEq)]
+pub enum LineSegmentIntersection {
+    /// Line and segment intersect on a point
+    ///
+    /// Point is given as a coordinate on the line.
+    PointOnLine(Scalar),
+
+    /// Line and segment are coincident
+    Coincident,
+}
+
 /// Determine the intersection between a [`Line`] and a [`Segment`]
 pub fn line_segment(
     line: &Line<2>,
@@ -40,18 +52,6 @@ pub fn line_segment(
     }
 
     Some(LineSegmentIntersection::PointOnLine(t))
-}
-
-/// An intersection between a [`Line`] and a [`Segment`]
-#[derive(Debug, Eq, PartialEq)]
-pub enum LineSegmentIntersection {
-    /// Line and segment intersect on a point
-    ///
-    /// Point is given as a coordinate on the line.
-    PointOnLine(Scalar),
-
-    /// Line and segment are coincident
-    Coincident,
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -6,7 +6,10 @@ pub enum LineSegmentIntersection {
     /// Line and segment intersect on a point
     ///
     /// Point is given as a coordinate on the line.
-    Point(Point<1>),
+    Point {
+        /// The intersection point, given as a coordinate on the line
+        point_on_line: Point<1>,
+    },
 
     /// Line and segment are coincident
     Coincident,
@@ -49,7 +52,9 @@ impl LineSegmentIntersection {
             return None;
         }
 
-        Some(Self::Point(Point::from([t])))
+        Some(Self::Point {
+            point_on_line: Point::from([t]),
+        })
     }
 }
 
@@ -71,7 +76,9 @@ mod tests {
                 &line,
                 &Segment::from_points([[1., -1.], [1., 1.]]),
             ),
-            Some(LineSegmentIntersection::Point(Point::from([Scalar::ONE]))),
+            Some(LineSegmentIntersection::Point {
+                point_on_line: Point::from([Scalar::ONE])
+            }),
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -6,7 +6,7 @@ pub enum LineSegmentIntersection {
     /// Line and segment intersect on a point
     ///
     /// Point is given as a coordinate on the line.
-    PointOnLine(Point<1>),
+    Point(Point<1>),
 
     /// Line and segment are coincident
     Coincident,
@@ -49,7 +49,7 @@ impl LineSegmentIntersection {
             return None;
         }
 
-        Some(Self::PointOnLine(Point::from([t])))
+        Some(Self::Point(Point::from([t])))
     }
 }
 
@@ -71,9 +71,7 @@ mod tests {
                 &line,
                 &Segment::from_points([[1., -1.], [1., 1.]]),
             ),
-            Some(LineSegmentIntersection::PointOnLine(Point::from([
-                Scalar::ONE
-            ]))),
+            Some(LineSegmentIntersection::Point(Point::from([Scalar::ONE]))),
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -1,4 +1,4 @@
-use fj_math::{Aabb, Line, Scalar, Segment, Vector};
+use fj_math::{Aabb, Line, Point, Scalar, Segment, Vector};
 
 /// An intersection between a [`Line`] and a [`Segment`]
 #[derive(Debug, Eq, PartialEq)]
@@ -6,7 +6,7 @@ pub enum LineSegmentIntersection {
     /// Line and segment intersect on a point
     ///
     /// Point is given as a coordinate on the line.
-    PointOnLine(Scalar),
+    PointOnLine(Point<1>),
 
     /// Line and segment are coincident
     Coincident,
@@ -49,7 +49,7 @@ impl LineSegmentIntersection {
             return None;
         }
 
-        Some(Self::PointOnLine(t))
+        Some(Self::PointOnLine(Point::from([t])))
     }
 }
 
@@ -71,7 +71,9 @@ mod tests {
                 &line,
                 &Segment::from_points([[1., -1.], [1., 1.]]),
             ),
-            Some(LineSegmentIntersection::PointOnLine(Scalar::ONE)),
+            Some(LineSegmentIntersection::PointOnLine(Point::from([
+                Scalar::ONE
+            ]))),
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -14,7 +14,7 @@ pub enum LineSegmentIntersection {
 
 impl LineSegmentIntersection {
     /// Determine the intersection between a [`Line`] and a [`Segment`]
-    pub fn line_segment(line: &Line<2>, segment: &Segment<2>) -> Option<Self> {
+    pub fn compute(line: &Line<2>, segment: &Segment<2>) -> Option<Self> {
         // Algorithm adapted from Real-Time Collision Detection by Christer
         // Ericson. See section 5.1.9.1, 2D Segment Intersection.
 
@@ -68,7 +68,7 @@ mod tests {
 
         // regular hit
         assert_eq!(
-            LineSegmentIntersection::line_segment(
+            LineSegmentIntersection::compute(
                 &line,
                 &Segment::from_points([[1., -1.], [1., 1.]]),
             ),
@@ -77,7 +77,7 @@ mod tests {
 
         // hit, where line and segment are parallel
         assert_eq!(
-            LineSegmentIntersection::line_segment(
+            LineSegmentIntersection::compute(
                 &line,
                 &Segment::from_points([[1., 0.], [2., 0.]]),
             ),
@@ -86,7 +86,7 @@ mod tests {
 
         // segment above line
         assert_eq!(
-            LineSegmentIntersection::line_segment(
+            LineSegmentIntersection::compute(
                 &line,
                 &Segment::from_points([[1., 1.], [1., 2.]]),
             ),
@@ -95,7 +95,7 @@ mod tests {
 
         // segment below line
         assert_eq!(
-            LineSegmentIntersection::line_segment(
+            LineSegmentIntersection::compute(
                 &line,
                 &Segment::from_points([[1., -2.], [1., -1.]]),
             ),
@@ -104,7 +104,7 @@ mod tests {
 
         // segment parallel to line
         assert_eq!(
-            LineSegmentIntersection::line_segment(
+            LineSegmentIntersection::compute(
                 &line,
                 &Segment::from_points([[-1., 1.], [1., 1.]]),
             ),

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -10,7 +10,10 @@ pub enum LineSegmentIntersection {
     },
 
     /// Line and segment are coincident
-    Coincident,
+    Coincident {
+        /// The end points of the segment, given as coordinates on the line
+        points_on_line: [Point<1>; 2],
+    },
 }
 
 impl LineSegmentIntersection {
@@ -35,7 +38,11 @@ impl LineSegmentIntersection {
 
             if n_dot_origin == Scalar::ZERO {
                 // `line` and `segment` are not just parallel, but coincident!
-                return Some(Self::Coincident);
+                return Some(Self::Coincident {
+                    points_on_line: segment
+                        .points()
+                        .map(|point| line.point_to_line_coords(point)),
+                });
             }
 
             return None;
@@ -93,7 +100,9 @@ mod tests {
                 &line,
                 &Segment::from_points([[1., 0.], [2., 0.]]),
             ),
-            Some(LineSegmentIntersection::Coincident),
+            Some(LineSegmentIntersection::Coincident {
+                points_on_line: [Point::from([1.]), Point::from([2.])],
+            }),
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -14,10 +14,7 @@ pub enum LineSegmentIntersection {
 
 impl LineSegmentIntersection {
     /// Determine the intersection between a [`Line`] and a [`Segment`]
-    pub fn line_segment(
-        line: &Line<2>,
-        segment: &Segment<2>,
-    ) -> Option<LineSegmentIntersection> {
+    pub fn line_segment(line: &Line<2>, segment: &Segment<2>) -> Option<Self> {
         // Algorithm adapted from Real-Time Collision Detection by Christer
         // Ericson. See section 5.1.9.1, 2D Segment Intersection.
 
@@ -34,7 +31,7 @@ impl LineSegmentIntersection {
 
         if n_dot_origin == Scalar::ZERO && n_dot_direction == Scalar::ZERO {
             // `line` and `segment` are not just parallel, but coincident!
-            return Some(LineSegmentIntersection::Coincident);
+            return Some(Self::Coincident);
         }
 
         if n_dot_direction == Scalar::ZERO {
@@ -52,7 +49,7 @@ impl LineSegmentIntersection {
             return None;
         }
 
-        Some(LineSegmentIntersection::PointOnLine(t))
+        Some(Self::PointOnLine(t))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/line_segment.rs
@@ -30,13 +30,14 @@ impl LineSegmentIntersection {
         let n_dot_origin = n.dot(&(b - line.origin));
         let n_dot_direction = n.dot(&line.direction);
 
-        if n_dot_origin == Scalar::ZERO && n_dot_direction == Scalar::ZERO {
-            // `line` and `segment` are not just parallel, but coincident!
-            return Some(Self::Coincident);
-        }
-
         if n_dot_direction == Scalar::ZERO {
-            // `line` and `segment` are parallel, but not coincident
+            // `line` and `segment` are parallel
+
+            if n_dot_origin == Scalar::ZERO {
+                // `line` and `segment` are not just parallel, but coincident!
+                return Some(Self::Coincident);
+            }
+
             return None;
         }
 

--- a/crates/fj-kernel/src/algorithms/intersection/mod.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/mod.rs
@@ -8,6 +8,6 @@ mod surface_surface;
 pub use self::{
     curve_edge::CurveEdgeIntersection,
     curve_face::{CurveFaceIntersection, CurveFaceIntersectionList},
-    line_segment::{line_segment, LineSegmentIntersection},
+    line_segment::LineSegmentIntersection,
     surface_surface::surface_surface,
 };


### PR DESCRIPTION
It seems I had forgotten that I wrote the line/segment intersection algorithm, then rewrote it (but worse) for the curve/edge intersection.