### PR TITLE
Simplify cycle/edge/curve approximation code

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -64,9 +64,10 @@ fn approx_circle(
     let n = number_of_vertices_for_circle(tolerance, radius, range.length());
 
     let mut points = Vec::new();
+    points.push(range.start());
 
-    for i in 0..n {
-        let angle = range.start().t
+    for i in 1..n {
+        let angle = range.start().0.t
             + (Scalar::TAU / n as f64 * i as f64) * range.direction();
 
         let point_curve = Point::from([angle]);
@@ -91,20 +92,20 @@ fn number_of_vertices_for_circle(
 }
 
 pub struct RangeOnCurve {
-    pub boundary: [Point<1>; 2],
+    pub boundary: [(Point<1>, Point<3>); 2],
 }
 
 impl RangeOnCurve {
-    fn start(&self) -> Point<1> {
+    fn start(&self) -> (Point<1>, Point<3>) {
         self.boundary[0]
     }
 
-    fn end(&self) -> Point<1> {
+    fn end(&self) -> (Point<1>, Point<3>) {
         self.boundary[1]
     }
 
     fn signed_length(&self) -> Scalar {
-        (self.end() - self.start()).t
+        (self.end().0 - self.start().0).t
     }
 
     fn length(&self) -> Scalar {

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -38,7 +38,7 @@ impl Approx for GlobalCurve {
     ) -> Self::Approximation {
         match self.kind() {
             CurveKind::Circle(curve) => approx_circle(curve, range, tolerance),
-            CurveKind::Line(_) => Vec::new(),
+            CurveKind::Line(_) => vec![range.start()],
         }
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -7,7 +7,7 @@ use crate::objects::{Curve, CurveKind, GlobalCurve};
 use super::{Approx, Tolerance};
 
 impl Approx for Curve {
-    type Approximation = Vec<(Point<1>, Point<3>)>;
+    type Approximation = Vec<(Point<2>, Point<3>)>;
     type Params = RangeOnCurve;
 
     fn approx(
@@ -15,7 +15,15 @@ impl Approx for Curve {
         tolerance: Tolerance,
         range: Self::Params,
     ) -> Self::Approximation {
-        self.global().approx(tolerance, range)
+        self.global()
+            .approx(tolerance, range)
+            .into_iter()
+            .map(|(point_curve, point_global)| {
+                let point_surface =
+                    self.kind().point_from_curve_coords(point_curve);
+                (point_surface, point_global)
+            })
+            .collect()
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -27,9 +27,9 @@ impl Approx for Cycle {
             }));
         }
 
-        // Can't just rely on `dedup`, as the conversion from curve coordinates
-        // could lead to subtly different surface coordinates.
-        points.dedup_by(|(_, a), (_, b)| a == b);
+        if let Some(&point) = points.first() {
+            points.push(point);
+        }
 
         CycleApprox { points }
     }

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -17,14 +17,7 @@ impl Approx for Cycle {
 
         for edge in self.edges() {
             let edge_points = edge.approx(tolerance, ());
-
-            points.extend(edge_points.into_iter().map(|point| {
-                let (point_curve, point_global) = point;
-
-                let point_surface =
-                    edge.curve().kind().point_from_curve_coords(point_curve);
-                (point_surface, point_global)
-            }));
+            points.extend(edge_points);
         }
 
         if let Some(&point) = points.first() {

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -14,8 +14,13 @@ impl Approx for Edge {
         (): Self::Params,
     ) -> Self::Approximation {
         // The range is only used for circles right now.
-        let range = RangeOnCurve {
-            boundary: [[Scalar::ZERO].into(), [Scalar::TAU].into()],
+        let range = {
+            let start_curve = Point::from([Scalar::ZERO]);
+            let end_curve = Point::from([Scalar::TAU]);
+
+            RangeOnCurve {
+                boundary: [start_curve, end_curve],
+            }
         };
 
         let mut points = self.curve().approx(tolerance, range);

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -18,8 +18,19 @@ impl Approx for Edge {
             let start_curve = Point::from([Scalar::ZERO]);
             let end_curve = Point::from([Scalar::TAU]);
 
+            // We're dealing with a circle here. Start and end are identical
+            // points, in global coordinates.
+            let point_global = self
+                .global()
+                .curve()
+                .kind()
+                .point_from_curve_coords(start_curve);
+
             RangeOnCurve {
-                boundary: [start_curve, end_curve],
+                boundary: [
+                    (start_curve, point_global),
+                    (end_curve, point_global),
+                ],
             }
         };
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -13,13 +13,12 @@ impl Approx for Edge {
         tolerance: super::Tolerance,
         (): Self::Params,
     ) -> Self::Approximation {
-        let mut points = self.curve().approx(
-            tolerance,
-            // The range is only used for circles right now.
-            RangeOnCurve {
-                boundary: [[Scalar::ZERO].into(), [Scalar::TAU].into()],
-            },
-        );
+        // The range is only used for circles right now.
+        let range = RangeOnCurve {
+            boundary: [[Scalar::ZERO].into(), [Scalar::TAU].into()],
+        };
+
+        let mut points = self.curve().approx(tolerance, range);
 
         // Insert the exact vertices of this edge into the approximation. This
         // means we don't rely on the curve approximation to deliver accurate

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -40,18 +40,8 @@ pub fn approx_edge(
     // vertices.
     let vertices = vertices
         .convert(|vertex| (vertex.position(), vertex.global().position()));
-    if let Some([a, b]) = vertices {
+    if let Some([a, _]) = vertices {
         points.insert(0, a);
-        points.push(b);
-    }
-
-    if vertices.is_none() {
-        // The edge has no vertices, which means it connects to itself. We need
-        // to reflect that in the approximation.
-
-        if let Some(&point) = points.first() {
-            points.push(point);
-        }
     }
 }
 
@@ -79,16 +69,15 @@ mod test {
         let a = (Point::from([0.0]), a);
         let b = (Point::from([0.25]), b);
         let c = (Point::from([0.75]), c);
-        let d = (Point::from([1.0]), d);
 
         // Regular edge
         let mut points = vec![b, c];
         super::approx_edge(vertices, &mut points);
-        assert_eq!(points, vec![a, b, c, d]);
+        assert_eq!(points, vec![a, b, c]);
 
         // Continuous edge
         let mut points = vec![b, c];
         super::approx_edge(VerticesOfEdge::none(), &mut points);
-        assert_eq!(points, vec![b, c, b]);
+        assert_eq!(points, vec![b, c]);
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -34,26 +34,6 @@ impl Approx for Edge {
             }
         };
 
-        let mut points = self.curve().approx(tolerance, range);
-
-        // Insert the exact vertices of this edge into the approximation. This
-        // means we don't rely on the curve approximation to deliver accurate
-        // representations of these vertices, which they might not be able to
-        // do.
-        //
-        // If we used inaccurate representations of those vertices here, then
-        // that would lead to bugs in the approximation, as points that should
-        // refer to the same vertex would be understood to refer to very close,
-        // but distinct vertices.
-        let vertices = self
-            .vertices()
-            .convert(|vertex| (vertex.position(), vertex.global().position()));
-        if let Some([(point_curve, point_global), _]) = vertices {
-            let point_surface =
-                self.curve().kind().point_from_curve_coords(point_curve);
-            points.insert(0, (point_surface, point_global));
-        }
-
-        points
+        self.curve().approx(tolerance, range)
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -5,7 +5,7 @@ use crate::objects::Edge;
 use super::{curve::RangeOnCurve, Approx};
 
 impl Approx for Edge {
-    type Approximation = Vec<(Point<1>, Point<3>)>;
+    type Approximation = Vec<(Point<2>, Point<3>)>;
     type Params = ();
 
     fn approx(
@@ -33,8 +33,10 @@ impl Approx for Edge {
         let vertices = self
             .vertices()
             .convert(|vertex| (vertex.position(), vertex.global().position()));
-        if let Some([a, _]) = vertices {
-            points.insert(0, a);
+        if let Some([(point_curve, point_global), _]) = vertices {
+            let point_surface =
+                self.curve().kind().point_from_curve_coords(point_curve);
+            points.insert(0, (point_surface, point_global));
         }
 
         points


### PR DESCRIPTION
Reshuffles responsibilities between cycle, edge, and curve approximation. Aligns the approximation code for the different curve types, greatly simplifying edge approximation.

The resulting code is a bit more elegant, leading to a reduction in lines of code and complexity. It also paves the way for simplifying edge representation by removing the "continuous edge" edge case (no pun intended).