### PR TITLE
Clean up API of `VerticesOfEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -45,13 +45,13 @@ impl Intersect for (&Face, &Point<2>) {
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = edge.vertices().expect_vertices()[0];
+                        let vertex = edge.vertices().get_or_panic()[0];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = edge.vertices().expect_vertices()[1];
+                        let vertex = edge.vertices().get_or_panic()[1];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
@@ -236,7 +236,7 @@ mod tests {
             .edge_iter()
             .copied()
             .find(|edge| {
-                let [a, b] = edge.vertices().expect_vertices();
+                let [a, b] = edge.vertices().get_or_panic();
                 a.global().position() == Point::from([0., 0., 0.])
                     && b.global().position() == Point::from([2., 0., 0.])
             })

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -45,13 +45,13 @@ impl Intersect for (&Face, &Point<2>) {
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = edge.vertices().get_or_panic()[0];
+                        let vertex = *edge.vertices().get_or_panic()[0];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = edge.vertices().get_or_panic()[1];
+                        let vertex = *edge.vertices().get_or_panic()[1];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );

--- a/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
@@ -22,7 +22,7 @@ impl Intersect for (&HorizontalRayToTheRight<2>, &Edge) {
             }
         };
 
-        let points = edge.vertices().expect_vertices().map(|vertex| {
+        let points = edge.vertices().get_or_panic().map(|vertex| {
             let point = vertex.position();
             line.point_from_line_coords(point)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -215,7 +215,7 @@ mod tests {
             .edge_iter()
             .copied()
             .find(|edge| {
-                let [a, b] = edge.vertices().expect_vertices();
+                let [a, b] = edge.vertices().get_or_panic();
                 dbg!((a.global().position(), b.global().position()));
                 a.global().position() == Point::from([1., 0., 1.])
                     && b.global().position() == Point::from([1., 0., -1.])

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -62,11 +62,6 @@ impl fmt::Display for Edge {
 pub struct VerticesOfEdge(Option<[Vertex; 2]>);
 
 impl VerticesOfEdge {
-    /// Construct an instance of `VerticesOfEdge` from zero or two vertices
-    pub fn new(vertices: Option<[Vertex; 2]>) -> Self {
-        Self(vertices)
-    }
-
     /// Construct an instance of `VerticesOfEdge` from two vertices
     pub fn from_vertices(vertices: [Vertex; 2]) -> Self {
         Self(Some(vertices))
@@ -75,19 +70,6 @@ impl VerticesOfEdge {
     /// Construct an instance of `VerticesOfEdge` without vertices
     pub fn none() -> Self {
         Self(None)
-    }
-
-    /// Determine whether the other instance has the same vertices
-    ///
-    /// The order of vertices is ignored.
-    pub fn are_same(&self, other: &Self) -> bool {
-        if let Some([a, b]) = self.0 {
-            if let Some(other) = other.0 {
-                return [a, b] == other || [b, a] == other;
-            }
-        }
-
-        false
     }
 
     /// Access the vertices
@@ -140,21 +122,5 @@ impl VerticesOfEdge {
         F: FnMut(Vertex) -> T,
     {
         self.0.map(|vertices| vertices.map(f))
-    }
-
-    /// Convert each vertex using the provided fallible function
-    pub fn try_convert<F, T, E>(self, f: F) -> Result<Option<[T; 2]>, E>
-    where
-        F: FnMut(Vertex) -> Result<T, E>,
-    {
-        // Can be cleaned up using `try_map`, once that is stable:
-        // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
-        let vertices: Option<[Result<_, E>; 2]> = self.convert(f);
-        let vertices = match vertices {
-            Some([a, b]) => Some([a?, b?]),
-            None => None,
-        };
-
-        Ok(vertices)
     }
 }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -87,7 +87,7 @@ impl VerticesOfEdge {
     /// # Panics
     ///
     /// Panics, if the edge has no vertices.
-    pub fn expect_vertices(self) -> [Vertex; 2] {
+    pub fn get_or_panic(self) -> [Vertex; 2] {
         self.0.expect("Expected edge to have vertices")
     }
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -87,8 +87,8 @@ impl VerticesOfEdge {
     /// # Panics
     ///
     /// Panics, if the edge has no vertices.
-    pub fn get_or_panic(self) -> [Vertex; 2] {
-        self.0.expect("Expected edge to have vertices")
+    pub fn get_or_panic(&self) -> [&Vertex; 2] {
+        self.get().expect("Expected edge to have vertices")
     }
 
     /// Iterate over the vertices

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -4,7 +4,7 @@ use crate::builder::EdgeBuilder;
 
 use super::{Curve, Vertex};
 
-/// An edge of a shape
+/// An edge
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edge {
     curve: Curve,


### PR DESCRIPTION
Remove methods that are not used within the Fornjot code base and clean up the remaining API.