### PR TITLE
Add `SurfaceVertex`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -15,7 +15,7 @@ impl Approx for Curve {
         tolerance: Tolerance,
         range: Self::Params,
     ) -> Self::Approximation {
-        self.global()
+        self.global_form()
             .approx(tolerance, range)
             .into_iter()
             .map(|(point_curve, point_global)| {

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -15,8 +15,9 @@ impl Approx for Edge {
     ) -> Self::Approximation {
         // The range is only used for circles right now.
         let boundary = match self.vertices().get() {
-            Some(vertices) => vertices
-                .map(|vertex| (vertex.position(), vertex.global().position())),
+            Some(vertices) => vertices.map(|vertex| {
+                (vertex.position(), vertex.global_form().position())
+            }),
             None => {
                 let start_curve = Point::from([Scalar::ZERO]);
                 let end_curve = Point::from([Scalar::TAU]);

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -25,7 +25,7 @@ impl Approx for Edge {
                 // We're dealing with a circle here. Start and end are identical
                 // points, in global coordinates.
                 let point_global = self
-                    .global()
+                    .global_form()
                     .curve()
                     .kind()
                     .point_from_curve_coords(start_curve);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -238,8 +238,8 @@ mod tests {
             .copied()
             .find(|edge| {
                 let [a, b] = edge.vertices().get_or_panic();
-                a.global().position() == Point::from([0., 0., 0.])
-                    && b.global().position() == Point::from([2., 0., 0.])
+                a.global_form().position() == Point::from([0., 0., 0.])
+                    && b.global_form().position() == Point::from([2., 0., 0.])
             })
             .unwrap();
         assert_eq!(
@@ -261,7 +261,7 @@ mod tests {
             .vertex_iter()
             .copied()
             .find(|vertex| {
-                vertex.global().position() == Point::from([1., 0., 0.])
+                vertex.global_form().position() == Point::from([1., 0., 0.])
             })
             .unwrap();
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -217,8 +217,8 @@ mod tests {
             .copied()
             .find(|edge| {
                 let [a, b] = edge.vertices().get_or_panic();
-                a.global().position() == Point::from([1., 0., 1.])
-                    && b.global().position() == Point::from([1., 0., -1.])
+                a.global_form().position() == Point::from([1., 0., 1.])
+                    && b.global_form().position() == Point::from([1., 0., -1.])
             })
             .unwrap();
         assert_eq!(
@@ -240,7 +240,7 @@ mod tests {
             .vertex_iter()
             .copied()
             .find(|vertex| {
-                vertex.global().position() == Point::from([1., 0., 0.])
+                vertex.global_form().position() == Point::from([1., 0., 0.])
             })
             .unwrap();
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/reverse/curve.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/curve.rs
@@ -20,7 +20,7 @@ impl Reverse for Curve {
         Curve::new(
             *self.surface(),
             self.kind().reverse(),
-            self.global().reverse(),
+            self.global_form().reverse(),
         )
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -1,6 +1,8 @@
 use fj_math::{Circle, Line, Point, Vector};
 
-use crate::objects::{Curve, CurveKind, Cycle, Edge, Face, Vertex};
+use crate::objects::{
+    Curve, CurveKind, Cycle, Edge, Face, SurfaceVertex, Vertex,
+};
 
 use super::Reverse;
 
@@ -77,7 +79,27 @@ fn reverse_local_coordinates_in_cycle<'r>(
             };
 
             let vertices = edge.vertices().map(|vertex| {
-                Vertex::new(vertex.position(), curve, *vertex.global_form())
+                let surface_vertex = {
+                    let vertex = vertex.surface_form();
+
+                    let position = Point::from([
+                        vertex.position().u,
+                        -vertex.position().v,
+                    ]);
+
+                    SurfaceVertex::new(
+                        position,
+                        vertex.surface().reverse(),
+                        *vertex.global_form(),
+                    )
+                };
+
+                Vertex::new(
+                    vertex.position(),
+                    curve,
+                    surface_vertex,
+                    *vertex.global_form(),
+                )
             });
 
             Edge::from_curve_and_vertices(curve, vertices)

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -72,7 +72,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
                 Curve::new(
                     edge.curve().surface().reverse(),
                     local,
-                    *edge.curve().global(),
+                    *edge.curve().global_form(),
                 )
             };
 

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -77,7 +77,7 @@ fn reverse_local_coordinates_in_cycle<'r>(
             };
 
             let vertices = edge.vertices().map(|vertex| {
-                Vertex::new(vertex.position(), curve, *vertex.global())
+                Vertex::new(vertex.position(), curve, *vertex.global_form())
             });
 
             Edge::from_curve_and_vertices(curve, vertices)

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -11,7 +11,7 @@ impl Sweep for Curve {
         tolerance: impl Into<crate::algorithms::approx::Tolerance>,
         color: fj_interop::mesh::Color,
     ) -> Self::Swept {
-        self.global().sweep(path, tolerance, color)
+        self.global_form().sweep(path, tolerance, color)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -72,7 +72,7 @@ fn create_non_continuous_side_face(
 
         let vertices = {
             let vertices = vertices.map(|vertex| {
-                Vertex::new(vertex.position(), curve, *vertex.global())
+                Vertex::new(vertex.position(), curve, *vertex.global_form())
             });
             VerticesOfEdge::from_vertices(vertices)
         };
@@ -90,7 +90,7 @@ fn create_non_continuous_side_face(
 
         let global_vertices = side_edges.map(|edge| {
             let [_, vertex] = edge.vertices().get_or_panic();
-            *vertex.global()
+            *vertex.global_form()
         });
 
         let curve = {
@@ -145,7 +145,7 @@ fn create_non_continuous_side_face(
             let [_, prev_last] = edges[i].vertices().get_or_panic();
             let [next_first, _] = edges[j].vertices().get_or_panic();
 
-            if prev_last.global() != next_first.global() {
+            if prev_last.global_form() != next_first.global_form() {
                 edges[j] = edges[j].reverse();
             }
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -57,13 +57,14 @@ fn create_non_continuous_side_face(
     let bottom_edge = {
         let vertices = edge.vertices().get_or_panic();
 
+        let points_curve_and_surface = vertices.map(|vertex| {
+            (vertex.position(), [vertex.position().t, Scalar::ZERO])
+        });
+
         let curve = {
             // Please note that creating a line here is correct, even if the
             // global curve is a circle. Projected into the side surface, it is
             // going to be a line either way.
-            let points_curve_and_surface = vertices.map(|vertex| {
-                (vertex.position(), [vertex.position().t, Scalar::ZERO])
-            });
             let kind = CurveKind::Line(Line::from_points_with_line_coords(
                 points_curve_and_surface,
             ));

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -102,11 +102,12 @@ fn create_non_continuous_side_face(
             // Please note that creating a line here is correct, even if the
             // global curve is a circle. Projected into the side surface, it is
             // going to be a line either way.
-            let points = bottom_vertices.map(|vertex| {
+            let points_curve_and_surface = bottom_vertices.map(|vertex| {
                 (vertex.position(), [vertex.position().t, Scalar::ONE])
             });
-            let kind =
-                CurveKind::Line(Line::from_points_with_line_coords(points));
+            let kind = CurveKind::Line(Line::from_points_with_line_coords(
+                points_curve_and_surface,
+            ));
 
             Curve::new(surface, kind, global)
         };

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -127,8 +127,8 @@ fn create_non_continuous_side_face(
             let [a_global, b_global] = global_vertices;
             let vertices = [(a_bottom, a_global), (b_bottom, b_global)];
 
-            vertices.map(|(bottom, global)| {
-                Vertex::new(bottom.position(), curve, global)
+            vertices.map(|(vertex, global)| {
+                Vertex::new(vertex.position(), curve, global)
             })
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -95,6 +95,10 @@ fn create_non_continuous_side_face(
             *vertex.global_form()
         });
 
+        let points_curve_and_surface = bottom_vertices.map(|vertex| {
+            (vertex.position(), [vertex.position().t, Scalar::ONE])
+        });
+
         let curve = {
             let global =
                 bottom_edge.curve().global_form().translate(path.inner());
@@ -102,9 +106,6 @@ fn create_non_continuous_side_face(
             // Please note that creating a line here is correct, even if the
             // global curve is a circle. Projected into the side surface, it is
             // going to be a line either way.
-            let points_curve_and_surface = bottom_vertices.map(|vertex| {
-                (vertex.position(), [vertex.position().t, Scalar::ONE])
-            });
             let kind = CurveKind::Line(Line::from_points_with_line_coords(
                 points_curve_and_surface,
             ));

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -77,7 +77,7 @@ fn create_non_continuous_side_face(
             VerticesOfEdge::from_vertices(vertices)
         };
 
-        Edge::new(curve, vertices, *edge.global())
+        Edge::new(curve, vertices, *edge.global_form())
     };
 
     let side_edges = bottom_edge

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -127,8 +127,8 @@ fn create_non_continuous_side_face(
             let [a_global, b_global] = global_vertices;
             let vertices = [(a_bottom, a_global), (b_bottom, b_global)];
 
-            vertices.map(|(vertex, global)| {
-                Vertex::new(vertex.position(), curve, global)
+            vertices.map(|(vertex, vertex_global)| {
+                Vertex::new(vertex.position(), curve, vertex_global)
             })
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -123,9 +123,9 @@ fn create_non_continuous_side_face(
         let vertices = {
             // Can be cleaned up, once `zip` is stable:
             // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-            let [a_bottom, b_bottom] = bottom_vertices;
+            let [a_vertex, b_vertex] = bottom_vertices;
             let [a_global, b_global] = global_vertices;
-            let vertices = [(a_bottom, a_global), (b_bottom, b_global)];
+            let vertices = [(a_vertex, a_global), (b_vertex, b_global)];
 
             vertices.map(|(vertex, vertex_global)| {
                 Vertex::new(vertex.position(), curve, vertex_global)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -61,11 +61,12 @@ fn create_non_continuous_side_face(
             // Please note that creating a line here is correct, even if the
             // global curve is a circle. Projected into the side surface, it is
             // going to be a line either way.
-            let points = vertices.map(|vertex| {
+            let points_curve_and_surface = vertices.map(|vertex| {
                 (vertex.position(), [vertex.position().t, Scalar::ZERO])
             });
-            let kind =
-                CurveKind::Line(Line::from_points_with_line_coords(points));
+            let kind = CurveKind::Line(Line::from_points_with_line_coords(
+                points_curve_and_surface,
+            ));
 
             Curve::new(surface, kind, *edge.curve().global_form())
         };

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -67,7 +67,7 @@ fn create_non_continuous_side_face(
             let kind =
                 CurveKind::Line(Line::from_points_with_line_coords(points));
 
-            Curve::new(surface, kind, *edge.curve().global())
+            Curve::new(surface, kind, *edge.curve().global_form())
         };
 
         let vertices = {
@@ -94,7 +94,8 @@ fn create_non_continuous_side_face(
         });
 
         let curve = {
-            let global = bottom_edge.curve().global().translate(path.inner());
+            let global =
+                bottom_edge.curve().global_form().translate(path.inner());
 
             // Please note that creating a line here is correct, even if the
             // global curve is a circle. Projected into the side surface, it is
@@ -110,7 +111,7 @@ fn create_non_continuous_side_face(
 
         let global = {
             GlobalEdge::new(
-                *curve.global(),
+                *curve.global_form(),
                 VerticesOfEdge::from_vertices(global_vertices),
             )
         };

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -68,7 +68,7 @@ impl Sweep for (Vertex, Surface) {
         // With that out of the way, let's start by creating the `GlobalEdge`,
         // as that is the most straight-forward part of this operations, and
         // we're going to need it soon anyway.
-        let edge_global = vertex.global().sweep(path, tolerance, color);
+        let edge_global = vertex.global_form().sweep(path, tolerance, color);
 
         // Next, let's compute the surface coordinates of the two vertices of
         // the output `Edge`, as we're going to need these for the rest of this

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -5,7 +5,7 @@ use crate::{
     algorithms::approx::Tolerance,
     objects::{
         Curve, CurveKind, Edge, GlobalCurve, GlobalEdge, GlobalVertex, Surface,
-        SweptCurve, Vertex, VerticesOfEdge,
+        SurfaceVertex, SweptCurve, Vertex, VerticesOfEdge,
     },
 };
 
@@ -105,10 +105,30 @@ impl Sweep for (Vertex, Surface) {
             // https://doc.rust-lang.org/std/primitive.array.html#method.zip
             let [a_surface, b_surface] = points_surface;
             let [a_global, b_global] = vertices_global;
+            let vertices_surface =
+                [(a_surface, a_global), (b_surface, b_global)].map(
+                    |(point_surface, &vertex_global)| {
+                        SurfaceVertex::new(
+                            point_surface,
+                            surface,
+                            vertex_global,
+                        )
+                    },
+                );
+
+            // Can be cleaned up, once `zip` is stable:
+            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
+            let [a_surface, b_surface] = vertices_surface;
+            let [a_global, b_global] = vertices_global;
             let vertices = [(a_surface, a_global), (b_surface, b_global)];
 
-            let vertices = vertices.map(|(point_surface, &vertex_global)| {
-                Vertex::new([point_surface.v], curve, vertex_global)
+            let vertices = vertices.map(|(vertex_surface, &vertex_global)| {
+                Vertex::new(
+                    [vertex_surface.position().v],
+                    curve,
+                    vertex_surface,
+                    vertex_global,
+                )
             });
 
             VerticesOfEdge::from_vertices(vertices)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -84,16 +84,12 @@ impl Sweep for (Vertex, Surface) {
         // thereby defined its coordinate system. That makes the v-coordinates
         // straight-forward: The start of the edge is at zero, the end is at
         // one.
-        let u = vertex.position().t;
-        let v_a = Scalar::ZERO;
-        let v_b = Scalar::ONE;
+        let a_surface = Point::from([vertex.position().t, Scalar::ZERO]);
+        let b_surface = Point::from([vertex.position().t, Scalar::ONE]);
 
         // Armed with those coordinates, creating the `Curve` of the output
         // `Edge` becomes straight-forward.
         let curve = {
-            let a_surface = Point::from([u, v_a]);
-            let b_surface = Point::from([u, v_b]);
-
             let line = Line::from_points([a_surface, b_surface]);
 
             Curve::new(surface, CurveKind::Line(line), *edge_global.curve())
@@ -103,8 +99,8 @@ impl Sweep for (Vertex, Surface) {
         let vertices = {
             let [&a_global, &b_global] = edge_global.vertices().get_or_panic();
 
-            let a = Vertex::new([v_a], curve, a_global);
-            let b = Vertex::new([v_b], curve, b_global);
+            let a = Vertex::new([a_surface.v], curve, a_global);
+            let b = Vertex::new([b_surface.v], curve, b_global);
 
             VerticesOfEdge::from_vertices([a, b])
         };

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -91,10 +91,10 @@ impl Sweep for (Vertex, Surface) {
         // Armed with those coordinates, creating the `Curve` of the output
         // `Edge` becomes straight-forward.
         let curve = {
-            let a = Point::from([u, v_a]);
-            let b = Point::from([u, v_b]);
+            let a_surface = Point::from([u, v_a]);
+            let b_surface = Point::from([u, v_b]);
 
-            let line = Line::from_points([a, b]);
+            let line = Line::from_points([a_surface, b_surface]);
 
             Curve::new(surface, CurveKind::Line(line), *edge_global.curve())
         };

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -61,7 +61,7 @@ impl Sweep for (Vertex, Surface) {
                 path: surface_path,
             }) = surface;
 
-            assert_eq!(vertex.curve().global().kind(), &surface_curve);
+            assert_eq!(vertex.curve().global_form().kind(), &surface_curve);
             assert_eq!(path.inner(), surface_path);
         }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -101,10 +101,10 @@ impl Sweep for (Vertex, Surface) {
 
         // And now the vertices. Again, nothing wild here.
         let vertices = {
-            let [&a, &b] = edge_global.vertices().get_or_panic();
+            let [&a_global, &b_global] = edge_global.vertices().get_or_panic();
 
-            let a = Vertex::new([v_a], curve, a);
-            let b = Vertex::new([v_b], curve, b);
+            let a = Vertex::new([v_a], curve, a_global);
+            let b = Vertex::new([v_b], curve, b_global);
 
             VerticesOfEdge::from_vertices([a, b])
         };

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -150,6 +150,7 @@ impl TransformObject for Vertex {
         Self::new(
             self.position(),
             self.curve().transform(transform),
+            self.surface_form().transform(transform),
             self.global_form().transform(transform),
         )
     }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -140,7 +140,7 @@ impl TransformObject for Vertex {
         Self::new(
             self.position(),
             self.curve().transform(transform),
-            self.global().transform(transform),
+            self.global_form().transform(transform),
         )
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -37,7 +37,7 @@ pub trait TransformObject: Sized {
 impl TransformObject for Curve {
     fn transform(self, transform: &Transform) -> Self {
         let surface = self.surface().transform(transform);
-        let global = self.global().transform(transform);
+        let global = self.global_form().transform(transform);
 
         // Don't need to transform `self.kind`, as that's in local form.
         Curve::new(surface, *self.kind(), global)

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -4,7 +4,7 @@ use fj_math::{Transform, Vector};
 
 use crate::objects::{
     Curve, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Shell, Sketch, Solid,
-    Surface, Vertex,
+    Surface, SurfaceVertex, Vertex,
 };
 
 /// Transform an object
@@ -132,6 +132,16 @@ impl TransformObject for Surface {
                 Self::SweptCurve(surface.transform(transform))
             }
         }
+    }
+}
+
+impl TransformObject for SurfaceVertex {
+    fn transform(self, transform: &Transform) -> Self {
+        Self::new(
+            self.position(),
+            self.surface().transform(transform),
+            self.global_form().transform(transform),
+        )
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/validate/coherence.rs
+++ b/crates/fj-kernel/src/algorithms/validate/coherence.rs
@@ -51,7 +51,7 @@ pub fn validate_vertex(
         .global()
         .kind()
         .point_from_curve_coords(local);
-    let global = vertex.global().position();
+    let global = vertex.global_form().position();
     let distance = (local_as_global - global).magnitude();
 
     if distance > max_distance {

--- a/crates/fj-kernel/src/algorithms/validate/coherence.rs
+++ b/crates/fj-kernel/src/algorithms/validate/coherence.rs
@@ -16,8 +16,10 @@ pub fn validate_curve(
         let point_surface = curve.kind().point_from_curve_coords(point_curve);
         let point_surface_as_global =
             curve.surface().point_from_surface_coords(point_surface);
-        let point_global =
-            curve.global().kind().point_from_curve_coords(point_curve);
+        let point_global = curve
+            .global_form()
+            .kind()
+            .point_from_curve_coords(point_curve);
 
         let distance = (point_surface_as_global - point_global).magnitude();
 
@@ -48,7 +50,7 @@ pub fn validate_vertex(
     let local = vertex.position();
     let local_as_global = vertex
         .curve()
-        .global()
+        .global_form()
         .kind()
         .point_from_curve_coords(local);
     let global = vertex.global_form().position();

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -161,8 +161,8 @@ mod tests {
     use crate::{
         algorithms::validate::{Validate, ValidationConfig, ValidationError},
         objects::{
-            Curve, CurveKind, Edge, GlobalCurve, GlobalVertex, Surface, Vertex,
-            VerticesOfEdge,
+            Curve, CurveKind, Edge, GlobalCurve, GlobalVertex, Surface,
+            SurfaceVertex, Vertex, VerticesOfEdge,
         },
     };
 
@@ -200,14 +200,27 @@ mod tests {
         let [a_global, b_global] =
             points_global.map(GlobalVertex::from_position);
 
+        let [a_surface, b_surface] = {
+            // Can be cleaned up, once `zip` is stable:
+            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
+            let [a_surface, b_surface] = points_surface;
+            [(a_surface, a_global), (b_surface, b_global)].map(
+                |(point_surface, vertex_global)| {
+                    SurfaceVertex::new(point_surface, surface, vertex_global)
+                },
+            )
+        };
+
         let deviation = Scalar::from_f64(0.25);
 
         let a = Vertex::new(
             Point::from([Scalar::ZERO + deviation]),
             curve,
+            a_surface,
             a_global,
         );
-        let b = Vertex::new(Point::from([Scalar::ONE]), curve, b_global);
+        let b =
+            Vertex::new(Point::from([Scalar::ONE]), curve, b_surface, b_global);
         let vertices = VerticesOfEdge::from_vertices([a, b]);
 
         let edge = Edge::from_curve_and_vertices(curve, vertices);

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -184,6 +184,8 @@ mod tests {
 
     #[test]
     fn coherence_edge() {
+        let surface = Surface::xy_plane();
+
         let points_surface = [[0., 0.], [1., 0.]];
         let points_global = [[0., 0., 0.], [1., 0., 0.]];
 
@@ -192,7 +194,7 @@ mod tests {
             let curve_global = GlobalCurve::from_kind(
                 CurveKind::line_from_points(points_global),
             );
-            Curve::new(Surface::xy_plane(), curve_local, curve_global)
+            Curve::new(surface, curve_local, curve_global)
         };
 
         let [a_global, b_global] =

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -184,18 +184,17 @@ mod tests {
 
     #[test]
     fn coherence_edge() {
-        let a = Point::from([0., 0., 0.]);
-        let b = Point::from([1., 0., 0.]);
+        let points_global = [[0., 0., 0.], [1., 0., 0.]];
 
         let curve = {
             let curve_local = CurveKind::line_from_points([[0., 0.], [1., 0.]]);
-            let curve_global =
-                GlobalCurve::from_kind(CurveKind::line_from_points([a, b]));
+            let curve_global = GlobalCurve::from_kind(
+                CurveKind::line_from_points(points_global),
+            );
             Curve::new(Surface::xy_plane(), curve_local, curve_global)
         };
 
-        let a = GlobalVertex::from_position(a);
-        let b = GlobalVertex::from_position(b);
+        let [a, b] = points_global.map(GlobalVertex::from_position);
 
         let deviation = Scalar::from_f64(0.25);
 

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -195,12 +195,17 @@ mod tests {
             Curve::new(Surface::xy_plane(), curve_local, curve_global)
         };
 
-        let [a, b] = points_global.map(GlobalVertex::from_position);
+        let [a_global, b_global] =
+            points_global.map(GlobalVertex::from_position);
 
         let deviation = Scalar::from_f64(0.25);
 
-        let a = Vertex::new(Point::from([Scalar::ZERO + deviation]), curve, a);
-        let b = Vertex::new(Point::from([Scalar::ONE]), curve, b);
+        let a = Vertex::new(
+            Point::from([Scalar::ZERO + deviation]),
+            curve,
+            a_global,
+        );
+        let b = Vertex::new(Point::from([Scalar::ONE]), curve, b_global);
         let vertices = VerticesOfEdge::from_vertices([a, b]);
 
         let edge = Edge::from_curve_and_vertices(curve, vertices);

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -184,10 +184,11 @@ mod tests {
 
     #[test]
     fn coherence_edge() {
+        let points_surface = [[0., 0.], [1., 0.]];
         let points_global = [[0., 0., 0.], [1., 0., 0.]];
 
         let curve = {
-            let curve_local = CurveKind::line_from_points([[0., 0.], [1., 0.]]);
+            let curve_local = CurveKind::line_from_points(points_surface);
             let curve_global = GlobalCurve::from_kind(
                 CurveKind::line_from_points(points_global),
             );

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -63,10 +63,10 @@ impl EdgeBuilder {
         };
 
         let vertices = {
-            let [a, b] = global_vertices;
+            let [a_global, b_global] = global_vertices;
             let vertices = [
-                Vertex::new(Point::from([0.]), curve, a),
-                Vertex::new(Point::from([1.]), curve, b),
+                Vertex::new(Point::from([0.]), curve, a_global),
+                Vertex::new(Point::from([1.]), curve, b_global),
             ];
 
             VerticesOfEdge::from_vertices(vertices)

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -350,7 +350,7 @@ impl<T> Iterator for Iter<T> {
 mod tests {
     use crate::objects::{
         Curve, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Shell, Sketch,
-        Solid, Surface, Vertex,
+        Solid, Surface, SurfaceVertex, Vertex,
     };
 
     use super::ObjectIters as _;
@@ -547,7 +547,9 @@ mod tests {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
         let global_vertex = GlobalVertex::from_position([0., 0., 0.]);
-        let object = Vertex::new([0.], curve, global_vertex);
+        let surface_vertex =
+            SurfaceVertex::new([0., 0.], surface, global_vertex);
+        let object = Vertex::new([0.], curve, surface_vertex, global_vertex);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -139,7 +139,7 @@ pub trait ObjectIters<'r> {
 
 impl<'r> ObjectIters<'r> for Curve {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
-        vec![self.global() as &dyn ObjectIters]
+        vec![self.global_form() as &dyn ObjectIters]
     }
 
     fn curve_iter(&'r self) -> Iter<&'r Curve> {

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -281,7 +281,7 @@ impl<'r> ObjectIters<'r> for Vertex {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         vec![
             self.curve() as &dyn ObjectIters,
-            self.global() as &dyn ObjectIters,
+            self.global_form() as &dyn ObjectIters,
         ]
     }
 

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -42,7 +42,7 @@ impl Curve {
     }
 
     /// Access the global form of this curve
-    pub fn global(&self) -> &GlobalCurve {
+    pub fn global_form(&self) -> &GlobalCurve {
         &self.global
     }
 }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -55,8 +55,8 @@ impl Cycle {
                 let [next, _] = b.vertices().get_or_panic();
 
                 assert_eq!(
-                    prev.global_form(),
-                    next.global_form(),
+                    prev.surface_form(),
+                    next.surface_form(),
                     "Edges in cycle do not connect"
                 );
             }
@@ -68,8 +68,8 @@ impl Cycle {
                     let [_, last] = last.vertices().get_or_panic();
 
                     assert_eq!(
-                        first.global_form(),
-                        last.global_form(),
+                        first.surface_form(),
+                        last.surface_form(),
                         "Edges do not form a cycle"
                     );
                 }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -55,8 +55,8 @@ impl Cycle {
                 let [next, _] = b.vertices().get_or_panic();
 
                 assert_eq!(
-                    prev.global(),
-                    next.global(),
+                    prev.global_form(),
+                    next.global_form(),
                     "Edges in cycle do not connect"
                 );
             }
@@ -68,8 +68,8 @@ impl Cycle {
                     let [_, last] = last.vertices().get_or_panic();
 
                     assert_eq!(
-                        first.global(),
-                        last.global(),
+                        first.global_form(),
+                        last.global_form(),
                         "Edges do not form a cycle"
                     );
                 }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -216,11 +216,13 @@ impl VerticesOfEdge<Vertex> {
                 Vertex::new(
                     -b.position(),
                     b.curve().reverse(),
+                    *b.surface_form(),
                     *b.global_form(),
                 ),
                 Vertex::new(
                     -a.position(),
                     a.curve().reverse(),
+                    *a.surface_form(),
                     *a.global_form(),
                 ),
             ]

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -212,14 +212,22 @@ impl VerticesOfEdge<Vertex> {
     pub fn reverse(self) -> Self {
         Self(self.0.map(|[a, b]| {
             [
-                Vertex::new(-b.position(), b.curve().reverse(), *b.global()),
-                Vertex::new(-a.position(), a.curve().reverse(), *a.global()),
+                Vertex::new(
+                    -b.position(),
+                    b.curve().reverse(),
+                    *b.global_form(),
+                ),
+                Vertex::new(
+                    -a.position(),
+                    a.curve().reverse(),
+                    *a.global_form(),
+                ),
             ]
         }))
     }
 
     /// Convert this instance into its global variant
     pub fn to_global(&self) -> VerticesOfEdge<GlobalVertex> {
-        VerticesOfEdge(self.convert(|vertex| *vertex.global()))
+        VerticesOfEdge(self.convert(|vertex| *vertex.global_form()))
     }
 }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -34,7 +34,7 @@ impl Edge {
         vertices: VerticesOfEdge<Vertex>,
         global: GlobalEdge,
     ) -> Self {
-        assert_eq!(curve.global(), global.curve());
+        assert_eq!(curve.global_form(), global.curve());
         assert_eq!(&vertices.to_global(), global.vertices());
 
         // Make sure that the edge vertices are not coincident on the curve. If
@@ -67,7 +67,8 @@ impl Edge {
         curve: Curve,
         vertices: VerticesOfEdge<Vertex>,
     ) -> Self {
-        let global = GlobalEdge::new(*curve.global(), vertices.to_global());
+        let global =
+            GlobalEdge::new(*curve.global_form(), vertices.to_global());
         Self::new(curve, vertices, global)
     }
 
@@ -105,7 +106,7 @@ impl fmt::Display for Edge {
             None => write!(f, "continuous edge")?,
         }
 
-        write!(f, " on {:?}", self.curve().global())?;
+        write!(f, " on {:?}", self.curve().global_form())?;
 
         Ok(())
     }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -91,7 +91,7 @@ impl Edge {
     }
 
     /// Access the global form of this edge
-    pub fn global(&self) -> &GlobalEdge {
+    pub fn global_form(&self) -> &GlobalEdge {
         &self.global
     }
 }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -23,5 +23,5 @@ pub use self::{
     sketch::Sketch,
     solid::Solid,
     surface::{Surface, SweptCurve},
-    vertex::{GlobalVertex, Vertex},
+    vertex::{GlobalVertex, SurfaceVertex, Vertex},
 };

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -19,7 +19,7 @@ use super::{Curve, Surface};
 pub struct Vertex {
     position: Point<1>,
     curve: Curve,
-    global: GlobalVertex,
+    global_form: GlobalVertex,
 }
 
 impl Vertex {
@@ -27,13 +27,13 @@ impl Vertex {
     pub fn new(
         position: impl Into<Point<1>>,
         curve: Curve,
-        global: GlobalVertex,
+        global_form: GlobalVertex,
     ) -> Self {
         let position = position.into();
         Self {
             position,
             curve,
-            global,
+            global_form,
         }
     }
 
@@ -49,7 +49,7 @@ impl Vertex {
 
     /// Access the global form of this vertex
     pub fn global_form(&self) -> &GlobalVertex {
-        &self.global
+        &self.global_form
     }
 }
 

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -19,6 +19,7 @@ use super::{Curve, Surface};
 pub struct Vertex {
     position: Point<1>,
     curve: Curve,
+    surface_form: SurfaceVertex,
     global_form: GlobalVertex,
 }
 
@@ -27,12 +28,14 @@ impl Vertex {
     pub fn new(
         position: impl Into<Point<1>>,
         curve: Curve,
+        surface_form: SurfaceVertex,
         global_form: GlobalVertex,
     ) -> Self {
         let position = position.into();
         Self {
             position,
             curve,
+            surface_form,
             global_form,
         }
     }
@@ -45,6 +48,11 @@ impl Vertex {
     /// Access the curve that the vertex is defined on
     pub fn curve(&self) -> &Curve {
         &self.curve
+    }
+
+    /// Access the surface form of this vertex
+    pub fn surface_form(&self) -> &SurfaceVertex {
+        &self.surface_form
     }
 
     /// Access the global form of this vertex

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -5,8 +5,8 @@ use super::Curve;
 /// A vertex
 ///
 /// `Vertex` is defined in terms of a 1-dimensional position on a curve. If you
-/// need the 3D position of a vertex, you can use [`Vertex::global`], to get
-/// access of the global form of a vertex ([`GlobalVertex`]).
+/// need the 3D position of a vertex, you can use [`Vertex::global_form`], to
+/// get access of the global form of a vertex ([`GlobalVertex`]).
 ///
 /// # Implementation Note
 ///
@@ -48,7 +48,7 @@ impl Vertex {
     }
 
     /// Access the global form of this vertex
-    pub fn global(&self) -> &GlobalVertex {
+    pub fn global_form(&self) -> &GlobalVertex {
         &self.global
     }
 }

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -1,6 +1,6 @@
 use fj_math::Point;
 
-use super::Curve;
+use super::{Curve, Surface};
 
 /// A vertex
 ///
@@ -50,6 +50,45 @@ impl Vertex {
     /// Access the global form of this vertex
     pub fn global_form(&self) -> &GlobalVertex {
         &self.global
+    }
+}
+
+/// A vertex, defined in surface (2D) coordinates
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct SurfaceVertex {
+    position: Point<2>,
+    surface: Surface,
+    global_form: GlobalVertex,
+}
+
+impl SurfaceVertex {
+    /// Construct a new instance of `SurfaceVertex`
+    pub fn new(
+        position: impl Into<Point<2>>,
+        surface: Surface,
+        global_form: GlobalVertex,
+    ) -> Self {
+        let position = position.into();
+        Self {
+            position,
+            surface,
+            global_form,
+        }
+    }
+
+    /// Access the position of the vertex on the surface
+    pub fn position(&self) -> Point<2> {
+        self.position
+    }
+
+    /// Access the surface that the vertex is defined on
+    pub fn surface(&self) -> &Surface {
+        &self.surface
+    }
+
+    /// Access the global form of this vertex
+    pub fn global_form(&self) -> &GlobalVertex {
+        &self.global_form
     }
 }
 


### PR DESCRIPTION
Add a new form of vertices, `SurfaceVertex`, which is defined in 2D surface coordinates. Citing from one of the commit messages:

> Some code needs to deal with vertices in surface coordinates.
Approximation is a current example of that, but there will be more in
the future.
>
> Calculating these surface coordinates is a bit of an error-prone
process, for the same reason that calculating global coordinates is an
error-prone process: Surface coordinates that are supposed to be the
same can be slightly different, due to floating-point accuracy.
>
> By having a `SurfaceVertex`, we're forcing code that creates vertices to
calculate those surface coordinates once, and then they are available to
all other code that deals with these vertices. This once-at-creation
calculation can then benefit from all the protections that are available
for the construction of objects (right now, this is the validation
infrastructure, but more can be done in the future).

The trade-off is complexity, but I think the added reliability (which isn't realized, since `SurfaceVertex` isn't included in validation yet) is worth it. Another way to view this change is that it doesn't add complexity, but just makes the inherent complexity explicit.

It would be a bit of a pay-off to update the curve approximation code to not re-compute the surface coordinates. But that would require some more changes there, and I felt that this pull request is already big enough.