### PR TITLE
Replace `Curve` with `Curve`/`GlobalCurve`/`CurveKind`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curves.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curves.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 
 use fj_math::{Circle, Point, Scalar};
 
-use crate::{local::Local, objects::Curve};
+use crate::{local::Local, objects::CurveKind};
 
 use super::Tolerance;
 
@@ -21,13 +21,13 @@ use super::Tolerance;
 /// The `approximate_between` methods of the curves then need to make sure to
 /// only return points in between those vertices, not the vertices themselves.
 pub fn approx_curve(
-    curve: &Curve<3>,
+    curve: &CurveKind<3>,
     tolerance: Tolerance,
     out: &mut Vec<Local<Point<1>>>,
 ) {
     match curve {
-        Curve::Circle(curve) => approx_circle(curve, tolerance, out),
-        Curve::Line(_) => {}
+        CurveKind::Circle(curve) => approx_circle(curve, tolerance, out),
+        CurveKind::Line(_) => {}
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/curves.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curves.rs
@@ -2,7 +2,10 @@ use std::cmp::max;
 
 use fj_math::{Circle, Point, Scalar};
 
-use crate::{local::Local, objects::CurveKind};
+use crate::{
+    local::Local,
+    objects::{CurveKind, GlobalCurve},
+};
 
 use super::Tolerance;
 
@@ -21,11 +24,11 @@ use super::Tolerance;
 /// The `approximate_between` methods of the curves then need to make sure to
 /// only return points in between those vertices, not the vertices themselves.
 pub fn approx_curve(
-    curve: &CurveKind<3>,
+    curve: &GlobalCurve,
     tolerance: Tolerance,
     out: &mut Vec<Local<Point<1>>>,
 ) {
-    match curve {
+    match curve.kind() {
         CurveKind::Circle(curve) => approx_circle(curve, tolerance, out),
         CurveKind::Line(_) => {}
     }

--- a/crates/fj-kernel/src/algorithms/approx/cycles.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycles.rs
@@ -21,17 +21,13 @@ impl CycleApprox {
 
         for edge in cycle.edges() {
             let mut edge_points = Vec::new();
-            approx_curve(
-                edge.curve().global_form(),
-                tolerance,
-                &mut edge_points,
-            );
+            approx_curve(edge.curve().global(), tolerance, &mut edge_points);
             approx_edge(*edge.vertices(), &mut edge_points);
 
             points.extend(edge_points.into_iter().map(|point| {
                 let local = edge
                     .curve()
-                    .local_form()
+                    .kind()
                     .point_from_curve_coords(*point.local_form());
                 Local::new(local, *point.global_form())
             }));

--- a/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
@@ -1,6 +1,6 @@
 use fj_math::{Point, Segment};
 
-use crate::objects::{Curve, Edge};
+use crate::objects::{CurveKind, Edge};
 
 use super::LineSegmentIntersection;
 
@@ -28,15 +28,15 @@ impl CurveEdgeIntersection {
     /// Currently, only intersections between lines and line segments can be
     /// computed. Panics, if a different type of [`Curve`] or [`Edge`] is
     /// passed.
-    pub fn compute(curve: &Curve<2>, edge: &Edge) -> Option<Self> {
+    pub fn compute(curve: &CurveKind<2>, edge: &Edge) -> Option<Self> {
         let curve_as_line = match curve {
-            Curve::Line(line) => line,
+            CurveKind::Line(line) => line,
             _ => todo!("Curve-edge intersection only supports lines"),
         };
 
         let edge_as_segment = {
             let edge_curve_as_line = match edge.curve().local_form() {
-                Curve::Line(line) => line,
+                CurveKind::Line(line) => line,
                 _ => {
                     todo!("Curve-edge intersection only supports line segments")
                 }
@@ -76,14 +76,14 @@ impl CurveEdgeIntersection {
 mod tests {
     use fj_math::Point;
 
-    use crate::objects::{Curve, Edge, Surface};
+    use crate::objects::{CurveKind, Edge, Surface};
 
     use super::CurveEdgeIntersection;
 
     #[test]
     fn compute_edge_in_front_of_curve_origin() {
         let surface = Surface::xy_plane();
-        let curve = Curve::u_axis();
+        let curve = CurveKind::u_axis();
         let edge = Edge::build()
             .line_segment_from_points(&surface, [[1., -1.], [1., 1.]]);
 
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn compute_edge_behind_curve_origin() {
         let surface = Surface::xy_plane();
-        let curve = Curve::u_axis();
+        let curve = CurveKind::u_axis();
         let edge = Edge::build()
             .line_segment_from_points(&surface, [[-1., -1.], [-1., 1.]]);
 
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn compute_edge_parallel_to_curve() {
         let surface = Surface::xy_plane();
-        let curve = Curve::u_axis();
+        let curve = CurveKind::u_axis();
         let edge = Edge::build()
             .line_segment_from_points(&surface, [[-1., -1.], [1., -1.]]);
 
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn compute_edge_on_curve() {
         let surface = Surface::xy_plane();
-        let curve = Curve::u_axis();
+        let curve = CurveKind::u_axis();
         let edge = Edge::build()
             .line_segment_from_points(&surface, [[-1., 0.], [1., 0.]]);
 

--- a/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
@@ -4,7 +4,7 @@ use crate::objects::{CurveKind, Edge};
 
 use super::LineSegmentIntersection;
 
-/// The intersection between a [`Curve`] and an [`Edge`], in curve coordinates
+/// The intersection between a curve and an [`Edge`], in curve coordinates
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CurveEdgeIntersection {
     /// The curve and edge intersect at a point
@@ -26,7 +26,7 @@ impl CurveEdgeIntersection {
     /// # Panics
     ///
     /// Currently, only intersections between lines and line segments can be
-    /// computed. Panics, if a different type of [`Curve`] or [`Edge`] is
+    /// computed. Panics, if a different type of curve or [`Edge`] is
     /// passed.
     pub fn compute(curve: &CurveKind<2>, edge: &Edge) -> Option<Self> {
         let curve_as_line = match curve {

--- a/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_edge.rs
@@ -35,7 +35,7 @@ impl CurveEdgeIntersection {
         };
 
         let edge_as_segment = {
-            let edge_curve_as_line = match edge.curve().local_form() {
+            let edge_curve_as_line = match edge.curve().kind() {
                 CurveKind::Line(line) => line,
                 _ => {
                     todo!("Curve-edge intersection only supports line segments")

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -4,7 +4,7 @@ use fj_math::Point;
 
 use crate::{
     algorithms::intersection::CurveEdgeIntersection,
-    objects::{Curve, Face},
+    objects::{CurveKind, Face},
 };
 
 /// The intersections between a [`Curve`] and a [`Face`], in curve coordinates
@@ -28,7 +28,7 @@ impl CurveFaceIntersectionList {
     }
 
     /// Compute the intersections between a [`Curve`] and a [`Face`]
-    pub fn compute(curve: &Curve<2>, face: &Face) -> Self {
+    pub fn compute(curve: &CurveKind<2>, face: &Face) -> Self {
         let edges = face.all_cycles().flat_map(|cycle| {
             let edges: Vec<_> = cycle.edges().cloned().collect();
             edges
@@ -142,13 +142,13 @@ pub type CurveFaceIntersection = [Point<1>; 2];
 mod tests {
     use fj_math::{Line, Point, Vector};
 
-    use crate::objects::{Curve, Face, Surface};
+    use crate::objects::{CurveKind, Face, Surface};
 
     use super::CurveFaceIntersectionList;
 
     #[test]
     fn compute() {
-        let curve = Curve::Line(Line {
+        let curve = CurveKind::Line(Line {
             origin: Point::from([-3., 0.]),
             direction: Vector::from([1., 0.]),
         });

--- a/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/curve_face.rs
@@ -7,7 +7,7 @@ use crate::{
     objects::{CurveKind, Face},
 };
 
-/// The intersections between a [`Curve`] and a [`Face`], in curve coordinates
+/// The intersections between a curve and a [`Face`], in curve coordinates
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct CurveFaceIntersectionList {
     intervals: Vec<CurveFaceIntersection>,
@@ -27,7 +27,7 @@ impl CurveFaceIntersectionList {
         Self { intervals }
     }
 
-    /// Compute the intersections between a [`Curve`] and a [`Face`]
+    /// Compute the intersections between a curve and a [`Face`]
     pub fn compute(curve: &CurveKind<2>, face: &Face) -> Self {
         let edges = face.all_cycles().flat_map(|cycle| {
             let edges: Vec<_> = cycle.edges().cloned().collect();

--- a/crates/fj-kernel/src/algorithms/intersection/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersection/surface_surface.rs
@@ -1,15 +1,15 @@
 use fj_math::{Line, Point, Scalar, Vector};
 
-use crate::objects::{Curve, Surface};
+use crate::objects::{CurveKind, Surface};
 
 /// The intersection between two surfaces
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfaceSurfaceIntersection {
     /// The intersection curves, in the coordinates of the input surfaces
-    pub local_intersection_curves: [Curve<2>; 2],
+    pub local_intersection_curves: [CurveKind<2>; 2],
 
     /// The intersection curve, in global coordinates
-    pub global_intersection_curve: Curve<3>,
+    pub global_intersection_curve: CurveKind<3>,
 }
 
 impl SurfaceSurfaceIntersection {
@@ -50,7 +50,7 @@ impl SurfaceSurfaceIntersection {
 
         let curve_a = project_line_into_plane(&line, &a_parametric);
         let curve_b = project_line_into_plane(&line, &b_parametric);
-        let curve_global = Curve::Line(Line { origin, direction });
+        let curve_global = CurveKind::Line(Line { origin, direction });
 
         Some(Self {
             local_intersection_curves: [curve_a, curve_b],
@@ -70,7 +70,7 @@ impl PlaneParametric {
     pub fn extract_from_surface(surface: &Surface) -> Self {
         let Surface::SweptCurve(surface) = surface;
         let line = match surface.curve {
-            Curve::Line(line) => line,
+            CurveKind::Line(line) => line,
             _ => todo!("Only plane-plane intersection is currently supported."),
         };
 
@@ -111,7 +111,7 @@ impl PlaneConstantNormal {
 fn project_line_into_plane(
     line: &Line<3>,
     plane: &PlaneParametric,
-) -> Curve<2> {
+) -> CurveKind<2> {
     let line_origin_relative_to_plane = line.origin - plane.origin;
     let line_origin_in_plane = Vector::from([
         plane
@@ -134,7 +134,7 @@ fn project_line_into_plane(
         direction: line_direction_in_plane,
     };
 
-    Curve::Line(line)
+    CurveKind::Line(line)
 }
 
 #[cfg(test)]
@@ -143,7 +143,7 @@ mod tests {
 
     use crate::{
         algorithms::TransformObject,
-        objects::{Curve, Surface},
+        objects::{CurveKind, Surface},
     };
 
     use super::SurfaceSurfaceIntersection;
@@ -163,9 +163,9 @@ mod tests {
             None,
         );
 
-        let expected_xy = Curve::u_axis();
-        let expected_xz = Curve::u_axis();
-        let expected_global = Curve::x_axis();
+        let expected_xy = CurveKind::u_axis();
+        let expected_xz = CurveKind::u_axis();
+        let expected_global = CurveKind::x_axis();
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute(&xy, &xz),

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -1,9 +1,6 @@
 use fj_math::{Circle, Line, Point, Vector};
 
-use crate::{
-    local::Local,
-    objects::{CurveKind, Cycle, Edge, Face},
-};
+use crate::objects::{Curve, CurveKind, Cycle, Edge, Face};
 
 /// Reverse the direction of a face
 pub fn reverse_face(face: &Face) -> Face {
@@ -28,7 +25,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
     cycles.into_iter().map(|cycle| {
         let edges = cycle.edges().map(|edge| {
             let curve = {
-                let local = match edge.curve().local_form() {
+                let local = match edge.curve().kind() {
                     CurveKind::Circle(Circle { center, a, b }) => {
                         let center = Point::from([center.u, -center.v]);
 
@@ -46,7 +43,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
                     }
                 };
 
-                Local::new(local, *edge.curve().global_form())
+                Curve::new(local, *edge.curve().global())
             };
 
             Edge::new(curve, *edge.vertices())

--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -2,7 +2,7 @@ use fj_math::{Circle, Line, Point, Vector};
 
 use crate::{
     local::Local,
-    objects::{Curve, Cycle, Edge, Face},
+    objects::{CurveKind, Cycle, Edge, Face},
 };
 
 /// Reverse the direction of a face
@@ -29,20 +29,20 @@ fn reverse_local_coordinates_in_cycle<'r>(
         let edges = cycle.edges().map(|edge| {
             let curve = {
                 let local = match edge.curve().local_form() {
-                    Curve::Circle(Circle { center, a, b }) => {
+                    CurveKind::Circle(Circle { center, a, b }) => {
                         let center = Point::from([center.u, -center.v]);
 
                         let a = Vector::from([a.u, -a.v]);
                         let b = Vector::from([b.u, -b.v]);
 
-                        Curve::Circle(Circle { center, a, b })
+                        CurveKind::Circle(Circle { center, a, b })
                     }
-                    Curve::Line(Line { origin, direction }) => {
+                    CurveKind::Line(Line { origin, direction }) => {
                         let origin = Point::from([origin.u, -origin.v]);
                         let direction =
                             Vector::from([direction.u, -direction.v]);
 
-                        Curve::Line(Line { origin, direction })
+                        CurveKind::Line(Line { origin, direction })
                     }
                 };
 

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -5,8 +5,8 @@ use crate::{
     iter::ObjectIters,
     local::Local,
     objects::{
-        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
-        VerticesOfEdge,
+        CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface,
+        Vertex, VerticesOfEdge,
     },
 };
 
@@ -140,10 +140,10 @@ fn create_non_continuous_side_face(
             let [a, b] = [&vertices[0], &vertices[1]];
 
             let curve = {
-                let local = Curve::line_from_points([a.0, b.0]);
+                let local = CurveKind::line_from_points([a.0, b.0]);
 
                 let global = [a, b].map(|vertex| vertex.1.position());
-                let global = Curve::line_from_points(global);
+                let global = CurveKind::line_from_points(global);
 
                 Local::new(local, global)
             };

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -5,8 +5,8 @@ use crate::{
     iter::ObjectIters,
     local::Local,
     objects::{
-        CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface,
-        Vertex, VerticesOfEdge,
+        CurveKind, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid,
+        Surface, Vertex, VerticesOfEdge,
     },
 };
 
@@ -143,7 +143,8 @@ fn create_non_continuous_side_face(
                 let local = CurveKind::line_from_points([a.0, b.0]);
 
                 let global = [a, b].map(|vertex| vertex.1.position());
-                let global = CurveKind::line_from_points(global);
+                let global =
+                    GlobalCurve::from_kind(CurveKind::line_from_points(global));
 
                 Local::new(local, global)
             };

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -3,10 +3,9 @@ use fj_math::{Point, Scalar, Transform, Triangle, Vector};
 
 use crate::{
     iter::ObjectIters,
-    local::Local,
     objects::{
-        CurveKind, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid,
-        Surface, Vertex, VerticesOfEdge,
+        Curve, CurveKind, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch,
+        Solid, Surface, Vertex, VerticesOfEdge,
     },
 };
 
@@ -146,7 +145,7 @@ fn create_non_continuous_side_face(
                 let global =
                     GlobalCurve::from_kind(CurveKind::line_from_points(global));
 
-                Local::new(local, global)
+                Curve::new(local, global)
             };
 
             let vertices = VerticesOfEdge::from_vertices([

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -3,7 +3,7 @@ use fj_math::{Transform, Vector};
 use crate::{
     local::Local,
     objects::{
-        CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface,
+        Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid, Surface,
         Vertex,
     },
 };
@@ -35,14 +35,10 @@ pub trait TransformObject: Sized {
     }
 }
 
-impl TransformObject for CurveKind<3> {
+impl TransformObject for GlobalCurve {
     fn transform(self, transform: &Transform) -> Self {
-        match self {
-            Self::Circle(curve) => {
-                Self::Circle(transform.transform_circle(&curve))
-            }
-            Self::Line(curve) => Self::Line(transform.transform_line(&curve)),
-        }
+        let kind = self.kind().transform(transform);
+        GlobalCurve::from_kind(kind)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -1,11 +1,8 @@
 use fj_math::{Transform, Vector};
 
-use crate::{
-    local::Local,
-    objects::{
-        Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid, Surface,
-        Vertex,
-    },
+use crate::objects::{
+    Curve, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid,
+    Surface, Vertex,
 };
 
 /// Transform an object
@@ -35,6 +32,15 @@ pub trait TransformObject: Sized {
     }
 }
 
+impl TransformObject for Curve {
+    fn transform(self, transform: &Transform) -> Self {
+        // Don't need to transform `self.kind`, as that's in local form.
+        let global = self.global().transform(transform);
+
+        Curve::new(*self.kind(), global)
+    }
+}
+
 impl TransformObject for Cycle {
     fn transform(self, transform: &Transform) -> Self {
         Self::new()
@@ -44,9 +50,9 @@ impl TransformObject for Cycle {
 
 impl TransformObject for Edge {
     fn transform(self, transform: &Transform) -> Self {
-        let curve = Local::new(
-            *self.curve().local_form(),
-            self.curve().global_form().transform(transform),
+        let curve = Curve::new(
+            *self.curve().kind(),
+            self.curve().global().transform(transform),
         );
 
         let vertices =

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -3,7 +3,8 @@ use fj_math::{Transform, Vector};
 use crate::{
     local::Local,
     objects::{
-        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
+        CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface,
+        Vertex,
     },
 };
 
@@ -34,7 +35,7 @@ pub trait TransformObject: Sized {
     }
 }
 
-impl TransformObject for Curve<3> {
+impl TransformObject for CurveKind<3> {
     fn transform(self, transform: &Transform) -> Self {
         match self {
             Self::Circle(curve) => {

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -35,13 +35,6 @@ pub trait TransformObject: Sized {
     }
 }
 
-impl TransformObject for GlobalCurve {
-    fn transform(self, transform: &Transform) -> Self {
-        let kind = self.kind().transform(transform);
-        GlobalCurve::from_kind(kind)
-    }
-}
-
 impl TransformObject for Cycle {
     fn transform(self, transform: &Transform) -> Self {
         Self::new()
@@ -87,6 +80,13 @@ impl TransformObject for Face {
             .with_exteriors(exteriors)
             .with_interiors(interiors)
             .with_color(color)
+    }
+}
+
+impl TransformObject for GlobalCurve {
+    fn transform(self, transform: &Transform) -> Self {
+        let kind = self.kind().transform(transform);
+        GlobalCurve::from_kind(kind)
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -2,7 +2,7 @@ use fj_math::{Circle, Line, Point, Scalar, Vector};
 
 use crate::{
     local::Local,
-    objects::{Curve, Edge, GlobalVertex, Surface, Vertex, VerticesOfEdge},
+    objects::{CurveKind, Edge, GlobalVertex, Surface, Vertex, VerticesOfEdge},
 };
 
 /// API for building an [`Edge`]
@@ -11,12 +11,12 @@ pub struct EdgeBuilder;
 impl EdgeBuilder {
     /// Create a circle from the given radius
     pub fn circle_from_radius(&self, radius: Scalar) -> Edge {
-        let curve_local = Curve::Circle(Circle {
+        let curve_local = CurveKind::Circle(Circle {
             center: Point::origin(),
             a: Vector::from([radius, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius]),
         });
-        let curve_canonical = Curve::Circle(Circle {
+        let curve_canonical = CurveKind::Circle(Circle {
             center: Point::origin(),
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
@@ -41,11 +41,11 @@ impl EdgeBuilder {
             GlobalVertex::from_position(position)
         });
 
-        let curve_local = Curve::Line(Line::from_points(points));
+        let curve_local = CurveKind::Line(Line::from_points(points));
         let curve_canonical = {
             let points =
                 global_vertices.map(|global_vertex| global_vertex.position());
-            Curve::Line(Line::from_points(points))
+            CurveKind::Line(Line::from_points(points))
         };
 
         let vertices = {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -2,7 +2,10 @@ use fj_math::{Circle, Line, Point, Scalar, Vector};
 
 use crate::{
     local::Local,
-    objects::{CurveKind, Edge, GlobalVertex, Surface, Vertex, VerticesOfEdge},
+    objects::{
+        CurveKind, Edge, GlobalCurve, GlobalVertex, Surface, Vertex,
+        VerticesOfEdge,
+    },
 };
 
 /// API for building an [`Edge`]
@@ -16,11 +19,11 @@ impl EdgeBuilder {
             a: Vector::from([radius, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius]),
         });
-        let curve_global = CurveKind::Circle(Circle {
+        let curve_global = GlobalCurve::from_kind(CurveKind::Circle(Circle {
             center: Point::origin(),
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
-        });
+        }));
 
         Edge::new(
             Local::new(curve_local, curve_global),
@@ -45,7 +48,8 @@ impl EdgeBuilder {
         let curve_global = {
             let points =
                 global_vertices.map(|global_vertex| global_vertex.position());
-            CurveKind::Line(Line::from_points(points))
+            let kind = CurveKind::Line(Line::from_points(points));
+            GlobalCurve::from_kind(kind)
         };
 
         let vertices = {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -16,14 +16,14 @@ impl EdgeBuilder {
             a: Vector::from([radius, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius]),
         });
-        let curve_canonical = CurveKind::Circle(Circle {
+        let curve_global = CurveKind::Circle(Circle {
             center: Point::origin(),
             a: Vector::from([radius, Scalar::ZERO, Scalar::ZERO]),
             b: Vector::from([Scalar::ZERO, radius, Scalar::ZERO]),
         });
 
         Edge::new(
-            Local::new(curve_local, curve_canonical),
+            Local::new(curve_local, curve_global),
             VerticesOfEdge::none(),
         )
     }
@@ -42,7 +42,7 @@ impl EdgeBuilder {
         });
 
         let curve_local = CurveKind::Line(Line::from_points(points));
-        let curve_canonical = {
+        let curve_global = {
             let points =
                 global_vertices.map(|global_vertex| global_vertex.position());
             CurveKind::Line(Line::from_points(points))
@@ -57,7 +57,7 @@ impl EdgeBuilder {
         };
 
         Edge::new(
-            Local::new(curve_local, curve_canonical),
+            Local::new(curve_local, curve_global),
             VerticesOfEdge::from_vertices(vertices),
         )
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -1,11 +1,8 @@
 use fj_math::{Circle, Line, Point, Scalar, Vector};
 
-use crate::{
-    local::Local,
-    objects::{
-        CurveKind, Edge, GlobalCurve, GlobalVertex, Surface, Vertex,
-        VerticesOfEdge,
-    },
+use crate::objects::{
+    Curve, CurveKind, Edge, GlobalCurve, GlobalVertex, Surface, Vertex,
+    VerticesOfEdge,
 };
 
 /// API for building an [`Edge`]
@@ -26,7 +23,7 @@ impl EdgeBuilder {
         }));
 
         Edge::new(
-            Local::new(curve_local, curve_global),
+            Curve::new(curve_local, curve_global),
             VerticesOfEdge::none(),
         )
     }
@@ -61,7 +58,7 @@ impl EdgeBuilder {
         };
 
         Edge::new(
-            Local::new(curve_local, curve_global),
+            Curve::new(curve_local, curve_global),
             VerticesOfEdge::from_vertices(vertices),
         )
     }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -3,7 +3,8 @@
 use std::collections::VecDeque;
 
 use crate::objects::{
-    CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
+    Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid, Surface,
+    Vertex,
 };
 
 /// Access iterators over all objects of a shape, or part of it
@@ -15,7 +16,7 @@ pub trait ObjectIters<'r> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters>;
 
     /// Iterate over all curves
-    fn curve_iter(&'r self) -> Iter<&'r CurveKind<3>> {
+    fn curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
@@ -114,12 +115,12 @@ pub trait ObjectIters<'r> {
     }
 }
 
-impl<'r> ObjectIters<'r> for CurveKind<3> {
+impl<'r> ObjectIters<'r> for GlobalCurve {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         Vec::new()
     }
 
-    fn curve_iter(&'r self) -> Iter<&'r CurveKind<3>> {
+    fn curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
         Iter::from_object(self)
     }
 }
@@ -297,15 +298,15 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::objects::{
-        CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface,
-        Vertex,
+        CurveKind, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Sketch, Solid,
+        Surface, Vertex,
     };
 
     use super::ObjectIters as _;
 
     #[test]
     fn curve() {
-        let object = CurveKind::x_axis();
+        let object = GlobalCurve::from_kind(CurveKind::x_axis());
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 
 use crate::objects::{
-    Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
+    CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
 };
 
 /// Access iterators over all objects of a shape, or part of it
@@ -15,7 +15,7 @@ pub trait ObjectIters<'r> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters>;
 
     /// Iterate over all curves
-    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
+    fn curve_iter(&'r self) -> Iter<&'r CurveKind<3>> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
@@ -114,12 +114,12 @@ pub trait ObjectIters<'r> {
     }
 }
 
-impl<'r> ObjectIters<'r> for Curve<3> {
+impl<'r> ObjectIters<'r> for CurveKind<3> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         Vec::new()
     }
 
-    fn curve_iter(&'r self) -> Iter<&'r Curve<3>> {
+    fn curve_iter(&'r self) -> Iter<&'r CurveKind<3>> {
         Iter::from_object(self)
     }
 }
@@ -297,14 +297,15 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::objects::{
-        Curve, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface, Vertex,
+        CurveKind, Cycle, Edge, Face, GlobalVertex, Sketch, Solid, Surface,
+        Vertex,
     };
 
     use super::ObjectIters as _;
 
     #[test]
     fn curve() {
-        let object = Curve::x_axis();
+        let object = CurveKind::x_axis();
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -16,11 +16,11 @@ pub trait ObjectIters<'r> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters>;
 
     /// Iterate over all curves
-    fn curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
+    fn global_curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
-            iter = iter.with(object.curve_iter());
+            iter = iter.with(object.global_curve_iter());
         }
 
         iter
@@ -120,7 +120,7 @@ impl<'r> ObjectIters<'r> for GlobalCurve {
         Vec::new()
     }
 
-    fn curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
+    fn global_curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
         Iter::from_object(self)
     }
 }
@@ -308,7 +308,7 @@ mod tests {
     fn curve() {
         let object = GlobalCurve::from_kind(CurveKind::x_axis());
 
-        assert_eq!(1, object.curve_iter().count());
+        assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
         assert_eq!(0, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());
@@ -327,7 +327,7 @@ mod tests {
             [0., 1.],
         ]);
 
-        assert_eq!(3, object.curve_iter().count());
+        assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
         assert_eq!(3, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());
@@ -345,7 +345,7 @@ mod tests {
             [[0., 0.], [1., 0.]],
         );
 
-        assert_eq!(1, object.curve_iter().count());
+        assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
         assert_eq!(1, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());
@@ -365,7 +365,7 @@ mod tests {
             [0., 1.],
         ]);
 
-        assert_eq!(3, object.curve_iter().count());
+        assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
         assert_eq!(3, object.edge_iter().count());
         assert_eq!(1, object.face_iter().count());
@@ -380,7 +380,7 @@ mod tests {
     fn global_vertex() {
         let object = GlobalVertex::from_position([0., 0., 0.]);
 
-        assert_eq!(0, object.curve_iter().count());
+        assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
         assert_eq!(0, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());
@@ -401,7 +401,7 @@ mod tests {
         ]);
         let object = Sketch::new().with_faces([face]);
 
-        assert_eq!(3, object.curve_iter().count());
+        assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
         assert_eq!(3, object.edge_iter().count());
         assert_eq!(1, object.face_iter().count());
@@ -416,7 +416,7 @@ mod tests {
     fn solid() {
         let object = Solid::build().cube_from_edge_length(1.);
 
-        assert_eq!(18, object.curve_iter().count());
+        assert_eq!(18, object.global_curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());
         assert_eq!(20, object.edge_iter().count());
         assert_eq!(6, object.face_iter().count());
@@ -431,7 +431,7 @@ mod tests {
     fn surface() {
         let object = Surface::xy_plane();
 
-        assert_eq!(0, object.curve_iter().count());
+        assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
         assert_eq!(0, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());
@@ -447,7 +447,7 @@ mod tests {
         let global_vertex = GlobalVertex::from_position([0., 0., 0.]);
         let object = Vertex::new([0.], global_vertex);
 
-        assert_eq!(0, object.curve_iter().count());
+        assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
         assert_eq!(0, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -15,7 +15,7 @@ pub trait ObjectIters<'r> {
     /// Return all objects that this one references
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters>;
 
-    /// Iterate over all curves
+    /// Iterate over all global curves
     fn global_curve_iter(&'r self) -> Iter<&'r GlobalCurve> {
         let mut iter = Iter::empty();
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -305,7 +305,7 @@ mod tests {
     use super::ObjectIters as _;
 
     #[test]
-    fn curve() {
+    fn global_curve() {
         let object = GlobalCurve::from_kind(CurveKind::x_axis());
 
         assert_eq!(1, object.global_curve_iter().count());

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -2,7 +2,7 @@
 
 use fj_math::Point;
 
-use crate::objects::Curve;
+use crate::objects::CurveKind;
 
 /// A wrapper around the local and global forms of a type
 ///
@@ -50,8 +50,8 @@ pub trait LocalForm {
     type GlobalForm;
 }
 
-impl LocalForm for Curve<2> {
-    type GlobalForm = Curve<3>;
+impl LocalForm for CurveKind<2> {
+    type GlobalForm = CurveKind<3>;
 }
 
 impl LocalForm for Point<1> {

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -2,8 +2,6 @@
 
 use fj_math::Point;
 
-use crate::objects::{Curve, GlobalCurve};
-
 /// A wrapper around the local and global forms of a type
 ///
 /// The local form is whatever representation of the value that is most
@@ -48,10 +46,6 @@ impl<T: LocalForm> Local<T> {
 pub trait LocalForm {
     /// The global form of the implementing type
     type GlobalForm;
-}
-
-impl LocalForm for Curve {
-    type GlobalForm = GlobalCurve;
 }
 
 impl LocalForm for Point<1> {

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -2,7 +2,7 @@
 
 use fj_math::Point;
 
-use crate::objects::CurveKind;
+use crate::objects::{CurveKind, GlobalCurve};
 
 /// A wrapper around the local and global forms of a type
 ///
@@ -51,7 +51,7 @@ pub trait LocalForm {
 }
 
 impl LocalForm for CurveKind<2> {
-    type GlobalForm = CurveKind<3>;
+    type GlobalForm = GlobalCurve;
 }
 
 impl LocalForm for Point<1> {

--- a/crates/fj-kernel/src/local.rs
+++ b/crates/fj-kernel/src/local.rs
@@ -2,7 +2,7 @@
 
 use fj_math::Point;
 
-use crate::objects::{CurveKind, GlobalCurve};
+use crate::objects::{Curve, GlobalCurve};
 
 /// A wrapper around the local and global forms of a type
 ///
@@ -50,7 +50,7 @@ pub trait LocalForm {
     type GlobalForm;
 }
 
-impl LocalForm for CurveKind<2> {
+impl LocalForm for Curve {
     type GlobalForm = GlobalCurve;
 }
 

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use fj_math::{Circle, Line, Point, Vector};
 
 /// A one-dimensional shape
@@ -111,14 +109,5 @@ impl CurveKind<3> {
             origin: Point::origin(),
             direction: Vector::unit_z(),
         })
-    }
-}
-
-impl<const D: usize> fmt::Display for CurveKind<D> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Circle(curve) => write!(f, "{:?}", curve),
-            Self::Line(curve) => write!(f, "{:?}", curve),
-        }
     }
 }

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -1,4 +1,22 @@
-use fj_math::{Circle, Line, Point, Vector};
+use fj_math::{Circle, Line, Point, Transform, Vector};
+
+/// A curve, defined in global (3D) coordinates
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct GlobalCurve {
+    kind: CurveKind<3>,
+}
+
+impl GlobalCurve {
+    /// Construct a `GlobalCurve` from a [`CurveKind<3>`]
+    pub fn from_kind(kind: CurveKind<3>) -> Self {
+        Self { kind }
+    }
+
+    /// Access the kind of this curve
+    pub fn kind(&self) -> &CurveKind<3> {
+        &self.kind
+    }
+}
 
 /// A one-dimensional shape
 ///
@@ -109,5 +127,18 @@ impl CurveKind<3> {
             origin: Point::origin(),
             direction: Vector::unit_z(),
         })
+    }
+
+    /// Transform the surface
+    #[must_use]
+    pub fn transform(self, transform: &Transform) -> Self {
+        match self {
+            CurveKind::Circle(curve) => {
+                CurveKind::Circle(transform.transform_circle(&curve))
+            }
+            CurveKind::Line(curve) => {
+                CurveKind::Line(transform.transform_line(&curve))
+            }
+        }
     }
 }

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -16,7 +16,7 @@ use fj_math::{Circle, Line, Point, Vector};
 /// Typically, only `2` or `3` make sense, which means the curve is defined on
 /// a surface or in a space, respectively.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum Curve<const D: usize> {
+pub enum CurveKind<const D: usize> {
     /// A circle
     Circle(Circle<D>),
 
@@ -24,7 +24,7 @@ pub enum Curve<const D: usize> {
     Line(Line<D>),
 }
 
-impl<const D: usize> Curve<D> {
+impl<const D: usize> CurveKind<D> {
     /// Construct a line from two points
     pub fn line_from_points(points: [impl Into<Point<D>>; 2]) -> Self {
         Self::Line(Line::from_points(points))
@@ -70,7 +70,7 @@ impl<const D: usize> Curve<D> {
     }
 }
 
-impl Curve<2> {
+impl CurveKind<2> {
     /// Construct a `Curve` that represents the u-axis
     pub fn u_axis() -> Self {
         Self::Line(Line {
@@ -88,7 +88,7 @@ impl Curve<2> {
     }
 }
 
-impl Curve<3> {
+impl CurveKind<3> {
     /// Construct a `Curve` that represents the x-axis
     pub fn x_axis() -> Self {
         Self::Line(Line {
@@ -114,7 +114,7 @@ impl Curve<3> {
     }
 }
 
-impl<const D: usize> fmt::Display for Curve<D> {
+impl<const D: usize> fmt::Display for CurveKind<D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Circle(curve) => write!(f, "{:?}", curve),

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -1,5 +1,29 @@
 use fj_math::{Circle, Line, Point, Transform, Vector};
 
+/// A curve, defined in local surface coordinates
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Curve {
+    kind: CurveKind<2>,
+    global: GlobalCurve,
+}
+
+impl Curve {
+    /// Construct a new instance of `Curve`
+    pub fn new(kind: CurveKind<2>, global: GlobalCurve) -> Self {
+        Self { kind, global }
+    }
+
+    /// Access the kind of this curve
+    pub fn kind(&self) -> &CurveKind<2> {
+        &self.kind
+    }
+
+    /// Access the global form of this curve
+    pub fn global(&self) -> &GlobalCurve {
+        &self.global
+    }
+}
+
 /// A curve, defined in global (3D) coordinates
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct GlobalCurve {

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -2,12 +2,12 @@ use std::fmt;
 
 use crate::{builder::EdgeBuilder, local::Local};
 
-use super::{Curve, Vertex};
+use super::{CurveKind, Vertex};
 
 /// An edge of a shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edge {
-    curve: Local<Curve<2>>,
+    curve: Local<CurveKind<2>>,
     vertices: VerticesOfEdge,
 }
 
@@ -18,7 +18,7 @@ impl Edge {
     }
 
     /// Create a new instance
-    pub fn new(curve: Local<Curve<2>>, vertices: VerticesOfEdge) -> Self {
+    pub fn new(curve: Local<CurveKind<2>>, vertices: VerticesOfEdge) -> Self {
         Self { curve, vertices }
     }
 
@@ -27,7 +27,7 @@ impl Edge {
     /// The edge can be a segment of the curve that is bounded by two vertices,
     /// or if the curve is continuous (i.e. connects to itself), the edge could
     /// be defined by the whole curve, and have no bounding vertices.
-    pub fn curve(&self) -> &Local<Curve<2>> {
+    pub fn curve(&self) -> &Local<CurveKind<2>> {
         &self.curve
     }
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -51,7 +51,7 @@ impl fmt::Display for Edge {
             None => write!(f, "continuous edge")?,
         }
 
-        write!(f, " on {}", self.curve().global_form())?;
+        write!(f, " on {:?}", self.curve().global_form())?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 
-use crate::{builder::EdgeBuilder, local::Local};
+use crate::builder::EdgeBuilder;
 
-use super::{CurveKind, Vertex};
+use super::{Curve, Vertex};
 
 /// An edge of a shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edge {
-    curve: Local<CurveKind<2>>,
+    curve: Curve,
     vertices: VerticesOfEdge,
 }
 
@@ -18,7 +18,7 @@ impl Edge {
     }
 
     /// Create a new instance
-    pub fn new(curve: Local<CurveKind<2>>, vertices: VerticesOfEdge) -> Self {
+    pub fn new(curve: Curve, vertices: VerticesOfEdge) -> Self {
         Self { curve, vertices }
     }
 
@@ -27,7 +27,7 @@ impl Edge {
     /// The edge can be a segment of the curve that is bounded by two vertices,
     /// or if the curve is continuous (i.e. connects to itself), the edge could
     /// be defined by the whole curve, and have no bounding vertices.
-    pub fn curve(&self) -> &Local<CurveKind<2>> {
+    pub fn curve(&self) -> &Curve {
         &self.curve
     }
 
@@ -51,7 +51,7 @@ impl fmt::Display for Edge {
             None => write!(f, "continuous edge")?,
         }
 
-        write!(f, " on {:?}", self.curve().global_form())?;
+        write!(f, " on {:?}", self.curve().global())?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -14,7 +14,7 @@ mod surface;
 mod vertex;
 
 pub use self::{
-    curve::{CurveKind, GlobalCurve},
+    curve::{Curve, CurveKind, GlobalCurve},
     cycle::Cycle,
     edge::{Edge, VerticesOfEdge},
     face::Face,

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -14,7 +14,7 @@ mod surface;
 mod vertex;
 
 pub use self::{
-    curve::Curve,
+    curve::CurveKind,
     cycle::Cycle,
     edge::{Edge, VerticesOfEdge},
     face::Face,

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -14,7 +14,7 @@ mod surface;
 mod vertex;
 
 pub use self::{
-    curve::CurveKind,
+    curve::{CurveKind, GlobalCurve},
     cycle::Cycle,
     edge::{Edge, VerticesOfEdge},
     face::Face,

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -1,7 +1,5 @@
 use fj_math::{Line, Point, Transform, Vector};
 
-use crate::algorithms::TransformObject;
-
 use super::CurveKind;
 
 /// A two-dimensional shape

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -2,7 +2,7 @@ use fj_math::{Line, Point, Transform, Vector};
 
 use crate::algorithms::TransformObject;
 
-use super::Curve;
+use super::CurveKind;
 
 /// A two-dimensional shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -15,7 +15,7 @@ impl Surface {
     /// Construct a `Surface` that represents the xy-plane
     pub fn xy_plane() -> Self {
         Self::SweptCurve(SweptCurve {
-            curve: Curve::x_axis(),
+            curve: CurveKind::x_axis(),
             path: Vector::unit_y(),
         })
     }
@@ -23,7 +23,7 @@ impl Surface {
     /// Construct a `Surface` that represents the xz-plane
     pub fn xz_plane() -> Self {
         Self::SweptCurve(SweptCurve {
-            curve: Curve::x_axis(),
+            curve: CurveKind::x_axis(),
             path: Vector::unit_z(),
         })
     }
@@ -31,7 +31,7 @@ impl Surface {
     /// Construct a `Surface` that represents the yz-plane
     pub fn yz_plane() -> Self {
         Self::SweptCurve(SweptCurve {
-            curve: Curve::y_axis(),
+            curve: CurveKind::y_axis(),
             path: Vector::unit_z(),
         })
     }
@@ -40,7 +40,7 @@ impl Surface {
     pub fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Self {
         let [a, b, c] = points.map(Into::into);
 
-        let curve = Curve::Line(Line::from_points([a, b]));
+        let curve = CurveKind::Line(Line::from_points([a, b]));
         let path = c - a;
 
         Self::SweptCurve(SweptCurve { curve, path })
@@ -83,7 +83,7 @@ impl Surface {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SweptCurve {
     /// The curve that this surface was swept from
-    pub curve: Curve<3>,
+    pub curve: CurveKind<3>,
 
     /// The path that the curve was swept along
     pub path: Vector<3>,
@@ -138,14 +138,14 @@ mod tests {
     use fj_math::{Line, Point, Vector};
     use pretty_assertions::assert_eq;
 
-    use crate::objects::Curve;
+    use crate::objects::CurveKind;
 
     use super::SweptCurve;
 
     #[test]
     fn reverse() {
         let original = SweptCurve {
-            curve: Curve::Line(Line {
+            curve: CurveKind::Line(Line {
                 origin: Point::from([1., 0., 0.]),
                 direction: Vector::from([0., 2., 0.]),
             }),
@@ -155,7 +155,7 @@ mod tests {
         let reversed = original.reverse();
 
         let expected = SweptCurve {
-            curve: Curve::Line(Line {
+            curve: CurveKind::Line(Line {
                 origin: Point::from([1., 0., 0.]),
                 direction: Vector::from([0., 2., 0.]),
             }),
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn point_from_surface_coords() {
         let swept = SweptCurve {
-            curve: Curve::Line(Line {
+            curve: CurveKind::Line(Line {
                 origin: Point::from([1., 1., 1.]),
                 direction: Vector::from([0., 2., 0.]),
             }),
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn vector_from_surface_coords() {
         let swept = SweptCurve {
-            curve: Curve::Line(Line {
+            curve: CurveKind::Line(Line {
                 origin: Point::from([1., 0., 0.]),
                 direction: Vector::from([0., 2., 0.]),
             }),

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -61,7 +61,7 @@ pub struct GlobalVertex {
 }
 
 impl GlobalVertex {
-    /// Construct a `Vertex` from a point
+    /// Construct a `GlobalVertex` from a point
     pub fn from_position(position: impl Into<Point<3>>) -> Self {
         let position = position.into();
         Self { position }

--- a/crates/fj-kernel/src/validation/coherence.rs
+++ b/crates/fj-kernel/src/validation/coherence.rs
@@ -18,11 +18,8 @@ pub fn validate_edge(
 
     for vertex in edge.vertices().iter() {
         let local = vertex.position();
-        let local_as_global = edge
-            .curve()
-            .global_form()
-            .kind()
-            .point_from_curve_coords(local);
+        let local_as_global =
+            edge.curve().global().kind().point_from_curve_coords(local);
         let global = vertex.global().position();
         let distance = (local_as_global - global).magnitude();
 

--- a/crates/fj-kernel/src/validation/coherence.rs
+++ b/crates/fj-kernel/src/validation/coherence.rs
@@ -18,8 +18,11 @@ pub fn validate_edge(
 
     for vertex in edge.vertices().iter() {
         let local = vertex.position();
-        let local_as_global =
-            edge.curve().global_form().point_from_curve_coords(local);
+        let local_as_global = edge
+            .curve()
+            .global_form()
+            .kind()
+            .point_from_curve_coords(local);
         let global = vertex.global().position();
         let distance = (local_as_global - global).magnitude();
 

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -142,8 +142,8 @@ mod tests {
 
         let curve = {
             let curve_local = CurveKind::line_from_points([[0., 0.], [1., 0.]]);
-            let curve_canonical = CurveKind::line_from_points([a, b]);
-            Local::new(curve_local, curve_canonical)
+            let curve_global = CurveKind::line_from_points([a, b]);
+            Local::new(curve_local, curve_global)
         };
 
         let a = GlobalVertex::from_position(a);

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -131,7 +131,7 @@ mod tests {
 
     use crate::{
         local::Local,
-        objects::{Curve, Edge, GlobalVertex, Vertex, VerticesOfEdge},
+        objects::{CurveKind, Edge, GlobalVertex, Vertex, VerticesOfEdge},
         validation::{validate, ValidationConfig, ValidationError},
     };
 
@@ -141,8 +141,8 @@ mod tests {
         let b = Point::from([1., 0., 0.]);
 
         let curve = {
-            let curve_local = Curve::line_from_points([[0., 0.], [1., 0.]]);
-            let curve_canonical = Curve::line_from_points([a, b]);
+            let curve_local = CurveKind::line_from_points([[0., 0.], [1., 0.]]);
+            let curve_canonical = CurveKind::line_from_points([a, b]);
             Local::new(curve_local, curve_canonical)
         };
 

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -130,9 +130,9 @@ mod tests {
     use fj_math::{Point, Scalar};
 
     use crate::{
-        local::Local,
         objects::{
-            CurveKind, Edge, GlobalCurve, GlobalVertex, Vertex, VerticesOfEdge,
+            Curve, CurveKind, Edge, GlobalCurve, GlobalVertex, Vertex,
+            VerticesOfEdge,
         },
         validation::{validate, ValidationConfig, ValidationError},
     };
@@ -146,7 +146,7 @@ mod tests {
             let curve_local = CurveKind::line_from_points([[0., 0.], [1., 0.]]);
             let curve_global =
                 GlobalCurve::from_kind(CurveKind::line_from_points([a, b]));
-            Local::new(curve_local, curve_global)
+            Curve::new(curve_local, curve_global)
         };
 
         let a = GlobalVertex::from_position(a);

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -131,7 +131,9 @@ mod tests {
 
     use crate::{
         local::Local,
-        objects::{CurveKind, Edge, GlobalVertex, Vertex, VerticesOfEdge},
+        objects::{
+            CurveKind, Edge, GlobalCurve, GlobalVertex, Vertex, VerticesOfEdge,
+        },
         validation::{validate, ValidationConfig, ValidationError},
     };
 
@@ -142,7 +144,8 @@ mod tests {
 
         let curve = {
             let curve_local = CurveKind::line_from_points([[0., 0.], [1., 0.]]);
-            let curve_global = CurveKind::line_from_points([a, b]);
+            let curve_global =
+                GlobalCurve::from_kind(CurveKind::line_from_points([a, b]));
             Local::new(curve_local, curve_global)
         };
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -2,8 +2,7 @@ use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
     algorithms::Tolerance,
     iter::ObjectIters,
-    local::Local,
-    objects::{Cycle, Edge, Face, GlobalCurve, Sketch},
+    objects::{Curve, Cycle, Edge, Face, GlobalCurve, Sketch},
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
@@ -94,15 +93,15 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
     let mut edges = Vec::new();
     for edge in cycle.edges() {
         let curve_local = if reverse {
-            edge.curve().local_form().reverse()
+            edge.curve().kind().reverse()
         } else {
-            *edge.curve().local_form()
+            *edge.curve().kind()
         };
 
         let curve_global = GlobalCurve::from_kind(if reverse {
-            edge.curve().global_form().kind().reverse()
+            edge.curve().global().kind().reverse()
         } else {
-            *edge.curve().global_form().kind()
+            *edge.curve().global().kind()
         });
 
         let vertices = if reverse {
@@ -111,7 +110,7 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
             *edge.vertices()
         };
 
-        let edge = Edge::new(Local::new(curve_local, curve_global), vertices);
+        let edge = Edge::new(Curve::new(curve_local, curve_global), vertices);
 
         edges.push(edge);
     }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::Tolerance,
     iter::ObjectIters,
     local::Local,
-    objects::{Cycle, Edge, Face, Sketch},
+    objects::{Cycle, Edge, Face, GlobalCurve, Sketch},
     validation::{validate, Validated, ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
@@ -99,11 +99,11 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
             *edge.curve().local_form()
         };
 
-        let curve_global = if reverse {
-            edge.curve().global_form().reverse()
+        let curve_global = GlobalCurve::from_kind(if reverse {
+            edge.curve().global_form().kind().reverse()
         } else {
-            *edge.curve().global_form()
-        };
+            *edge.curve().global_form().kind()
+        });
 
         let vertices = if reverse {
             edge.vertices().reverse()


### PR DESCRIPTION
This brings curves in line with the way vertices already work. It also makes code that has to handle curves in multiple forms a bit easier.

It's unfortunate that this introduces the redundancy between the `CurveKind`s of `Curve` and `GlobalCurve`, but I don't think it is a problem right now. If it becomes one, it can be handled with validation (which it should be eventually anyways). Long-term, I can imagine that `CurveKind` won't be a thing any more, because every curve will be a b-spline, but we'll see how that's going to develop.