### PR TITLE
Move the model traits into their own fj::models module

### DIFF
--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -389,7 +389,7 @@ pub enum Error {
     #[error("No model was registered")]
     NoModelRegistered,
 
-    /// An error was returned from [`fj::Model::shape()`].
+    /// An error was returned from [`fj::models::Model::shape()`].
     #[error("Unable to determine the model's geometry")]
     Shape(#[source] fj::models::Error),
 

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -382,7 +382,7 @@ pub enum Error {
 
     /// Initializing a model failed.
     #[error("Unable to initialize the model")]
-    InitializeModel(#[source] Box<dyn std::error::Error + Send + Sync>),
+    InitializeModel(#[source] fj::models::Error),
 
     /// The user forgot to register a model when calling
     /// [`fj::register_model!()`].
@@ -391,7 +391,7 @@ pub enum Error {
 
     /// An error was returned from [`fj::Model::shape()`].
     #[error("Unable to determine the model's geometry")]
-    Shape(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Shape(#[source] fj::models::Error),
 
     /// Error while watching the model code for changes
     #[error("Error watching model for changes")]
@@ -422,16 +422,16 @@ pub enum Error {
 
 struct Host<'a> {
     args: &'a Parameters,
-    model: Option<Box<dyn fj::Model>>,
+    model: Option<Box<dyn fj::models::Model>>,
 }
 
-impl<'a> fj::Host for Host<'a> {
-    fn register_boxed_model(&mut self, model: Box<dyn fj::Model>) {
+impl<'a> fj::models::Host for Host<'a> {
+    fn register_boxed_model(&mut self, model: Box<dyn fj::models::Model>) {
         self.model = Some(model);
     }
 }
 
-impl<'a> fj::Context for Host<'a> {
+impl<'a> fj::models::Context for Host<'a> {
     fn get_argument(&self, name: &str) -> Option<&str> {
         self.args.get(name).map(|s| s.as_str())
     }

--- a/crates/fj-proc/src/expand.rs
+++ b/crates/fj-proc/src/expand.rs
@@ -11,10 +11,10 @@ impl Initializer {
         quote! {
             const _: () = {
                 fj::register_model!(|host| {
-                    fj::HostExt::register_model(host, Model);
+                    fj::models::HostExt::register_model(host, Model);
 
                     Ok(
-                        fj::Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+                        fj::models::Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
                             .with_short_description(env!("CARGO_PKG_DESCRIPTION"))
                             .with_homepage(env!("CARGO_PKG_HOMEPAGE"))
                             .with_repository(env!("CARGO_PKG_REPOSITORY"))
@@ -44,7 +44,7 @@ impl Model {
         let Model { metadata, geometry } = self;
 
         quote! {
-            impl fj::Model for Model {
+            impl fj::models::Model for Model {
                 #metadata
                 #geometry
             }
@@ -64,8 +64,8 @@ impl ToTokens for Metadata {
         let Metadata { name, arguments } = self;
 
         tokens.extend(quote! {
-            fn metadata(&self) -> fj::ModelMetadata {
-                fj::ModelMetadata::new(#name)
+            fn metadata(&self) -> fj::models::ModelMetadata {
+                fj::models::ModelMetadata::new(#name)
                 #( .with_argument(#arguments) )*
             }
         });
@@ -79,7 +79,7 @@ impl ToTokens for ArgumentMetadata {
             default_value,
         } = self;
 
-        tokens.extend(quote! { fj::ArgumentMetadata::new(#name) });
+        tokens.extend(quote! { fj::models::ArgumentMetadata::new(#name) });
 
         if let Some(default_value) = default_value {
             tokens.extend(quote! {
@@ -112,8 +112,8 @@ impl ToTokens for GeometryFunction {
         tokens.extend(quote! {
             fn shape(
                 &self,
-                ctx: &dyn fj::Context,
-            ) -> Result<fj::Shape, Box<dyn std::error::Error + Send + Sync>> {
+                ctx: &dyn fj::models::Context,
+            ) -> Result<fj::Shape, fj::models::Error> {
                 #( #arguments )*
                 #( #constraints )*
                 #invocation

--- a/crates/fj-proc/src/lib.rs
+++ b/crates/fj-proc/src/lib.rs
@@ -71,6 +71,20 @@ use syn::{parse_macro_input, FnArg, ItemFn};
 ///     spacer.into()
 /// }
 /// ```
+///
+/// For more complex situations, model functions are allowed to return any
+/// error type that converts into a model error.
+///
+/// ```rust
+/// #[fj::model]
+/// pub fn model() -> Result<fj::Shape, std::env::VarError> {
+///     let home_dir = std::env::var("HOME")?;
+///
+///     todo!("Do something with {home_dir}")
+/// }
+///
+/// fn assert_convertible(e: std::env::VarError) -> fj::models::Error { e.into() }
+/// ```
 #[proc_macro_attribute]
 pub fn model(_: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as syn::ItemFn);

--- a/crates/fj/src/abi/context.rs
+++ b/crates/fj/src/abi/context.rs
@@ -10,13 +10,13 @@ pub struct Context<'a> {
     _lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> From<&'a &dyn crate::Context> for Context<'a> {
-    fn from(ctx: &'a &dyn crate::Context) -> Self {
+impl<'a> From<&'a &dyn crate::models::Context> for Context<'a> {
+    fn from(ctx: &'a &dyn crate::models::Context) -> Self {
         unsafe extern "C" fn get_argument(
             user_data: *const c_void,
             name: StringSlice,
         ) -> StringSlice {
-            let ctx = &*(user_data as *const &dyn crate::Context);
+            let ctx = &*(user_data as *const &dyn crate::models::Context);
 
             match std::panic::catch_unwind(AssertUnwindSafe(|| {
                 ctx.get_argument(&*name)
@@ -28,14 +28,15 @@ impl<'a> From<&'a &dyn crate::Context> for Context<'a> {
         }
 
         Context {
-            user_data: ctx as *const &dyn crate::Context as *const c_void,
+            user_data: ctx as *const &dyn crate::models::Context
+                as *const c_void,
             get_argument,
             _lifetime: PhantomData,
         }
     }
 }
 
-impl crate::Context for Context<'_> {
+impl crate::models::Context for Context<'_> {
     fn get_argument(&self, name: &str) -> Option<&str> {
         unsafe {
             let Context {

--- a/crates/fj/src/abi/ffi_safe.rs
+++ b/crates/fj/src/abi/ffi_safe.rs
@@ -7,6 +7,8 @@ use std::{
     ptr::NonNull,
 };
 
+use crate::models::Error;
+
 /// A FFI-safe version of `Vec<T>`.
 #[repr(C)]
 pub(crate) struct Vec<T> {
@@ -312,8 +314,8 @@ impl Display for BoxedError {
 
 impl std::error::Error for BoxedError {}
 
-impl From<Box<dyn std::error::Error + Send + Sync>> for BoxedError {
-    fn from(err: Box<dyn std::error::Error + Send + Sync>) -> Self {
+impl From<Error> for BoxedError {
+    fn from(err: Error) -> Self {
         // Open question: is it worth capturing the message from each source
         // error, too? We could have some sort of `sources: Vec<Source>` field
         // where `Source` is a private wrapper around String that implements

--- a/crates/fj/src/abi/host.rs
+++ b/crates/fj/src/abi/host.rs
@@ -10,9 +10,9 @@ pub struct Host<'a> {
     _lifetime: PhantomData<&'a mut ()>,
 }
 
-impl<'a, H: crate::Host + Sized> From<&'a mut H> for Host<'a> {
+impl<'a, H: crate::models::Host + Sized> From<&'a mut H> for Host<'a> {
     fn from(host: &'a mut H) -> Self {
-        extern "C" fn register_boxed_model<H: crate::Host + Sized>(
+        extern "C" fn register_boxed_model<H: crate::models::Host + Sized>(
             user_data: *mut c_void,
             model: Model,
         ) {
@@ -33,8 +33,8 @@ impl<'a, H: crate::Host + Sized> From<&'a mut H> for Host<'a> {
     }
 }
 
-impl<'a> crate::Host for Host<'a> {
-    fn register_boxed_model(&mut self, model: Box<dyn crate::Model>) {
+impl<'a> crate::models::Host for Host<'a> {
+    fn register_boxed_model(&mut self, model: Box<dyn crate::models::Model>) {
         let Host {
             user_data,
             register_boxed_model,

--- a/crates/fj/src/abi/metadata.rs
+++ b/crates/fj/src/abi/metadata.rs
@@ -8,7 +8,7 @@ pub struct ModelMetadata {
     arguments: ffi_safe::Vec<ArgumentMetadata>,
 }
 
-impl From<ModelMetadata> for crate::ModelMetadata {
+impl From<ModelMetadata> for crate::models::ModelMetadata {
     fn from(m: ModelMetadata) -> Self {
         let ModelMetadata {
             name,
@@ -16,7 +16,7 @@ impl From<ModelMetadata> for crate::ModelMetadata {
             arguments,
         } = m;
 
-        crate::ModelMetadata {
+        crate::models::ModelMetadata {
             name: name.into(),
             description: description.map(Into::into).into(),
             arguments: arguments.iter().cloned().map(|a| a.into()).collect(),
@@ -24,9 +24,9 @@ impl From<ModelMetadata> for crate::ModelMetadata {
     }
 }
 
-impl From<crate::ModelMetadata> for ModelMetadata {
-    fn from(m: crate::ModelMetadata) -> Self {
-        let crate::ModelMetadata {
+impl From<crate::models::ModelMetadata> for ModelMetadata {
+    fn from(m: crate::models::ModelMetadata) -> Self {
+        let crate::models::ModelMetadata {
             name,
             description,
             arguments,
@@ -52,7 +52,7 @@ pub struct Metadata {
     license: ffi_safe::Option<ffi_safe::String>,
 }
 
-impl From<Metadata> for crate::Metadata {
+impl From<Metadata> for crate::models::Metadata {
     fn from(m: Metadata) -> Self {
         let Metadata {
             name,
@@ -64,7 +64,7 @@ impl From<Metadata> for crate::Metadata {
             license,
         } = m;
 
-        crate::Metadata {
+        crate::models::Metadata {
             name: name.into(),
             version: version.into(),
             short_description: short_description.map(Into::into).into(),
@@ -76,9 +76,9 @@ impl From<Metadata> for crate::Metadata {
     }
 }
 
-impl From<crate::Metadata> for Metadata {
-    fn from(m: crate::Metadata) -> Self {
-        let crate::Metadata {
+impl From<crate::models::Metadata> for Metadata {
+    fn from(m: crate::models::Metadata) -> Self {
+        let crate::models::Metadata {
             name,
             version,
             short_description,
@@ -108,9 +108,9 @@ pub struct ArgumentMetadata {
     default_value: ffi_safe::Option<ffi_safe::String>,
 }
 
-impl From<crate::ArgumentMetadata> for ArgumentMetadata {
-    fn from(meta: crate::ArgumentMetadata) -> Self {
-        let crate::ArgumentMetadata {
+impl From<crate::models::ArgumentMetadata> for ArgumentMetadata {
+    fn from(meta: crate::models::ArgumentMetadata) -> Self {
+        let crate::models::ArgumentMetadata {
             name,
             description,
             default_value,
@@ -124,7 +124,7 @@ impl From<crate::ArgumentMetadata> for ArgumentMetadata {
     }
 }
 
-impl From<ArgumentMetadata> for crate::ArgumentMetadata {
+impl From<ArgumentMetadata> for crate::models::ArgumentMetadata {
     fn from(meta: ArgumentMetadata) -> Self {
         let ArgumentMetadata {
             name,
@@ -132,7 +132,7 @@ impl From<ArgumentMetadata> for crate::ArgumentMetadata {
             default_value,
         } = meta;
 
-        crate::ArgumentMetadata {
+        crate::models::ArgumentMetadata {
             name: name.into(),
             description: description.map(Into::into).into(),
             default_value: default_value.map(Into::into).into(),

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -23,27 +23,14 @@ pub mod syntax;
 #[doc(hidden)]
 pub mod abi;
 mod angle;
-mod context;
 mod group;
-mod host;
-mod metadata;
-mod model;
+pub mod models;
 mod shape_2d;
 mod sweep;
 mod transform;
 
 pub use self::{
-    angle::*,
-    context::{
-        Context, ContextError, ContextExt, MissingArgument, ParseFailed,
-    },
-    group::Group,
-    host::{Host, HostExt},
-    metadata::{ArgumentMetadata, Metadata, ModelMetadata},
-    model::Model,
-    shape_2d::*,
-    sweep::Sweep,
-    transform::Transform,
+    angle::*, group::Group, shape_2d::*, sweep::Sweep, transform::Transform,
 };
 pub use fj_proc::*;
 #[cfg(feature = "serde")]

--- a/crates/fj/src/models/context.rs
+++ b/crates/fj/src/models/context.rs
@@ -4,8 +4,10 @@ use std::{
     str::FromStr,
 };
 
-/// Contextual information passed to a [`Model`][crate::Model] when it is being
-/// initialized.
+use crate::models::Error;
+
+/// Contextual information passed to a [`Model`][crate::models::Model] when it
+/// is being initialized.
 ///
 /// Check out the [`ContextExt`] trait for some helper methods.
 pub trait Context {
@@ -191,7 +193,7 @@ pub struct ParseFailed {
     /// The actual value.
     pub value: String,
     /// The error that occurred.
-    pub error: Box<dyn std::error::Error + Send + Sync>,
+    pub error: Error,
 }
 
 impl Display for ParseFailed {

--- a/crates/fj/src/models/host.rs
+++ b/crates/fj/src/models/host.rs
@@ -1,4 +1,4 @@
-use crate::Model;
+use crate::models::Model;
 
 /// An abstract interface to the Fornjot host.
 pub trait Host {

--- a/crates/fj/src/models/metadata.rs
+++ b/crates/fj/src/models/metadata.rs
@@ -115,7 +115,7 @@ impl Metadata {
     }
 }
 
-/// Metadata about a [`crate::Model`].
+/// Metadata about a [`crate::models::Model`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct ModelMetadata {
     /// A short, human-friendly name used to identify this model.

--- a/crates/fj/src/models/mod.rs
+++ b/crates/fj/src/models/mod.rs
@@ -1,0 +1,18 @@
+//! Interfaces used when defining models.
+
+mod context;
+mod host;
+mod metadata;
+mod model;
+
+pub use self::{
+    context::{
+        Context, ContextError, ContextExt, MissingArgument, ParseFailed,
+    },
+    host::{Host, HostExt},
+    metadata::{ArgumentMetadata, Metadata, ModelMetadata},
+    model::Model,
+};
+
+/// A generic error used when defining a model.
+pub type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/crates/fj/src/models/model.rs
+++ b/crates/fj/src/models/model.rs
@@ -1,12 +1,12 @@
-use crate::{Context, ModelMetadata, Shape};
+use crate::{
+    models::{Context, ModelMetadata, Error},
+    Shape,
+};
 
 /// A model.
 pub trait Model: Send + Sync {
     /// Calculate this model's concrete geometry.
-    fn shape(
-        &self,
-        ctx: &dyn Context,
-    ) -> Result<Shape, Box<dyn std::error::Error + Send + Sync>>;
+    fn shape(&self, ctx: &dyn Context) -> Result<Shape, Error>;
 
     /// Get metadata for the model.
     fn metadata(&self) -> ModelMetadata;


### PR DESCRIPTION
This is a follow-up to https://github.com/hannobraun/Fornjot/pull/885#issuecomment-1209235168 from @hannobraun. Originally I thought he meant to move the traits into a new crate (e.g. `fj-models`), but he was actually suggesting to move them out of the top-level namespace.