### PR TITLE
Rename `Edge` to `HalfEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -12,7 +12,10 @@ impl Approx for &Cycle {
     type Approximation = CycleApprox;
 
     fn approx(self, tolerance: Tolerance) -> Self::Approximation {
-        let edges = self.edges().map(|edge| edge.approx(tolerance)).collect();
+        let edges = self
+            .half_edges()
+            .map(|edge| edge.approx(tolerance))
+            .collect();
         CycleApprox { edges }
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -32,8 +32,8 @@ impl CycleApprox {
     pub fn points(&self) -> Vec<ApproxPoint<2>> {
         let mut points = Vec::new();
 
-        for edge_approx in &self.half_edges {
-            points.extend(edge_approx.points());
+        for approx in &self.half_edges {
+            points.extend(approx.points());
         }
 
         if let Some(point) = points.first() {

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -16,7 +16,7 @@ impl Approx for &Cycle {
             .half_edges()
             .map(|half_edge| half_edge.approx(tolerance))
             .collect();
-        CycleApprox { edges: half_edges }
+        CycleApprox { half_edges }
     }
 }
 
@@ -24,7 +24,7 @@ impl Approx for &Cycle {
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct CycleApprox {
     /// The approximated edges that make up the approximated cycle
-    pub edges: Vec<EdgeApprox>,
+    pub half_edges: Vec<EdgeApprox>,
 }
 
 impl CycleApprox {
@@ -32,7 +32,7 @@ impl CycleApprox {
     pub fn points(&self) -> Vec<ApproxPoint<2>> {
         let mut points = Vec::new();
 
-        for edge_approx in &self.edges {
+        for edge_approx in &self.half_edges {
             points.extend(edge_approx.points());
         }
 

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -14,7 +14,7 @@ impl Approx for &Cycle {
     fn approx(self, tolerance: Tolerance) -> Self::Approximation {
         let half_edges = self
             .half_edges()
-            .map(|edge| edge.approx(tolerance))
+            .map(|half_edge| half_edge.approx(tolerance))
             .collect();
         CycleApprox { edges: half_edges }
     }

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -6,7 +6,7 @@ use fj_math::Segment;
 
 use crate::objects::Cycle;
 
-use super::{edge::EdgeApprox, Approx, ApproxPoint, Tolerance};
+use super::{edge::HalfEdgeApprox, Approx, ApproxPoint, Tolerance};
 
 impl Approx for &Cycle {
     type Approximation = CycleApprox;
@@ -24,7 +24,7 @@ impl Approx for &Cycle {
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct CycleApprox {
     /// The approximated edges that make up the approximated cycle
-    pub half_edges: Vec<EdgeApprox>,
+    pub half_edges: Vec<HalfEdgeApprox>,
 }
 
 impl CycleApprox {

--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -12,11 +12,11 @@ impl Approx for &Cycle {
     type Approximation = CycleApprox;
 
     fn approx(self, tolerance: Tolerance) -> Self::Approximation {
-        let edges = self
+        let half_edges = self
             .half_edges()
             .map(|edge| edge.approx(tolerance))
             .collect();
-        CycleApprox { edges }
+        CycleApprox { edges: half_edges }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -5,14 +5,14 @@
 //! approximations are usually used to build cycle approximations, and this way,
 //! the caller doesn't have to call with duplicate vertices.
 
-use crate::objects::Edge;
+use crate::objects::HalfEdge;
 
 use super::{
     curve::{CurveApprox, RangeOnCurve},
     Approx, ApproxPoint,
 };
 
-impl Approx for &Edge {
+impl Approx for &HalfEdge {
     type Approximation = EdgeApprox;
 
     fn approx(self, tolerance: super::Tolerance) -> Self::Approximation {
@@ -32,7 +32,7 @@ impl Approx for &Edge {
     }
 }
 
-/// An approximation of an [`Edge`]
+/// An approximation of an [`HalfEdge`]
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct EdgeApprox {
     /// The point that approximates the first vertex of the curve

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -13,7 +13,7 @@ use super::{
 };
 
 impl Approx for &HalfEdge {
-    type Approximation = EdgeApprox;
+    type Approximation = HalfEdgeApprox;
 
     fn approx(self, tolerance: super::Tolerance) -> Self::Approximation {
         let &[a, b] = self.vertices();
@@ -25,7 +25,7 @@ impl Approx for &HalfEdge {
         );
         let curve_approx = (self.curve(), range).approx(tolerance);
 
-        EdgeApprox {
+        HalfEdgeApprox {
             first,
             curve_approx,
         }
@@ -34,7 +34,7 @@ impl Approx for &HalfEdge {
 
 /// An approximation of an [`HalfEdge`]
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct EdgeApprox {
+pub struct HalfEdgeApprox {
     /// The point that approximates the first vertex of the curve
     pub first: ApproxPoint<2>,
 
@@ -42,7 +42,7 @@ pub struct EdgeApprox {
     pub curve_approx: CurveApprox,
 }
 
-impl EdgeApprox {
+impl HalfEdgeApprox {
     /// Compute the points that approximate the edge
     pub fn points(&self) -> Vec<ApproxPoint<2>> {
         let mut points = Vec::new();

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -28,21 +28,21 @@ impl CurveEdgeIntersection {
     /// Currently, only intersections between lines and line segments can be
     /// computed. Panics, if a different type of [`Curve`] or [`HalfEdge`] is
     /// passed.
-    pub fn compute(curve: &Curve, edge: &HalfEdge) -> Option<Self> {
+    pub fn compute(curve: &Curve, half_edge: &HalfEdge) -> Option<Self> {
         let curve_as_line = match curve.kind() {
             CurveKind::Line(line) => line,
             _ => todo!("Curve-edge intersection only supports lines"),
         };
 
         let edge_as_segment = {
-            let edge_curve_as_line = match edge.curve().kind() {
+            let edge_curve_as_line = match half_edge.curve().kind() {
                 CurveKind::Line(line) => line,
                 _ => {
                     todo!("Curve-edge intersection only supports line segments")
                 }
             };
 
-            let edge_vertices = edge.vertices().map(|vertex| {
+            let edge_vertices = half_edge.vertices().map(|vertex| {
                 edge_curve_as_line.point_from_line_coords(vertex.position())
             });
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -1,10 +1,10 @@
 use fj_math::{Point, Segment};
 
-use crate::objects::{Curve, CurveKind, Edge};
+use crate::objects::{Curve, CurveKind, HalfEdge};
 
 use super::LineSegmentIntersection;
 
-/// The intersection between a [`Curve`] and an [`Edge`]
+/// The intersection between a [`Curve`] and a [`HalfEdge`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CurveEdgeIntersection {
     /// The curve and edge intersect at a point
@@ -26,9 +26,9 @@ impl CurveEdgeIntersection {
     /// # Panics
     ///
     /// Currently, only intersections between lines and line segments can be
-    /// computed. Panics, if a different type of [`Curve`] or [`Edge`] is
+    /// computed. Panics, if a different type of [`Curve`] or [`HalfEdge`] is
     /// passed.
-    pub fn compute(curve: &Curve, edge: &Edge) -> Option<Self> {
+    pub fn compute(curve: &Curve, edge: &HalfEdge) -> Option<Self> {
         let curve_as_line = match curve.kind() {
             CurveKind::Line(line) => line,
             _ => todo!("Curve-edge intersection only supports lines"),
@@ -71,7 +71,7 @@ impl CurveEdgeIntersection {
 mod tests {
     use fj_math::Point;
 
-    use crate::objects::{Curve, Edge, Surface};
+    use crate::objects::{Curve, HalfEdge, Surface};
 
     use super::CurveEdgeIntersection;
 
@@ -79,7 +79,7 @@ mod tests {
     fn compute_edge_in_front_of_curve_origin() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = Edge::build(surface)
+        let edge = HalfEdge::build(surface)
             .line_segment_from_points([[1., -1.], [1., 1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &edge);
@@ -96,7 +96,7 @@ mod tests {
     fn compute_edge_behind_curve_origin() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = Edge::build(surface)
+        let edge = HalfEdge::build(surface)
             .line_segment_from_points([[-1., -1.], [-1., 1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &edge);
@@ -113,7 +113,7 @@ mod tests {
     fn compute_edge_parallel_to_curve() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = Edge::build(surface)
+        let edge = HalfEdge::build(surface)
             .line_segment_from_points([[-1., -1.], [1., -1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &edge);
@@ -125,7 +125,7 @@ mod tests {
     fn compute_edge_on_curve() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = Edge::build(surface)
+        let edge = HalfEdge::build(surface)
             .line_segment_from_points([[-1., 0.], [1., 0.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &edge);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -79,10 +79,10 @@ mod tests {
     fn compute_edge_in_front_of_curve_origin() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = HalfEdge::build(surface)
+        let half_edge = HalfEdge::build(surface)
             .line_segment_from_points([[1., -1.], [1., 1.]]);
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert_eq!(
             intersection,
@@ -96,10 +96,10 @@ mod tests {
     fn compute_edge_behind_curve_origin() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = HalfEdge::build(surface)
+        let half_edge = HalfEdge::build(surface)
             .line_segment_from_points([[-1., -1.], [-1., 1.]]);
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert_eq!(
             intersection,
@@ -113,10 +113,10 @@ mod tests {
     fn compute_edge_parallel_to_curve() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = HalfEdge::build(surface)
+        let half_edge = HalfEdge::build(surface)
             .line_segment_from_points([[-1., -1.], [1., -1.]]);
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert!(intersection.is_none());
     }
@@ -125,10 +125,10 @@ mod tests {
     fn compute_edge_on_curve() {
         let surface = Surface::xy_plane();
         let curve = Curve::build(surface).u_axis();
-        let edge = HalfEdge::build(surface)
+        let half_edge = HalfEdge::build(surface)
             .line_segment_from_points([[-1., 0.], [1., 0.]]);
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert_eq!(
             intersection,

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -4,7 +4,7 @@ use crate::objects::{Curve, CurveKind, Edge};
 
 use super::LineSegmentIntersection;
 
-/// The intersection between a [`Curve`] and an [`Edge`], in curve coordinates
+/// The intersection between a [`Curve`] and an [`Edge`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CurveEdgeIntersection {
     /// The curve and edge intersect at a point

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -28,14 +28,14 @@ impl CurveFaceIntersection {
 
     /// Compute the intersections between a [`Curve`] and a [`Face`]
     pub fn compute(curve: &Curve, face: &Face) -> Self {
-        let edges = face.all_cycles().flat_map(|cycle| {
+        let half_edges = face.all_cycles().flat_map(|cycle| {
             let edges: Vec<_> = cycle.half_edges().cloned().collect();
             edges
         });
 
         let mut intersections = Vec::new();
 
-        for edge in edges {
+        for edge in half_edges {
             let intersection = CurveEdgeIntersection::compute(curve, &edge);
 
             if let Some(intersection) = intersection {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -28,15 +28,12 @@ impl CurveFaceIntersection {
 
     /// Compute the intersections between a [`Curve`] and a [`Face`]
     pub fn compute(curve: &Curve, face: &Face) -> Self {
-        let half_edges = face.all_cycles().flat_map(|cycle| {
-            let edges: Vec<_> = cycle.half_edges().cloned().collect();
-            edges
-        });
+        let half_edges = face.all_cycles().flat_map(|cycle| cycle.half_edges());
 
         let mut intersections = Vec::new();
 
         for edge in half_edges {
-            let intersection = CurveEdgeIntersection::compute(curve, &edge);
+            let intersection = CurveEdgeIntersection::compute(curve, edge);
 
             if let Some(intersection) = intersection {
                 match intersection {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -29,7 +29,7 @@ impl CurveFaceIntersection {
     /// Compute the intersections between a [`Curve`] and a [`Face`]
     pub fn compute(curve: &Curve, face: &Face) -> Self {
         let edges = face.all_cycles().flat_map(|cycle| {
-            let edges: Vec<_> = cycle.edges().cloned().collect();
+            let edges: Vec<_> = cycle.half_edges().cloned().collect();
             edges
         });
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -32,8 +32,8 @@ impl CurveFaceIntersection {
 
         let mut intersections = Vec::new();
 
-        for edge in half_edges {
-            let intersection = CurveEdgeIntersection::compute(curve, edge);
+        for half_edge in half_edges {
+            let intersection = CurveEdgeIntersection::compute(curve, half_edge);
 
             if let Some(intersection) = intersection {
                 match intersection {

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -2,7 +2,7 @@
 
 use fj_math::Point;
 
-use crate::objects::{Edge, Face, Vertex};
+use crate::objects::{Face, HalfEdge, Vertex};
 
 use super::{
     ray_segment::RaySegmentIntersection, HorizontalRayToTheRight, Intersect,
@@ -120,7 +120,7 @@ pub enum FacePointIntersection {
     PointIsInsideFace,
 
     /// The point is coincident with an edge
-    PointIsOnEdge(Edge),
+    PointIsOnEdge(HalfEdge),
 
     /// The point is coincident with a vertex
     PointIsOnVertex(Vertex),

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -30,8 +30,8 @@ impl Intersect for (&Face, &Point<2>) {
                 .copied()
                 .and_then(|edge| (&ray, &edge).intersect());
 
-            for edge in cycle.half_edges() {
-                let hit = (&ray, edge).intersect();
+            for half_edge in cycle.half_edges() {
+                let hit = (&ray, half_edge).intersect();
 
                 let count_hit = match (hit, previous_hit) {
                     (
@@ -41,17 +41,17 @@ impl Intersect for (&Face, &Point<2>) {
                         // If the ray starts on the boundary of the face,
                         // there's nothing to else check.
                         return Some(
-                            FacePointIntersection::PointIsOnEdge(*edge)
+                            FacePointIntersection::PointIsOnEdge(*half_edge)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = edge.vertices()[0];
+                        let vertex = half_edge.vertices()[0];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = edge.vertices()[1];
+                        let vertex = half_edge.vertices()[1];
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -234,7 +234,7 @@ mod tests {
         let intersection = (&face, &point).intersect();
 
         let edge = face
-            .edge_iter()
+            .half_edge_iter()
             .copied()
             .find(|edge| {
                 let [a, b] = edge.vertices();

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -25,12 +25,12 @@ impl Intersect for (&Face, &Point<2>) {
             // as long as we initialize the `previous_hit` variable with the
             // result of the last segment.
             let mut previous_hit = cycle
-                .edges()
+                .half_edges()
                 .last()
                 .copied()
                 .and_then(|edge| (&ray, &edge).intersect());
 
-            for edge in cycle.edges() {
+            for edge in cycle.half_edges() {
                 let hit = (&ray, edge).intersect();
 
                 let count_hit = match (hit, previous_hit) {

--- a/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
@@ -4,12 +4,12 @@ use fj_math::Segment;
 
 use crate::{
     algorithms::intersect::{HorizontalRayToTheRight, Intersect},
-    objects::{CurveKind, Edge},
+    objects::{CurveKind, HalfEdge},
 };
 
 use super::ray_segment::RaySegmentIntersection;
 
-impl Intersect for (&HorizontalRayToTheRight<2>, &Edge) {
+impl Intersect for (&HorizontalRayToTheRight<2>, &HalfEdge) {
     type Intersection = RaySegmentIntersection;
 
     fn intersect(self) -> Option<Self::Intersection> {

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -213,7 +213,7 @@ mod tests {
             .translate([1., 1., 0.]);
 
         let edge = face
-            .edge_iter()
+            .half_edge_iter()
             .copied()
             .find(|edge| {
                 let [a, b] = edge.vertices();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -4,7 +4,7 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     algorithms::intersect::face_point::FacePointIntersection,
-    objects::{Edge, Face, Vertex},
+    objects::{Face, HalfEdge, Vertex},
 };
 
 use super::{HorizontalRayToTheRight, Intersect};
@@ -142,7 +142,7 @@ pub enum RayFaceIntersection {
     RayHitsFaceAndAreParallel,
 
     /// The ray hits an edge
-    RayHitsEdge(Edge),
+    RayHitsEdge(HalfEdge),
 
     /// The ray hits a vertex
     RayHitsVertex(Vertex),

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -7,7 +7,7 @@ impl Reverse for Cycle {
         let surface = *self.surface();
 
         let mut edges = self
-            .into_edges()
+            .into_half_edges()
             .map(|edge| edge.reverse_including_curve())
             .collect::<Vec<_>>();
 

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -1,14 +1,14 @@
-use crate::objects::Edge;
+use crate::objects::HalfEdge;
 
 use super::Reverse;
 
-impl Reverse for Edge {
+impl Reverse for HalfEdge {
     fn reverse(self) -> Self {
         let vertices = {
             let &[a, b] = self.vertices();
             [b, a]
         };
 
-        Edge::from_curve_and_vertices(*self.curve(), vertices)
+        HalfEdge::from_curve_and_vertices(*self.curve(), vertices)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -41,7 +41,7 @@ fn reverse_local_coordinates_in_cycles<'r>(
 fn reverse_local_coordinates_in_cycle(cycle: &Cycle) -> Cycle {
     let surface = cycle.surface().reverse();
 
-    let edges = cycle.half_edges().map(|edge| {
+    let half_edges = cycle.half_edges().map(|edge| {
         let curve = {
             let local = match edge.curve().kind() {
                 CurveKind::Circle(circle) => {
@@ -97,7 +97,7 @@ fn reverse_local_coordinates_in_cycle(cycle: &Cycle) -> Cycle {
         HalfEdge::from_curve_and_vertices(curve, vertices)
     });
 
-    Cycle::new(surface, edges)
+    Cycle::new(surface, half_edges)
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -1,7 +1,7 @@
 use fj_math::{Circle, Line, Point, Vector};
 
 use crate::objects::{
-    Curve, CurveKind, Cycle, Edge, Face, SurfaceVertex, Vertex,
+    Curve, CurveKind, Cycle, Face, HalfEdge, SurfaceVertex, Vertex,
 };
 
 use super::Reverse;
@@ -94,7 +94,7 @@ fn reverse_local_coordinates_in_cycle(cycle: &Cycle) -> Cycle {
             )
         });
 
-        Edge::from_curve_and_vertices(curve, vertices)
+        HalfEdge::from_curve_and_vertices(curve, vertices)
     });
 
     Cycle::new(surface, edges)

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -41,9 +41,9 @@ fn reverse_local_coordinates_in_cycles<'r>(
 fn reverse_local_coordinates_in_cycle(cycle: &Cycle) -> Cycle {
     let surface = cycle.surface().reverse();
 
-    let half_edges = cycle.half_edges().map(|edge| {
+    let half_edges = cycle.half_edges().map(|half_edge| {
         let curve = {
-            let local = match edge.curve().kind() {
+            let local = match half_edge.curve().kind() {
                 CurveKind::Circle(circle) => {
                     let center =
                         Point::from([circle.center().u, -circle.center().v]);
@@ -66,13 +66,13 @@ fn reverse_local_coordinates_in_cycle(cycle: &Cycle) -> Cycle {
             };
 
             Curve::new(
-                edge.curve().surface().reverse(),
+                half_edge.curve().surface().reverse(),
                 local,
-                *edge.curve().global_form(),
+                *half_edge.curve().global_form(),
             )
         };
 
-        let vertices = edge.vertices().map(|vertex| {
+        let vertices = half_edge.vertices().map(|vertex| {
             let surface_vertex = {
                 let vertex = vertex.surface_form();
 

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -41,7 +41,7 @@ fn reverse_local_coordinates_in_cycles<'r>(
 fn reverse_local_coordinates_in_cycle(cycle: &Cycle) -> Cycle {
     let surface = cycle.surface().reverse();
 
-    let edges = cycle.edges().map(|edge| {
+    let edges = cycle.half_edges().map(|edge| {
         let curve = {
             let local = match edge.curve().kind() {
                 CurveKind::Circle(circle) => {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -4,13 +4,14 @@ use fj_math::{Line, Scalar, Vector};
 use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
     objects::{
-        Curve, CurveKind, Cycle, Edge, Face, GlobalEdge, SurfaceVertex, Vertex,
+        Curve, CurveKind, Cycle, Face, GlobalEdge, HalfEdge, SurfaceVertex,
+        Vertex,
     },
 };
 
 use super::Sweep;
 
-impl Sweep for (Edge, Color) {
+impl Sweep for (HalfEdge, Color) {
     type Swept = Face;
 
     fn sweep(self, path: impl Into<Vector<3>>) -> Self::Swept {
@@ -67,7 +68,7 @@ impl Sweep for (Edge, Color) {
                 })
             };
 
-            Edge::new(curve, vertices, *edge.global_form())
+            HalfEdge::new(curve, vertices, *edge.global_form())
         };
 
         let side_edges = bottom_edge
@@ -130,7 +131,7 @@ impl Sweep for (Edge, Color) {
                 })
             };
 
-            Edge::new(curve, vertices, global)
+            HalfEdge::new(curve, vertices, global)
         };
 
         let cycle = {

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -39,7 +39,7 @@ impl Sweep for Face {
         faces.push(top_face);
 
         for cycle in self.all_cycles() {
-            for &edge in cycle.edges() {
+            for &edge in cycle.half_edges() {
                 let edge = if is_negative_sweep {
                     edge.reverse_including_curve()
                 } else {

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -39,11 +39,11 @@ impl Sweep for Face {
         faces.push(top_face);
 
         for cycle in self.all_cycles() {
-            for &edge in cycle.half_edges() {
+            for &half_edge in cycle.half_edges() {
                 let edge = if is_negative_sweep {
-                    edge.reverse_including_curve()
+                    half_edge.reverse_including_curve()
                 } else {
-                    edge
+                    half_edge
                 };
                 let face = (edge, self.color()).sweep(path);
                 faces.push(face);

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -1,14 +1,14 @@
 use fj_math::{Line, Point, Scalar, Vector};
 
 use crate::objects::{
-    Curve, CurveKind, Edge, GlobalCurve, GlobalEdge, GlobalVertex, Surface,
+    Curve, CurveKind, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface,
     SurfaceVertex, SweptCurve, Vertex,
 };
 
 use super::Sweep;
 
 impl Sweep for (Vertex, Surface) {
-    type Swept = Edge;
+    type Swept = HalfEdge;
 
     fn sweep(self, path: impl Into<Vector<3>>) -> Self::Swept {
         let (vertex, surface) = self;
@@ -125,7 +125,7 @@ impl Sweep for (Vertex, Surface) {
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.
-        Edge::new(curve, vertices, edge_global)
+        HalfEdge::new(curve, vertices, edge_global)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -3,8 +3,8 @@
 use fj_math::{Transform, Vector};
 
 use crate::objects::{
-    Curve, Cycle, Edge, Face, Faces, GlobalCurve, GlobalVertex, Shell, Sketch,
-    Solid, Surface, SurfaceVertex, Vertex,
+    Curve, Cycle, Face, Faces, GlobalCurve, GlobalVertex, HalfEdge, Shell,
+    Sketch, Solid, Surface, SurfaceVertex, Vertex,
 };
 
 /// Transform an object
@@ -53,7 +53,7 @@ impl TransformObject for Cycle {
     }
 }
 
-impl TransformObject for Edge {
+impl TransformObject for HalfEdge {
     fn transform(self, transform: &Transform) -> Self {
         let curve = self.curve().transform(transform);
         let vertices =

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -48,7 +48,7 @@ impl TransformObject for Cycle {
     fn transform(self, transform: &Transform) -> Self {
         Self::new(
             self.surface().transform(transform),
-            self.into_edges().map(|edge| edge.transform(transform)),
+            self.into_half_edges().map(|edge| edge.transform(transform)),
         )
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -53,16 +53,6 @@ impl TransformObject for Cycle {
     }
 }
 
-impl TransformObject for HalfEdge {
-    fn transform(self, transform: &Transform) -> Self {
-        let curve = self.curve().transform(transform);
-        let vertices =
-            self.vertices().map(|vertex| vertex.transform(transform));
-
-        Self::from_curve_and_vertices(curve, vertices)
-    }
-}
-
 impl TransformObject for Face {
     fn transform(self, transform: &Transform) -> Self {
         let surface = self.surface().transform(transform);
@@ -99,6 +89,16 @@ impl TransformObject for GlobalVertex {
     fn transform(self, transform: &Transform) -> Self {
         let position = transform.transform_point(&self.position());
         Self::from_position(position)
+    }
+}
+
+impl TransformObject for HalfEdge {
+    fn transform(self, transform: &Transform) -> Self {
+        let curve = self.curve().transform(transform);
+        let vertices =
+            self.vertices().map(|vertex| vertex.transform(transform));
+
+        Self::from_curve_and_vertices(curve, vertices)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -161,7 +161,7 @@ mod tests {
     use crate::{
         algorithms::validate::{Validate, ValidationConfig, ValidationError},
         objects::{
-            Curve, CurveKind, Edge, GlobalCurve, GlobalVertex, Surface,
+            Curve, CurveKind, GlobalCurve, GlobalVertex, HalfEdge, Surface,
             SurfaceVertex, Vertex,
         },
     };
@@ -223,7 +223,7 @@ mod tests {
             Vertex::new(Point::from([Scalar::ONE]), curve, b_surface, b_global);
         let vertices = [a, b];
 
-        let edge = Edge::from_curve_and_vertices(curve, vertices);
+        let edge = HalfEdge::from_curve_and_vertices(curve, vertices);
 
         let result = edge.validate_with_config(&ValidationConfig {
             identical_max_distance: deviation * 2.,

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -223,15 +223,15 @@ mod tests {
             Vertex::new(Point::from([Scalar::ONE]), curve, b_surface, b_global);
         let vertices = [a, b];
 
-        let edge = HalfEdge::from_curve_and_vertices(curve, vertices);
+        let half_edge = HalfEdge::from_curve_and_vertices(curve, vertices);
 
-        let result = edge.validate_with_config(&ValidationConfig {
+        let result = half_edge.validate_with_config(&ValidationConfig {
             identical_max_distance: deviation * 2.,
             ..ValidationConfig::default()
         });
         assert!(result.is_ok());
 
-        let result = edge.validate_with_config(&ValidationConfig {
+        let result = half_edge.validate_with_config(&ValidationConfig {
             identical_max_distance: deviation / 2.,
             ..ValidationConfig::default()
         });

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -28,18 +28,18 @@ impl CycleBuilder {
             points.push(point);
         }
 
-        let mut edges = Vec::new();
+        let mut half_edges = Vec::new();
         for points in points.windows(2) {
             // Can't panic, as we passed `2` to `windows`.
             //
             // Can be cleaned up, once `array_windows` is stable.
             let points = [points[0], points[1]];
 
-            edges.push(
+            half_edges.push(
                 HalfEdge::build(self.surface).line_segment_from_points(points),
             );
         }
 
-        Cycle::new(self.surface, edges)
+        Cycle::new(self.surface, half_edges)
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -1,6 +1,6 @@
 use fj_math::Point;
 
-use crate::objects::{Cycle, Edge, Surface};
+use crate::objects::{Cycle, HalfEdge, Surface};
 
 /// API for building a [`Cycle`]
 pub struct CycleBuilder {
@@ -36,7 +36,7 @@ impl CycleBuilder {
             let points = [points[0], points[1]];
 
             edges.push(
-                Edge::build(self.surface).line_segment_from_points(points),
+                HalfEdge::build(self.surface).line_segment_from_points(points),
             );
         }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -1,11 +1,11 @@
 use fj_math::{Circle, Line, Point, Scalar, Vector};
 
 use crate::objects::{
-    Curve, CurveKind, Edge, GlobalCurve, GlobalVertex, Surface, SurfaceVertex,
-    Vertex,
+    Curve, CurveKind, GlobalCurve, GlobalVertex, HalfEdge, Surface,
+    SurfaceVertex, Vertex,
 };
 
-/// API for building an [`Edge`]
+/// API for building an [`HalfEdge`]
 pub struct EdgeBuilder {
     surface: Surface,
 }
@@ -13,13 +13,13 @@ pub struct EdgeBuilder {
 impl EdgeBuilder {
     /// Construct a new instance of [`EdgeBuilder`]
     ///
-    /// Also see [`Edge::build`].
+    /// Also see [`HalfEdge::build`].
     pub fn new(surface: Surface) -> Self {
         Self { surface }
     }
 
     /// Create a circle from the given radius
-    pub fn circle_from_radius(&self, radius: Scalar) -> Edge {
+    pub fn circle_from_radius(&self, radius: Scalar) -> HalfEdge {
         let curve = {
             let local = CurveKind::Circle(Circle::new(
                 Point::origin(),
@@ -65,14 +65,14 @@ impl EdgeBuilder {
             )
         };
 
-        Edge::from_curve_and_vertices(curve, vertices)
+        HalfEdge::from_curve_and_vertices(curve, vertices)
     }
 
     /// Create a line segment from two points
     pub fn line_segment_from_points(
         &self,
         points: [impl Into<Point<2>>; 2],
-    ) -> Edge {
+    ) -> HalfEdge {
         let points = points.map(Into::into);
 
         let global_vertices = points.map(|position| {
@@ -118,6 +118,6 @@ impl EdgeBuilder {
             ]
         };
 
-        Edge::from_curve_and_vertices(curve, vertices)
+        HalfEdge::from_curve_and_vertices(curve, vertices)
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -6,12 +6,12 @@ use crate::objects::{
 };
 
 /// API for building an [`HalfEdge`]
-pub struct EdgeBuilder {
+pub struct HalfEdgeBuilder {
     surface: Surface,
 }
 
-impl EdgeBuilder {
-    /// Construct a new instance of [`EdgeBuilder`]
+impl HalfEdgeBuilder {
+    /// Construct a new instance of [`HalfEdgeBuilder`]
     ///
     /// Also see [`HalfEdge::build`].
     pub fn new(surface: Surface) -> Self {

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -11,7 +11,7 @@ mod solid;
 pub use self::{
     curve::{CurveBuilder, GlobalCurveBuilder},
     cycle::CycleBuilder,
-    edge::EdgeBuilder,
+    edge::HalfEdgeBuilder,
     face::{FaceBuilder, FacePolygon},
     shell::ShellBuilder,
     sketch::SketchBuilder,

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -37,17 +37,6 @@ pub trait ObjectIters<'r> {
         iter
     }
 
-    /// Iterate over all half-edges
-    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
-        let mut iter = Iter::empty();
-
-        for object in self.referenced_objects() {
-            iter = iter.with(object.half_edge_iter());
-        }
-
-        iter
-    }
-
     /// Iterate over all faces
     fn face_iter(&'r self) -> Iter<&'r Face> {
         let mut iter = Iter::empty();
@@ -76,6 +65,17 @@ pub trait ObjectIters<'r> {
 
         for object in self.referenced_objects() {
             iter = iter.with(object.global_vertex_iter());
+        }
+
+        iter
+    }
+
+    /// Iterate over all half-edges
+    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
+        let mut iter = Iter::empty();
+
+        for object in self.referenced_objects() {
+            iter = iter.with(object.half_edge_iter());
         }
 
         iter

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -391,24 +391,6 @@ mod tests {
     }
 
     #[test]
-    fn half_edge() {
-        let object = HalfEdge::build(Surface::xy_plane())
-            .line_segment_from_points([[0., 0.], [1., 0.]]);
-
-        assert_eq!(1, object.curve_iter().count());
-        assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(1, object.half_edge_iter().count());
-        assert_eq!(0, object.face_iter().count());
-        assert_eq!(1, object.global_curve_iter().count());
-        assert_eq!(2, object.global_vertex_iter().count());
-        assert_eq!(0, object.shell_iter().count());
-        assert_eq!(0, object.sketch_iter().count());
-        assert_eq!(0, object.solid_iter().count());
-        assert_eq!(0, object.surface_iter().count());
-        assert_eq!(2, object.vertex_iter().count());
-    }
-
-    #[test]
     fn face() {
         let surface = Surface::xy_plane();
         let object = Face::build(surface).polygon_from_points([
@@ -462,6 +444,24 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
+    }
+
+    #[test]
+    fn half_edge() {
+        let object = HalfEdge::build(Surface::xy_plane())
+            .line_segment_from_points([[0., 0.], [1., 0.]]);
+
+        assert_eq!(1, object.curve_iter().count());
+        assert_eq!(0, object.cycle_iter().count());
+        assert_eq!(1, object.half_edge_iter().count());
+        assert_eq!(0, object.face_iter().count());
+        assert_eq!(1, object.global_curve_iter().count());
+        assert_eq!(2, object.global_vertex_iter().count());
+        assert_eq!(0, object.shell_iter().count());
+        assert_eq!(0, object.sketch_iter().count());
+        assert_eq!(0, object.solid_iter().count());
+        assert_eq!(0, object.surface_iter().count());
+        assert_eq!(2, object.vertex_iter().count());
     }
 
     #[test]

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -151,8 +151,8 @@ impl<'r> ObjectIters<'r> for Cycle {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         let mut objects = Vec::new();
 
-        for edge in self.half_edges() {
-            objects.push(edge as &dyn ObjectIters);
+        for half_edge in self.half_edges() {
+            objects.push(half_edge as &dyn ObjectIters);
         }
 
         objects

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -3,8 +3,8 @@
 use std::collections::VecDeque;
 
 use crate::objects::{
-    Curve, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Shell, Sketch, Solid,
-    Surface, Vertex,
+    Curve, Cycle, Face, GlobalCurve, GlobalVertex, HalfEdge, Shell, Sketch,
+    Solid, Surface, Vertex,
 };
 
 /// Access iterators over all objects of a shape, or part of it
@@ -38,7 +38,7 @@ pub trait ObjectIters<'r> {
     }
 
     /// Iterate over all edges
-    fn edge_iter(&'r self) -> Iter<&'r Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r HalfEdge> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
@@ -163,7 +163,7 @@ impl<'r> ObjectIters<'r> for Cycle {
     }
 }
 
-impl<'r> ObjectIters<'r> for Edge {
+impl<'r> ObjectIters<'r> for HalfEdge {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         let mut objects = vec![self.curve() as &dyn ObjectIters];
 
@@ -174,7 +174,7 @@ impl<'r> ObjectIters<'r> for Edge {
         objects
     }
 
-    fn edge_iter(&'r self) -> Iter<&'r Edge> {
+    fn edge_iter(&'r self) -> Iter<&'r HalfEdge> {
         Iter::from_object(self)
     }
 }
@@ -345,7 +345,7 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::objects::{
-        Curve, Cycle, Edge, Face, GlobalCurve, GlobalVertex, Shell, Sketch,
+        Curve, Cycle, Face, GlobalCurve, GlobalVertex, HalfEdge, Shell, Sketch,
         Solid, Surface, SurfaceVertex, Vertex,
     };
 
@@ -392,7 +392,7 @@ mod tests {
 
     #[test]
     fn edge() {
-        let object = Edge::build(Surface::xy_plane())
+        let object = HalfEdge::build(Surface::xy_plane())
             .line_segment_from_points([[0., 0.], [1., 0.]]);
 
         assert_eq!(1, object.curve_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -151,7 +151,7 @@ impl<'r> ObjectIters<'r> for Cycle {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         let mut objects = Vec::new();
 
-        for edge in self.edges() {
+        for edge in self.half_edges() {
             objects.push(edge as &dyn ObjectIters);
         }
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -163,22 +163,6 @@ impl<'r> ObjectIters<'r> for Cycle {
     }
 }
 
-impl<'r> ObjectIters<'r> for HalfEdge {
-    fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
-        let mut objects = vec![self.curve() as &dyn ObjectIters];
-
-        for vertex in self.vertices().iter() {
-            objects.push(vertex);
-        }
-
-        objects
-    }
-
-    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
-        Iter::from_object(self)
-    }
-}
-
 impl<'r> ObjectIters<'r> for Face {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         let mut objects = vec![self.surface() as &dyn ObjectIters];
@@ -211,6 +195,22 @@ impl<'r> ObjectIters<'r> for GlobalVertex {
     }
 
     fn global_vertex_iter(&'r self) -> Iter<&'r GlobalVertex> {
+        Iter::from_object(self)
+    }
+}
+
+impl<'r> ObjectIters<'r> for HalfEdge {
+    fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
+        let mut objects = vec![self.curve() as &dyn ObjectIters];
+
+        for vertex in self.vertices().iter() {
+            objects.push(vertex);
+        }
+
+        objects
+    }
+
+    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
         Iter::from_object(self)
     }
 }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -358,10 +358,10 @@ mod tests {
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -379,10 +379,10 @@ mod tests {
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
-        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
+        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -401,10 +401,10 @@ mod tests {
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
-        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(1, object.face_iter().count());
         assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
+        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -418,10 +418,10 @@ mod tests {
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -435,10 +435,10 @@ mod tests {
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -453,10 +453,10 @@ mod tests {
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(1, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(2, object.global_vertex_iter().count());
+        assert_eq!(1, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -470,10 +470,10 @@ mod tests {
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());
-        assert_eq!(24, object.half_edge_iter().count());
         assert_eq!(6, object.face_iter().count());
         assert_eq!(18, object.global_curve_iter().count());
         assert_eq!(8, object.global_vertex_iter().count());
+        assert_eq!(24, object.half_edge_iter().count());
         assert_eq!(1, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -493,10 +493,10 @@ mod tests {
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
-        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(1, object.face_iter().count());
         assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
+        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(1, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -510,10 +510,10 @@ mod tests {
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());
-        assert_eq!(24, object.half_edge_iter().count());
         assert_eq!(6, object.face_iter().count());
         assert_eq!(18, object.global_curve_iter().count());
         assert_eq!(8, object.global_vertex_iter().count());
+        assert_eq!(24, object.half_edge_iter().count());
         assert_eq!(1, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(1, object.solid_iter().count());
@@ -527,10 +527,10 @@ mod tests {
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());
@@ -549,10 +549,10 @@ mod tests {
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.shell_iter().count());
         assert_eq!(0, object.sketch_iter().count());
         assert_eq!(0, object.solid_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -38,11 +38,11 @@ pub trait ObjectIters<'r> {
     }
 
     /// Iterate over all edges
-    fn edge_iter(&'r self) -> Iter<&'r HalfEdge> {
+    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
-            iter = iter.with(object.edge_iter());
+            iter = iter.with(object.half_edge_iter());
         }
 
         iter
@@ -174,7 +174,7 @@ impl<'r> ObjectIters<'r> for HalfEdge {
         objects
     }
 
-    fn edge_iter(&'r self) -> Iter<&'r HalfEdge> {
+    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
         Iter::from_object(self)
     }
 }
@@ -358,7 +358,7 @@ mod tests {
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.edge_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
@@ -379,7 +379,7 @@ mod tests {
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
-        assert_eq!(3, object.edge_iter().count());
+        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
@@ -397,7 +397,7 @@ mod tests {
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(1, object.edge_iter().count());
+        assert_eq!(1, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(2, object.global_vertex_iter().count());
@@ -419,7 +419,7 @@ mod tests {
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
-        assert_eq!(3, object.edge_iter().count());
+        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(1, object.face_iter().count());
         assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
@@ -436,7 +436,7 @@ mod tests {
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.edge_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
@@ -453,7 +453,7 @@ mod tests {
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.edge_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());
@@ -470,7 +470,7 @@ mod tests {
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());
-        assert_eq!(24, object.edge_iter().count());
+        assert_eq!(24, object.half_edge_iter().count());
         assert_eq!(6, object.face_iter().count());
         assert_eq!(18, object.global_curve_iter().count());
         assert_eq!(8, object.global_vertex_iter().count());
@@ -493,7 +493,7 @@ mod tests {
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
-        assert_eq!(3, object.edge_iter().count());
+        assert_eq!(3, object.half_edge_iter().count());
         assert_eq!(1, object.face_iter().count());
         assert_eq!(3, object.global_curve_iter().count());
         assert_eq!(3, object.global_vertex_iter().count());
@@ -510,7 +510,7 @@ mod tests {
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());
-        assert_eq!(24, object.edge_iter().count());
+        assert_eq!(24, object.half_edge_iter().count());
         assert_eq!(6, object.face_iter().count());
         assert_eq!(18, object.global_curve_iter().count());
         assert_eq!(8, object.global_vertex_iter().count());
@@ -527,7 +527,7 @@ mod tests {
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.edge_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(0, object.global_curve_iter().count());
         assert_eq!(0, object.global_vertex_iter().count());
@@ -549,7 +549,7 @@ mod tests {
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
-        assert_eq!(0, object.edge_iter().count());
+        assert_eq!(0, object.half_edge_iter().count());
         assert_eq!(0, object.face_iter().count());
         assert_eq!(1, object.global_curve_iter().count());
         assert_eq!(1, object.global_vertex_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -37,7 +37,7 @@ pub trait ObjectIters<'r> {
         iter
     }
 
-    /// Iterate over all edges
+    /// Iterate over all half-edges
     fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
         let mut iter = Iter::empty();
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -391,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn edge() {
+    fn half_edge() {
         let object = HalfEdge::build(Surface::xy_plane())
             .line_segment_from_points([[0., 0.], [1., 0.]]);
 

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -44,12 +44,12 @@ impl Cycle {
             // panic.
 
             // Verify that all edges connect.
-            for edges in half_edges.windows(2) {
+            for half_edges in half_edges.windows(2) {
                 // Can't panic, as we passed `2` to `windows`.
                 //
                 // Can be cleaned up, once `array_windows` is stable"
                 // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
-                let [a, b] = [&edges[0], &edges[1]];
+                let [a, b] = [&half_edges[0], &half_edges[1]];
 
                 let [_, prev] = a.vertices();
                 let [next, _] = b.vertices();

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -6,7 +6,7 @@ use super::{HalfEdge, Surface};
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
     surface: Surface,
-    edges: Vec<HalfEdge>,
+    half_edges: Vec<HalfEdge>,
 }
 
 impl Cycle {
@@ -76,7 +76,10 @@ impl Cycle {
             }
         }
 
-        Self { surface, edges }
+        Self {
+            surface,
+            half_edges: edges,
+        }
     }
 
     /// Access the surface that this cycle is in
@@ -86,11 +89,11 @@ impl Cycle {
 
     /// Access edges that make up the cycle
     pub fn edges(&self) -> impl Iterator<Item = &HalfEdge> + '_ {
-        self.edges.iter()
+        self.half_edges.iter()
     }
 
     /// Consume the cycle and return its edges
     pub fn into_edges(self) -> impl Iterator<Item = HalfEdge> {
-        self.edges.into_iter()
+        self.half_edges.into_iter()
     }
 }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -93,7 +93,7 @@ impl Cycle {
     }
 
     /// Consume the cycle and return its edges
-    pub fn into_edges(self) -> impl Iterator<Item = HalfEdge> {
+    pub fn into_half_edges(self) -> impl Iterator<Item = HalfEdge> {
         self.half_edges.into_iter()
     }
 }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -1,12 +1,12 @@
 use crate::builder::CycleBuilder;
 
-use super::{Edge, Surface};
+use super::{HalfEdge, Surface};
 
 /// A cycle of connected edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
     surface: Surface,
-    edges: Vec<Edge>,
+    edges: Vec<HalfEdge>,
 }
 
 impl Cycle {
@@ -23,7 +23,7 @@ impl Cycle {
     /// next edge.
     pub fn new(
         surface: Surface,
-        edges: impl IntoIterator<Item = Edge>,
+        edges: impl IntoIterator<Item = HalfEdge>,
     ) -> Self {
         let edges = edges.into_iter().collect::<Vec<_>>();
 
@@ -85,12 +85,12 @@ impl Cycle {
     }
 
     /// Access edges that make up the cycle
-    pub fn edges(&self) -> impl Iterator<Item = &Edge> + '_ {
+    pub fn edges(&self) -> impl Iterator<Item = &HalfEdge> + '_ {
         self.edges.iter()
     }
 
     /// Consume the cycle and return its edges
-    pub fn into_edges(self) -> impl Iterator<Item = Edge> {
+    pub fn into_edges(self) -> impl Iterator<Item = HalfEdge> {
         self.edges.into_iter()
     }
 }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -88,7 +88,7 @@ impl Cycle {
     }
 
     /// Access edges that make up the cycle
-    pub fn edges(&self) -> impl Iterator<Item = &HalfEdge> + '_ {
+    pub fn half_edges(&self) -> impl Iterator<Item = &HalfEdge> + '_ {
         self.half_edges.iter()
     }
 

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -25,11 +25,11 @@ impl Cycle {
         surface: Surface,
         edges: impl IntoIterator<Item = HalfEdge>,
     ) -> Self {
-        let edges = edges.into_iter().collect::<Vec<_>>();
+        let half_edges = edges.into_iter().collect::<Vec<_>>();
 
         // Verify, that the curves of all edges are defined in the correct
         // surface.
-        for edge in &edges {
+        for edge in &half_edges {
             assert_eq!(
                 &surface,
                 edge.curve().surface(),
@@ -37,14 +37,14 @@ impl Cycle {
             );
         }
 
-        if edges.len() != 1 {
+        if half_edges.len() != 1 {
             // If the length is one, we might have a cycle made up of just one
             // circle. If that isn't the case, we are dealing with line segments
             // and can be sure that the following `get_or_panic` calls won't
             // panic.
 
             // Verify that all edges connect.
-            for edges in edges.windows(2) {
+            for edges in half_edges.windows(2) {
                 // Can't panic, as we passed `2` to `windows`.
                 //
                 // Can be cleaned up, once `array_windows` is stable"
@@ -62,8 +62,8 @@ impl Cycle {
             }
 
             // Verify that the edges form a cycle
-            if let Some(first) = edges.first() {
-                if let Some(last) = edges.last() {
+            if let Some(first) = half_edges.first() {
+                if let Some(last) = half_edges.last() {
                     let [first, _] = first.vertices();
                     let [_, last] = last.vertices();
 
@@ -78,7 +78,7 @@ impl Cycle {
 
         Self {
             surface,
-            half_edges: edges,
+            half_edges,
         }
     }
 

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -2,7 +2,7 @@ use crate::builder::CycleBuilder;
 
 use super::{HalfEdge, Surface};
 
-/// A cycle of connected edges
+/// A cycle of connected half-edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
     surface: Surface,
@@ -19,8 +19,8 @@ impl Cycle {
     ///
     /// # Panics
     ///
-    /// Panic, if the end of each edge does not connect to the beginning of the
-    /// next edge.
+    /// Panic, if the end of each half-edge does not connect to the beginning of
+    /// the next one.
     pub fn new(
         surface: Surface,
         half_edges: impl IntoIterator<Item = HalfEdge>,
@@ -87,12 +87,12 @@ impl Cycle {
         &self.surface
     }
 
-    /// Access edges that make up the cycle
+    /// Access the half-edges that make up the cycle
     pub fn half_edges(&self) -> impl Iterator<Item = &HalfEdge> + '_ {
         self.half_edges.iter()
     }
 
-    /// Consume the cycle and return its edges
+    /// Consume the cycle and return its half-edges
     pub fn into_half_edges(self) -> impl Iterator<Item = HalfEdge> {
         self.half_edges.into_iter()
     }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -23,9 +23,9 @@ impl Cycle {
     /// next edge.
     pub fn new(
         surface: Surface,
-        edges: impl IntoIterator<Item = HalfEdge>,
+        half_edges: impl IntoIterator<Item = HalfEdge>,
     ) -> Self {
-        let half_edges = edges.into_iter().collect::<Vec<_>>();
+        let half_edges = half_edges.into_iter().collect::<Vec<_>>();
 
         // Verify, that the curves of all edges are defined in the correct
         // surface.

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{algorithms::reverse::Reverse, builder::EdgeBuilder};
+use crate::{algorithms::reverse::Reverse, builder::HalfEdgeBuilder};
 
 use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
@@ -13,9 +13,9 @@ pub struct HalfEdge {
 }
 
 impl HalfEdge {
-    /// Build an edge using [`EdgeBuilder`]
-    pub fn build(surface: Surface) -> EdgeBuilder {
-        EdgeBuilder::new(surface)
+    /// Build an edge using [`HalfEdgeBuilder`]
+    pub fn build(surface: Surface) -> HalfEdgeBuilder {
+        HalfEdgeBuilder::new(surface)
     }
 
     /// Create a new instance of `Edge`

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -6,13 +6,13 @@ use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
 /// An edge
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Edge {
+pub struct HalfEdge {
     curve: Curve,
     vertices: [Vertex; 2],
     global: GlobalEdge,
 }
 
-impl Edge {
+impl HalfEdge {
     /// Build an edge using [`EdgeBuilder`]
     pub fn build(surface: Surface) -> EdgeBuilder {
         EdgeBuilder::new(surface)
@@ -21,8 +21,8 @@ impl Edge {
     /// Create a new instance of `Edge`
     ///
     /// If you only have a curve and the edge vertices, please check out
-    /// [`Edge::from_curve_and_vertices`], which is a convenience wrapper around
-    /// this method, which creates an instance of [`GlobalEdge`].
+    /// [`HalfEdge::from_curve_and_vertices`], which is a convenience wrapper
+    /// around this method, which creates an instance of [`GlobalEdge`].
     ///
     /// # Panics
     ///
@@ -63,7 +63,7 @@ impl Edge {
     /// Create a new instance of `Edge` from a curve and vertices
     ///
     /// The [`GlobalEdge`] instance is created from the provided curve and
-    /// vertices. Please refer to [`Edge::new`], if you already have a
+    /// vertices. Please refer to [`HalfEdge::new`], if you already have a
     /// [`GlobalEdge`] instance that you can provide.
     pub fn from_curve_and_vertices(
         curve: Curve,
@@ -129,7 +129,7 @@ impl Edge {
     }
 }
 
-impl fmt::Display for Edge {
+impl fmt::Display for HalfEdge {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let [a, b] = self.vertices().map(|vertex| vertex.position());
         write!(f, "edge from {:?} to {:?}", a, b)?;

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -4,7 +4,7 @@ use crate::{algorithms::reverse::Reverse, builder::HalfEdgeBuilder};
 
 use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
-/// An edge
+/// A half-edge
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
     curve: Curve,
@@ -13,12 +13,12 @@ pub struct HalfEdge {
 }
 
 impl HalfEdge {
-    /// Build an edge using [`HalfEdgeBuilder`]
+    /// Build a half-edge using [`HalfEdgeBuilder`]
     pub fn build(surface: Surface) -> HalfEdgeBuilder {
         HalfEdgeBuilder::new(surface)
     }
 
-    /// Create a new instance of `Edge`
+    /// Create a new instance of `HalfEdge`
     ///
     /// If you only have a curve and the edge vertices, please check out
     /// [`HalfEdge::from_curve_and_vertices`], which is a convenience wrapper
@@ -60,7 +60,7 @@ impl HalfEdge {
         }
     }
 
-    /// Create a new instance of `Edge` from a curve and vertices
+    /// Create a new instance of `HalfEdge` from a curve and vertices
     ///
     /// The [`GlobalEdge`] instance is created from the provided curve and
     /// vertices. Please refer to [`HalfEdge::new`], if you already have a
@@ -76,7 +76,7 @@ impl HalfEdge {
         Self::new(curve, vertices, global)
     }
 
-    /// Reverse the edge, including the curve
+    /// Reverse the half-edge, including the curve
     ///
     /// # Implementation Note
     ///
@@ -105,7 +105,7 @@ impl HalfEdge {
         Self::from_curve_and_vertices(self.curve().reverse(), vertices)
     }
 
-    /// Access the curve that defines the edge's geometry
+    /// Access the curve that defines the half-edge's geometry
     ///
     /// The edge can be a segment of the curve that is bounded by two vertices,
     /// or if the curve is continuous (i.e. connects to itself), the edge could
@@ -114,7 +114,7 @@ impl HalfEdge {
         &self.curve
     }
 
-    /// Access the vertices that bound the edge on the curve
+    /// Access the vertices that bound the half-edge on the curve
     ///
     /// An edge has either two bounding vertices or none. The latter is possible
     /// if the edge's curve is continuous (i.e. connects to itself), and defines
@@ -123,7 +123,7 @@ impl HalfEdge {
         &self.vertices
     }
 
-    /// Access the global form of this edge
+    /// Access the global form of this half-edge
     pub fn global_form(&self) -> &GlobalEdge {
         &self.global
     }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -17,7 +17,7 @@ mod vertex;
 pub use self::{
     curve::{Curve, CurveKind, GlobalCurve},
     cycle::Cycle,
-    edge::{Edge, GlobalEdge},
+    edge::{GlobalEdge, HalfEdge},
     face::{Face, Faces},
     shell::Shell,
     sketch::Sketch,

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -7,14 +7,6 @@ use super::{Curve, Surface};
 /// `Vertex` is defined in terms of a 1-dimensional position on a curve. If you
 /// need the 3D position of a vertex, you can use [`Vertex::global_form`], to
 /// get access of the global form of a vertex ([`GlobalVertex`]).
-///
-/// # Implementation Note
-///
-/// Since `Vertex` is defined in terms of the curve it lies on, a reference to
-/// that curve should be available here. As of this writing, this reference
-/// still lives in [`Edge`].
-///
-/// [`Edge`]: super::Edge
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     position: Point<1>,

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -24,9 +24,9 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let edge = HalfEdge::build(surface)
+                let half_edge = HalfEdge::build(surface)
                     .circle_from_radius(Scalar::from_f64(circle.radius()));
-                let cycle = Cycle::new(surface, [edge]);
+                let cycle = Cycle::new(surface, [half_edge]);
 
                 Face::new(surface, cycle).with_color(Color(self.color()))
             }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -3,7 +3,7 @@ use fj_kernel::{
     algorithms::validate::{
         Validate, Validated, ValidationConfig, ValidationError,
     },
-    objects::{Cycle, Edge, Face, Sketch, Surface},
+    objects::{Cycle, Face, HalfEdge, Sketch, Surface},
 };
 use fj_math::{Aabb, Point, Scalar};
 
@@ -24,7 +24,7 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let edge = Edge::build(surface)
+                let edge = HalfEdge::build(surface)
                     .circle_from_radius(Scalar::from_f64(circle.radius()));
                 let cycle = Cycle::new(surface, [edge]);
 


### PR DESCRIPTION
`HalfEdge` is directed, so the new name is more descriptive.