### PR TITLE
Expand sweep test suite

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -165,3 +165,42 @@ impl Sweep for (HalfEdge, Color) {
         Face::new(surface, cycle).with_color(color)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use fj_interop::mesh::Color;
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        algorithms::{reverse::Reverse, sweep::Sweep},
+        objects::{Cycle, Face, HalfEdge, Surface},
+    };
+
+    #[test]
+    fn sweep() {
+        let half_edge = HalfEdge::build(Surface::xy_plane())
+            .line_segment_from_points([[0., 0.], [1., 0.]]);
+
+        let face = (half_edge, Color::default()).sweep([0., 0., 1.]);
+
+        let expected_face = {
+            let surface = Surface::xz_plane();
+            let builder = HalfEdge::build(surface);
+
+            let bottom = builder.line_segment_from_points([[0., 0.], [1., 0.]]);
+            let top = builder
+                .line_segment_from_points([[0., 1.], [1., 1.]])
+                .reverse();
+            let left = builder
+                .line_segment_from_points([[0., 0.], [0., 1.]])
+                .reverse();
+            let right = builder.line_segment_from_points([[1., 0.], [1., 1.]]);
+
+            let cycle = Cycle::new(surface, [bottom, right, top, left]);
+
+            Face::new(surface, cycle)
+        };
+
+        assert_eq!(face, expected_face);
+    }
+}

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -83,7 +83,6 @@ impl Sweep for (Vertex, Surface) {
         // `Edge` is straight-forward.
         let curve = {
             let line = Line::from_points(points_surface);
-
             Curve::new(surface, CurveKind::Line(line), *edge_global.curve())
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -140,3 +140,23 @@ impl Sweep for GlobalVertex {
         GlobalEdge::new(curve, [a, b])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        algorithms::sweep::Sweep,
+        objects::{GlobalCurve, GlobalEdge, GlobalVertex},
+    };
+
+    #[test]
+    fn global_vertex() {
+        let edge =
+            GlobalVertex::from_position([0., 0., 0.]).sweep([0., 0., 1.]);
+
+        let expected_edge = GlobalEdge::new(
+            GlobalCurve::build().z_axis(),
+            [[0., 0., 0.], [0., 0., 1.]].map(GlobalVertex::from_position),
+        );
+        assert_eq!(edge, expected_edge);
+    }
+}

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -145,8 +145,24 @@ impl Sweep for GlobalVertex {
 mod tests {
     use crate::{
         algorithms::sweep::Sweep,
-        objects::{GlobalCurve, GlobalEdge, GlobalVertex},
+        objects::{
+            Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface,
+            Vertex,
+        },
     };
+
+    #[test]
+    fn vertex_surface() {
+        let surface = Surface::xz_plane();
+        let curve = Curve::build(surface).u_axis();
+        let vertex = Vertex::build(curve).from_point([0.]);
+
+        let half_edge = (vertex, surface).sweep([0., 0., 1.]);
+
+        let expected_half_edge = HalfEdge::build(surface)
+            .line_segment_from_points([[0., 0.], [0., 1.]]);
+        assert_eq!(half_edge, expected_half_edge);
+    }
 
     #[test]
     fn global_vertex() {

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -22,15 +22,14 @@ impl Sweep for (Vertex, Surface) {
         //    `Curve` is defined in a `Surface`, and we're going to need that to
         //    create the `Curve`. Which is why this `Sweep` implementation is
         //    for `(Vertex, Surface)`, and not just for `Vertex`.
-        // 2. Please note that, while the result `Edge` has two vertices, our
+        // 2. Please note that, while the output `Edge` has two vertices, our
         //    input `Vertex` is not one of them! It can't be, unless the `Curve`
-        //    of the resulting `Edge` happens to be the same `Curve` that the
-        //    input `Vertex` is defined on. That would be an edge case that
-        //    probably can't result in anything valid, and we're going to ignore
-        //    it for now.
+        //    of the output `Edge` happens to be the same `Curve` that the input
+        //    `Vertex` is defined on. That would be an edge case that probably
+        //    can't result in anything valid, and we're going to ignore it for
+        //    now.
         // 3. This means, we have to compute everything that defines the
-        //    resulting `Edge`: The `Curve`, the vertices, and the
-        //    `GlobalCurve`.
+        //    output `Edge`: The `Curve`, the vertices, and the `GlobalCurve`.
         //
         // Before we get to that though, let's make sure that whoever called
         // this didn't give us bad input.
@@ -81,7 +80,7 @@ impl Sweep for (Vertex, Surface) {
         ];
 
         // Armed with those coordinates, creating the `Curve` of the output
-        // `Edge` becomes straight-forward.
+        // `Edge` is straight-forward.
         let curve = {
             let line = Line::from_points(points_surface);
 


### PR DESCRIPTION
The way I dealt with the sweep test suite in #1068 ended up not sitting quite right with me. The updated test suite was a bit weaker than the original one (well, before I started disabling some of the tests, so I could make progress on other things). The tests of one sweep implementation ended up using other sweep implementations, which I think is fine, but those other sweep implementations themselves didn't have test suites.

I've rectified that now. All the non-trivial `Sweep` implementations have test coverage now. I'm sure it doesn't cover all the edge cases that the code implements, but that's fine for now. All in all, we're in much better shape now than we were a while ago, when it comes to the sweep algorithm (both the clarity/quality of the code itself, as well as the test suite).

cc @dwcarr, who has expressed interest in working on circular sweeps (#997)