### PR TITLE
Bypass `GlobalCurve` in sweep algorithm

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -1,7 +1,7 @@
 use fj_math::Vector;
 
 use crate::{
-    objects::{Curve, GlobalCurve, Surface},
+    objects::{Curve, Surface},
     stores::Stores,
 };
 
@@ -10,15 +10,7 @@ use super::Sweep;
 impl Sweep for Curve {
     type Swept = Surface;
 
-    fn sweep(self, path: impl Into<Vector<3>>, stores: &Stores) -> Self::Swept {
-        self.global_form().sweep(path, stores)
-    }
-}
-
-impl Sweep for GlobalCurve {
-    type Swept = Surface;
-
     fn sweep(self, path: impl Into<Vector<3>>, _: &Stores) -> Self::Swept {
-        Surface::new(self.path(), path.into())
+        Surface::new(self.global_form().path(), path)
     }
 }


### PR DESCRIPTION
Once #1079 is implemented, it will no longer be possible for `GlobalCurve` to support the previous sweep implementation (see that issue for context). This pull request takes completely bypasses `GlobalCurve` in the sweep code, paving the way for #1079.

This exposes a limitation in the sweep algorithm, namely that it's not possible to sweep from a sketch that is defined in a curved surface. Please note that...

- ...this isn't a new limitation. It's just one that has become obvious, now that the sweep code bypasses the more limited `GlobalCurve` representation.
- ...that this doesn't affect Fornjot models, as those currently can't specify the surface that a sketch is defined in.

I'm going to open a new issue after merging this, to track this limitation.