### PR TITLE
Add builder API for `GlobalVertex`

### DIFF
--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -68,8 +68,8 @@ impl<'a> HalfEdgeBuilder<'a> {
         let points = points.map(Into::into);
 
         let global_vertices = points.map(|position| {
-            let position = self.surface.point_from_surface_coords(position);
-            GlobalVertex::from_position(position)
+            GlobalVertex::build()
+                .from_surface_and_position(&self.surface, position)
         });
 
         let surface_vertices = {

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -17,5 +17,5 @@ pub use self::{
     shell::ShellBuilder,
     sketch::SketchBuilder,
     solid::SolidBuilder,
-    vertex::VertexBuilder,
+    vertex::{GlobalVertexBuilder, VertexBuilder},
 };

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -20,12 +20,9 @@ impl VertexBuilder {
         let point = point.into();
         let &surface = self.curve.surface();
 
-        let global_form = GlobalVertex::from_position(
-            self.curve
-                .global_form()
-                .path()
-                .point_from_path_coords(point),
-        );
+        let global_form =
+            GlobalVertex::build().from_curve_and_position(&self.curve, point);
+
         let surface_form = SurfaceVertex::new(
             self.curve.path().point_from_path_coords(point),
             surface,
@@ -38,3 +35,16 @@ impl VertexBuilder {
 
 /// API for building a [`GlobalVertex`]
 pub struct GlobalVertexBuilder;
+
+impl GlobalVertexBuilder {
+    /// Build a [`GlobalVertex`] from a curve and a position on that curve
+    pub fn from_curve_and_position(
+        &self,
+        curve: &Curve,
+        position: impl Into<Point<1>>,
+    ) -> GlobalVertex {
+        let position_global =
+            curve.global_form().path().point_from_path_coords(position);
+        GlobalVertex::from_position(position_global)
+    }
+}

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -35,3 +35,6 @@ impl VertexBuilder {
         Vertex::new([0.], self.curve.clone(), surface_form, global_form)
     }
 }
+
+/// API for building a [`GlobalVertex`]
+pub struct GlobalVertexBuilder;

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -43,8 +43,9 @@ impl GlobalVertexBuilder {
         curve: &Curve,
         position: impl Into<Point<1>>,
     ) -> GlobalVertex {
+        let position_surface = curve.path().point_from_path_coords(position);
         let position_global =
-            curve.global_form().path().point_from_path_coords(position);
+            curve.surface().point_from_surface_coords(position_surface);
         GlobalVertex::from_position(position_global)
     }
 }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,6 +1,6 @@
 use fj_math::Point;
 
-use crate::objects::{Curve, GlobalVertex, SurfaceVertex, Vertex};
+use crate::objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex};
 
 /// API for building a [`Vertex`]
 pub struct VertexBuilder {
@@ -44,8 +44,16 @@ impl GlobalVertexBuilder {
         position: impl Into<Point<1>>,
     ) -> GlobalVertex {
         let position_surface = curve.path().point_from_path_coords(position);
-        let position_global =
-            curve.surface().point_from_surface_coords(position_surface);
-        GlobalVertex::from_position(position_global)
+        self.from_surface_and_position(curve.surface(), position_surface)
+    }
+
+    /// Build a [`GlobalVertex`] from a surface and a position on that surface
+    pub fn from_surface_and_position(
+        &self,
+        surface: &Surface,
+        position: impl Into<Point<2>>,
+    ) -> GlobalVertex {
+        let position = surface.point_from_surface_coords(position);
+        GlobalVertex::from_position(position)
     }
 }

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 use pretty_assertions::assert_eq;
 
-use crate::builder::VertexBuilder;
+use crate::builder::{GlobalVertexBuilder, VertexBuilder};
 
 use super::{Curve, Surface};
 
@@ -134,6 +134,11 @@ pub struct GlobalVertex {
 }
 
 impl GlobalVertex {
+    /// Build a `GlobalVertex` using [`GlobalVertexBuilder`]
+    pub fn build() -> GlobalVertexBuilder {
+        GlobalVertexBuilder
+    }
+
     /// Construct a `GlobalVertex` from a point
     pub fn from_position(position: impl Into<Point<3>>) -> Self {
         let position = position.into();


### PR DESCRIPTION
Consolidates some redundant code into a new `GlobalVertexBuilder`. Adjusts `GlobalVertexBuilder` to bypass `GlobalCurve`, which also makes this a small step towards #1079.