### PR TITLE
Bound all edges by vertices

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -18,7 +18,6 @@ impl Approx for &Edge {
     type Approximation = EdgeApprox;
 
     fn approx(self, tolerance: super::Tolerance) -> Self::Approximation {
-        // The range is only used for circles right now.
         let [a, b] = match self.vertices().get() {
             Some(vertices) => vertices.map(|&vertex| vertex),
             None => {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -42,14 +42,9 @@ impl CurveEdgeIntersection {
                 }
             };
 
-            let edge_vertices = match edge.vertices().get() {
-                Some(vertices) => vertices.map(|vertex| {
-                    edge_curve_as_line.point_from_line_coords(vertex.position())
-                }),
-                None => todo!(
-                    "Curve-edge intersection does not support continuous edges"
-                ),
-            };
+            let edge_vertices = edge.vertices().get().map(|vertex| {
+                edge_curve_as_line.point_from_line_coords(vertex.position())
+            });
 
             Segment::from_points(edge_vertices)
         };

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -45,13 +45,13 @@ impl Intersect for (&Face, &Point<2>) {
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = *edge.vertices().get_or_panic()[0];
+                        let vertex = *edge.vertices().get()[0];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = *edge.vertices().get_or_panic()[1];
+                        let vertex = *edge.vertices().get()[1];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
@@ -237,7 +237,7 @@ mod tests {
             .edge_iter()
             .copied()
             .find(|edge| {
-                let [a, b] = edge.vertices().get_or_panic();
+                let [a, b] = edge.vertices().get();
                 a.global_form().position() == Point::from([0., 0., 0.])
                     && b.global_form().position() == Point::from([2., 0., 0.])
             })

--- a/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
@@ -22,7 +22,7 @@ impl Intersect for (&HorizontalRayToTheRight<2>, &Edge) {
             }
         };
 
-        let points = edge.vertices().get_or_panic().map(|vertex| {
+        let points = edge.vertices().get().map(|vertex| {
             let point = vertex.position();
             line.point_from_line_coords(point)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -216,7 +216,7 @@ mod tests {
             .edge_iter()
             .copied()
             .find(|edge| {
-                let [a, b] = edge.vertices().get_or_panic();
+                let [a, b] = edge.vertices().get();
                 a.global_form().position() == Point::from([1., 0., 1.])
                     && b.global_form().position() == Point::from([1., 0., -1.])
             })

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -8,10 +8,6 @@ use super::Reverse;
 
 impl Reverse for Face {
     fn reverse(self) -> Self {
-        if self.triangles().is_some() {
-            panic!("Reversing tri-rep faces is not supported");
-        }
-
         let surface = self.surface().reverse();
 
         let exteriors = reverse_local_coordinates_in_cycle(self.exteriors());

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -8,10 +8,9 @@ impl Sweep for Curve {
     fn sweep(
         self,
         path: impl Into<super::Path>,
-        tolerance: impl Into<crate::algorithms::approx::Tolerance>,
         color: fj_interop::mesh::Color,
     ) -> Self::Swept {
-        self.global_form().sweep(path, tolerance, color)
+        self.global_form().sweep(path, color)
     }
 }
 
@@ -21,7 +20,6 @@ impl Sweep for GlobalCurve {
     fn sweep(
         self,
         path: impl Into<super::Path>,
-        _: impl Into<crate::algorithms::approx::Tolerance>,
         _: fj_interop::mesh::Color,
     ) -> Self::Swept {
         Surface::SweptCurve(SweptCurve {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -2,9 +2,7 @@ use fj_interop::mesh::Color;
 use fj_math::{Line, Scalar};
 
 use crate::{
-    algorithms::{
-        approx::Tolerance, reverse::Reverse, transform::TransformObject,
-    },
+    algorithms::{reverse::Reverse, transform::TransformObject},
     objects::{
         Curve, CurveKind, Cycle, Edge, Face, GlobalEdge, SurfaceVertex, Vertex,
         VerticesOfEdge,
@@ -16,14 +14,8 @@ use super::{Path, Sweep};
 impl Sweep for Edge {
     type Swept = Face;
 
-    fn sweep(
-        self,
-        path: impl Into<Path>,
-        tolerance: impl Into<Tolerance>,
-        color: Color,
-    ) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
         let path = path.into();
-        let tolerance = tolerance.into();
 
         let edge = if path.is_negative_direction() {
             self.reverse_including_curve()
@@ -31,7 +23,7 @@ impl Sweep for Edge {
             self
         };
 
-        let surface = edge.curve().sweep(path, tolerance, color);
+        let surface = edge.curve().sweep(path, color);
 
         // We can't use the edge we're sweeping from as the bottom edge, as that
         // is not defined in the right surface. Let's create a new bottom edge,
@@ -90,7 +82,7 @@ impl Sweep for Edge {
         let side_edges = bottom_edge
             .vertices()
             .get()
-            .map(|&vertex| (vertex, surface).sweep(path, tolerance, color));
+            .map(|&vertex| (vertex, surface).sweep(path, color));
 
         let top_edge = {
             let bottom_vertices = bottom_edge.vertices().get();

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -1,15 +1,13 @@
 use fj_interop::mesh::Color;
-use fj_math::{Line, Scalar, Transform, Triangle};
+use fj_math::{Line, Scalar};
 
 use crate::{
     algorithms::{
-        approx::{Approx, Tolerance},
-        reverse::Reverse,
-        transform::TransformObject,
+        approx::Tolerance, reverse::Reverse, transform::TransformObject,
     },
     objects::{
-        Curve, CurveKind, Cycle, Edge, Face, GlobalEdge, Surface,
-        SurfaceVertex, Vertex, VerticesOfEdge,
+        Curve, CurveKind, Cycle, Edge, Face, GlobalEdge, SurfaceVertex, Vertex,
+        VerticesOfEdge,
     },
 };
 
@@ -27,13 +25,7 @@ impl Sweep for Edge {
         let path = path.into();
         let tolerance = tolerance.into();
 
-        if self.vertices().get().is_some() {
-            let face =
-                create_non_continuous_side_face(&self, path, tolerance, color);
-            return face;
-        }
-
-        create_continuous_side_face(self, path, tolerance, color)
+        create_non_continuous_side_face(&self, path, tolerance, color)
     }
 }
 
@@ -55,7 +47,7 @@ fn create_non_continuous_side_face(
     // not defined in the right surface. Let's create a new bottom edge, by
     // swapping the surface of the original.
     let bottom_edge = {
-        let vertices = edge.vertices().get_or_panic();
+        let vertices = edge.vertices().get();
 
         let points_curve_and_surface = vertices.map(|vertex| {
             (vertex.position(), [vertex.position().t, Scalar::ZERO])
@@ -106,14 +98,14 @@ fn create_non_continuous_side_face(
 
     let side_edges = bottom_edge
         .vertices()
-        .get_or_panic()
+        .get()
         .map(|&vertex| (vertex, surface).sweep(path, tolerance, color));
 
     let top_edge = {
-        let bottom_vertices = bottom_edge.vertices().get_or_panic();
+        let bottom_vertices = bottom_edge.vertices().get();
 
         let global_vertices = side_edges.map(|edge| {
-            let [_, vertex] = edge.vertices().get_or_panic();
+            let [_, vertex] = edge.vertices().get();
             *vertex.global_form()
         });
 
@@ -183,8 +175,8 @@ fn create_non_continuous_side_face(
         while i < edges.len() {
             let j = (i + 1) % edges.len();
 
-            let [_, prev_last] = edges[i].vertices().get_or_panic();
-            let [next_first, _] = edges[j].vertices().get_or_panic();
+            let [_, prev_last] = edges[i].vertices().get();
+            let [next_first, _] = edges[j].vertices().get();
 
             // Need to compare surface forms here, as the global forms might be
             // coincident when sweeping circles, despite the vertices being
@@ -200,41 +192,4 @@ fn create_non_continuous_side_face(
     };
 
     Face::new(surface).with_exteriors([cycle]).with_color(color)
-}
-
-fn create_continuous_side_face(
-    edge: Edge,
-    path: Path,
-    tolerance: Tolerance,
-    color: Color,
-) -> Face {
-    let translation = Transform::translation(path.inner());
-
-    // This is definitely the wrong surface, but it shouldn't matter. Since this
-    // code will hopefully soon be gone anyway (this is the last piece of code
-    // that prevents us from removing triangle representation), it hopefully
-    // won't start to matter at some point either.
-    let placeholder = Surface::xy_plane();
-
-    let cycle = Cycle::new(placeholder, [edge]);
-    let approx = cycle.approx(tolerance);
-
-    let mut quads = Vec::new();
-    for segment in approx.segments() {
-        let [v0, v1] = segment.points();
-        let [v3, v2] = {
-            let segment = translation.transform_segment(&segment);
-            segment.points()
-        };
-
-        quads.push([v0, v1, v2, v3]);
-    }
-
-    let mut side_face: Vec<(Triangle<3>, _)> = Vec::new();
-    for [v0, v1, v2, v3] in quads {
-        side_face.push(([v0, v1, v2].into(), color));
-        side_face.push(([v0, v2, v3].into(), color));
-    }
-
-    Face::from_triangles(side_face)
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -25,171 +25,166 @@ impl Sweep for Edge {
         let path = path.into();
         let tolerance = tolerance.into();
 
-        create_non_continuous_side_face(&self, path, tolerance, color)
-    }
-}
-
-fn create_non_continuous_side_face(
-    edge: &Edge,
-    path: Path,
-    tolerance: Tolerance,
-    color: Color,
-) -> Face {
-    let edge = if path.is_negative_direction() {
-        edge.reverse_including_curve()
-    } else {
-        *edge
-    };
-
-    let surface = edge.curve().sweep(path, tolerance, color);
-
-    // We can't use the edge we're sweeping from as the bottom edge, as that is
-    // not defined in the right surface. Let's create a new bottom edge, by
-    // swapping the surface of the original.
-    let bottom_edge = {
-        let vertices = edge.vertices().get();
-
-        let points_curve_and_surface = vertices.map(|vertex| {
-            (vertex.position(), [vertex.position().t, Scalar::ZERO])
-        });
-
-        let curve = {
-            // Please note that creating a line here is correct, even if the
-            // global curve is a circle. Projected into the side surface, it is
-            // going to be a line either way.
-            let kind = CurveKind::Line(Line::from_points_with_line_coords(
-                points_curve_and_surface,
-            ));
-
-            Curve::new(surface, kind, *edge.curve().global_form())
+        let edge = if path.is_negative_direction() {
+            self.reverse_including_curve()
+        } else {
+            self
         };
 
-        let vertices = {
-            let points_surface = points_curve_and_surface
-                .map(|(_, point_surface)| point_surface);
+        let surface = edge.curve().sweep(path, tolerance, color);
 
-            // Can be cleaned up, once `zip` is stable:
-            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-            let [a_vertex, b_vertex] = vertices;
-            let [a_surface, b_surface] = points_surface;
-            let vertices_with_surface_points =
-                [(a_vertex, a_surface), (b_vertex, b_surface)];
+        // We can't use the edge we're sweeping from as the bottom edge, as that
+        // is not defined in the right surface. Let's create a new bottom edge,
+        // by swapping the surface of the original.
+        let bottom_edge = {
+            let vertices = edge.vertices().get();
 
-            let vertices =
-                vertices_with_surface_points.map(|(vertex, point_surface)| {
-                    let surface_vertex = SurfaceVertex::new(
+            let points_curve_and_surface = vertices.map(|vertex| {
+                (vertex.position(), [vertex.position().t, Scalar::ZERO])
+            });
+
+            let curve = {
+                // Please note that creating a line here is correct, even if the
+                // global curve is a circle. Projected into the side surface, it is
+                // going to be a line either way.
+                let kind = CurveKind::Line(Line::from_points_with_line_coords(
+                    points_curve_and_surface,
+                ));
+
+                Curve::new(surface, kind, *edge.curve().global_form())
+            };
+
+            let vertices = {
+                let points_surface = points_curve_and_surface
+                    .map(|(_, point_surface)| point_surface);
+
+                // Can be cleaned up, once `zip` is stable:
+                // https://doc.rust-lang.org/std/primitive.array.html#method.zip
+                let [a_vertex, b_vertex] = vertices;
+                let [a_surface, b_surface] = points_surface;
+                let vertices_with_surface_points =
+                    [(a_vertex, a_surface), (b_vertex, b_surface)];
+
+                let vertices = vertices_with_surface_points.map(
+                    |(vertex, point_surface)| {
+                        let surface_vertex = SurfaceVertex::new(
+                            point_surface,
+                            surface,
+                            *vertex.global_form(),
+                        );
+
+                        Vertex::new(
+                            vertex.position(),
+                            curve,
+                            surface_vertex,
+                            *vertex.global_form(),
+                        )
+                    },
+                );
+                VerticesOfEdge::from_vertices(vertices)
+            };
+
+            Edge::new(curve, vertices, *edge.global_form())
+        };
+
+        let side_edges = bottom_edge
+            .vertices()
+            .get()
+            .map(|&vertex| (vertex, surface).sweep(path, tolerance, color));
+
+        let top_edge = {
+            let bottom_vertices = bottom_edge.vertices().get();
+
+            let global_vertices = side_edges.map(|edge| {
+                let [_, vertex] = edge.vertices().get();
+                *vertex.global_form()
+            });
+
+            let points_curve_and_surface = bottom_vertices.map(|vertex| {
+                (vertex.position(), [vertex.position().t, Scalar::ONE])
+            });
+
+            let curve = {
+                let global =
+                    bottom_edge.curve().global_form().translate(path.inner());
+
+                // Please note that creating a line here is correct, even if the
+                // global curve is a circle. Projected into the side surface, it
+                // is going to be a line either way.
+                let kind = CurveKind::Line(Line::from_points_with_line_coords(
+                    points_curve_and_surface,
+                ));
+
+                Curve::new(surface, kind, global)
+            };
+
+            let global = {
+                GlobalEdge::new(
+                    *curve.global_form(),
+                    VerticesOfEdge::from_vertices(global_vertices),
+                )
+            };
+
+            let vertices = {
+                let surface_points = points_curve_and_surface
+                    .map(|(_, point_surface)| point_surface);
+
+                // Can be cleaned up, once `zip` is stable:
+                // https://doc.rust-lang.org/std/primitive.array.html#method.zip
+                let [a_vertex, b_vertex] = bottom_vertices;
+                let [a_surface, b_surface] = surface_points;
+                let [a_global, b_global] = global_vertices;
+                let vertices = [
+                    (a_vertex, a_surface, a_global),
+                    (b_vertex, b_surface, b_global),
+                ];
+
+                vertices.map(|(vertex, point_surface, vertex_global)| {
+                    let vertex_surface = SurfaceVertex::new(
                         point_surface,
                         surface,
-                        *vertex.global_form(),
+                        vertex_global,
                     );
-
                     Vertex::new(
                         vertex.position(),
                         curve,
-                        surface_vertex,
-                        *vertex.global_form(),
+                        vertex_surface,
+                        vertex_global,
                     )
-                });
-            VerticesOfEdge::from_vertices(vertices)
+                })
+            };
+
+            Edge::new(curve, VerticesOfEdge::from_vertices(vertices), global)
         };
 
-        Edge::new(curve, vertices, *edge.global_form())
-    };
+        let cycle = {
+            let a = bottom_edge;
+            let [d, b] = side_edges;
+            let c = top_edge;
 
-    let side_edges = bottom_edge
-        .vertices()
-        .get()
-        .map(|&vertex| (vertex, surface).sweep(path, tolerance, color));
+            let mut edges = [a, b, c, d];
 
-    let top_edge = {
-        let bottom_vertices = bottom_edge.vertices().get();
+            // Make sure that edges are oriented correctly.
+            let mut i = 0;
+            while i < edges.len() {
+                let j = (i + 1) % edges.len();
 
-        let global_vertices = side_edges.map(|edge| {
-            let [_, vertex] = edge.vertices().get();
-            *vertex.global_form()
-        });
+                let [_, prev_last] = edges[i].vertices().get();
+                let [next_first, _] = edges[j].vertices().get();
 
-        let points_curve_and_surface = bottom_vertices.map(|vertex| {
-            (vertex.position(), [vertex.position().t, Scalar::ONE])
-        });
+                // Need to compare surface forms here, as the global forms might
+                // be coincident when sweeping circles, despite the vertices
+                // being different!
+                if prev_last.surface_form() != next_first.surface_form() {
+                    edges[j] = edges[j].reverse();
+                }
 
-        let curve = {
-            let global =
-                bottom_edge.curve().global_form().translate(path.inner());
-
-            // Please note that creating a line here is correct, even if the
-            // global curve is a circle. Projected into the side surface, it is
-            // going to be a line either way.
-            let kind = CurveKind::Line(Line::from_points_with_line_coords(
-                points_curve_and_surface,
-            ));
-
-            Curve::new(surface, kind, global)
-        };
-
-        let global = {
-            GlobalEdge::new(
-                *curve.global_form(),
-                VerticesOfEdge::from_vertices(global_vertices),
-            )
-        };
-
-        let vertices = {
-            let surface_points = points_curve_and_surface
-                .map(|(_, point_surface)| point_surface);
-
-            // Can be cleaned up, once `zip` is stable:
-            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-            let [a_vertex, b_vertex] = bottom_vertices;
-            let [a_surface, b_surface] = surface_points;
-            let [a_global, b_global] = global_vertices;
-            let vertices = [
-                (a_vertex, a_surface, a_global),
-                (b_vertex, b_surface, b_global),
-            ];
-
-            vertices.map(|(vertex, point_surface, vertex_global)| {
-                let vertex_surface =
-                    SurfaceVertex::new(point_surface, surface, vertex_global);
-                Vertex::new(
-                    vertex.position(),
-                    curve,
-                    vertex_surface,
-                    vertex_global,
-                )
-            })
-        };
-
-        Edge::new(curve, VerticesOfEdge::from_vertices(vertices), global)
-    };
-
-    let cycle = {
-        let a = bottom_edge;
-        let [d, b] = side_edges;
-        let c = top_edge;
-
-        let mut edges = [a, b, c, d];
-
-        // Make sure that edges are oriented correctly.
-        let mut i = 0;
-        while i < edges.len() {
-            let j = (i + 1) % edges.len();
-
-            let [_, prev_last] = edges[i].vertices().get();
-            let [next_first, _] = edges[j].vertices().get();
-
-            // Need to compare surface forms here, as the global forms might be
-            // coincident when sweeping circles, despite the vertices being
-            // different!
-            if prev_last.surface_form() != next_first.surface_form() {
-                edges[j] = edges[j].reverse();
+                i += 1;
             }
 
-            i += 1;
-        }
+            Cycle::new(surface, edges)
+        };
 
-        Cycle::new(surface, edges)
-    };
-
-    Face::new(surface).with_exteriors([cycle]).with_color(color)
+        Face::new(surface).with_exteriors([cycle]).with_color(color)
+    }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -1,9 +1,7 @@
 use fj_interop::mesh::Color;
 
 use crate::{
-    algorithms::{
-        approx::Tolerance, reverse::Reverse, transform::TransformObject,
-    },
+    algorithms::{reverse::Reverse, transform::TransformObject},
     objects::{Face, Shell},
 };
 
@@ -12,14 +10,8 @@ use super::{Path, Sweep};
 impl Sweep for Face {
     type Swept = Shell;
 
-    fn sweep(
-        self,
-        path: impl Into<Path>,
-        tolerance: impl Into<Tolerance>,
-        color: Color,
-    ) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
         let path = path.into();
-        let tolerance = tolerance.into();
 
         let mut faces = Vec::new();
 
@@ -32,7 +24,7 @@ impl Sweep for Face {
 
         for cycle in self.all_cycles() {
             for edge in cycle.edges() {
-                let face = edge.sweep(path, tolerance, color);
+                let face = edge.sweep(path, color);
                 faces.push(face);
             }
         }

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -9,20 +9,13 @@ mod vertex;
 use fj_interop::mesh::Color;
 use fj_math::{Scalar, Vector};
 
-use super::approx::Tolerance;
-
 /// Sweep an object along a path to create another object
 pub trait Sweep {
     /// The object that is created by sweeping the implementing object
     type Swept;
 
     /// Sweep the object along the given path
-    fn sweep(
-        self,
-        path: impl Into<Path>,
-        tolerance: impl Into<Tolerance>,
-        color: Color,
-    ) -> Self::Swept;
+    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept;
 }
 
 /// A path to be used with [`Sweep`]

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -1,27 +1,18 @@
 use fj_interop::mesh::Color;
 
-use crate::{
-    algorithms::approx::Tolerance,
-    objects::{Sketch, Solid},
-};
+use crate::objects::{Sketch, Solid};
 
 use super::{Path, Sweep};
 
 impl Sweep for Sketch {
     type Swept = Solid;
 
-    fn sweep(
-        self,
-        path: impl Into<Path>,
-        tolerance: impl Into<Tolerance>,
-        color: Color,
-    ) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
         let path = path.into();
-        let tolerance = tolerance.into();
 
         let mut shells = Vec::new();
         for face in self.into_faces() {
-            let shell = face.sweep(path, tolerance, color);
+            let shell = face.sweep(path, color);
             shells.push(shell);
         }
 
@@ -32,10 +23,9 @@ impl Sweep for Sketch {
 #[cfg(test)]
 mod tests {
     use fj_interop::mesh::Color;
-    use fj_math::{Point, Scalar, Vector};
+    use fj_math::{Point, Vector};
 
     use crate::{
-        algorithms::approx::Tolerance,
         iter::ObjectIters,
         objects::{Face, Sketch, Surface},
     };
@@ -144,8 +134,6 @@ mod tests {
         expected_surfaces: impl IntoIterator<Item = [impl Into<Point<3>>; 3]>,
         expected_vertices: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> anyhow::Result<()> {
-        let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
-
         let surface = Surface::xy_plane();
         let face = Face::build(surface).polygon_from_points([
             [0., 0.],
@@ -154,7 +142,7 @@ mod tests {
         ]);
         let sketch = Sketch::new().with_faces([face]);
 
-        let solid = sketch.sweep(direction, tolerance, Color([255, 0, 0, 255]));
+        let solid = sketch.sweep(direction, Color([255, 0, 0, 255]));
 
         let expected_vertices: Vec<_> = expected_vertices
             .into_iter()

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -99,7 +99,7 @@ impl Sweep for (Vertex, Surface) {
 
         // And now the vertices. Again, nothing wild here.
         let vertices = {
-            let vertices_global = edge_global.vertices().get_or_panic();
+            let vertices_global = edge_global.vertices().get();
 
             // Can be cleaned up, once `zip` is stable:
             // https://doc.rust-lang.org/std/primitive.array.html#method.zip

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -1,12 +1,9 @@
 use fj_interop::mesh::Color;
 use fj_math::{Line, Point, Scalar};
 
-use crate::{
-    algorithms::approx::Tolerance,
-    objects::{
-        Curve, CurveKind, Edge, GlobalCurve, GlobalEdge, GlobalVertex, Surface,
-        SurfaceVertex, SweptCurve, Vertex, VerticesOfEdge,
-    },
+use crate::objects::{
+    Curve, CurveKind, Edge, GlobalCurve, GlobalEdge, GlobalVertex, Surface,
+    SurfaceVertex, SweptCurve, Vertex, VerticesOfEdge,
 };
 
 use super::{Path, Sweep};
@@ -14,12 +11,7 @@ use super::{Path, Sweep};
 impl Sweep for (Vertex, Surface) {
     type Swept = Edge;
 
-    fn sweep(
-        self,
-        path: impl Into<Path>,
-        tolerance: impl Into<Tolerance>,
-        color: Color,
-    ) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
         let (vertex, surface) = self;
         let path = path.into();
 
@@ -68,7 +60,7 @@ impl Sweep for (Vertex, Surface) {
         // With that out of the way, let's start by creating the `GlobalEdge`,
         // as that is the most straight-forward part of this operations, and
         // we're going to need it soon anyway.
-        let edge_global = vertex.global_form().sweep(path, tolerance, color);
+        let edge_global = vertex.global_form().sweep(path, color);
 
         // Next, let's compute the surface coordinates of the two vertices of
         // the output `Edge`, as we're going to need these for the rest of this
@@ -143,12 +135,7 @@ impl Sweep for (Vertex, Surface) {
 impl Sweep for GlobalVertex {
     type Swept = GlobalEdge;
 
-    fn sweep(
-        self,
-        path: impl Into<Path>,
-        _: impl Into<Tolerance>,
-        _: Color,
-    ) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, _: Color) -> Self::Swept {
         let a = self;
         let b =
             GlobalVertex::from_position(self.position() + path.into().inner());

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -65,17 +65,6 @@ impl TransformObject for Edge {
 
 impl TransformObject for Face {
     fn transform(self, transform: &Transform) -> Self {
-        if let Some(triangles) = self.triangles() {
-            let mut target = Vec::new();
-
-            for (triangle, color) in triangles.clone() {
-                let triangle = transform.transform_triangle(&triangle);
-                target.push((triangle, color));
-            }
-
-            return Self::from_triangles(target);
-        }
-
         let surface = self.surface().transform(transform);
 
         let exteriors = transform_cycles(self.exteriors(), transform);

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -62,13 +62,6 @@ impl Triangulate for Face {
         mesh: &mut Mesh<Point<3>>,
         debug_info: &mut DebugInfo,
     ) {
-        if let Some(triangles) = self.triangles() {
-            for &(triangle, color) in triangles {
-                mesh.push_triangle(triangle, color);
-            }
-            return;
-        }
-
         let surface = self.surface();
         let approx = self.approx(tolerance.into());
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -181,10 +181,6 @@ impl<'r> ObjectIters<'r> for Edge {
 
 impl<'r> ObjectIters<'r> for Face {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
-        if self.triangles().is_some() {
-            return Vec::new();
-        }
-
         let mut objects = vec![self.surface() as &dyn ObjectIters];
 
         for cycle in self.all_cycles() {

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -51,8 +51,8 @@ impl Cycle {
                 // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
                 let [a, b] = [&edges[0], &edges[1]];
 
-                let [_, prev] = a.vertices().get_or_panic();
-                let [next, _] = b.vertices().get_or_panic();
+                let [_, prev] = a.vertices().get();
+                let [next, _] = b.vertices().get();
 
                 assert_eq!(
                     prev.surface_form(),
@@ -64,8 +64,8 @@ impl Cycle {
             // Verify that the edges form a cycle
             if let Some(first) = edges.first() {
                 if let Some(last) = edges.last() {
-                    let [first, _] = first.vertices().get_or_panic();
-                    let [_, last] = last.vertices().get_or_panic();
+                    let [first, _] = first.vertices().get();
+                    let [_, last] = last.vertices().get();
 
                     assert_eq!(
                         first.surface_form(),

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -1,7 +1,6 @@
 use std::collections::{btree_set, BTreeSet};
 
 use fj_interop::mesh::Color;
-use fj_math::Triangle;
 
 use crate::builder::FaceBuilder;
 
@@ -68,20 +67,6 @@ impl Face {
                 interiors: Vec::new(),
                 color: Color::default(),
             }),
-        }
-    }
-
-    /// Construct an instance that uses triangle representation
-    ///
-    /// Triangle representation is obsolete, and only still present because
-    /// there is one last place in the kernel code that uses it. Don't add any
-    /// more of those places!
-    ///
-    /// See this issue for more context:
-    /// <https://github.com/hannobraun/Fornjot/issues/97>
-    pub fn from_triangles(triangles: TriRep) -> Self {
-        Self {
-            representation: Representation::TriRep(triangles),
         }
     }
 
@@ -171,46 +156,22 @@ impl Face {
         self.brep().color
     }
 
-    /// Access triangles, if this face uses triangle representation
-    ///
-    /// Only some faces still use triangle representation. At some point, none
-    /// will. This method exists as a workaround, while the transition is still
-    /// in progress.
-    pub fn triangles(&self) -> Option<&TriRep> {
-        if let Representation::TriRep(triangles) = &self.representation {
-            return Some(triangles);
-        }
-
-        None
-    }
-
     /// Access the boundary representation of the face
     fn brep(&self) -> &BRep {
-        if let Representation::BRep(face) = &self.representation {
-            return face;
-        }
-
-        // No code that still uses triangle representation is calling this
-        // method.
-        unreachable!()
+        let Representation::BRep(face) = &self.representation;
+        face
     }
 
     /// Access the boundary representation of the face mutably
     fn brep_mut(&mut self) -> &mut BRep {
-        if let Representation::BRep(face) = &mut self.representation {
-            return face;
-        }
-
-        // No code that still uses triangle representation is calling this
-        // method.
-        unreachable!()
+        let Representation::BRep(face) = &mut self.representation;
+        face
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 enum Representation {
     BRep(BRep),
-    TriRep(TriRep),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -220,5 +181,3 @@ struct BRep {
     interiors: Vec<Cycle>,
     color: Color,
 }
-
-type TriRep = Vec<(Triangle<3>, Color)>;

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -46,7 +46,10 @@ impl<'a> IntoIterator for &'a Faces {
 /// A face of a shape
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Face {
-    representation: Representation,
+    surface: Surface,
+    exteriors: Vec<Cycle>,
+    interiors: Vec<Cycle>,
+    color: Color,
 }
 
 impl Face {
@@ -61,12 +64,10 @@ impl Face {
     /// This can be overridden using the `with_` methods.
     pub fn new(surface: Surface) -> Self {
         Self {
-            representation: Representation::BRep(BRep {
-                surface,
-                exteriors: Vec::new(),
-                interiors: Vec::new(),
-                color: Color::default(),
-            }),
+            surface,
+            exteriors: Vec::new(),
+            interiors: Vec::new(),
+            color: Color::default(),
         }
     }
 
@@ -88,7 +89,7 @@ impl Face {
                 "Cycles that bound a face must be in face's surface"
             );
 
-            self.brep_mut().exteriors.push(cycle);
+            self.exteriors.push(cycle);
         }
 
         self
@@ -112,7 +113,7 @@ impl Face {
                 "Cycles that bound a face must be in face's surface"
             );
 
-            self.brep_mut().interiors.push(cycle);
+            self.interiors.push(cycle);
         }
 
         self
@@ -122,25 +123,25 @@ impl Face {
     ///
     /// Consumes the face and returns the updated instance.
     pub fn with_color(mut self, color: Color) -> Self {
-        self.brep_mut().color = color;
+        self.color = color;
         self
     }
 
     /// Access this face's surface
     pub fn surface(&self) -> &Surface {
-        &self.brep().surface
+        &self.surface
     }
 
     /// Access the cycles that bound the face on the outside
     pub fn exteriors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().exteriors.iter()
+        self.exteriors.iter()
     }
 
     /// Access the cycles that bound the face on the inside
     ///
     /// Each of these cycles defines a hole in the face.
     pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
-        self.brep().interiors.iter()
+        self.interiors.iter()
     }
 
     /// Access all cycles of this face
@@ -153,31 +154,6 @@ impl Face {
 
     /// Access the color of the face
     pub fn color(&self) -> Color {
-        self.brep().color
+        self.color
     }
-
-    /// Access the boundary representation of the face
-    fn brep(&self) -> &BRep {
-        let Representation::BRep(face) = &self.representation;
-        face
-    }
-
-    /// Access the boundary representation of the face mutably
-    fn brep_mut(&mut self) -> &mut BRep {
-        let Representation::BRep(face) = &mut self.representation;
-        face
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-enum Representation {
-    BRep(BRep),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-struct BRep {
-    surface: Surface,
-    exteriors: Vec<Cycle>,
-    interiors: Vec<Cycle>,
-    color: Color,
 }

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -25,7 +25,7 @@ impl Shape for fj::Sweep {
         let path = Vector::from(self.path());
         let color = self.shape().color();
 
-        let solid = sketch.into_inner().sweep(path, tolerance, Color(color));
+        let solid = sketch.into_inner().sweep(path, Color(color));
         solid.validate_with_config(config)
     }
 


### PR DESCRIPTION
Removes a special case (the handling of edges/faces that connect to themselves) from the core CAD kernel data structures, simplifying a lot of stuff, and addressing some long-standing issues!

Close #97 
Close #250 
Close #1020