### PR TITLE
Fix #1015 start gui independent of model

### DIFF
--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -73,6 +73,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let watcher = model.load_and_watch(parameters)?;
+    // run(Some(watcher), shape_processor, status)?;
     run(None, shape_processor, status)?;
 
     Ok(())

--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let watcher = model.load_and_watch(parameters)?;
-    run(watcher, shape_processor, status)?;
+    run(None, shape_processor, status)?;
 
     Ok(())
 }

--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -52,22 +52,25 @@ fn main() -> anyhow::Result<()> {
         tolerance: args.tolerance,
     };
 
+    let model = if let Some(model) = args.model.or(config.default_model) {
+        let mut model_path = path;
+        model_path.push(model);
+        Some(Model::from_path(model_path.clone()).with_context(|| {
+            format!("Failed to load model: {}", model_path.display())
+        })?)
+    } else {
+        None
+    };
+
     if let Some(export_path) = args.export {
         // export only mode. just load model, process, export and exit
 
-        let model = args.model.or(config.default_model).ok_or_else(|| {
+        let model = model.ok_or_else(|| {
             anyhow!(
                 "No model specified, and no default model configured.\n\
             Specify a model by passing `--model path/to/model`."
             )
         })?;
-        let mut model_path = path;
-        model_path.push(model);
-
-        let model =
-            Model::from_path(model_path.clone()).with_context(|| {
-                format!("Failed to load model: {}", model_path.display())
-            })?;
 
         let shape = model.load_once(&parameters, &mut status)?;
         let shape = shape_processor.process(&shape)?;
@@ -77,9 +80,12 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // let watcher = model.load_and_watch(parameters)?;
-    // run(Some(watcher), shape_processor, status)?;
-    run(None, shape_processor, status)?;
+    if let Some(model) = model {
+        let watcher = model.load_and_watch(parameters)?;
+        run(Some(watcher), shape_processor, status)?;
+    } else {
+        run(None, shape_processor, status)?;
+    }
 
     Ok(())
 }

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -14,7 +14,6 @@ mod vertices;
 pub use self::{
     draw_config::DrawConfig,
     renderer::{DrawError, InitError, Renderer},
-    vertices::Vertices,
 };
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -14,6 +14,7 @@ mod vertices;
 pub use self::{
     draw_config::DrawConfig,
     renderer::{DrawError, InitError, Renderer},
+    vertices::Vertices,
 };
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -10,7 +10,7 @@ use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_viewer::{
     camera::Camera,
-    graphics::{self, DrawConfig, Renderer, Vertices},
+    graphics::{self, DrawConfig, Renderer},
     input,
     screen::{NormalizedPosition, Screen as _, Size},
 };
@@ -47,6 +47,7 @@ pub fn run(
 
     let mut shape = None;
     let mut camera = Camera::new(&Default::default());
+    let mut camera_update_once = watcher.is_some();
 
     event_loop.run(move |event, _, control_flow| {
         trace!("Handling event: {:?}", event);
@@ -61,7 +62,10 @@ pub fn run(
                             new_shape.aabb,
                         );
 
-                        camera.update_planes(&new_shape.aabb);
+                        if camera_update_once {
+                            camera_update_once = false;
+                            camera = Camera::new(&new_shape.aabb);
+                        }
 
                         shape = Some(new_shape);
                     }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -10,7 +10,7 @@ use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_viewer::{
     camera::Camera,
-    graphics::{self, DrawConfig, Renderer},
+    graphics::{self, DrawConfig, Renderer, Vertices},
     input,
     screen::{NormalizedPosition, Screen as _, Size},
 };
@@ -84,6 +84,16 @@ pub fn run(
                     }
                 }
             }
+        } else if camera.is_none() {
+            renderer.update_geometry(
+                Vertices::empty(),
+                Vertices::empty(),
+                Default::default(),
+            );
+
+            camera = Some(Camera::new(&Default::default()));
+
+            println!("camera is set");
         }
 
         //
@@ -177,7 +187,9 @@ pub fn run(
             Event::RedrawRequested(_) => {
                 if let (Some(shape), Some(camera)) = (&shape, &mut camera) {
                     camera.update_planes(&shape.aabb);
+                }
 
+                if let Some(camera) = &mut camera {
                     if let Err(err) = renderer.draw(
                         camera,
                         &mut draw_config,
@@ -186,6 +198,8 @@ pub fn run(
                     ) {
                         warn!("Draw error: {}", err);
                     }
+                } else {
+                    println!("redraw without camera");
                 }
             }
             _ => {}


### PR DESCRIPTION
Fixes #1015
Rendering the gui depends on a camera being there but the camera was only initialized when the model watcher loads something from the model.
Now there is always a camera and in case there is a model watcher the camera is reset on load once.

In main loading a model was always assumed. Since a model is now optional upon start of the app, we have following cases.
If there is a model parameter or config, create a Model::from this model parameter. If this fails already, exit.
If there is an export parameter, check that there is a model. If not exit with "no model specified". Else load once, process and export. Done.
If there is a model, create a watcher and load. Run the GUI.

If there is no model, run the GUI without watcher. This is kind of useless now until we can select and load a model from the GUI.