### PR TITLE
Clean up and document approximation code

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -6,21 +6,24 @@ use crate::objects::{Curve, CurveKind, GlobalCurve, Vertex};
 
 use super::{Approx, Tolerance};
 
-impl Approx for Curve {
+impl Approx for (Curve, RangeOnCurve) {
     type Approximation = Vec<(Point<2>, Point<3>)>;
-    type Params = RangeOnCurve;
+    type Params = ();
 
     fn approx(
         &self,
         tolerance: Tolerance,
-        range: Self::Params,
+        _: Self::Params,
     ) -> Self::Approximation {
-        self.global_form()
+        let &(curve, range) = self;
+
+        curve
+            .global_form()
             .approx(tolerance, range)
             .into_iter()
             .map(|(point_curve, point_global)| {
                 let point_surface =
-                    self.kind().point_from_curve_coords(point_curve);
+                    curve.kind().point_from_curve_coords(point_curve);
                 (point_surface, point_global)
             })
             .collect()

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -97,6 +97,7 @@ fn number_of_vertices_for_circle(
     max(n, 3)
 }
 
+#[derive(Clone, Copy)]
 pub struct RangeOnCurve {
     pub boundary: [Vertex; 2],
 }

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -37,15 +37,16 @@ impl Approx for GlobalCurve {
         range: Self::Params,
     ) -> Self::Approximation {
         let mut points = Vec::new();
+        points.push((
+            range.start().position(),
+            range.start().global_form().position(),
+        ));
 
         match self.kind() {
             CurveKind::Circle(curve) => {
                 approx_circle(curve, range, tolerance, &mut points);
             }
-            CurveKind::Line(_) => points.push((
-                range.start().position(),
-                range.start().global_form().position(),
-            )),
+            CurveKind::Line(_) => {}
         }
 
         points
@@ -72,11 +73,6 @@ fn approx_circle(
     // the circumscribed circle and the incircle.
 
     let n = number_of_vertices_for_circle(tolerance, radius, range.length());
-
-    points.push((
-        range.start().position(),
-        range.start().global_form().position(),
-    ));
 
     for i in 1..n {
         let angle = range.start().position().t

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -8,17 +8,12 @@ use super::{Approx, Tolerance};
 
 impl Approx for (Curve, RangeOnCurve) {
     type Approximation = Vec<(Point<2>, Point<3>)>;
-    type Params = ();
 
-    fn approx(
-        &self,
-        tolerance: Tolerance,
-        _: Self::Params,
-    ) -> Self::Approximation {
+    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
         let &(curve, range) = self;
 
         (*curve.global_form(), range)
-            .approx(tolerance, ())
+            .approx(tolerance)
             .into_iter()
             .map(|(point_curve, point_global)| {
                 let point_surface =
@@ -31,13 +26,8 @@ impl Approx for (Curve, RangeOnCurve) {
 
 impl Approx for (GlobalCurve, RangeOnCurve) {
     type Approximation = Vec<(Point<1>, Point<3>)>;
-    type Params = ();
 
-    fn approx(
-        &self,
-        tolerance: Tolerance,
-        _: Self::Params,
-    ) -> Self::Approximation {
+    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
         let &(curve, range) = self;
 
         let mut points = Vec::new();

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -6,13 +6,13 @@ use crate::objects::{Curve, CurveKind, GlobalCurve, Vertex};
 
 use super::{Approx, Tolerance};
 
-impl Approx for (Curve, RangeOnCurve) {
+impl Approx for (&Curve, RangeOnCurve) {
     type Approximation = Vec<(Point<2>, Point<3>)>;
 
-    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
-        let &(curve, range) = self;
+    fn approx(self, tolerance: Tolerance) -> Self::Approximation {
+        let (curve, range) = self;
 
-        (*curve.global_form(), range)
+        (curve.global_form(), range)
             .approx(tolerance)
             .into_iter()
             .map(|(point_curve, point_global)| {
@@ -24,11 +24,11 @@ impl Approx for (Curve, RangeOnCurve) {
     }
 }
 
-impl Approx for (GlobalCurve, RangeOnCurve) {
+impl Approx for (&GlobalCurve, RangeOnCurve) {
     type Approximation = Vec<(Point<1>, Point<3>)>;
 
-    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
-        let &(curve, range) = self;
+    fn approx(self, tolerance: Tolerance) -> Self::Approximation {
+        let (curve, range) = self;
 
         let mut points = Vec::new();
 

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -37,10 +37,6 @@ impl Approx for GlobalCurve {
         range: Self::Params,
     ) -> Self::Approximation {
         let mut points = Vec::new();
-        points.push((
-            range.start().position(),
-            range.start().global_form().position(),
-        ));
 
         match self.kind() {
             CurveKind::Circle(curve) => {

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -36,13 +36,19 @@ impl Approx for GlobalCurve {
         tolerance: Tolerance,
         range: Self::Params,
     ) -> Self::Approximation {
+        let mut points = Vec::new();
+
         match self.kind() {
-            CurveKind::Circle(curve) => approx_circle(curve, range, tolerance),
-            CurveKind::Line(_) => vec![(
+            CurveKind::Circle(curve) => {
+                approx_circle(curve, range, tolerance, &mut points);
+            }
+            CurveKind::Line(_) => points.push((
                 range.start().position(),
                 range.start().global_form().position(),
-            )],
+            )),
         }
+
+        points
     }
 }
 
@@ -54,7 +60,8 @@ fn approx_circle(
     circle: &Circle<3>,
     range: impl Into<RangeOnCurve>,
     tolerance: Tolerance,
-) -> Vec<(Point<1>, Point<3>)> {
+    points: &mut Vec<(Point<1>, Point<3>)>,
+) {
     let radius = circle.a().magnitude();
     let range = range.into();
 
@@ -66,7 +73,6 @@ fn approx_circle(
 
     let n = number_of_vertices_for_circle(tolerance, radius, range.length());
 
-    let mut points = Vec::new();
     points.push((
         range.start().position(),
         range.start().global_form().position(),
@@ -81,8 +87,6 @@ fn approx_circle(
 
         points.push((point_curve, point_global));
     }
-
-    points
 }
 
 fn number_of_vertices_for_circle(

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -102,23 +102,23 @@ pub struct RangeOnCurve {
 }
 
 impl RangeOnCurve {
-    fn start(&self) -> Vertex {
+    pub fn start(&self) -> Vertex {
         self.boundary[0]
     }
 
-    fn end(&self) -> Vertex {
+    pub fn end(&self) -> Vertex {
         self.boundary[1]
     }
 
-    fn signed_length(&self) -> Scalar {
+    pub fn signed_length(&self) -> Scalar {
         (self.end().position() - self.start().position()).t
     }
 
-    fn length(&self) -> Scalar {
+    pub fn length(&self) -> Scalar {
         self.signed_length().abs()
     }
 
-    fn direction(&self) -> Scalar {
+    pub fn direction(&self) -> Scalar {
         self.signed_length().sign()
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 
 use fj_math::{Circle, Point, Scalar};
 
-use crate::objects::{Curve, CurveKind, GlobalCurve};
+use crate::objects::{Curve, CurveKind, GlobalCurve, Vertex};
 
 use super::{Approx, Tolerance};
 
@@ -38,7 +38,10 @@ impl Approx for GlobalCurve {
     ) -> Self::Approximation {
         match self.kind() {
             CurveKind::Circle(curve) => approx_circle(curve, range, tolerance),
-            CurveKind::Line(_) => vec![range.start()],
+            CurveKind::Line(_) => vec![(
+                range.start().position(),
+                range.start().global_form().position(),
+            )],
         }
     }
 }
@@ -64,10 +67,13 @@ fn approx_circle(
     let n = number_of_vertices_for_circle(tolerance, radius, range.length());
 
     let mut points = Vec::new();
-    points.push(range.start());
+    points.push((
+        range.start().position(),
+        range.start().global_form().position(),
+    ));
 
     for i in 1..n {
-        let angle = range.start().0.t
+        let angle = range.start().position().t
             + (Scalar::TAU / n as f64 * i as f64) * range.direction();
 
         let point_curve = Point::from([angle]);
@@ -92,20 +98,20 @@ fn number_of_vertices_for_circle(
 }
 
 pub struct RangeOnCurve {
-    pub boundary: [(Point<1>, Point<3>); 2],
+    pub boundary: [Vertex; 2],
 }
 
 impl RangeOnCurve {
-    fn start(&self) -> (Point<1>, Point<3>) {
+    fn start(&self) -> Vertex {
         self.boundary[0]
     }
 
-    fn end(&self) -> (Point<1>, Point<3>) {
+    fn end(&self) -> Vertex {
         self.boundary[1]
     }
 
     fn signed_length(&self) -> Scalar {
-        (self.end().0 - self.start().0).t
+        (self.end().position() - self.start().position()).t
     }
 
     fn length(&self) -> Scalar {

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -1,3 +1,14 @@
+//! Curve approximation
+//!
+//! Since curves are infinite (even circles have an infinite coordinate space,
+//! even though they connect to themselves in global coordinates), a range must
+//! be provided to approximate them. The approximation then returns points
+//! within that range.
+//!
+//! The boundaries of the range are not included in the approximation. This is
+//! done, to give the caller (who knows the boundary anyway) more options on how
+//! to further process the approximation.
+
 use std::cmp::max;
 
 use fj_math::{Circle, Point, Scalar};
@@ -87,28 +98,40 @@ fn number_of_vertices_for_circle(
     max(n, 3)
 }
 
+/// The range on which a curve should be approximated
 #[derive(Clone, Copy)]
 pub struct RangeOnCurve {
+    /// The boundary of the range
+    ///
+    /// The vertices that make up the boundary are themselves not included in
+    /// the approximation.
     pub boundary: [Vertex; 2],
 }
 
 impl RangeOnCurve {
+    /// Access the start of the range
     pub fn start(&self) -> Vertex {
         self.boundary[0]
     }
 
+    /// Access the end of the range
     pub fn end(&self) -> Vertex {
         self.boundary[1]
     }
 
+    /// Compute the signed length of the range
     pub fn signed_length(&self) -> Scalar {
         (self.end().position() - self.start().position()).t
     }
 
+    /// Compute the absolute length of the range
     pub fn length(&self) -> Scalar {
         self.signed_length().abs()
     }
 
+    /// Compute the direction of the range
+    ///
+    /// Returns a [`Scalar`] that is zero or +/- one.
     pub fn direction(&self) -> Scalar {
         self.signed_length().sign()
     }

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -17,9 +17,8 @@ impl Approx for (Curve, RangeOnCurve) {
     ) -> Self::Approximation {
         let &(curve, range) = self;
 
-        curve
-            .global_form()
-            .approx(tolerance, range)
+        (*curve.global_form(), range)
+            .approx(tolerance, ())
             .into_iter()
             .map(|(point_curve, point_global)| {
                 let point_surface =
@@ -30,18 +29,20 @@ impl Approx for (Curve, RangeOnCurve) {
     }
 }
 
-impl Approx for GlobalCurve {
+impl Approx for (GlobalCurve, RangeOnCurve) {
     type Approximation = Vec<(Point<1>, Point<3>)>;
-    type Params = RangeOnCurve;
+    type Params = ();
 
     fn approx(
         &self,
         tolerance: Tolerance,
-        range: Self::Params,
+        _: Self::Params,
     ) -> Self::Approximation {
+        let &(curve, range) = self;
+
         let mut points = Vec::new();
 
-        match self.kind() {
+        match curve.kind() {
             CurveKind::Circle(curve) => {
                 approx_circle(curve, range, tolerance, &mut points);
             }

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -1,3 +1,7 @@
+//! Cycle approximation
+//!
+//! See [`CycleApprox`].
+
 use fj_math::{Point, Segment};
 
 use crate::objects::Cycle;

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -4,10 +4,10 @@ use crate::objects::Cycle;
 
 use super::{Approx, Tolerance};
 
-impl Approx for Cycle {
+impl Approx for &Cycle {
     type Approximation = CycleApprox;
 
-    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
+    fn approx(self, tolerance: Tolerance) -> Self::Approximation {
         let mut points = Vec::new();
 
         for edge in self.edges() {

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -6,17 +6,12 @@ use super::{Approx, Tolerance};
 
 impl Approx for Cycle {
     type Approximation = CycleApprox;
-    type Params = ();
 
-    fn approx(
-        &self,
-        tolerance: Tolerance,
-        (): Self::Params,
-    ) -> Self::Approximation {
+    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
         let mut points = Vec::new();
 
         for edge in self.edges() {
-            let edge_points = edge.approx(tolerance, ());
+            let edge_points = edge.approx(tolerance);
             points.extend(edge_points);
         }
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -1,3 +1,10 @@
+//! Edge approximation
+//!
+//! The approximation of a curve is its first vertex, combined with the
+//! approximation of its curve. The second vertex is left off, as edge
+//! approximations are usually used to build cycle approximations, and this way,
+//! the caller doesn't have to call with duplicate vertices.
+
 use fj_math::{Point, Scalar};
 
 use crate::objects::{Edge, GlobalVertex, SurfaceVertex, Vertex};

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -69,6 +69,15 @@ impl Approx for Edge {
 
         let range = RangeOnCurve { boundary };
 
-        self.curve().approx(tolerance, range)
+        let mut points = self.curve().approx(tolerance, range);
+        points.insert(
+            0,
+            (
+                range.start().surface_form().position(),
+                range.start().global_form().position(),
+            ),
+        );
+
+        points
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -4,10 +4,10 @@ use crate::objects::{Edge, GlobalVertex, SurfaceVertex, Vertex};
 
 use super::{curve::RangeOnCurve, Approx};
 
-impl Approx for Edge {
+impl Approx for &Edge {
     type Approximation = Vec<(Point<2>, Point<3>)>;
 
-    fn approx(&self, tolerance: super::Tolerance) -> Self::Approximation {
+    fn approx(self, tolerance: super::Tolerance) -> Self::Approximation {
         // The range is only used for circles right now.
         let boundary = match self.vertices().get() {
             Some(vertices) => vertices.map(|&vertex| vertex),
@@ -64,7 +64,7 @@ impl Approx for Edge {
 
         let range = RangeOnCurve { boundary };
 
-        let mut points = (*self.curve(), range).approx(tolerance);
+        let mut points = (self.curve(), range).approx(tolerance);
         points.insert(
             0,
             (

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -69,7 +69,7 @@ impl Approx for Edge {
 
         let range = RangeOnCurve { boundary };
 
-        let mut points = self.curve().approx(tolerance, range);
+        let mut points = (*self.curve(), range).approx(tolerance, ());
         points.insert(
             0,
             (

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -6,13 +6,8 @@ use super::{curve::RangeOnCurve, Approx};
 
 impl Approx for Edge {
     type Approximation = Vec<(Point<2>, Point<3>)>;
-    type Params = ();
 
-    fn approx(
-        &self,
-        tolerance: super::Tolerance,
-        (): Self::Params,
-    ) -> Self::Approximation {
+    fn approx(&self, tolerance: super::Tolerance) -> Self::Approximation {
         // The range is only used for circles right now.
         let boundary = match self.vertices().get() {
             Some(vertices) => vertices.map(|&vertex| vertex),
@@ -69,7 +64,7 @@ impl Approx for Edge {
 
         let range = RangeOnCurve { boundary };
 
-        let mut points = (*self.curve(), range).approx(tolerance, ());
+        let mut points = (*self.curve(), range).approx(tolerance);
         points.insert(
             0,
             (

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -1,3 +1,7 @@
+//! Face approximation
+//!
+//! See [`FaceApprox`].
+
 use std::collections::HashSet;
 
 use fj_math::Point;

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -8,13 +8,8 @@ use super::{Approx, CycleApprox, Tolerance};
 
 impl Approx for Face {
     type Approximation = FaceApprox;
-    type Params = ();
 
-    fn approx(
-        &self,
-        tolerance: Tolerance,
-        (): Self::Params,
-    ) -> Self::Approximation {
+    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
         // Curved faces whose curvature is not fully defined by their edges
         // are not supported yet. For that reason, we can fully ignore `face`'s
         // `surface` field and just pass the edges to `Self::for_edges`.
@@ -33,13 +28,13 @@ impl Approx for Face {
         let mut interiors = HashSet::new();
 
         for cycle in self.exteriors() {
-            let cycle = cycle.approx(tolerance, ());
+            let cycle = cycle.approx(tolerance);
 
             points.extend(cycle.points.iter().copied());
             exteriors.push(cycle);
         }
         for cycle in self.interiors() {
-            let cycle = cycle.approx(tolerance, ());
+            let cycle = cycle.approx(tolerance);
 
             points.extend(cycle.points.iter().copied());
             interiors.insert(cycle);
@@ -123,7 +118,7 @@ mod tests {
         let g = (g, g.to_xyz());
         let h = (h, h.to_xyz());
 
-        let approx = face.approx(tolerance, ());
+        let approx = face.approx(tolerance);
         let expected = FaceApprox {
             points: set![a, b, c, d, e, f, g, h],
             exterior: CycleApprox {

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -8,7 +8,7 @@ use fj_math::Point;
 
 use crate::objects::Face;
 
-use super::{Approx, CycleApprox, Tolerance};
+use super::{cycle::CycleApprox, Approx, Tolerance};
 
 impl Approx for &Face {
     type Approximation = FaceApprox;

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -6,10 +6,10 @@ use crate::objects::Face;
 
 use super::{Approx, CycleApprox, Tolerance};
 
-impl Approx for Face {
+impl Approx for &Face {
     type Approximation = FaceApprox;
 
-    fn approx(&self, tolerance: Tolerance) -> Self::Approximation {
+    fn approx(self, tolerance: Tolerance) -> Self::Approximation {
         // Curved faces whose curvature is not fully defined by their edges
         // are not supported yet. For that reason, we can fully ignore `face`'s
         // `surface` field and just pass the edges to `Self::for_edges`.

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -1,10 +1,10 @@
 //! Approximation of objects
 
-mod curve;
-mod cycle;
-mod edge;
-mod face;
-mod tolerance;
+pub mod curve;
+pub mod cycle;
+pub mod edge;
+pub mod face;
+pub mod tolerance;
 
 pub use self::{
     cycle::CycleApprox,

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -17,16 +17,9 @@ pub trait Approx {
     /// The approximation of the object
     type Approximation;
 
-    /// Additional parameters required for the approximation
-    type Params;
-
     /// Approximate the object
     ///
     /// `tolerance` defines how far the approximation is allowed to deviate from
     /// the actual object.
-    fn approx(
-        &self,
-        tolerance: Tolerance,
-        params: Self::Params,
-    ) -> Self::Approximation;
+    fn approx(&self, tolerance: Tolerance) -> Self::Approximation;
 }

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -21,5 +21,5 @@ pub trait Approx {
     ///
     /// `tolerance` defines how far the approximation is allowed to deviate from
     /// the actual object.
-    fn approx(&self, tolerance: Tolerance) -> Self::Approximation;
+    fn approx(self, tolerance: Tolerance) -> Self::Approximation;
 }

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -7,7 +7,6 @@ pub mod face;
 pub mod tolerance;
 
 pub use self::{
-    cycle::CycleApprox,
     face::FaceApprox,
     tolerance::{InvalidTolerance, Tolerance},
 };

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -6,10 +6,7 @@ pub mod edge;
 pub mod face;
 pub mod tolerance;
 
-pub use self::{
-    face::FaceApprox,
-    tolerance::{InvalidTolerance, Tolerance},
-};
+pub use self::tolerance::{InvalidTolerance, Tolerance};
 
 /// Approximate an object
 pub trait Approx {

--- a/crates/fj-kernel/src/algorithms/approx/tolerance.rs
+++ b/crates/fj-kernel/src/algorithms/approx/tolerance.rs
@@ -1,3 +1,7 @@
+//! Tolerance value for approximation
+//!
+//! See [`Tolerance`].
+
 use fj_math::Scalar;
 
 /// A tolerance value

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -214,7 +214,7 @@ fn create_continuous_side_face(
     let placeholder = Surface::xy_plane();
 
     let cycle = Cycle::new(placeholder, [edge]);
-    let approx = cycle.approx(tolerance, ());
+    let approx = cycle.approx(tolerance);
 
     let mut quads = Vec::new();
     for segment in approx.segments() {

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -27,7 +27,7 @@ pub fn triangulate(
         }
 
         let surface = face.surface();
-        let approx = face.approx(tolerance, ());
+        let approx = face.approx(tolerance);
 
         let points: Vec<_> = approx
             .points


### PR DESCRIPTION
Makes use of #1048 to remove an error-prone re-calculation of a surface point. While I was at it, I cleaned up more things and added some documentation.