### PR TITLE
Expand release automation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "map-macro",
  "octocrab",
  "tokio",
  "url",

--- a/tools/automator/Cargo.toml
+++ b/tools/automator/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.62"
 chrono = "0.4.22"
+map-macro = "0.2.4"
 octocrab = "0.17.0"
 url = "2.2.2"
 

--- a/tools/automator/src/announcement.rs
+++ b/tools/automator/src/announcement.rs
@@ -50,12 +50,18 @@ async fn generate_announcement(
     pull_requests: impl IntoIterator<Item = PullRequest>,
     file: &mut File,
 ) -> anyhow::Result<()> {
+    let mut pull_request_list = String::new();
     let mut pull_request_links = String::new();
 
     for pull_request in pull_requests {
         let PullRequest {
-            number, html_url, ..
+            number,
+            title,
+            html_url,
         } = pull_request;
+
+        let item = format!("- {title} ([#{number}])\n");
+        pull_request_list.push_str(&item);
 
         let link = format!("[#{number}]: {html_url}\n");
         pull_request_links.push_str(&link);
@@ -104,6 +110,12 @@ Improvements that are relevant to developers working on Fornjot itself.
 
 **TASK: Add internal improvements.**
 
+
+### Unsorted pull requests
+
+**TASK: Sort into the categories above; update/merge as appropriate.**
+
+{pull_request_list}
 
 ### Issue of the Week
 

--- a/tools/automator/src/announcement.rs
+++ b/tools/automator/src/announcement.rs
@@ -1,13 +1,14 @@
-use std::{fmt::Write, path::PathBuf};
+use std::{collections::HashSet, fmt::Write, path::PathBuf};
 
 use anyhow::Context;
 use chrono::{Date, Datelike, Utc};
+use map_macro::set;
 use tokio::{
     fs::{self, File},
     io::AsyncWriteExt,
 };
 
-use crate::pull_requests::PullRequest;
+use crate::pull_requests::{Author, PullRequest};
 
 pub async fn create_release_announcement(
     last_release_date: Date<Utc>,
@@ -52,17 +53,41 @@ async fn generate_announcement(
 ) -> anyhow::Result<()> {
     let mut pull_request_list = String::new();
     let mut pull_request_links = String::new();
+    let mut author_links = String::new();
+
+    let author_blacklist = set! {
+        "hannobraun",
+        "dependabot[bot]"
+    };
+    let mut authors = HashSet::new();
 
     for pull_request in pull_requests {
         let PullRequest {
-            number, title, url, ..
+            number,
+            title,
+            url,
+            author,
         } = pull_request;
+
+        let author = if authors.contains(&author.name)
+            || author_blacklist.contains(author.name.as_str())
+        {
+            None
+        } else {
+            authors.insert(author.name.clone());
+            Some(author)
+        };
 
         let item = format!("- {title} ([#{number}])\n");
         pull_request_list.push_str(&item);
 
         let link = format!("[#{number}]: {url}\n");
         pull_request_links.push_str(&link);
+
+        if let Some(Author { name, profile }) = author {
+            let author_link = format!("[@{name}]: {profile}\n");
+            author_links.push_str(&author_link);
+        }
     }
 
     let mut buf = String::new();
@@ -125,7 +150,8 @@ Improvements that are relevant to developers working on Fornjot itself.
 **TASK: Write.**
 
 
-{pull_request_links}\
+{pull_request_links}
+{author_links}\
     "
     )?;
 

--- a/tools/automator/src/announcement.rs
+++ b/tools/automator/src/announcement.rs
@@ -53,7 +53,9 @@ async fn generate_announcement(
     let mut pull_request_links = String::new();
 
     for pull_request in pull_requests {
-        let PullRequest { number, html_url } = pull_request;
+        let PullRequest {
+            number, html_url, ..
+        } = pull_request;
 
         let link = format!("[#{number}]: {html_url}\n");
         pull_request_links.push_str(&link);

--- a/tools/automator/src/announcement.rs
+++ b/tools/automator/src/announcement.rs
@@ -54,7 +54,9 @@ async fn generate_announcement(
     let mut pull_request_links = String::new();
 
     for pull_request in pull_requests {
-        let PullRequest { number, title, url } = pull_request;
+        let PullRequest {
+            number, title, url, ..
+        } = pull_request;
 
         let item = format!("- {title} ([#{number}])\n");
         pull_request_list.push_str(&item);

--- a/tools/automator/src/announcement.rs
+++ b/tools/automator/src/announcement.rs
@@ -52,9 +52,10 @@ async fn generate_announcement(
 ) -> anyhow::Result<()> {
     let mut pull_request_links = String::new();
 
-    for PullRequest { number, html_url } in pull_requests {
-        let link = format!("[#{number}]: {html_url}\n");
+    for pull_request in pull_requests {
+        let PullRequest { number, html_url } = pull_request;
 
+        let link = format!("[#{number}]: {html_url}\n");
         pull_request_links.push_str(&link);
     }
 

--- a/tools/automator/src/announcement.rs
+++ b/tools/automator/src/announcement.rs
@@ -54,16 +54,12 @@ async fn generate_announcement(
     let mut pull_request_links = String::new();
 
     for pull_request in pull_requests {
-        let PullRequest {
-            number,
-            title,
-            html_url,
-        } = pull_request;
+        let PullRequest { number, title, url } = pull_request;
 
         let item = format!("- {title} ([#{number}])\n");
         pull_request_list.push_str(&item);
 
-        let link = format!("[#{number}]: {html_url}\n");
+        let link = format!("[#{number}]: {url}\n");
         pull_request_links.push_str(&link);
     }
 

--- a/tools/automator/src/pull_requests.rs
+++ b/tools/automator/src/pull_requests.rs
@@ -18,6 +18,8 @@ impl PullRequest {
         let mut page = 1u32;
 
         'outer: loop {
+            const MAX_RESULTS_PER_PAGE: u8 = 100;
+
             println!("Fetching page {}...", page);
             let pull_request_page = octocrab::instance()
                 .pulls("hannobraun", "Fornjot")
@@ -25,7 +27,7 @@ impl PullRequest {
                 .state(State::Closed)
                 .sort(Sort::Updated)
                 .direction(Direction::Descending)
-                .per_page(100) // this is the maximum number of results per page
+                .per_page(MAX_RESULTS_PER_PAGE)
                 .page(page)
                 .send()
                 .await?;

--- a/tools/automator/src/pull_requests.rs
+++ b/tools/automator/src/pull_requests.rs
@@ -8,7 +8,7 @@ use url::Url;
 pub struct PullRequest {
     pub number: u64,
     pub title: String,
-    pub html_url: Url,
+    pub url: Url,
 }
 
 impl PullRequest {
@@ -54,16 +54,11 @@ impl PullRequest {
                         let title = pull_request.title.ok_or_else(|| {
                             anyhow!("Pull request is missing title")
                         })?;
-                        let html_url =
-                            pull_request.html_url.ok_or_else(|| {
-                                anyhow!("Pull request is missing URL")
-                            })?;
+                        let url = pull_request.html_url.ok_or_else(|| {
+                            anyhow!("Pull request is missing URL")
+                        })?;
 
-                        let pull_request = Self {
-                            number,
-                            title,
-                            html_url,
-                        };
+                        let pull_request = Self { number, title, url };
 
                         pull_requests.insert(pull_request.number, pull_request);
                     }

--- a/tools/automator/src/pull_requests.rs
+++ b/tools/automator/src/pull_requests.rs
@@ -25,6 +25,9 @@ impl PullRequest {
                 .pulls("hannobraun", "Fornjot")
                 .list()
                 .state(State::Closed)
+                // It would be *much* better to sort by the date the pull
+                // requests were merged, since "updated" could result in false
+                // positives. GitHub doesn't support that though.
                 .sort(Sort::Updated)
                 .direction(Direction::Descending)
                 .per_page(MAX_RESULTS_PER_PAGE)

--- a/tools/automator/src/pull_requests.rs
+++ b/tools/automator/src/pull_requests.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 pub struct PullRequest {
     pub number: u64,
+    pub title: String,
     pub html_url: Url,
 }
 
@@ -50,12 +51,19 @@ impl PullRequest {
                 if let Some(merged_at) = pull_request.merged_at {
                     if merged_at.date() >= last_release_date {
                         let number = pull_request.number;
+                        let title = pull_request.title.ok_or_else(|| {
+                            anyhow!("Pull request is missing title")
+                        })?;
                         let html_url =
                             pull_request.html_url.ok_or_else(|| {
                                 anyhow!("Pull request is missing URL")
                             })?;
 
-                        let pull_request = Self { number, html_url };
+                        let pull_request = Self {
+                            number,
+                            title,
+                            html_url,
+                        };
 
                         pull_requests.insert(pull_request.number, pull_request);
                     }


### PR DESCRIPTION
Expand the `automator` tool to add more useful information to the release announcement draft, reducing the amount of work required to write the pull request.

cc #104 