### PR TITLE
Reference `Curve` in `Vertex`

### DIFF
--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -1,6 +1,6 @@
 use fj_math::{Circle, Line, Point, Vector};
 
-use crate::objects::{Curve, CurveKind, Cycle, Edge, Face};
+use crate::objects::{Curve, CurveKind, Cycle, Edge, Face, Vertex};
 
 use super::Reverse;
 
@@ -72,7 +72,11 @@ fn reverse_local_coordinates_in_cycle<'r>(
                 Curve::new(local, *edge.curve().global())
             };
 
-            Edge::from_curve_and_vertices(curve, *edge.vertices())
+            let vertices = edge.vertices().map(|vertex| {
+                Vertex::new(vertex.position(), curve, *vertex.global())
+            });
+
+            Edge::from_curve_and_vertices(curve, vertices)
         });
 
         Cycle::new(surface).with_edges(edges)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -89,8 +89,8 @@ fn create_non_continuous_side_face(
             };
 
             let vertices = VerticesOfEdge::from_vertices([
-                Vertex::new(Point::from([0.]), a.1),
-                Vertex::new(Point::from([1.]), b.1),
+                Vertex::new(Point::from([0.]), curve, a.1),
+                Vertex::new(Point::from([1.]), curve, b.1),
             ]);
 
             let edge = Edge::from_curve_and_vertices(curve, vertices);

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -138,7 +138,11 @@ impl TransformObject for Surface {
 
 impl TransformObject for Vertex {
     fn transform(self, transform: &Transform) -> Self {
-        Self::new(self.position(), self.global().transform(transform))
+        Self::new(
+            self.position(),
+            self.curve().transform(transform),
+            self.global().transform(transform),
+        )
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -57,8 +57,8 @@ impl EdgeBuilder {
         let vertices = {
             let [a, b] = global_vertices;
             let vertices = [
-                Vertex::new(Point::from([0.]), a),
-                Vertex::new(Point::from([1.]), b),
+                Vertex::new(Point::from([0.]), curve, a),
+                Vertex::new(Point::from([1.]), curve, b),
             ];
 
             VerticesOfEdge::from_vertices(vertices)

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -279,7 +279,10 @@ impl<'r> ObjectIters<'r> for Surface {
 
 impl<'r> ObjectIters<'r> for Vertex {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
-        vec![self.global() as &dyn ObjectIters]
+        vec![
+            self.curve() as &dyn ObjectIters,
+            self.global() as &dyn ObjectIters,
+        ]
     }
 
     fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
@@ -481,7 +484,7 @@ mod tests {
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(6, object.surface_iter().count());
-        assert_eq!(16, object.vertex_iter().count());
+        assert_eq!(40, object.vertex_iter().count());
     }
 
     #[test]
@@ -521,7 +524,7 @@ mod tests {
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(1, object.solid_iter().count());
         assert_eq!(6, object.surface_iter().count());
-        assert_eq!(16, object.vertex_iter().count());
+        assert_eq!(40, object.vertex_iter().count());
     }
 
     #[test]
@@ -543,14 +546,16 @@ mod tests {
 
     #[test]
     fn vertex() {
+        let surface = Surface::xy_plane();
+        let curve = Curve::build(surface).u_axis();
         let global_vertex = GlobalVertex::from_position([0., 0., 0.]);
-        let object = Vertex::new([0.], global_vertex);
+        let object = Vertex::new([0.], curve, global_vertex);
 
-        assert_eq!(0, object.curve_iter().count());
+        assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
         assert_eq!(0, object.edge_iter().count());
         assert_eq!(0, object.face_iter().count());
-        assert_eq!(0, object.global_curve_iter().count());
+        assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::builder::EdgeBuilder;
+use crate::{algorithms::reverse::Reverse, builder::EdgeBuilder};
 
 use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
 
@@ -198,8 +198,8 @@ impl VerticesOfEdge<Vertex> {
     pub fn reverse(self) -> Self {
         Self(self.0.map(|[a, b]| {
             [
-                Vertex::new(-b.position(), *b.global()),
-                Vertex::new(-a.position(), *a.global()),
+                Vertex::new(-b.position(), b.curve().reverse(), *b.global()),
+                Vertex::new(-a.position(), a.curve().reverse(), *a.global()),
             ]
         }))
     }

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -1,5 +1,7 @@
 use fj_math::Point;
 
+use super::Curve;
+
 /// A vertex
 ///
 /// `Vertex` is defined in terms of a 1-dimensional position on a curve. If you
@@ -16,19 +18,33 @@ use fj_math::Point;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     position: Point<1>,
+    curve: Curve,
     global: GlobalVertex,
 }
 
 impl Vertex {
     /// Construct an instance of `Vertex`
-    pub fn new(position: impl Into<Point<1>>, global: GlobalVertex) -> Self {
+    pub fn new(
+        position: impl Into<Point<1>>,
+        curve: Curve,
+        global: GlobalVertex,
+    ) -> Self {
         let position = position.into();
-        Self { position, global }
+        Self {
+            position,
+            curve,
+            global,
+        }
     }
 
     /// Access the position of the vertex on the curve
     pub fn position(&self) -> Point<1> {
         self.position
+    }
+
+    /// Access the curve that the vertex is defined on
+    pub fn curve(&self) -> &Curve {
+        &self.curve
     }
 
     /// Access the global form of this vertex

--- a/crates/fj-kernel/src/validation/mod.rs
+++ b/crates/fj-kernel/src/validation/mod.rs
@@ -154,8 +154,8 @@ mod tests {
 
         let deviation = Scalar::from_f64(0.25);
 
-        let a = Vertex::new(Point::from([Scalar::ZERO + deviation]), a);
-        let b = Vertex::new(Point::from([Scalar::ONE]), b);
+        let a = Vertex::new(Point::from([Scalar::ZERO + deviation]), curve, a);
+        let b = Vertex::new(Point::from([Scalar::ONE]), curve, b);
         let vertices = VerticesOfEdge::from_vertices([a, b]);
 
         let edge = Edge::from_curve_and_vertices(curve, vertices);


### PR DESCRIPTION
This fixes false positives when determining `Vertex` equality. Due to
the missing reference to `Curve`, it was possible for two `Vertex`
instances to be considered equal, if they shared a `GlobalVertex`, even
if they were defined on different `Curve`s.