### PR TITLE
Clean up `Surface`

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -16,7 +16,7 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Face) {
         let (ray, face) = self;
 
         let (plane_origin, plane_direction_1, plane_direction_2) =
-            match face.surface().curve {
+            match face.surface().u {
                 CurveKind::Circle(_) => todo!(
                     "Casting a ray against a swept circle is not supported yet"
                 ),

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -4,7 +4,7 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     algorithms::intersect::face_point::FacePointIntersection,
-    objects::{Face, HalfEdge, Vertex},
+    objects::{CurveKind, Face, HalfEdge, Surface, Vertex},
 };
 
 use super::{HorizontalRayToTheRight, Intersect};
@@ -15,19 +15,17 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Face) {
     fn intersect(self) -> Option<Self::Intersection> {
         let (ray, face) = self;
 
-        let (plane_origin, plane_direction_1, plane_direction_2) = match face
-            .surface()
-        {
-            crate::objects::Surface::SweptCurve(surface) => match surface.curve
-            {
-                crate::objects::CurveKind::Circle(_) => todo!(
+        let (plane_origin, plane_direction_1, plane_direction_2) =
+            match face.surface() {
+                Surface::SweptCurve(surface) => match surface.curve {
+                    CurveKind::Circle(_) => todo!(
                     "Casting a ray against a swept circle is not supported yet"
                 ),
-                crate::objects::CurveKind::Line(line) => {
-                    (line.origin(), line.direction(), surface.path)
-                }
-            },
-        };
+                    CurveKind::Line(line) => {
+                        (line.origin(), line.direction(), surface.path)
+                    }
+                },
+            };
 
         let plane_and_ray_are_parallel = {
             let plane_normal = plane_direction_1.cross(&plane_direction_2);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -21,7 +21,7 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Face) {
                     "Casting a ray against a swept circle is not supported yet"
                 ),
                 CurveKind::Line(line) => {
-                    (line.origin(), line.direction(), face.surface().path)
+                    (line.origin(), line.direction(), face.surface().v)
                 }
             };
 

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -4,7 +4,7 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     algorithms::intersect::face_point::FacePointIntersection,
-    objects::{CurveKind, Face, HalfEdge, Surface, Vertex},
+    objects::{CurveKind, Face, HalfEdge, Vertex},
 };
 
 use super::{HorizontalRayToTheRight, Intersect};
@@ -16,15 +16,13 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Face) {
         let (ray, face) = self;
 
         let (plane_origin, plane_direction_1, plane_direction_2) =
-            match face.surface() {
-                Surface::SweptCurve(surface) => match surface.curve {
-                    CurveKind::Circle(_) => todo!(
+            match face.surface().curve {
+                CurveKind::Circle(_) => todo!(
                     "Casting a ray against a swept circle is not supported yet"
                 ),
-                    CurveKind::Line(line) => {
-                        (line.origin(), line.direction(), surface.path)
-                    }
-                },
+                CurveKind::Line(line) => {
+                    (line.origin(), line.direction(), face.surface().path)
+                }
             };
 
         let plane_and_ray_are_parallel = {

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -16,12 +16,12 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Face) {
         let (ray, face) = self;
 
         let (plane_origin, plane_direction_1, plane_direction_2) =
-            match face.surface().u {
+            match face.surface().u() {
                 CurveKind::Circle(_) => todo!(
                     "Casting a ray against a swept circle is not supported yet"
                 ),
                 CurveKind::Line(line) => {
-                    (line.origin(), line.direction(), face.surface().v)
+                    (line.origin(), line.direction(), face.surface().v())
                 }
             };
 

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -73,7 +73,6 @@ struct PlaneParametric {
 impl PlaneParametric {
     pub fn extract_from_surface(surface: &Surface) -> Self {
         let (line, path) = {
-            let Surface::SweptCurve(surface) = surface;
             let line = match surface.curve {
                 CurveKind::Line(line) => line,
                 _ => todo!(

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -73,7 +73,7 @@ struct PlaneParametric {
 impl PlaneParametric {
     pub fn extract_from_surface(surface: &Surface) -> Self {
         let (line, path) = {
-            let line = match surface.curve {
+            let line = match surface.u {
                 CurveKind::Line(line) => line,
                 _ => todo!(
                     "Only plane-plane intersection is currently supported."

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -73,14 +73,14 @@ struct PlaneParametric {
 impl PlaneParametric {
     pub fn extract_from_surface(surface: &Surface) -> Self {
         let (line, path) = {
-            let line = match surface.u {
+            let line = match surface.u() {
                 CurveKind::Line(line) => line,
                 _ => todo!(
                     "Only plane-plane intersection is currently supported."
                 ),
             };
 
-            (line, surface.v)
+            (line, surface.v())
         };
 
         Self {

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -80,7 +80,7 @@ impl PlaneParametric {
                 ),
             };
 
-            (line, surface.path)
+            (line, surface.v)
         };
 
         Self {

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -17,7 +17,7 @@ impl Sweep for GlobalCurve {
 
     fn sweep(self, path: impl Into<Vector<3>>) -> Self::Swept {
         Surface {
-            curve: *self.kind(),
+            u: *self.kind(),
             path: path.into(),
         }
     }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -1,6 +1,6 @@
 use fj_math::Vector;
 
-use crate::objects::{Curve, GlobalCurve, Surface, SweptCurve};
+use crate::objects::{Curve, GlobalCurve, Surface};
 
 use super::Sweep;
 
@@ -16,9 +16,9 @@ impl Sweep for GlobalCurve {
     type Swept = Surface;
 
     fn sweep(self, path: impl Into<Vector<3>>) -> Self::Swept {
-        Surface::SweptCurve(SweptCurve {
+        Surface {
             curve: *self.kind(),
             path: path.into(),
-        })
+        }
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -16,9 +16,6 @@ impl Sweep for GlobalCurve {
     type Swept = Surface;
 
     fn sweep(self, path: impl Into<Vector<3>>) -> Self::Swept {
-        Surface {
-            u: *self.kind(),
-            v: path.into(),
-        }
+        Surface::new(*self.kind(), path.into())
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -18,7 +18,7 @@ impl Sweep for GlobalCurve {
     fn sweep(self, path: impl Into<Vector<3>>) -> Self::Swept {
         Surface {
             u: *self.kind(),
-            path: path.into(),
+            v: path.into(),
         }
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -16,7 +16,7 @@ impl Sweep for Face {
         let mut faces = Vec::new();
 
         let is_negative_sweep = {
-            let a = match self.surface().curve {
+            let a = match self.surface().u {
                 CurveKind::Circle(_) => todo!(
                     "Sweeping from faces defined in round surfaces is not \
                     supported"

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -2,7 +2,7 @@ use fj_math::{Scalar, Vector};
 
 use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
-    objects::{CurveKind, Face, Shell, Surface},
+    objects::{CurveKind, Face, Shell},
 };
 
 use super::Sweep;
@@ -16,16 +16,14 @@ impl Sweep for Face {
         let mut faces = Vec::new();
 
         let is_negative_sweep = {
-            let Surface::SweptCurve(surface) = self.surface();
-
-            let a = match surface.curve {
+            let a = match self.surface().curve {
                 CurveKind::Circle(_) => todo!(
                     "Sweeping from faces defined in round surfaces is not \
                     supported"
                 ),
                 CurveKind::Line(line) => line.direction(),
             };
-            let b = surface.path;
+            let b = self.surface().path;
 
             let normal = a.cross(&b);
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -16,14 +16,14 @@ impl Sweep for Face {
         let mut faces = Vec::new();
 
         let is_negative_sweep = {
-            let a = match self.surface().u {
+            let a = match self.surface().u() {
                 CurveKind::Circle(_) => todo!(
                     "Sweeping from faces defined in round surfaces is not \
                     supported"
                 ),
                 CurveKind::Line(line) => line.direction(),
             };
-            let b = self.surface().v;
+            let b = self.surface().v();
 
             let normal = a.cross(&b);
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -23,7 +23,7 @@ impl Sweep for Face {
                 ),
                 CurveKind::Line(line) => line.direction(),
             };
-            let b = self.surface().path;
+            let b = self.surface().v;
 
             let normal = a.cross(&b);
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -46,7 +46,7 @@ impl Sweep for (Vertex, Surface) {
         //
         // Let's make sure that these requirements are met.
         {
-            assert_eq!(vertex.curve().global_form().kind(), &surface.curve);
+            assert_eq!(vertex.curve().global_form().kind(), &surface.u);
             assert_eq!(path, surface.path);
         }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -46,8 +46,8 @@ impl Sweep for (Vertex, Surface) {
         //
         // Let's make sure that these requirements are met.
         {
-            assert_eq!(vertex.curve().global_form().kind(), &surface.u);
-            assert_eq!(path, surface.v);
+            assert_eq!(vertex.curve().global_form().kind(), &surface.u());
+            assert_eq!(path, surface.v());
         }
 
         // With that out of the way, let's start by creating the `GlobalEdge`,

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::{Line, Point, Scalar, Vector};
 
 use crate::objects::{
     Curve, CurveKind, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface,
-    SurfaceVertex, SweptCurve, Vertex,
+    SurfaceVertex, Vertex,
 };
 
 use super::Sweep;
@@ -46,13 +46,8 @@ impl Sweep for (Vertex, Surface) {
         //
         // Let's make sure that these requirements are met.
         {
-            let Surface::SweptCurve(SweptCurve {
-                curve: surface_curve,
-                path: surface_path,
-            }) = surface;
-
-            assert_eq!(vertex.curve().global_form().kind(), &surface_curve);
-            assert_eq!(path, surface_path);
+            assert_eq!(vertex.curve().global_form().kind(), &surface.curve);
+            assert_eq!(path, surface.path);
         }
 
         // With that out of the way, let's start by creating the `GlobalEdge`,

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -47,7 +47,7 @@ impl Sweep for (Vertex, Surface) {
         // Let's make sure that these requirements are met.
         {
             assert_eq!(vertex.curve().global_form().kind(), &surface.u);
-            assert_eq!(path, surface.path);
+            assert_eq!(path, surface.v);
         }
 
         // With that out of the way, let's start by creating the `GlobalEdge`,

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -131,10 +131,10 @@ impl TransformObject for Solid {
 
 impl TransformObject for Surface {
     fn transform(self, transform: &Transform) -> Self {
-        Self {
-            u: self.u.transform(transform),
-            v: transform.transform_vector(&self.v),
-        }
+        Self::new(
+            self.u.transform(transform),
+            transform.transform_vector(&self.v),
+        )
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -132,7 +132,7 @@ impl TransformObject for Solid {
 impl TransformObject for Surface {
     fn transform(mut self, transform: &Transform) -> Self {
         self.u = self.u.transform(transform);
-        self.path = transform.transform_vector(&self.path);
+        self.v = transform.transform_vector(&self.v);
         self
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -130,10 +130,11 @@ impl TransformObject for Solid {
 }
 
 impl TransformObject for Surface {
-    fn transform(mut self, transform: &Transform) -> Self {
-        self.u = self.u.transform(transform);
-        self.v = transform.transform_vector(&self.v);
-        self
+    fn transform(self, transform: &Transform) -> Self {
+        Self {
+            u: self.u.transform(transform),
+            v: transform.transform_vector(&self.v),
+        }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -130,15 +130,10 @@ impl TransformObject for Solid {
 }
 
 impl TransformObject for Surface {
-    fn transform(self, transform: &Transform) -> Self {
-        match self {
-            Self::SweptCurve(mut surface) => {
-                surface.curve = surface.curve.transform(transform);
-                surface.path = transform.transform_vector(&surface.path);
-
-                Self::SweptCurve(surface)
-            }
-        }
+    fn transform(mut self, transform: &Transform) -> Self {
+        self.curve = self.curve.transform(transform);
+        self.path = transform.transform_vector(&self.path);
+        self
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -132,8 +132,11 @@ impl TransformObject for Solid {
 impl TransformObject for Surface {
     fn transform(self, transform: &Transform) -> Self {
         match self {
-            Self::SweptCurve(surface) => {
-                Self::SweptCurve(surface.transform(transform))
+            Self::SweptCurve(mut surface) => {
+                surface.curve = surface.curve.transform(transform);
+                surface.path = transform.transform_vector(&surface.path);
+
+                Self::SweptCurve(surface)
             }
         }
     }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -132,8 +132,8 @@ impl TransformObject for Solid {
 impl TransformObject for Surface {
     fn transform(self, transform: &Transform) -> Self {
         Self::new(
-            self.u.transform(transform),
-            transform.transform_vector(&self.v),
+            self.u().transform(transform),
+            transform.transform_vector(&self.v()),
         )
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -131,7 +131,7 @@ impl TransformObject for Solid {
 
 impl TransformObject for Surface {
     fn transform(mut self, transform: &Transform) -> Self {
-        self.curve = self.curve.transform(transform);
+        self.u = self.u.transform(transform);
         self.path = transform.transform_vector(&self.path);
         self
     }

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -106,15 +106,6 @@ impl<const D: usize> CurveKind<D> {
         }
     }
 
-    /// Create a new instance that is reversed
-    #[must_use]
-    pub fn reverse(self) -> Self {
-        match self {
-            Self::Circle(curve) => Self::Circle(curve.reverse()),
-            Self::Line(curve) => Self::Line(curve.reverse()),
-        }
-    }
-
     /// Convert a point on the curve into model coordinates
     pub fn point_from_curve_coords(
         &self,

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -22,6 +22,6 @@ pub use self::{
     shell::Shell,
     sketch::Sketch,
     solid::Solid,
-    surface::{Surface, SweptCurve},
+    surface::Surface,
     vertex::{GlobalVertex, SurfaceVertex, Vertex},
 };

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -4,34 +4,37 @@ use super::CurveKind;
 
 /// A two-dimensional shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum Surface {
-    /// A swept curve
-    SweptCurve(SweptCurve),
+pub struct Surface {
+    /// The curve that this surface was swept from
+    pub curve: CurveKind<3>,
+
+    /// The path that the curve was swept along
+    pub path: Vector<3>,
 }
 
 impl Surface {
     /// Construct a `Surface` that represents the xy-plane
     pub fn xy_plane() -> Self {
-        Self::SweptCurve(SweptCurve {
+        Self {
             curve: CurveKind::x_axis(),
             path: Vector::unit_y(),
-        })
+        }
     }
 
     /// Construct a `Surface` that represents the xz-plane
     pub fn xz_plane() -> Self {
-        Self::SweptCurve(SweptCurve {
+        Self {
             curve: CurveKind::x_axis(),
             path: Vector::unit_z(),
-        })
+        }
     }
 
     /// Construct a `Surface` that represents the yz-plane
     pub fn yz_plane() -> Self {
-        Self::SweptCurve(SweptCurve {
+        Self {
             curve: CurveKind::y_axis(),
             path: Vector::unit_z(),
-        })
+        }
     }
 
     /// Construct a plane from 3 points
@@ -41,45 +44,9 @@ impl Surface {
         let curve = CurveKind::Line(Line::from_points([a, b]));
         let path = c - a;
 
-        Self::SweptCurve(SweptCurve { curve, path })
+        Self { curve, path }
     }
 
-    /// Convert a point in surface coordinates to model coordinates
-    pub fn point_from_surface_coords(
-        &self,
-        point: impl Into<Point<2>>,
-    ) -> Point<3> {
-        match self {
-            Self::SweptCurve(surface) => {
-                surface.point_from_surface_coords(point)
-            }
-        }
-    }
-
-    /// Convert a vector in surface coordinates to model coordinates
-    pub fn vector_from_surface_coords(
-        &self,
-        vector: impl Into<Vector<2>>,
-    ) -> Vector<3> {
-        match self {
-            Self::SweptCurve(surface) => {
-                surface.vector_from_surface_coords(vector)
-            }
-        }
-    }
-}
-
-/// A surface that was swept from a curve
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct SweptCurve {
-    /// The curve that this surface was swept from
-    pub curve: CurveKind<3>,
-
-    /// The path that the curve was swept along
-    pub path: Vector<3>,
-}
-
-impl SweptCurve {
     /// Convert a point in surface coordinates to model coordinates
     pub fn point_from_surface_coords(
         &self,
@@ -112,11 +79,11 @@ mod tests {
 
     use crate::objects::CurveKind;
 
-    use super::SweptCurve;
+    use super::Surface;
 
     #[test]
     fn point_from_surface_coords() {
-        let swept = SweptCurve {
+        let swept = Surface {
             curve: CurveKind::Line(Line::from_origin_and_direction(
                 Point::from([1., 1., 1.]),
                 Vector::from([0., 2., 0.]),
@@ -132,7 +99,7 @@ mod tests {
 
     #[test]
     fn vector_from_surface_coords() {
-        let swept = SweptCurve {
+        let swept = Surface {
             curve: CurveKind::Line(Line::from_origin_and_direction(
                 Point::from([1., 0., 0.]),
                 Vector::from([0., 2., 0.]),

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -13,6 +13,11 @@ pub struct Surface {
 }
 
 impl Surface {
+    /// Construct a `Surface` from two paths that define its coordinate system
+    pub fn new(u: CurveKind<3>, v: Vector<3>) -> Self {
+        Self { u, v }
+    }
+
     /// Construct a `Surface` that represents the xy-plane
     pub fn xy_plane() -> Self {
         Self {

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -5,11 +5,8 @@ use super::CurveKind;
 /// A two-dimensional shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Surface {
-    /// The path that defines the u-coordinate of this surface
-    pub u: CurveKind<3>,
-
-    /// The path that defines the v-coordinate of this surface
-    pub v: Vector<3>,
+    u: CurveKind<3>,
+    v: Vector<3>,
 }
 
 impl Surface {

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -9,7 +9,7 @@ pub struct Surface {
     pub u: CurveKind<3>,
 
     /// The path that the curve was swept along
-    pub path: Vector<3>,
+    pub v: Vector<3>,
 }
 
 impl Surface {
@@ -17,7 +17,7 @@ impl Surface {
     pub fn xy_plane() -> Self {
         Self {
             u: CurveKind::x_axis(),
-            path: Vector::unit_y(),
+            v: Vector::unit_y(),
         }
     }
 
@@ -25,7 +25,7 @@ impl Surface {
     pub fn xz_plane() -> Self {
         Self {
             u: CurveKind::x_axis(),
-            path: Vector::unit_z(),
+            v: Vector::unit_z(),
         }
     }
 
@@ -33,7 +33,7 @@ impl Surface {
     pub fn yz_plane() -> Self {
         Self {
             u: CurveKind::y_axis(),
-            path: Vector::unit_z(),
+            v: Vector::unit_z(),
         }
     }
 
@@ -42,9 +42,9 @@ impl Surface {
         let [a, b, c] = points.map(Into::into);
 
         let u = CurveKind::Line(Line::from_points([a, b]));
-        let path = c - a;
+        let v = c - a;
 
-        Self { u, path }
+        Self { u, v }
     }
 
     /// Convert a point in surface coordinates to model coordinates
@@ -68,7 +68,7 @@ impl Surface {
     }
 
     fn path_to_line(&self) -> Line<3> {
-        Line::from_origin_and_direction(self.u.origin(), self.path)
+        Line::from_origin_and_direction(self.u.origin(), self.v)
     }
 }
 
@@ -88,7 +88,7 @@ mod tests {
                 Point::from([1., 1., 1.]),
                 Vector::from([0., 2., 0.]),
             )),
-            path: Vector::from([0., 0., 2.]),
+            v: Vector::from([0., 0., 2.]),
         };
 
         assert_eq!(
@@ -104,7 +104,7 @@ mod tests {
                 Point::from([1., 0., 0.]),
                 Vector::from([0., 2., 0.]),
             )),
-            path: Vector::from([0., 0., 2.]),
+            v: Vector::from([0., 0., 2.]),
         };
 
         assert_eq!(

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -6,7 +6,7 @@ use super::CurveKind;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Surface {
     /// The curve that this surface was swept from
-    pub curve: CurveKind<3>,
+    pub u: CurveKind<3>,
 
     /// The path that the curve was swept along
     pub path: Vector<3>,
@@ -16,7 +16,7 @@ impl Surface {
     /// Construct a `Surface` that represents the xy-plane
     pub fn xy_plane() -> Self {
         Self {
-            curve: CurveKind::x_axis(),
+            u: CurveKind::x_axis(),
             path: Vector::unit_y(),
         }
     }
@@ -24,7 +24,7 @@ impl Surface {
     /// Construct a `Surface` that represents the xz-plane
     pub fn xz_plane() -> Self {
         Self {
-            curve: CurveKind::x_axis(),
+            u: CurveKind::x_axis(),
             path: Vector::unit_z(),
         }
     }
@@ -32,7 +32,7 @@ impl Surface {
     /// Construct a `Surface` that represents the yz-plane
     pub fn yz_plane() -> Self {
         Self {
-            curve: CurveKind::y_axis(),
+            u: CurveKind::y_axis(),
             path: Vector::unit_z(),
         }
     }
@@ -41,10 +41,10 @@ impl Surface {
     pub fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Self {
         let [a, b, c] = points.map(Into::into);
 
-        let curve = CurveKind::Line(Line::from_points([a, b]));
+        let u = CurveKind::Line(Line::from_points([a, b]));
         let path = c - a;
 
-        Self { curve, path }
+        Self { u, path }
     }
 
     /// Convert a point in surface coordinates to model coordinates
@@ -53,7 +53,7 @@ impl Surface {
         point: impl Into<Point<2>>,
     ) -> Point<3> {
         let point = point.into();
-        self.curve.point_from_curve_coords([point.u])
+        self.u.point_from_curve_coords([point.u])
             + self.path_to_line().vector_from_line_coords([point.v])
     }
 
@@ -63,12 +63,12 @@ impl Surface {
         vector: impl Into<Vector<2>>,
     ) -> Vector<3> {
         let vector = vector.into();
-        self.curve.vector_from_curve_coords([vector.u])
+        self.u.vector_from_curve_coords([vector.u])
             + self.path_to_line().vector_from_line_coords([vector.v])
     }
 
     fn path_to_line(&self) -> Line<3> {
-        Line::from_origin_and_direction(self.curve.origin(), self.path)
+        Line::from_origin_and_direction(self.u.origin(), self.path)
     }
 }
 
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn point_from_surface_coords() {
         let swept = Surface {
-            curve: CurveKind::Line(Line::from_origin_and_direction(
+            u: CurveKind::Line(Line::from_origin_and_direction(
                 Point::from([1., 1., 1.]),
                 Vector::from([0., 2., 0.]),
             )),
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn vector_from_surface_coords() {
         let swept = Surface {
-            curve: CurveKind::Line(Line::from_origin_and_direction(
+            u: CurveKind::Line(Line::from_origin_and_direction(
                 Point::from([1., 0., 0.]),
                 Vector::from([0., 2., 0.]),
             )),

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -80,13 +80,6 @@ pub struct SweptCurve {
 }
 
 impl SweptCurve {
-    /// Create a new instance that is reversed
-    #[must_use]
-    pub fn reverse(mut self) -> Self {
-        self.path = -self.path;
-        self
-    }
-
     /// Transform the surface
     #[must_use]
     pub fn transform(mut self, transform: &Transform) -> Self {
@@ -128,28 +121,6 @@ mod tests {
     use crate::objects::CurveKind;
 
     use super::SweptCurve;
-
-    #[test]
-    fn reverse() {
-        let original = SweptCurve {
-            curve: CurveKind::Line(Line::from_origin_and_direction(
-                Point::from([1., 0., 0.]),
-                Vector::from([0., 2., 0.]),
-            )),
-            path: Vector::from([0., 0., 3.]),
-        };
-
-        let reversed = original.reverse();
-
-        let expected = SweptCurve {
-            curve: CurveKind::Line(Line::from_origin_and_direction(
-                Point::from([1., 0., 0.]),
-                Vector::from([0., 2., 0.]),
-            )),
-            path: Vector::from([0., 0., -3.]),
-        };
-        assert_eq!(expected, reversed);
-    }
 
     #[test]
     fn point_from_surface_coords() {

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -1,4 +1,4 @@
-use fj_math::{Line, Point, Transform, Vector};
+use fj_math::{Line, Point, Vector};
 
 use super::CurveKind;
 
@@ -80,14 +80,6 @@ pub struct SweptCurve {
 }
 
 impl SweptCurve {
-    /// Transform the surface
-    #[must_use]
-    pub fn transform(mut self, transform: &Transform) -> Self {
-        self.curve = self.curve.transform(transform);
-        self.path = transform.transform_vector(&self.path);
-        self
-    }
-
     /// Convert a point in surface coordinates to model coordinates
     pub fn point_from_surface_coords(
         &self,

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -52,6 +52,16 @@ impl Surface {
         Self { u, v }
     }
 
+    /// Access the path that defines the u-coordinate of this surface
+    pub fn u(&self) -> CurveKind<3> {
+        self.u
+    }
+
+    /// Access the path that defines the v-coordinate of this surface
+    pub fn v(&self) -> Vector<3> {
+        self.v
+    }
+
     /// Convert a point in surface coordinates to model coordinates
     pub fn point_from_surface_coords(
         &self,

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -5,10 +5,10 @@ use super::CurveKind;
 /// A two-dimensional shape
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Surface {
-    /// The curve that this surface was swept from
+    /// The path that defines the u-coordinate of this surface
     pub u: CurveKind<3>,
 
-    /// The path that the curve was swept along
+    /// The path that defines the v-coordinate of this surface
     pub v: Vector<3>,
 }
 


### PR DESCRIPTION
Simplify `Surface`, clean up the nomenclature it uses, and bring its API in line with that of other objects.