### PR TITLE
Add `Surface` to `Cycle`

### DIFF
--- a/crates/fj-kernel/src/algorithms/reverse.rs
+++ b/crates/fj-kernel/src/algorithms/reverse.rs
@@ -23,6 +23,8 @@ fn reverse_local_coordinates_in_cycle<'r>(
     cycles: impl IntoIterator<Item = &'r Cycle> + 'r,
 ) -> impl Iterator<Item = Cycle> + 'r {
     cycles.into_iter().map(|cycle| {
+        let surface = cycle.surface().reverse();
+
         let edges = cycle.edges().map(|edge| {
             let curve = {
                 let local = match edge.curve().kind() {
@@ -57,7 +59,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
             Edge::new(curve, *edge.vertices())
         });
 
-        Cycle::new().with_edges(edges)
+        Cycle::new(surface).with_edges(edges)
     })
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep.rs
+++ b/crates/fj-kernel/src/algorithms/sweep.rs
@@ -158,7 +158,7 @@ fn create_non_continuous_side_face(
             edges.push(edge);
         }
 
-        Cycle::new().with_edges(edges)
+        Cycle::new(surface).with_edges(edges)
     };
 
     let face = Face::new(surface).with_exteriors([cycle]).with_color(color);
@@ -174,7 +174,13 @@ fn create_continuous_side_face(
 ) {
     let translation = Transform::translation(path);
 
-    let cycle = Cycle::new().with_edges([edge]);
+    // This is definitely the wrong surface, but it shouldn't matter. Since this
+    // code will hopefully soon be gone anyway (this is the last piece of code
+    // that prevents us from removing triangle representation), it hopefully
+    // won't start to matter at some point either.
+    let placeholder = Surface::xy_plane();
+
+    let cycle = Cycle::new(placeholder).with_edges([edge]);
     let approx = CycleApprox::new(&cycle, tolerance);
 
     let mut quads = Vec::new();

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -43,7 +43,7 @@ impl TransformObject for Curve {
 
 impl TransformObject for Cycle {
     fn transform(self, transform: &Transform) -> Self {
-        Self::new()
+        Self::new(self.surface().transform(transform))
             .with_edges(self.into_edges().map(|edge| edge.transform(transform)))
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -40,6 +40,6 @@ impl CycleBuilder {
             );
         }
 
-        Cycle::new().with_edges(edges)
+        Cycle::new(self.surface).with_edges(edges)
     }
 }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -9,6 +9,7 @@ use super::{Edge, Surface};
 /// one.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
+    surface: Surface,
     edges: Vec<Edge>,
 }
 
@@ -20,14 +21,17 @@ impl Cycle {
 
     /// Create a new cycle
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(surface: Surface) -> Self {
         // Implementation note:
         // As I'm writing this, this constructor has no arguments. I expect it
         // to take a `Surface` at some point. Remove the `#[allow(...)]`
         // attribute then.
         // - @hannobraun
 
-        Self { edges: Vec::new() }
+        Self {
+            surface,
+            edges: Vec::new(),
+        }
     }
 
     /// Add edges to the cycle
@@ -36,6 +40,11 @@ impl Cycle {
     pub fn with_edges(mut self, edges: impl IntoIterator<Item = Edge>) -> Self {
         self.edges.extend(edges);
         self
+    }
+
+    /// Access the surface that this cycle is in
+    pub fn surface(&self) -> &Surface {
+        &self.surface
     }
 
     /// Access edges that make up the cycle

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -49,6 +49,10 @@ impl Face {
     /// Add exterior cycles to the face
     ///
     /// Consumes the face and returns the updated instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the added cycles are not defined in the face's surface.
     pub fn with_exteriors(
         mut self,
         exteriors: impl IntoIterator<Item = Cycle>,
@@ -69,6 +73,10 @@ impl Face {
     /// Add interior cycles to the face
     ///
     /// Consumes the face and returns the updated instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the added cycles are not defined in the face's surface.
     pub fn with_interiors(
         mut self,
         interiors: impl IntoIterator<Item = Cycle>,

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -53,8 +53,8 @@ impl Face {
         mut self,
         exteriors: impl IntoIterator<Item = Cycle>,
     ) -> Self {
-        for exterior in exteriors.into_iter() {
-            self.brep_mut().exteriors.push(exterior);
+        for cycle in exteriors.into_iter() {
+            self.brep_mut().exteriors.push(cycle);
         }
 
         self
@@ -67,8 +67,8 @@ impl Face {
         mut self,
         interiors: impl IntoIterator<Item = Cycle>,
     ) -> Self {
-        for interior in interiors.into_iter() {
-            self.brep_mut().interiors.push(interior);
+        for cycle in interiors.into_iter() {
+            self.brep_mut().interiors.push(cycle);
         }
 
         self

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -54,6 +54,12 @@ impl Face {
         exteriors: impl IntoIterator<Item = Cycle>,
     ) -> Self {
         for cycle in exteriors.into_iter() {
+            assert_eq!(
+                self.surface(),
+                cycle.surface(),
+                "Cycles that bound a face must be in face's surface"
+            );
+
             self.brep_mut().exteriors.push(cycle);
         }
 
@@ -68,6 +74,12 @@ impl Face {
         interiors: impl IntoIterator<Item = Cycle>,
     ) -> Self {
         for cycle in interiors.into_iter() {
+            assert_eq!(
+                self.surface(),
+                cycle.surface(),
+                "Cycles that bound a face must be in face's surface"
+            );
+
             self.brep_mut().interiors.push(cycle);
         }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -33,6 +33,13 @@ impl Face {
     }
 
     /// Construct an instance that uses triangle representation
+    ///
+    /// Triangle representation is obsolete, and only still present because
+    /// there is one last place in the kernel code that uses it. Don't add any
+    /// more of those places!
+    ///
+    /// See this issue for more context:
+    /// <https://github.com/hannobraun/Fornjot/issues/97>
     pub fn from_triangles(triangles: TriRep) -> Self {
         Self {
             representation: Representation::TriRep(triangles),

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -119,5 +119,5 @@ fn add_cycle(cycle: Cycle, reverse: bool) -> Cycle {
         edges.reverse();
     }
 
-    Cycle::new().with_edges(edges)
+    Cycle::new(*cycle.surface()).with_edges(edges)
 }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -26,7 +26,7 @@ impl Shape for fj::Sketch {
 
                 let edge = Edge::build()
                     .circle_from_radius(Scalar::from_f64(circle.radius()));
-                let cycle = Cycle::new().with_edges([edge]);
+                let cycle = Cycle::new(surface).with_edges([edge]);
 
                 Face::new(surface)
                     .with_exteriors([cycle])


### PR DESCRIPTION
Cycles are defined in surface coordinates, so it makes sense to have the surface they're defined in available. This also adds some small (but not yet complete) measure of robustness, as faces can now verify that the cycles added to them have the right surface.