### PR TITLE
Add support for arcs to low-level circle approximation code

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -28,16 +28,10 @@ impl Approx for GlobalCurve {
     /// To support that, we will need additional information here, to define
     /// between which points the curve needs to be approximated.
     fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
-        let mut points = Vec::new();
-
         match self.kind() {
-            CurveKind::Circle(curve) => {
-                approx_circle(curve, tolerance, &mut points)
-            }
-            CurveKind::Line(_) => {}
+            CurveKind::Circle(curve) => approx_circle(curve, tolerance),
+            CurveKind::Line(_) => Vec::new(),
         }
-
-        points
     }
 }
 
@@ -48,8 +42,9 @@ impl Approx for GlobalCurve {
 pub fn approx_circle(
     circle: &Circle<3>,
     tolerance: Tolerance,
-    out: &mut Vec<Local<Point<1>>>,
-) {
+) -> Vec<Local<Point<1>>> {
+    let mut out = Vec::new();
+
     let radius = circle.a().magnitude();
 
     // To approximate the circle, we use a regular polygon for which
@@ -65,6 +60,8 @@ pub fn approx_circle(
         let point = circle.point_from_circle_coords([angle]);
         out.push(Local::new([angle], point));
     }
+
+    out
 }
 
 fn number_of_vertices_for_circle(tolerance: Tolerance, radius: Scalar) -> u64 {

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -43,7 +43,7 @@ pub fn approx_circle(
     circle: &Circle<3>,
     tolerance: Tolerance,
 ) -> Vec<Local<Point<1>>> {
-    let mut out = Vec::new();
+    let mut points = Vec::new();
 
     let radius = circle.a().magnitude();
 
@@ -58,10 +58,10 @@ pub fn approx_circle(
     for i in 0..n {
         let angle = Scalar::TAU / n as f64 * i as f64;
         let point = circle.point_from_circle_coords([angle]);
-        out.push(Local::new([angle], point));
+        points.push(Local::new([angle], point));
     }
 
-    out
+    points
 }
 
 fn number_of_vertices_for_circle(tolerance: Tolerance, radius: Scalar) -> u64 {


### PR DESCRIPTION
This doesn't mean arcs are supported yet (#100 remains unaddressed), but it paves the way for implementing support for arcs later. It also paves the way for some big cleanups that I'm currently working on. If this works out, this could result in some huge simplifications!