### PR TITLE
Dumb down `RangeOnPath`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -23,7 +23,8 @@ impl Approx for &HalfEdge {
         cache: &mut Self::Cache,
     ) -> Self::Approximation {
         let &[a, b] = self.vertices();
-        let range = RangeOnPath::new([a, b].map(|vertex| vertex.position()));
+        let boundary = [a, b].map(|vertex| vertex.position());
+        let range = RangeOnPath { boundary };
 
         let first = ApproxPoint::new(
             a.surface_form().position(),

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -59,33 +59,8 @@ impl Approx for (GlobalPath, RangeOnPath) {
 /// The range on which a path should be approximated
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct RangeOnPath {
-    boundary: [Point<1>; 2],
-}
-
-impl RangeOnPath {
-    /// Construct an instance of `RangeOnCurve`
-    ///
-    /// Ranges are normalized on construction, meaning that the order of
-    /// vertices passed to this constructor does not influence the range that is
-    /// constructed.
-    ///
-    /// This is done to prevent bugs during mesh construction: The curve
-    /// approximation code is regularly faced with ranges that are reversed
-    /// versions of each other. This can lead to slightly different
-    /// approximations, which in turn leads to the aforementioned invalid
-    /// meshes.
-    ///
-    /// The caller can use `is_reversed` to determine, if the range was reversed
-    /// during normalization, to adjust the approximation accordingly.
-    pub fn new(boundary: [impl Into<Point<1>>; 2]) -> Self {
-        let boundary = boundary.map(Into::into);
-        Self { boundary }
-    }
-
-    /// Access the boundary of the range
-    pub fn boundary(&self) -> [Point<1>; 2] {
-        self.boundary
-    }
+    /// The boundary of the range
+    pub boundary: [Point<1>; 2],
 }
 
 impl<T> From<[T; 2]> for RangeOnPath
@@ -93,7 +68,8 @@ where
     T: Into<Point<1>>,
 {
     fn from(boundary: [T; 2]) -> Self {
-        Self::new(boundary)
+        let boundary = boundary.map(Into::into);
+        Self { boundary }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -227,7 +227,7 @@ mod tests {
     #[test]
     fn points_for_circle() {
         // At the chosen values for radius and tolerance (see below), the
-        // increment is roughly 1.25.
+        // increment is `PI / 4`, so ~1.57.
 
         // Empty range
         let empty: [Scalar; 0] = [];
@@ -235,23 +235,23 @@ mod tests {
 
         // Ranges contain all generated points. Start is before the first
         // increment and after the last one in each case.
-        test_path([[0.], [TAU]], [1., 2., 3., 4.]);
-        test_path([[1.], [TAU]], [1., 2., 3., 4.]);
-        test_path([[0.], [TAU - 1.]], [1., 2., 3., 4.]);
+        test_path([[0.], [TAU]], [1., 2., 3.]);
+        test_path([[1.], [TAU]], [1., 2., 3.]);
+        test_path([[0.], [TAU - 1.]], [1., 2., 3.]);
 
         // Here the range is restricted to cut of the first or last increment.
-        test_path([[2.], [TAU]], [2., 3., 4.]);
-        test_path([[0.], [TAU - 2.]], [1., 2., 3.]);
+        test_path([[2.], [TAU]], [2., 3.]);
+        test_path([[0.], [TAU - 2.]], [1., 2.]);
 
         fn test_path(
             range: impl Into<RangeOnPath>,
             expected_coords: impl IntoIterator<Item = impl Into<Scalar>>,
         ) {
-            // Choose radius and tolerance such, that we need 5 vertices to
+            // Choose radius and tolerance such, that we need 4 vertices to
             // approximate a full circle. This is the lowest number that we can
             // still cover all the edge cases with
             let radius = 1.;
-            let tolerance = 0.25;
+            let tolerance = 0.375;
 
             let circle = Circle::from_center_and_radius([0., 0.], radius);
             let params = PathApproxParams::for_circle(&circle, tolerance);

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -28,6 +28,8 @@
 //! fit together in a valid mesh, no matter which ranges of a path are being
 //! approximated, and how many times.
 
+use std::iter;
+
 use fj_math::{Circle, Point, Scalar};
 
 use crate::path::GlobalPath;
@@ -168,8 +170,6 @@ impl PathApproxParams {
         &self,
         range: impl Into<RangeOnPath>,
     ) -> impl Iterator<Item = Point<1>> + '_ {
-        use std::iter;
-
         let range = range.into();
 
         let [a, b] = range.boundary.map(|point| point.t / self.increment());

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -174,12 +174,10 @@ impl PathApproxParams {
 
         let [a, b] = range.boundary.map(|point| point.t / self.increment());
 
-        // We can't generate a point exactly at the end of the range as part of
-        // the approximation. Make sure we stop one step before that.
-        let b = if b.ceil() == b { b - 1. } else { b };
-
+        // We can't generate a point exactly at the boundaries of the range as
+        // part of the approximation. Make sure we stay inside the range.
         let start = a.floor() + 1.;
-        let end = b;
+        let end = b.ceil() - 1.;
 
         let mut i = start;
         iter::from_fn(move || {

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -226,16 +226,22 @@ mod tests {
 
     #[test]
     fn points_for_circle() {
-        // Needed to support type inference.
-        let empty: [Scalar; 0] = [];
+        // At the chosen values for radius and tolerance (see below), the
+        // increment is roughly 1.25.
 
-        // At the chosen values, the increment is ~1.25.
-        test_path([[0.], [0.]], empty); // empty range
-        test_path([[0.], [TAU]], [1., 2., 3.]); // start before first increment
-        test_path([[1.], [TAU]], [1., 2., 3.]); // start before first increment
-        test_path([[0.], [TAU - 1.]], [1., 2., 3.]); // end after last increment
-        test_path([[2.], [TAU]], [2., 3.]); // start after first increment
-        test_path([[0.], [TAU - 2.]], [1., 2.]); // end before last increment
+        // Empty range
+        let empty: [Scalar; 0] = [];
+        test_path([[0.], [0.]], empty);
+
+        // Ranges contain all generated points. Start is before the first
+        // increment and after the last one in each case.
+        test_path([[0.], [TAU]], [1., 2., 3.]);
+        test_path([[1.], [TAU]], [1., 2., 3.]);
+        test_path([[0.], [TAU - 1.]], [1., 2., 3.]);
+
+        // Here the range is restricted to cut of the first or last increment.
+        test_path([[2.], [TAU]], [2., 3.]);
+        test_path([[0.], [TAU - 2.]], [1., 2.]);
 
         fn test_path(
             range: impl Into<RangeOnPath>,

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -183,14 +183,14 @@ impl PathApproxParams {
 
         let mut i = start;
         iter::from_fn(move || {
-            if i <= end {
-                let t = self.increment() * i;
-                i += Scalar::ONE;
-
-                Some(Point::from([t]))
-            } else {
-                None
+            if i > end {
+                return None;
             }
+
+            let t = self.increment() * i;
+            i += Scalar::ONE;
+
+            Some(Point::from([t]))
         })
     }
 }

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -179,7 +179,7 @@ impl PathApproxParams {
         let b = if b.ceil() == b { b - 1. } else { b };
 
         let start = a.floor() + 1.;
-        let end = b - 1.;
+        let end = b;
 
         let mut i = start;
         iter::from_fn(move || {
@@ -235,13 +235,13 @@ mod tests {
 
         // Ranges contain all generated points. Start is before the first
         // increment and after the last one in each case.
-        test_path([[0.], [TAU]], [1., 2., 3.]);
-        test_path([[1.], [TAU]], [1., 2., 3.]);
-        test_path([[0.], [TAU - 1.]], [1., 2., 3.]);
+        test_path([[0.], [TAU]], [1., 2., 3., 4.]);
+        test_path([[1.], [TAU]], [1., 2., 3., 4.]);
+        test_path([[0.], [TAU - 1.]], [1., 2., 3., 4.]);
 
         // Here the range is restricted to cut of the first or last increment.
-        test_path([[2.], [TAU]], [2., 3.]);
-        test_path([[0.], [TAU - 2.]], [1., 2.]);
+        test_path([[2.], [TAU]], [2., 3., 4.]);
+        test_path([[0.], [TAU - 2.]], [1., 2., 3.]);
 
         fn test_path(
             range: impl Into<RangeOnPath>,


### PR DESCRIPTION
Simplify `RangeOnPath` and concentrate all the complexity regarding ranges in one function. This feels less error-prone to me, as the caller of the API can't do anything wrong any more. Also, it seems to fix a bug I'm observing in a local branch, where approximated points were in the wrong direction (although I don't know what that bug was specifically; I do know this change fixes it).