### PR TITLE
Simplify builder API

### DIFF
--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -7,19 +7,17 @@ use crate::{
 };
 
 /// API for building a [`Curve`]
+///
+/// Also see [`Curve::build`].
 pub struct CurveBuilder<'a> {
-    stores: &'a Stores,
-    surface: Surface,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
+
+    /// The surface that the [`Curve`] is defined in
+    pub surface: Surface,
 }
 
 impl<'a> CurveBuilder<'a> {
-    /// Construct a new instance of [`CurveBuilder`]
-    ///
-    /// Also see [`Curve::build`].
-    pub fn new(stores: &'a Stores, surface: Surface) -> Self {
-        Self { stores, surface }
-    }
-
     /// Build a line that represents the u-axis on the surface
     pub fn u_axis(&self) -> Curve {
         let a = Point::origin();

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -6,19 +6,17 @@ use crate::{
 };
 
 /// API for building a [`Cycle`]
+///
+/// Also see [`Cycle::build`].
 pub struct CycleBuilder<'a> {
-    stores: &'a Stores,
-    surface: Surface,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
+
+    /// The surface that the [`Cycle`] is defined in
+    pub surface: Surface,
 }
 
 impl<'a> CycleBuilder<'a> {
-    /// Construct an instance of `CycleBuilder`
-    ///
-    /// Also see [`Cycle::build`].
-    pub fn new(stores: &'a Stores, surface: Surface) -> Self {
-        Self { stores, surface }
-    }
-
     /// Create a polygon from a list of points
     pub fn polygon_from_points(
         &self,

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -10,19 +10,17 @@ use crate::{
 };
 
 /// API for building an [`HalfEdge`]
+///
+/// Also see [`HalfEdge::build`].
 pub struct HalfEdgeBuilder<'a> {
-    stores: &'a Stores,
-    surface: Surface,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
+
+    /// The surface that the [`HalfEdge`] is defined in
+    pub surface: Surface,
 }
 
 impl<'a> HalfEdgeBuilder<'a> {
-    /// Construct a new instance of [`HalfEdgeBuilder`]
-    ///
-    /// Also see [`HalfEdge::build`].
-    pub fn new(stores: &'a Stores, surface: Surface) -> Self {
-        Self { stores, surface }
-    }
-
     /// Build a circle from the given radius
     pub fn circle_from_radius(&self, radius: impl Into<Scalar>) -> HalfEdge {
         let curve =

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -8,19 +8,17 @@ use crate::{
 };
 
 /// API for building a [`Face`]
+///
+/// Also see [`Face::build`].
 pub struct FaceBuilder<'a> {
-    stores: &'a Stores,
-    surface: Surface,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
+
+    /// The surface that the [`Face`] is defined in
+    pub surface: Surface,
 }
 
 impl<'a> FaceBuilder<'a> {
-    /// Construct an instance of `FaceBuilder`
-    ///
-    /// Also see [`Face::build`].
-    pub fn new(stores: &'a Stores, surface: Surface) -> Self {
-        Self { stores, surface }
-    }
-
     /// Construct a polygon from a list of points
     pub fn polygon_from_points(
         &self,

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -7,18 +7,14 @@ use crate::{
 };
 
 /// API for building a [`Shell`]
+///
+/// Also see [`Shell::build`].
 pub struct ShellBuilder<'a> {
-    stores: &'a Stores,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
 }
 
 impl<'a> ShellBuilder<'a> {
-    /// Construct a new instance of `ShellBuilder`
-    ///
-    /// Also see [`Shell::build`].
-    pub fn new(stores: &'a Stores) -> Self {
-        Self { stores }
-    }
-
     /// Create a cube from the length of its edges
     pub fn cube_from_edge_length(
         &self,

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -6,19 +6,17 @@ use crate::{
 };
 
 /// API for building a [`Sketch`]
+///
+/// Also see [`Sketch::build`].
 pub struct SketchBuilder<'a> {
-    stores: &'a Stores,
-    surface: Surface,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
+
+    /// The surface that the [`Sketch`] is defined in
+    pub surface: Surface,
 }
 
 impl<'a> SketchBuilder<'a> {
-    /// Construct an instance of `SketchBuilder`
-    ///
-    /// Also see [`Sketch::build`].
-    pub fn new(stores: &'a Stores, surface: Surface) -> Self {
-        Self { stores, surface }
-    }
-
     /// Construct a polygon from a list of points
     pub fn polygon_from_points(
         &self,

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -6,18 +6,14 @@ use crate::{
 };
 
 /// API for building a [`Solid`]
+///
+/// Also see [`Solid::build`].
 pub struct SolidBuilder<'a> {
-    stores: &'a Stores,
+    /// The stores that the created objects are put in
+    pub stores: &'a Stores,
 }
 
 impl<'a> SolidBuilder<'a> {
-    /// Construct a new instance of `SolidBuilder`
-    ///
-    /// Also see [`Solid::build`].
-    pub fn new(stores: &'a Stores) -> Self {
-        Self { stores }
-    }
-
     /// Create a cube from the length of its edges
     pub fn cube_from_edge_length(
         &self,

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -3,18 +3,14 @@ use fj_math::Point;
 use crate::objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex};
 
 /// API for building a [`Vertex`]
+///
+/// Also see [`Vertex::build`].
 pub struct VertexBuilder {
-    curve: Curve,
+    /// The curve that the [`Vertex`] is defined in
+    pub curve: Curve,
 }
 
 impl VertexBuilder {
-    /// Construct a new instance of `VertexBuilder`
-    ///
-    /// Also see [`Vertex::build`].
-    pub fn new(curve: Curve) -> Self {
-        Self { curve }
-    }
-
     /// Build a vertex from a curve position
     pub fn from_point(&self, point: impl Into<Point<1>>) -> Vertex {
         let point = point.into();

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -17,7 +17,7 @@ pub struct Curve {
 impl Curve {
     /// Build a curve using [`CurveBuilder`]
     pub fn build(stores: &Stores, surface: Surface) -> CurveBuilder {
-        CurveBuilder::new(stores, surface)
+        CurveBuilder { stores, surface }
     }
 
     /// Construct a new instance of `Curve`

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -15,7 +15,7 @@ pub struct Cycle {
 impl Cycle {
     /// Build a cycle using [`CycleBuilder`]
     pub fn build(stores: &Stores, surface: Surface) -> CycleBuilder {
-        CycleBuilder::new(stores, surface)
+        CycleBuilder { stores, surface }
     }
 
     /// Create a new cycle

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -18,7 +18,7 @@ pub struct HalfEdge {
 impl HalfEdge {
     /// Build a half-edge using [`HalfEdgeBuilder`]
     pub fn build(stores: &Stores, surface: Surface) -> HalfEdgeBuilder {
-        HalfEdgeBuilder::new(stores, surface)
+        HalfEdgeBuilder { stores, surface }
     }
 
     /// Create a new instance of `HalfEdge`

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -67,7 +67,7 @@ pub struct Face {
 impl Face {
     /// Build a face using [`FaceBuilder`]
     pub fn build(stores: &Stores, surface: Surface) -> FaceBuilder {
-        FaceBuilder::new(stores, surface)
+        FaceBuilder { stores, surface }
     }
 
     /// Construct a new instance of `Face`

--- a/crates/fj-kernel/src/objects/shell.rs
+++ b/crates/fj-kernel/src/objects/shell.rs
@@ -16,7 +16,7 @@ pub struct Shell {
 impl Shell {
     /// Build a shell using [`ShellBuilder`]
     pub fn build(stores: &Stores) -> ShellBuilder {
-        ShellBuilder::new(stores)
+        ShellBuilder { stores }
     }
 
     /// Construct an empty instance of `Shell`

--- a/crates/fj-kernel/src/objects/sketch.rs
+++ b/crates/fj-kernel/src/objects/sketch.rs
@@ -16,7 +16,7 @@ pub struct Sketch {
 impl Sketch {
     /// Build a sketch using [`SketchBuilder`]
     pub fn build(stores: &Stores, surface: Surface) -> SketchBuilder {
-        SketchBuilder::new(stores, surface)
+        SketchBuilder { stores, surface }
     }
 
     /// Construct an empty instance of `Sketch`

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -18,7 +18,7 @@ pub struct Solid {
 impl Solid {
     /// Build a solid using [`SolidBuilder`]
     pub fn build(stores: &Stores) -> SolidBuilder {
-        SolidBuilder::new(stores)
+        SolidBuilder { stores }
     }
 
     /// Construct an empty instance of `Solid`

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -21,7 +21,7 @@ pub struct Vertex {
 impl Vertex {
     /// Build a vertex using [`VertexBuilder`]
     pub fn build(curve: Curve) -> VertexBuilder {
-        VertexBuilder::new(curve)
+        VertexBuilder { curve }
     }
 
     /// Construct an instance of `Vertex`


### PR DESCRIPTION
Do away with those useless constructors, making the builder structs simpler, more flexible, and better documented.