### PR TITLE
Un-derive `Copy` from various object types

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -44,7 +44,7 @@ impl Approx for (&Curve, RangeOnPath) {
                     curve.path().point_from_path_coords(point.local_form);
 
                 ApproxPoint::new(point_surface, point.global_form)
-                    .with_source((*curve, point.local_form))
+                    .with_source((curve.clone(), point.local_form))
             }),
         )
     }

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -22,7 +22,7 @@ impl Approx for &HalfEdge {
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
     ) -> Self::Approximation {
-        let &[a, b] = self.vertices();
+        let [a, b] = self.vertices();
         let boundary = [a, b].map(|vertex| vertex.position());
         let range = RangeOnPath { boundary };
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -45,7 +45,7 @@ impl CurveEdgeIntersection {
                 }
             };
 
-            let edge_vertices = half_edge.vertices().map(|vertex| {
+            let edge_vertices = half_edge.vertices().clone().map(|vertex| {
                 edge_curve_as_line.point_from_line_coords(vertex.position())
             });
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -30,11 +30,11 @@ impl FaceFaceIntersection {
         // Can be cleaned up, once `zip` is stable:
         // https://doc.rust-lang.org/std/primitive.array.html#method.zip
         let curve_face_intersections = {
-            let [curve_a, curve_b] = intersection_curves;
+            let [curve_a, curve_b] = &intersection_curves;
             let [face_a, face_b] = faces;
 
             [(curve_a, face_a), (curve_b, face_b)].map(|(curve, face)| {
-                CurveFaceIntersection::compute(&curve, face)
+                CurveFaceIntersection::compute(curve, face)
             })
         };
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -45,13 +45,13 @@ impl Intersect for (&Face, &Point<2>) {
                         ));
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = half_edge.vertices()[0];
+                        let vertex = half_edge.vertices()[0].clone();
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = half_edge.vertices()[1];
+                        let vertex = half_edge.vertices()[1].clone();
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
@@ -264,7 +264,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             intersection,
-            Some(FacePointIntersection::PointIsOnVertex(*vertex))
+            Some(FacePointIntersection::PointIsOnVertex(vertex.clone()))
         );
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -40,9 +40,9 @@ impl Intersect for (&Face, &Point<2>) {
                     ) => {
                         // If the ray starts on the boundary of the face,
                         // there's nothing to else check.
-                        return Some(
-                            FacePointIntersection::PointIsOnEdge(*half_edge)
-                        );
+                        return Some(FacePointIntersection::PointIsOnEdge(
+                            half_edge.clone()
+                        ));
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
                         let vertex = half_edge.vertices()[0];
@@ -243,7 +243,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             intersection,
-            Some(FacePointIntersection::PointIsOnEdge(*edge))
+            Some(FacePointIntersection::PointIsOnEdge(edge.clone()))
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -27,7 +27,7 @@ impl Intersect for (&Face, &Point<2>) {
             let mut previous_hit = cycle
                 .half_edges()
                 .last()
-                .copied()
+                .cloned()
                 .and_then(|edge| (&ray, &edge).intersect());
 
             for half_edge in cycle.half_edges() {
@@ -235,7 +235,6 @@ mod tests {
 
         let edge = face
             .half_edge_iter()
-            .copied()
             .find(|edge| {
                 let [a, b] = edge.vertices();
                 a.global_form().position() == Point::from([0., 0., 0.])
@@ -244,7 +243,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             intersection,
-            Some(FacePointIntersection::PointIsOnEdge(edge))
+            Some(FacePointIntersection::PointIsOnEdge(*edge))
         );
     }
 
@@ -259,14 +258,13 @@ mod tests {
 
         let vertex = face
             .vertex_iter()
-            .copied()
             .find(|vertex| {
                 vertex.global_form().position() == Point::from([1., 0., 0.])
             })
             .unwrap();
         assert_eq!(
             intersection,
-            Some(FacePointIntersection::PointIsOnVertex(vertex))
+            Some(FacePointIntersection::PointIsOnVertex(*vertex))
         );
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
@@ -23,7 +23,7 @@ impl Intersect for (&HorizontalRayToTheRight<2>, &HalfEdge) {
             }
         };
 
-        let points = edge.vertices().map(|vertex| {
+        let points = edge.vertices().clone().map(|vertex| {
             let point = vertex.position();
             line.point_from_line_coords(point)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -129,7 +129,7 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Face) {
 }
 
 /// A hit between a ray and a face
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum RayFaceIntersection {
     /// The ray hits the face itself
@@ -219,7 +219,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             (&ray, &face).intersect(),
-            Some(RayFaceIntersection::RayHitsEdge(*edge))
+            Some(RayFaceIntersection::RayHitsEdge(edge.clone()))
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -211,7 +211,6 @@ mod tests {
 
         let edge = face
             .half_edge_iter()
-            .copied()
             .find(|edge| {
                 let [a, b] = edge.vertices();
                 a.global_form().position() == Point::from([1., 0., 1.])
@@ -220,7 +219,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             (&ray, &face).intersect(),
-            Some(RayFaceIntersection::RayHitsEdge(edge))
+            Some(RayFaceIntersection::RayHitsEdge(*edge))
         );
     }
 
@@ -235,14 +234,13 @@ mod tests {
 
         let vertex = face
             .vertex_iter()
-            .copied()
             .find(|vertex| {
                 vertex.global_form().position() == Point::from([1., 0., 0.])
             })
             .unwrap();
         assert_eq!(
             (&ray, &face).intersect(),
-            Some(RayFaceIntersection::RayHitsVertex(vertex))
+            Some(RayFaceIntersection::RayHitsVertex(*vertex))
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -240,7 +240,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             (&ray, &face).intersect(),
-            Some(RayFaceIntersection::RayHitsVertex(*vertex))
+            Some(RayFaceIntersection::RayHitsVertex(vertex.clone()))
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -9,6 +9,6 @@ impl Reverse for HalfEdge {
             [b, a]
         };
 
-        HalfEdge::from_curve_and_vertices(*self.curve(), vertices)
+        HalfEdge::from_curve_and_vertices(self.curve().clone(), vertices)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -5,7 +5,7 @@ use super::Reverse;
 impl Reverse for HalfEdge {
     fn reverse(self) -> Self {
         let vertices = {
-            let &[a, b] = self.vertices();
+            let [a, b] = self.vertices().clone();
             [b, a]
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -18,7 +18,7 @@ impl Sweep for (HalfEdge, Color) {
         let (edge, color) = self;
         let path = path.into();
 
-        let surface = edge.curve().sweep(path);
+        let surface = edge.curve().clone().sweep(path);
 
         // We can't use the edge we're sweeping from as the bottom edge, as that
         // is not defined in the right surface. Let's create a new bottom edge,
@@ -62,7 +62,7 @@ impl Sweep for (HalfEdge, Color) {
 
                     Vertex::new(
                         vertex.position(),
-                        curve,
+                        curve.clone(),
                         surface_vertex,
                         *vertex.global_form(),
                     )
@@ -128,7 +128,7 @@ impl Sweep for (HalfEdge, Color) {
                     );
                     Vertex::new(
                         vertex.position(),
-                        curve,
+                        curve.clone(),
                         vertex_surface,
                         vertex_global,
                     )

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -26,7 +26,7 @@ impl Sweep for (HalfEdge, Color) {
         let bottom_edge = {
             let vertices = edge.vertices();
 
-            let points_curve_and_surface = vertices.map(|vertex| {
+            let points_curve_and_surface = vertices.clone().map(|vertex| {
                 (vertex.position(), [vertex.position().t, Scalar::ZERO])
             });
 
@@ -74,6 +74,7 @@ impl Sweep for (HalfEdge, Color) {
 
         let side_edges = bottom_edge
             .vertices()
+            .clone()
             .map(|vertex| (vertex, surface).sweep(path));
 
         let top_edge = {
@@ -84,9 +85,10 @@ impl Sweep for (HalfEdge, Color) {
                 *vertex.global_form()
             });
 
-            let points_curve_and_surface = bottom_vertices.map(|vertex| {
-                (vertex.position(), [vertex.position().t, Scalar::ONE])
-            });
+            let points_curve_and_surface =
+                bottom_vertices.clone().map(|vertex| {
+                    (vertex.position(), [vertex.position().t, Scalar::ONE])
+                });
 
             let curve = {
                 let global = bottom_edge.curve().global_form().translate(path);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -69,7 +69,7 @@ impl Sweep for (HalfEdge, Color) {
                 })
             };
 
-            HalfEdge::new(curve, vertices, *edge.global_form())
+            HalfEdge::new(curve, vertices, edge.global_form().clone())
         };
 
         let side_edges = bottom_edge

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -79,7 +79,7 @@ impl Sweep for (HalfEdge, Color) {
         let top_edge = {
             let bottom_vertices = bottom_edge.vertices();
 
-            let global_vertices = side_edges.map(|edge| {
+            let global_vertices = side_edges.clone().map(|edge| {
                 let [_, vertex] = edge.vertices();
                 *vertex.global_form()
             });
@@ -155,7 +155,7 @@ impl Sweep for (HalfEdge, Color) {
                 // be coincident when sweeping circles, despite the vertices
                 // being different!
                 if prev_last.surface_form() != next_first.surface_form() {
-                    edges[j] = edges[j].reverse();
+                    edges[j] = edges[j].clone().reverse();
                 }
 
                 i += 1;

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -38,11 +38,11 @@ impl Sweep for Face {
         faces.push(top_face);
 
         for cycle in self.all_cycles() {
-            for &half_edge in cycle.half_edges() {
+            for half_edge in cycle.half_edges() {
                 let edge = if is_negative_sweep {
-                    half_edge.reverse()
+                    half_edge.clone().reverse()
                 } else {
-                    half_edge
+                    half_edge.clone()
                 };
                 let face = (edge, self.color()).sweep(path);
                 faces.push(face);

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -112,7 +112,7 @@ impl Sweep for (Vertex, Surface) {
             vertices.map(|(vertex_surface, &vertex_global)| {
                 Vertex::new(
                     [vertex_surface.position().v],
-                    curve,
+                    curve.clone(),
                     vertex_surface,
                     vertex_global,
                 )

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -107,7 +107,7 @@ impl TransformObject for GlobalVertex {
 
 impl TransformObject for HalfEdge {
     fn transform(self, transform: &Transform) -> Self {
-        let curve = self.curve().transform(transform);
+        let curve = self.curve().clone().transform(transform);
         let vertices = self
             .vertices()
             .clone()
@@ -167,7 +167,7 @@ impl TransformObject for Vertex {
     fn transform(self, transform: &Transform) -> Self {
         Self::new(
             self.position(),
-            self.curve().transform(transform),
+            self.curve().clone().transform(transform),
             self.surface_form().transform(transform),
             self.global_form().transform(transform),
         )

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -108,8 +108,10 @@ impl TransformObject for GlobalVertex {
 impl TransformObject for HalfEdge {
     fn transform(self, transform: &Transform) -> Self {
         let curve = self.curve().transform(transform);
-        let vertices =
-            self.vertices().map(|vertex| vertex.transform(transform));
+        let vertices = self
+            .vertices()
+            .clone()
+            .map(|vertex| vertex.transform(transform));
 
         Self::from_curve_and_vertices(curve, vertices)
     }

--- a/crates/fj-kernel/src/algorithms/validate/coherence.rs
+++ b/crates/fj-kernel/src/algorithms/validate/coherence.rs
@@ -29,7 +29,7 @@ pub fn validate_curve(
                 point_surface,
                 point_surface_as_global,
                 point_global,
-                curve: *curve,
+                curve: curve.clone(),
             })?
         }
     }

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -217,12 +217,16 @@ mod tests {
 
         let a = Vertex::new(
             Point::from([Scalar::ZERO + deviation]),
-            curve,
+            curve.clone(),
             a_surface,
             a_global,
         );
-        let b =
-            Vertex::new(Point::from([Scalar::ONE]), curve, b_surface, b_global);
+        let b = Vertex::new(
+            Point::from([Scalar::ONE]),
+            curve.clone(),
+            b_surface,
+            b_global,
+        );
         let vertices = [a, b];
 
         let half_edge = HalfEdge::from_curve_and_vertices(curve, vertices);

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -227,10 +227,11 @@ mod tests {
 
         let half_edge = HalfEdge::from_curve_and_vertices(curve, vertices);
 
-        let result = half_edge.validate_with_config(&ValidationConfig {
-            identical_max_distance: deviation * 2.,
-            ..ValidationConfig::default()
-        });
+        let result =
+            half_edge.clone().validate_with_config(&ValidationConfig {
+                identical_max_distance: deviation * 2.,
+                ..ValidationConfig::default()
+            });
         assert!(result.is_ok());
 
         let result = half_edge.validate_with_config(&ValidationConfig {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -46,7 +46,7 @@ impl HalfEdgeBuilder {
                 |(point_curve, surface_vertex)| {
                     Vertex::new(
                         point_curve,
-                        curve,
+                        curve.clone(),
                         surface_vertex,
                         global_vertex,
                     )
@@ -103,8 +103,18 @@ impl HalfEdgeBuilder {
             let [a_surface, b_surface] = surface_vertices;
 
             [
-                Vertex::new(Point::from([0.]), curve, a_surface, a_global),
-                Vertex::new(Point::from([1.]), curve, b_surface, b_global),
+                Vertex::new(
+                    Point::from([0.]),
+                    curve.clone(),
+                    a_surface,
+                    a_global,
+                ),
+                Vertex::new(
+                    Point::from([1.]),
+                    curve.clone(),
+                    b_surface,
+                    b_global,
+                ),
             ]
         };
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -32,6 +32,6 @@ impl VertexBuilder {
             global_form,
         );
 
-        Vertex::new([0.], self.curve, surface_form, global_form)
+        Vertex::new([0.], self.curve.clone(), surface_form, global_form)
     }
 }

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::Surface;
 
 /// A curve, defined in local surface coordinates
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Curve {
     path: SurfacePath,
     surface: Surface,

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -130,7 +130,7 @@ impl Cycle {
             //
             // Can be cleaned up, once `array_windows` is stable:
             // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
-            let [a, b] = [half_edge[0], half_edge[1]];
+            let [a, b] = [&half_edge[0], &half_edge[1]];
 
             let [a, b] = [a, b].map(|half_edge| {
                 let [vertex, _] = half_edge.vertices();

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -43,7 +43,7 @@ impl HalfEdge {
         global_form: GlobalEdge,
     ) -> Self {
         // Make sure `curve` and `vertices` match.
-        for vertex in vertices {
+        for vertex in &vertices {
             assert_eq!(
                 &curve,
                 vertex.curve(),
@@ -59,7 +59,7 @@ impl HalfEdge {
         );
 
         // Make sure that the edge vertices are not coincident on the curve.
-        let [a, b] = vertices;
+        let [a, b] = &vertices;
         assert_ne!(
             a.position(),
             b.position(),

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -54,7 +54,7 @@ impl HalfEdge {
         // Make sure `curve` and `vertices` match `global_form`.
         assert_eq!(curve.global_form(), global_form.curve());
         assert_eq!(
-            &vertices.map(|vertex| *vertex.global_form()),
+            &vertices.clone().map(|vertex| *vertex.global_form()),
             global_form.vertices()
         );
 
@@ -84,7 +84,7 @@ impl HalfEdge {
     ) -> Self {
         let global = GlobalEdge::new(
             *curve.global_form(),
-            vertices.map(|vertex| *vertex.global_form()),
+            vertices.clone().map(|vertex| *vertex.global_form()),
         );
         Self::new(curve, vertices, global)
     }
@@ -115,7 +115,7 @@ impl HalfEdge {
 
 impl fmt::Display for HalfEdge {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let [a, b] = self.vertices().map(|vertex| vertex.position());
+        let [a, b] = self.vertices().clone().map(|vertex| vertex.position());
         write!(f, "edge from {:?} to {:?}", a, b)?;
         write!(f, " on {:?}", self.curve().global_form())?;
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -124,7 +124,7 @@ impl fmt::Display for HalfEdge {
 }
 
 /// An edge, defined in global (3D) coordinates
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct GlobalEdge {
     curve: GlobalCurve,
     vertices: [GlobalVertex; 2],

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -5,7 +5,7 @@ use crate::builder::HalfEdgeBuilder;
 use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
 /// A half-edge
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
     curve: Curve,
     vertices: [Vertex; 2],

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -10,7 +10,7 @@ use super::{Curve, Surface};
 /// `Vertex` is defined in terms of a 1-dimensional position on a curve. If you
 /// need the 3D position of a vertex, you can use [`Vertex::global_form`], to
 /// get access of the global form of a vertex ([`GlobalVertex`]).
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     position: Point<1>,
     curve: Curve,


### PR DESCRIPTION
All objects that reference other objects won't be able to sustain a `Copy` implementation much longer. As #1021 progresses, objects will soon reference other objects using a `Handle` type, which can't be `Copy`.