### PR TITLE
Simplify `Edge` reversal

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -102,7 +102,7 @@ fn number_of_vertices_for_circle(
 }
 
 /// The range on which a curve should be approximated
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct RangeOnCurve {
     /// The boundary of the range
     ///

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -8,7 +8,7 @@ impl Reverse for Cycle {
 
         let mut edges = self
             .into_edges()
-            .map(|edge| edge.reverse())
+            .map(|edge| edge.reverse_including_curve())
             .collect::<Vec<_>>();
 
         edges.reverse();

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -4,6 +4,6 @@ use super::Reverse;
 
 impl Reverse for Edge {
     fn reverse(self) -> Self {
-        self.reverse_including_curve()
+        Edge::from_curve_and_vertices(*self.curve(), self.vertices().reverse())
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -4,9 +4,6 @@ use super::Reverse;
 
 impl Reverse for Edge {
     fn reverse(self) -> Self {
-        Edge::from_curve_and_vertices(
-            self.curve().reverse(),
-            self.vertices().reverse(),
-        )
+        self.reverse_including_curve()
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -44,7 +44,7 @@ fn create_non_continuous_side_face(
     color: Color,
 ) -> Face {
     let edge = if path.is_negative_direction() {
-        edge.reverse()
+        edge.reverse_including_curve()
     } else {
         *edge
     };

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -239,22 +239,7 @@ impl VerticesOfEdge<Vertex> {
     ///
     /// Makes sure that the local coordinates are still correct.
     pub fn reverse(self) -> Self {
-        Self(self.0.map(|[a, b]| {
-            [
-                Vertex::new(
-                    -b.position(),
-                    b.curve().reverse(),
-                    *b.surface_form(),
-                    *b.global_form(),
-                ),
-                Vertex::new(
-                    -a.position(),
-                    a.curve().reverse(),
-                    *a.surface_form(),
-                    *a.global_form(),
-                ),
-            ]
-        }))
+        Self(self.0.map(|[a, b]| [b, a]))
     }
 
     /// Convert this instance into its global variant

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -72,6 +72,34 @@ impl Edge {
         Self::new(curve, vertices, global)
     }
 
+    /// Reverse the edge, including the curve
+    ///
+    /// # Implementation Note
+    ///
+    /// It would be much nicer to just reverse the edge normally everywhere, but
+    /// we can't do that, until #695 is addressed:
+    /// <https://github.com/hannobraun/Fornjot/issues/695>
+    pub fn reverse_including_curve(self) -> Self {
+        let vertices = VerticesOfEdge(self.vertices.get().map(|[a, b]| {
+            [
+                Vertex::new(
+                    -b.position(),
+                    b.curve().reverse(),
+                    *b.surface_form(),
+                    *b.global_form(),
+                ),
+                Vertex::new(
+                    -a.position(),
+                    a.curve().reverse(),
+                    *a.surface_form(),
+                    *a.global_form(),
+                ),
+            ]
+        }));
+
+        Self::from_curve_and_vertices(self.curve().reverse(), vertices)
+    }
+
     /// Access the curve that defines the edge's geometry
     ///
     /// The edge can be a segment of the curve that is bounded by two vertices,


### PR DESCRIPTION
This is another small step towards #1020. The simplified `Edge` reversal, which no longer includes reversing the curve, removes some sources of bugs that could otherwise be triggered by the approximation code.

The old behavior is preserved, and still used where that is needed. This will remain to be necessary, as long as #695 remains unaddressed.