### PR TITLE
add compile time to status message

### DIFF
--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     process::Command,
+    str,
     sync::mpsc,
     thread,
 };
@@ -92,12 +93,14 @@ impl Model {
 
         let command = command_root
             .arg("build")
-            .arg("-q")
             .args(["--manifest-path", &manifest_path]);
-        let exit_status = command.status()?;
+
+        let cargo_output = command.output()?;
+        let exit_status = cargo_output.status;
 
         if exit_status.success() {
-            status.update_status("Model compiled successfully!");
+            let seconds_taken = str::from_utf8(&cargo_output.stderr).unwrap().rsplit_once(' ').unwrap().1.trim();
+            status.update_status(format!("Model compiled successfully in {seconds_taken}!").as_str());
         } else {
             let output = match command.output() {
                 Ok(output) => {

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -99,8 +99,16 @@ impl Model {
         let exit_status = cargo_output.status;
 
         if exit_status.success() {
-            let seconds_taken = str::from_utf8(&cargo_output.stderr).unwrap().rsplit_once(' ').unwrap().1.trim();
-            status.update_status(format!("Model compiled successfully in {seconds_taken}!").as_str());
+            let seconds_taken = str::from_utf8(&cargo_output.stderr)
+                .unwrap()
+                .rsplit_once(' ')
+                .unwrap()
+                .1
+                .trim();
+            status.update_status(
+                format!("Model compiled successfully in {seconds_taken}!")
+                    .as_str(),
+            );
         } else {
             let output = match command.output() {
                 Ok(output) => {


### PR DESCRIPTION
Addresses issue #936 .

I've changed how the command is being run from using `...status()` to `...output()`, which allows us to capture stdout/stderr earlier than in the error state. Quick parse over stderr in the success case gets us the time it took to compile, which I've inserted into the status update string to indicate how long it took to compile.

edit by @hannobraun, to close the issue:
Close #936