### PR TITLE
Disable mesh and debug rendering checkboxes if line drawing is unavailable

### DIFF
--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -424,16 +424,23 @@ impl Renderer {
             info
         }
 
+        let line_drawing_available = self.is_line_drawing_available();
         egui::SidePanel::left("fj-left-panel").show(&self.egui.context, |ui| {
             ui.add_space(16.0);
 
             ui.group(|ui| {
                 ui.checkbox(&mut config.draw_model, "Render model")
                     .on_hover_text_at_pointer("Toggle with 1");
-                ui.checkbox(&mut config.draw_mesh, "Render mesh")
-                    .on_hover_text_at_pointer("Toggle with 2");
-                ui.checkbox(&mut config.draw_debug, "Render debug")
-                    .on_hover_text_at_pointer("Toggle with 3");
+                ui.add_enabled(line_drawing_available, egui::Checkbox::new(&mut config.draw_mesh, "Render mesh"))
+                    .on_hover_text_at_pointer("Toggle with 2")
+                    .on_disabled_hover_text(
+                        "Rendering device does not have line rendering feature support",
+                    );
+                ui.add_enabled(line_drawing_available, egui::Checkbox::new(&mut config.draw_debug, "Render debug"))
+                    .on_hover_text_at_pointer("Toggle with 3")
+                    .on_disabled_hover_text(
+                        "Rendering device does not have line rendering feature support"
+                    );
                 ui.checkbox(
                     &mut self.egui.options.show_original_ui,
                     "Render original UI",
@@ -635,6 +642,11 @@ impl Renderer {
                 },
             ),
         });
+    }
+
+    /// Returns true if the renderer's adapter can draw lines
+    pub fn is_line_drawing_available(&self) -> bool {
+        self.features.contains(wgpu::Features::POLYGON_MODE_LINE)
     }
 }
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -137,10 +137,14 @@ pub fn run(
                     draw_config.draw_model = !draw_config.draw_model
                 }
                 VirtualKeyCode::Key2 => {
-                    draw_config.draw_mesh = !draw_config.draw_mesh
+                    if renderer.is_line_drawing_available() {
+                        draw_config.draw_mesh = !draw_config.draw_mesh
+                    }
                 }
                 VirtualKeyCode::Key3 => {
-                    draw_config.draw_debug = !draw_config.draw_debug
+                    if renderer.is_line_drawing_available() {
+                        draw_config.draw_debug = !draw_config.draw_debug
+                    }
                 }
                 _ => {}
             },


### PR DESCRIPTION
This is to address #907. The changes do work (tested by making `is_line_drawing_available` return false always) but I doubt this is the best way to do it. Any alternatives/improvements are welcome.

edit by @hannobraun:
Close #907