### PR TITLE
Make triangulation more flexible

### DIFF
--- a/crates/fj-kernel/src/algorithms/mod.rs
+++ b/crates/fj-kernel/src/algorithms/mod.rs
@@ -3,13 +3,12 @@
 //! Algorithmic code is collected in this module, to keep other modules focused
 //! on their respective purpose.
 
-mod triangulate;
-
 pub mod approx;
 pub mod intersect;
 pub mod reverse;
 pub mod sweep;
 pub mod transform;
+pub mod triangulate;
 pub mod validate;
 
 pub use self::triangulate::triangulate;

--- a/crates/fj-kernel/src/algorithms/mod.rs
+++ b/crates/fj-kernel/src/algorithms/mod.rs
@@ -10,5 +10,3 @@ pub mod sweep;
 pub mod transform;
 pub mod triangulate;
 pub mod validate;
-
-pub use self::triangulate::triangulate;

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -22,6 +22,19 @@ pub trait Triangulate: Sized {
     ) -> Mesh<Point<3>>;
 }
 
+impl<T> Triangulate for T
+where
+    T: IntoIterator<Item = Face>,
+{
+    fn triangulate(
+        self,
+        tolerance: impl Into<Tolerance>,
+        debug_info: &mut DebugInfo,
+    ) -> Mesh<Point<3>> {
+        triangulate(self.into_iter().collect(), tolerance.into(), debug_info)
+    }
+}
+
 /// Triangulate a shape
 pub fn triangulate(
     faces: Vec<Face>,
@@ -90,6 +103,8 @@ mod tests {
         algorithms::approx::Tolerance,
         objects::{Face, Surface},
     };
+
+    use super::Triangulate;
 
     #[test]
     fn simple() -> anyhow::Result<()> {
@@ -202,10 +217,6 @@ mod tests {
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
 
         let mut debug_info = DebugInfo::new();
-        Ok(super::triangulate(
-            vec![face.into()],
-            tolerance,
-            &mut debug_info,
-        ))
+        Ok(vec![face.into()].triangulate(tolerance, &mut debug_info))
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -19,20 +19,35 @@ pub trait Triangulate: Sized {
         self,
         tolerance: impl Into<Tolerance>,
         debug_info: &mut DebugInfo,
-    ) -> Mesh<Point<3>>;
+    ) -> Mesh<Point<3>> {
+        let mut mesh = Mesh::new();
+        self.triangulate_into_mesh(tolerance, &mut mesh, debug_info);
+        mesh
+    }
+
+    /// Triangulate a partial shape into the provided mesh
+    ///
+    /// This is a low-level method, intended for implementation of
+    /// `Triangulate`. Most callers should prefer [`Triangulate::triangulate`].
+    fn triangulate_into_mesh(
+        self,
+        tolerance: impl Into<Tolerance>,
+        mesh: &mut Mesh<Point<3>>,
+        debug_info: &mut DebugInfo,
+    );
 }
 
 impl<T> Triangulate for T
 where
     T: IntoIterator<Item = Face>,
 {
-    fn triangulate(
+    fn triangulate_into_mesh(
         self,
         tolerance: impl Into<Tolerance>,
+        mesh: &mut Mesh<Point<3>>,
         debug_info: &mut DebugInfo,
-    ) -> Mesh<Point<3>> {
+    ) {
         let tolerance = tolerance.into();
-        let mut mesh = Mesh::new();
 
         for face in self {
             if let Some(triangles) = face.triangles() {
@@ -81,8 +96,6 @@ where
                 mesh.push_triangle(points, face.color());
             }
         }
-
-        mesh
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -50,51 +50,62 @@ where
         let tolerance = tolerance.into();
 
         for face in self {
-            if let Some(triangles) = face.triangles() {
-                for &(triangle, color) in triangles {
-                    mesh.push_triangle(triangle, color);
-                }
-                continue;
+            face.triangulate_into_mesh(tolerance, mesh, debug_info);
+        }
+    }
+}
+
+impl Triangulate for Face {
+    fn triangulate_into_mesh(
+        self,
+        tolerance: impl Into<Tolerance>,
+        mesh: &mut Mesh<Point<3>>,
+        debug_info: &mut DebugInfo,
+    ) {
+        if let Some(triangles) = self.triangles() {
+            for &(triangle, color) in triangles {
+                mesh.push_triangle(triangle, color);
             }
+            return;
+        }
 
-            let surface = face.surface();
-            let approx = face.approx(tolerance);
+        let surface = self.surface();
+        let approx = self.approx(tolerance.into());
 
-            let points: Vec<_> = approx
-                .points
-                .into_iter()
-                .map(|(point_surface, point_global)| TriangulationPoint {
-                    point_surface,
-                    point_global,
-                })
-                .collect();
-            let face_as_polygon = Polygon::new(*surface)
-                .with_exterior(
-                    approx
-                        .exterior
-                        .points
-                        .into_iter()
-                        .map(|(point_surface, _)| point_surface),
-                )
-                .with_interiors(approx.interiors.into_iter().map(|interior| {
-                    interior
-                        .points
-                        .into_iter()
-                        .map(|(point_surface, _)| point_surface)
-                }));
+        let points: Vec<_> = approx
+            .points
+            .into_iter()
+            .map(|(point_surface, point_global)| TriangulationPoint {
+                point_surface,
+                point_global,
+            })
+            .collect();
+        let face_as_polygon = Polygon::new(*surface)
+            .with_exterior(
+                approx
+                    .exterior
+                    .points
+                    .into_iter()
+                    .map(|(point_surface, _)| point_surface),
+            )
+            .with_interiors(approx.interiors.into_iter().map(|interior| {
+                interior
+                    .points
+                    .into_iter()
+                    .map(|(point_surface, _)| point_surface)
+            }));
 
-            let mut triangles = delaunay::triangulate(points);
-            triangles.retain(|triangle| {
-                face_as_polygon.contains_triangle(
-                    triangle.map(|point| point.point_surface),
-                    debug_info,
-                )
-            });
+        let mut triangles = delaunay::triangulate(points);
+        triangles.retain(|triangle| {
+            face_as_polygon.contains_triangle(
+                triangle.map(|point| point.point_surface),
+                debug_info,
+            )
+        });
 
-            for triangle in triangles {
-                let points = triangle.map(|point| point.point_global);
-                mesh.push_triangle(points, face.color());
-            }
+        for triangle in triangles {
+            let points = triangle.map(|point| point.point_global);
+            mesh.push_triangle(points, self.color());
         }
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -13,6 +13,16 @@ use self::{delaunay::TriangulationPoint, polygon::Polygon};
 use super::approx::{Approx, Tolerance};
 
 /// Triangulate a shape
+pub trait Triangulate: Sized {
+    /// Triangulate the shape
+    fn triangulate(
+        self,
+        tolerance: impl Into<Tolerance>,
+        debug_info: &mut DebugInfo,
+    ) -> Mesh<Point<3>>;
+}
+
+/// Triangulate a shape
 pub fn triangulate(
     faces: Vec<Face>,
     tolerance: Tolerance,

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -1,3 +1,5 @@
+//! Shape triangulation
+
 mod delaunay;
 mod polygon;
 

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -3,7 +3,7 @@
 use fj_interop::{debug::DebugInfo, processed_shape::ProcessedShape};
 use fj_kernel::algorithms::{
     approx::{InvalidTolerance, Tolerance},
-    triangulate,
+    triangulate::Triangulate,
     validate::{ValidationConfig, ValidationError},
 };
 use fj_math::Scalar;
@@ -42,7 +42,7 @@ impl ShapeProcessor {
         let config = ValidationConfig::default();
         let mut debug_info = DebugInfo::new();
         let shape = shape.compute_brep(&config, tolerance, &mut debug_info)?;
-        let mesh = triangulate(shape.into_inner(), tolerance, &mut debug_info);
+        let mesh = shape.into_inner().triangulate(tolerance, &mut debug_info);
 
         Ok(ProcessedShape {
             aabb,


### PR DESCRIPTION
Adds a trait `Triangulate`, which brings `algorithms::triangulation` in line with the other modules in `algorithms`, and increases flexibility, by implementing `Triangulate` for both `Face` and iterators over `Face`.