### PR TITLE
Simplify `Sweep` trait

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -5,23 +5,15 @@ use super::Sweep;
 impl Sweep for Curve {
     type Swept = Surface;
 
-    fn sweep(
-        self,
-        path: impl Into<super::Path>,
-        color: fj_interop::mesh::Color,
-    ) -> Self::Swept {
-        self.global_form().sweep(path, color)
+    fn sweep(self, path: impl Into<super::Path>) -> Self::Swept {
+        self.global_form().sweep(path)
     }
 }
 
 impl Sweep for GlobalCurve {
     type Swept = Surface;
 
-    fn sweep(
-        self,
-        path: impl Into<super::Path>,
-        _: fj_interop::mesh::Color,
-    ) -> Self::Swept {
+    fn sweep(self, path: impl Into<super::Path>) -> Self::Swept {
         Surface::SweptCurve(SweptCurve {
             curve: *self.kind(),
             path: path.into().inner(),

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -11,16 +11,17 @@ use crate::{
 
 use super::{Path, Sweep};
 
-impl Sweep for Edge {
+impl Sweep for (Edge, Color) {
     type Swept = Face;
 
-    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, _: Color) -> Self::Swept {
+        let (edge, color) = self;
         let path = path.into();
 
         let edge = if path.is_negative_direction() {
-            self.reverse_including_curve()
+            edge.reverse_including_curve()
         } else {
-            self
+            edge
         };
 
         let surface = edge.curve().sweep(path, color);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -14,7 +14,7 @@ use super::{Path, Sweep};
 impl Sweep for (Edge, Color) {
     type Swept = Face;
 
-    fn sweep(self, path: impl Into<Path>, _: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>) -> Self::Swept {
         let (edge, color) = self;
         let path = path.into();
 
@@ -24,7 +24,7 @@ impl Sweep for (Edge, Color) {
             edge
         };
 
-        let surface = edge.curve().sweep(path, color);
+        let surface = edge.curve().sweep(path);
 
         // We can't use the edge we're sweeping from as the bottom edge, as that
         // is not defined in the right surface. Let's create a new bottom edge,
@@ -83,7 +83,7 @@ impl Sweep for (Edge, Color) {
         let side_edges = bottom_edge
             .vertices()
             .get()
-            .map(|&vertex| (vertex, surface).sweep(path, color));
+            .map(|&vertex| (vertex, surface).sweep(path));
 
         let top_edge = {
             let bottom_vertices = bottom_edge.vertices().get();

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -1,5 +1,3 @@
-use fj_interop::mesh::Color;
-
 use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
     objects::{Face, Shell},
@@ -10,7 +8,7 @@ use super::{Path, Sweep};
 impl Sweep for Face {
     type Swept = Shell;
 
-    fn sweep(self, path: impl Into<Path>, _: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>) -> Self::Swept {
         let path = path.into();
 
         let mut faces = Vec::new();
@@ -24,7 +22,7 @@ impl Sweep for Face {
 
         for cycle in self.all_cycles() {
             for &edge in cycle.edges() {
-                let face = (edge, self.color()).sweep(path, self.color());
+                let face = (edge, self.color()).sweep(path);
                 faces.push(face);
             }
         }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -23,8 +23,8 @@ impl Sweep for Face {
         faces.push(top_face);
 
         for cycle in self.all_cycles() {
-            for edge in cycle.edges() {
-                let face = edge.sweep(path, color);
+            for &edge in cycle.edges() {
+                let face = (edge, color).sweep(path, color);
                 faces.push(face);
             }
         }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -10,7 +10,7 @@ use super::{Path, Sweep};
 impl Sweep for Face {
     type Swept = Shell;
 
-    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>, _: Color) -> Self::Swept {
         let path = path.into();
 
         let mut faces = Vec::new();
@@ -24,7 +24,7 @@ impl Sweep for Face {
 
         for cycle in self.all_cycles() {
             for &edge in cycle.edges() {
-                let face = (edge, color).sweep(path, color);
+                let face = (edge, self.color()).sweep(path, self.color());
                 faces.push(face);
             }
         }

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -6,7 +6,6 @@ mod face;
 mod sketch;
 mod vertex;
 
-use fj_interop::mesh::Color;
 use fj_math::{Scalar, Vector};
 
 /// Sweep an object along a path to create another object
@@ -15,7 +14,7 @@ pub trait Sweep {
     type Swept;
 
     /// Sweep the object along the given path
-    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept;
+    fn sweep(self, path: impl Into<Path>) -> Self::Swept;
 }
 
 /// A path to be used with [`Sweep`]

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -1,5 +1,3 @@
-use fj_interop::mesh::Color;
-
 use crate::objects::{Sketch, Solid};
 
 use super::{Path, Sweep};
@@ -7,12 +5,12 @@ use super::{Path, Sweep};
 impl Sweep for Sketch {
     type Swept = Solid;
 
-    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>) -> Self::Swept {
         let path = path.into();
 
         let mut shells = Vec::new();
         for face in self.into_faces() {
-            let shell = face.sweep(path, color);
+            let shell = face.sweep(path);
             shells.push(shell);
         }
 
@@ -22,7 +20,6 @@ impl Sweep for Sketch {
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::mesh::Color;
     use fj_math::{Point, Vector};
 
     use crate::{
@@ -142,7 +139,7 @@ mod tests {
         ]);
         let sketch = Sketch::new().with_faces([face]);
 
-        let solid = sketch.sweep(direction, Color([255, 0, 0, 255]));
+        let solid = sketch.sweep(direction);
 
         let expected_vertices: Vec<_> = expected_vertices
             .into_iter()

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -1,4 +1,3 @@
-use fj_interop::mesh::Color;
 use fj_math::{Line, Point, Scalar};
 
 use crate::objects::{
@@ -11,7 +10,7 @@ use super::{Path, Sweep};
 impl Sweep for (Vertex, Surface) {
     type Swept = Edge;
 
-    fn sweep(self, path: impl Into<Path>, color: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>) -> Self::Swept {
         let (vertex, surface) = self;
         let path = path.into();
 
@@ -60,7 +59,7 @@ impl Sweep for (Vertex, Surface) {
         // With that out of the way, let's start by creating the `GlobalEdge`,
         // as that is the most straight-forward part of this operations, and
         // we're going to need it soon anyway.
-        let edge_global = vertex.global_form().sweep(path, color);
+        let edge_global = vertex.global_form().sweep(path);
 
         // Next, let's compute the surface coordinates of the two vertices of
         // the output `Edge`, as we're going to need these for the rest of this
@@ -135,7 +134,7 @@ impl Sweep for (Vertex, Surface) {
 impl Sweep for GlobalVertex {
     type Swept = GlobalEdge;
 
-    fn sweep(self, path: impl Into<Path>, _: Color) -> Self::Swept {
+    fn sweep(self, path: impl Into<Path>) -> Self::Swept {
         let a = self;
         let b =
             GlobalVertex::from_position(self.position() + path.into().inner());

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -1,4 +1,4 @@
-use fj_interop::{debug::DebugInfo, mesh::Color};
+use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::{
         sweep::Sweep,
@@ -20,9 +20,8 @@ impl Shape for fj::Sweep {
     ) -> Result<Validated<Self::Brep>, ValidationError> {
         let sketch = self.shape().compute_brep(config, debug_info)?;
         let path = Vector::from(self.path());
-        let color = self.shape().color();
 
-        let solid = sketch.into_inner().sweep(path, Color(color));
+        let solid = sketch.into_inner().sweep(path);
         solid.validate_with_config(config)
     }
 


### PR DESCRIPTION
Remove a trait method argument that is only used in one case, really.