### PR TITLE
Rename all object's `build` methods to `builder`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -207,7 +207,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::new(GlobalPath::x_axis(), [0., 0., 1.]);
-        let curve = Curve::build(&stores, surface)
+        let curve = Curve::builder(&stores, surface)
             .line_from_points([[1., 1.], [2., 1.]]);
         let range = RangeOnPath::from([[0.], [1.]]);
 
@@ -222,7 +222,7 @@ mod tests {
 
         let surface =
             Surface::new(GlobalPath::circle_from_radius(1.), [0., 0., 1.]);
-        let curve = Curve::build(&stores, surface)
+        let curve = Curve::builder(&stores, surface)
             .line_from_points([[1., 1.], [1., 2.]]);
         let range = RangeOnPath::from([[0.], [1.]]);
 
@@ -237,7 +237,7 @@ mod tests {
 
         let path = GlobalPath::circle_from_radius(1.);
         let surface = Surface::new(path, [0., 0., 1.]);
-        let curve = Curve::build(&stores, surface)
+        let curve = Curve::builder(&stores, surface)
             .line_from_points([[0., 1.], [1., 1.]]);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
@@ -264,7 +264,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::new(GlobalPath::x_axis(), [0., 0., 1.]);
-        let curve = Curve::build(&stores, surface).circle_from_radius(1.);
+        let curve = Curve::builder(&stores, surface).circle_from_radius(1.);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -87,7 +87,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let half_edge = HalfEdge::build(&stores, surface)
+        let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[1., -1.], [1., 1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -106,7 +106,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let half_edge = HalfEdge::build(&stores, surface)
+        let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[-1., -1.], [-1., 1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -125,7 +125,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let half_edge = HalfEdge::build(&stores, surface)
+        let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[-1., -1.], [1., -1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -139,7 +139,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let half_edge = HalfEdge::build(&stores, surface)
+        let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[-1., 0.], [1., 0.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -86,7 +86,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::build(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).u_axis();
         let half_edge = HalfEdge::build(&stores, surface)
             .line_segment_from_points([[1., -1.], [1., 1.]]);
 
@@ -105,7 +105,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::build(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).u_axis();
         let half_edge = HalfEdge::build(&stores, surface)
             .line_segment_from_points([[-1., -1.], [-1., 1.]]);
 
@@ -124,7 +124,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::build(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).u_axis();
         let half_edge = HalfEdge::build(&stores, surface)
             .line_segment_from_points([[-1., -1.], [1., -1.]]);
 
@@ -138,7 +138,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::build(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).u_axis();
         let half_edge = HalfEdge::build(&stores, surface)
             .line_segment_from_points([[-1., 0.], [1., 0.]]);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -186,7 +186,7 @@ mod tests {
             [-1.,  1.],
         ];
 
-        let face = Face::build(&stores, surface)
+        let face = Face::builder(&stores, surface)
             .polygon_from_points(exterior)
             .with_hole(interior)
             .into_face();

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -168,7 +168,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
 
-        let curve = Curve::build(&stores, surface)
+        let curve = Curve::builder(&stores, surface)
             .line_from_points([[-3., 0.], [-2., 0.]]);
 
         #[rustfmt::skip]

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -83,7 +83,7 @@ mod tests {
         ];
         let surfaces = [Surface::xy_plane(), Surface::xz_plane()];
         let [a, b] = surfaces.map(|surface| {
-            Face::build(&stores, surface)
+            Face::builder(&stores, surface)
                 .polygon_from_points(points)
                 .into_face()
         });
@@ -106,7 +106,7 @@ mod tests {
         ];
         let surfaces = [Surface::xy_plane(), Surface::xz_plane()];
         let [a, b] = surfaces.map(|surface| {
-            Face::build(&stores, surface)
+            Face::builder(&stores, surface)
                 .polygon_from_points(points)
                 .into_face()
         });

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -114,7 +114,7 @@ mod tests {
         let intersection = FaceFaceIntersection::compute([&a, &b], &stores);
 
         let expected_curves = surfaces.map(|surface| {
-            Curve::build(&stores, surface)
+            Curve::builder(&stores, surface)
                 .line_from_points([[0., 0.], [1., 0.]])
         });
         let expected_intervals =

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -142,7 +142,7 @@ mod tests {
     fn point_is_outside_face() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
             .into_face();
         let point = Point::from([2., 1.]);
@@ -155,7 +155,7 @@ mod tests {
     fn ray_hits_vertex_while_passing_outside() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
             .into_face();
         let point = Point::from([1., 1.]);
@@ -171,7 +171,7 @@ mod tests {
     fn ray_hits_vertex_at_cycle_seam() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
             .into_face();
         let point = Point::from([1., 2.]);
@@ -187,7 +187,7 @@ mod tests {
     fn ray_hits_vertex_while_staying_inside() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [2., 1.], [3., 0.], [3., 4.]])
             .into_face();
         let point = Point::from([1., 1.]);
@@ -203,7 +203,7 @@ mod tests {
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [2., 1.], [3., 1.], [0., 2.]])
             .into_face();
         let point = Point::from([1., 1.]);
@@ -219,7 +219,7 @@ mod tests {
     fn ray_hits_parallel_edge_and_does_not_leave_face_there() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([
                 [0., 0.],
                 [2., 1.],
@@ -241,7 +241,7 @@ mod tests {
     fn point_is_coincident_with_edge() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
             .into_face();
         let point = Point::from([1., 0.]);
@@ -266,7 +266,7 @@ mod tests {
     fn point_is_coincident_with_vertex() {
         let stores = Stores::new();
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .into_face();
         let point = Point::from([1., 0.]);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -168,7 +168,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::yz_plane())
+        let face = Face::builder(&stores, Surface::yz_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face()
             .translate([-1., 0., 0.], &stores);
@@ -182,7 +182,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::yz_plane())
+        let face = Face::builder(&stores, Surface::yz_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face()
             .translate([1., 0., 0.], &stores);
@@ -199,7 +199,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::yz_plane())
+        let face = Face::builder(&stores, Surface::yz_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face()
             .translate([0., 0., 2.], &stores);
@@ -213,7 +213,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::yz_plane())
+        let face = Face::builder(&stores, Surface::yz_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face()
             .translate([1., 1., 0.], &stores);
@@ -238,7 +238,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::yz_plane())
+        let face = Face::builder(&stores, Surface::yz_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face()
             .translate([1., 1., 1.], &stores);
@@ -261,7 +261,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face();
 
@@ -277,7 +277,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face = Face::build(&stores, Surface::xy_plane())
+        let face = Face::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
             .into_face()
             .translate([0., 0., 1.], &stores);

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -186,8 +186,8 @@ mod tests {
             None,
         );
 
-        let expected_xy = Curve::build(&stores, xy).u_axis();
-        let expected_xz = Curve::build(&stores, xz).u_axis();
+        let expected_xy = Curve::builder(&stores, xy).u_axis();
+        let expected_xz = Curve::builder(&stores, xz).u_axis();
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([&xy, &xz], &stores),

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -191,14 +191,14 @@ mod tests {
     fn sweep() {
         let stores = Stores::new();
 
-        let half_edge = HalfEdge::build(&stores, Surface::xy_plane())
+        let half_edge = HalfEdge::builder(&stores, Surface::xy_plane())
             .line_segment_from_points([[0., 0.], [1., 0.]]);
 
         let face = (half_edge, Color::default()).sweep([0., 0., 1.], &stores);
 
         let expected_face = {
             let surface = Surface::xz_plane();
-            let builder = HalfEdge::build(&stores, surface);
+            let builder = HalfEdge::builder(&stores, surface);
 
             let bottom = builder.line_segment_from_points([[0., 0.], [1., 0.]]);
             let top = builder

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -90,7 +90,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let solid = Sketch::build(&stores, surface)
+        let solid = Sketch::builder(&stores, surface)
             .polygon_from_points(TRIANGLE)
             .sweep(UP, &stores);
 
@@ -125,7 +125,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let solid = Sketch::build(&stores, surface)
+        let solid = Sketch::builder(&stores, surface)
             .polygon_from_points(TRIANGLE)
             .sweep(DOWN, &stores);
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -94,11 +94,11 @@ mod tests {
             .polygon_from_points(TRIANGLE)
             .sweep(UP, &stores);
 
-        let bottom = Face::build(&stores, surface)
+        let bottom = Face::builder(&stores, surface)
             .polygon_from_points(TRIANGLE)
             .into_face()
             .reverse();
-        let top = Face::build(&stores, surface.translate(UP, &stores))
+        let top = Face::builder(&stores, surface.translate(UP, &stores))
             .polygon_from_points(TRIANGLE)
             .into_face();
 
@@ -129,11 +129,11 @@ mod tests {
             .polygon_from_points(TRIANGLE)
             .sweep(DOWN, &stores);
 
-        let bottom = Face::build(&stores, surface.translate(DOWN, &stores))
+        let bottom = Face::builder(&stores, surface.translate(DOWN, &stores))
             .polygon_from_points(TRIANGLE)
             .into_face()
             .reverse();
-        let top = Face::build(&stores, surface)
+        let top = Face::builder(&stores, surface)
             .polygon_from_points(TRIANGLE)
             .into_face();
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -112,7 +112,7 @@ mod tests {
             // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
             let [a, b] = [window[0], window[1]];
 
-            let half_edge = HalfEdge::build(&stores, Surface::xy_plane())
+            let half_edge = HalfEdge::builder(&stores, Surface::xy_plane())
                 .line_segment_from_points([a, b]);
             (half_edge, Color::default()).sweep(UP, &stores)
         });
@@ -147,7 +147,7 @@ mod tests {
             // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
             let [a, b] = [window[0], window[1]];
 
-            let half_edge = HalfEdge::build(&stores, Surface::xy_plane())
+            let half_edge = HalfEdge::builder(&stores, Surface::xy_plane())
                 .line_segment_from_points([a, b])
                 .reverse();
             (half_edge, Color::default()).sweep(DOWN, &stores)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -160,7 +160,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xz_plane();
-        let curve = Curve::build(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).u_axis();
         let vertex = Vertex::build(curve).from_point([0.]);
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let surface = Surface::xz_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let vertex = Vertex::build(curve).from_point([0.]);
+        let vertex = Vertex::builder(curve).from_point([0.]);
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -165,7 +165,7 @@ mod tests {
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);
 
-        let expected_half_edge = HalfEdge::build(&stores, surface)
+        let expected_half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[0., 0.], [0., 1.]]);
         assert_eq!(half_edge, expected_half_edge);
     }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -111,7 +111,7 @@ mod tests {
         let d = [0., 1.];
 
         let surface = Surface::xy_plane();
-        let face = Face::build(&stores, surface)
+        let face = Face::builder(&stores, surface)
             .polygon_from_points([a, b, c, d])
             .into_face();
 
@@ -145,7 +145,7 @@ mod tests {
         let h = [1., 2.];
 
         let surface = Surface::xy_plane();
-        let face = Face::build(&stores, surface)
+        let face = Face::builder(&stores, surface)
             .polygon_from_points([a, b, c, d])
             .with_hole([e, f, g, h])
             .into_face();
@@ -198,7 +198,7 @@ mod tests {
         let e = Point::from([0., 0.8]);
 
         let surface = Surface::xy_plane();
-        let face = Face::build(&stores, surface)
+        let face = Face::builder(&stores, surface)
             .polygon_from_points([a, b, c, d, e])
             .into_face();
 

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// API for building a [`Curve`]
 ///
-/// Also see [`Curve::build`].
+/// Also see [`Curve::builder`].
 pub struct CurveBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -38,7 +38,7 @@ impl<'a> CycleBuilder<'a> {
             let points = [points[0], points[1]];
 
             half_edges.push(
-                HalfEdge::build(self.stores, self.surface)
+                HalfEdge::builder(self.stores, self.surface)
                     .line_segment_from_points(points),
             );
         }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// API for building a [`Cycle`]
 ///
-/// Also see [`Cycle::build`].
+/// Also see [`Cycle::builder`].
 pub struct CycleBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// API for building an [`HalfEdge`]
 ///
-/// Also see [`HalfEdge::build`].
+/// Also see [`HalfEdge::builder`].
 pub struct HalfEdgeBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -23,8 +23,8 @@ pub struct HalfEdgeBuilder<'a> {
 impl<'a> HalfEdgeBuilder<'a> {
     /// Build a circle from the given radius
     pub fn circle_from_radius(&self, radius: impl Into<Scalar>) -> HalfEdge {
-        let curve =
-            Curve::build(self.stores, self.surface).circle_from_radius(radius);
+        let curve = Curve::builder(self.stores, self.surface)
+            .circle_from_radius(radius);
 
         let vertices = {
             let [a_curve, b_curve] =

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -24,8 +24,8 @@ impl<'a> FaceBuilder<'a> {
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> FacePolygon {
-        let cycle =
-            Cycle::build(self.stores, self.surface).polygon_from_points(points);
+        let cycle = Cycle::builder(self.stores, self.surface)
+            .polygon_from_points(points);
         let face = Face::new(self.surface, cycle);
 
         FacePolygon {
@@ -51,7 +51,7 @@ impl FacePolygon<'_> {
         let surface = *self.face.surface();
         self.face =
             self.face
-                .with_interiors([Cycle::build(self.stores, surface)
+                .with_interiors([Cycle::builder(self.stores, surface)
                     .polygon_from_points(points)]);
 
         self

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// API for building a [`Face`]
 ///
-/// Also see [`Face::build`].
+/// Also see [`Face::builder`].
 pub struct FaceBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -8,7 +8,7 @@ use crate::{
 
 /// API for building a [`Shell`]
 ///
-/// Also see [`Shell::build`].
+/// Also see [`Shell::builder`].
 pub struct ShellBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -37,7 +37,7 @@ impl<'a> ShellBuilder<'a> {
         ];
 
         let faces = planes.map(|plane| {
-            Face::build(self.stores, plane)
+            Face::builder(self.stores, plane)
                 .polygon_from_points(points)
                 .into_face()
         });

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -22,7 +22,7 @@ impl<'a> SketchBuilder<'a> {
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Sketch {
-        let face = Face::build(self.stores, self.surface)
+        let face = Face::builder(self.stores, self.surface)
             .polygon_from_points(points)
             .into_face();
         Sketch::new().with_faces([face])

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// API for building a [`Sketch`]
 ///
-/// Also see [`Sketch::build`].
+/// Also see [`Sketch::builder`].
 pub struct SketchBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// API for building a [`Solid`]
 ///
-/// Also see [`Solid::build`].
+/// Also see [`Solid::builder`].
 pub struct SolidBuilder<'a> {
     /// The stores that the created objects are put in
     pub stores: &'a Stores,

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -20,7 +20,7 @@ impl<'a> SolidBuilder<'a> {
         edge_length: impl Into<Scalar>,
     ) -> Solid {
         let shell =
-            Shell::build(self.stores).cube_from_edge_length(edge_length);
+            Shell::builder(self.stores).cube_from_edge_length(edge_length);
         Solid::new().with_shells([shell])
     }
 }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -4,7 +4,7 @@ use crate::objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex};
 
 /// API for building a [`Vertex`]
 ///
-/// Also see [`Vertex::build`].
+/// Also see [`Vertex::builder`].
 pub struct VertexBuilder {
     /// The curve that the [`Vertex`] is defined in
     pub curve: Curve,

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -459,7 +459,7 @@ mod tests {
     fn half_edge() {
         let stores = Stores::new();
 
-        let object = HalfEdge::build(&stores, Surface::xy_plane())
+        let object = HalfEdge::builder(&stores, Surface::xy_plane())
             .line_segment_from_points([[0., 0.], [1., 0.]]);
 
         assert_eq!(1, object.curve_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -362,7 +362,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let object = Curve::build(&stores, surface).u_axis();
+        let object = Curve::builder(&stores, surface).u_axis();
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -558,7 +558,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::build(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).u_axis();
         let global_vertex = GlobalVertex::from_position([0., 0., 0.]);
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -521,7 +521,7 @@ mod tests {
     fn solid() {
         let stores = Stores::new();
 
-        let object = Solid::build(&stores).cube_from_edge_length(1.);
+        let object = Solid::builder(&stores).cube_from_edge_length(1.);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -381,7 +381,7 @@ mod tests {
     fn cycle() {
         let stores = Stores::new();
 
-        let object = Cycle::build(&stores, Surface::xy_plane())
+        let object = Cycle::builder(&stores, Surface::xy_plane())
             .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]]);
 
         assert_eq!(3, object.curve_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -402,7 +402,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let object = Face::build(&stores, surface)
+        let object = Face::builder(&stores, surface)
             .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .into_face();
 
@@ -499,7 +499,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let face = Face::build(&stores, surface)
+        let face = Face::builder(&stores, surface)
             .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .into_face();
         let object = Sketch::new().with_faces([face]);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -479,7 +479,7 @@ mod tests {
     fn shell() {
         let stores = Stores::new();
 
-        let object = Shell::build(&stores).cube_from_edge_length(1.);
+        let object = Shell::builder(&stores).cube_from_edge_length(1.);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -16,7 +16,7 @@ pub struct Curve {
 
 impl Curve {
     /// Build a curve using [`CurveBuilder`]
-    pub fn build(stores: &Stores, surface: Surface) -> CurveBuilder {
+    pub fn builder(stores: &Stores, surface: Surface) -> CurveBuilder {
         CurveBuilder { stores, surface }
     }
 

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -15,7 +15,7 @@ pub struct Curve {
 }
 
 impl Curve {
-    /// Build a curve using [`CurveBuilder`]
+    /// Build a `Curve` using [`CurveBuilder`]
     pub fn builder(stores: &Stores, surface: Surface) -> CurveBuilder {
         CurveBuilder { stores, surface }
     }

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -14,7 +14,7 @@ pub struct Cycle {
 
 impl Cycle {
     /// Build a cycle using [`CycleBuilder`]
-    pub fn build(stores: &Stores, surface: Surface) -> CycleBuilder {
+    pub fn builder(stores: &Stores, surface: Surface) -> CycleBuilder {
         CycleBuilder { stores, surface }
     }
 

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -13,7 +13,7 @@ pub struct Cycle {
 }
 
 impl Cycle {
-    /// Build a cycle using [`CycleBuilder`]
+    /// Build a `Cycle` using [`CycleBuilder`]
     pub fn builder(stores: &Stores, surface: Surface) -> CycleBuilder {
         CycleBuilder { stores, surface }
     }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -16,7 +16,7 @@ pub struct HalfEdge {
 }
 
 impl HalfEdge {
-    /// Build a half-edge using [`HalfEdgeBuilder`]
+    /// Build a `HalfEdge` using [`HalfEdgeBuilder`]
     pub fn builder(stores: &Stores, surface: Surface) -> HalfEdgeBuilder {
         HalfEdgeBuilder { stores, surface }
     }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -17,7 +17,7 @@ pub struct HalfEdge {
 
 impl HalfEdge {
     /// Build a half-edge using [`HalfEdgeBuilder`]
-    pub fn build(stores: &Stores, surface: Surface) -> HalfEdgeBuilder {
+    pub fn builder(stores: &Stores, surface: Surface) -> HalfEdgeBuilder {
         HalfEdgeBuilder { stores, surface }
     }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -65,7 +65,7 @@ pub struct Face {
 }
 
 impl Face {
-    /// Build a face using [`FaceBuilder`]
+    /// Build a `Face` using [`FaceBuilder`]
     pub fn builder(stores: &Stores, surface: Surface) -> FaceBuilder {
         FaceBuilder { stores, surface }
     }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -66,7 +66,7 @@ pub struct Face {
 
 impl Face {
     /// Build a face using [`FaceBuilder`]
-    pub fn build(stores: &Stores, surface: Surface) -> FaceBuilder {
+    pub fn builder(stores: &Stores, surface: Surface) -> FaceBuilder {
         FaceBuilder { stores, surface }
     }
 

--- a/crates/fj-kernel/src/objects/shell.rs
+++ b/crates/fj-kernel/src/objects/shell.rs
@@ -15,7 +15,7 @@ pub struct Shell {
 
 impl Shell {
     /// Build a shell using [`ShellBuilder`]
-    pub fn build(stores: &Stores) -> ShellBuilder {
+    pub fn builder(stores: &Stores) -> ShellBuilder {
         ShellBuilder { stores }
     }
 

--- a/crates/fj-kernel/src/objects/shell.rs
+++ b/crates/fj-kernel/src/objects/shell.rs
@@ -14,7 +14,7 @@ pub struct Shell {
 }
 
 impl Shell {
-    /// Build a shell using [`ShellBuilder`]
+    /// Build a `Shell` using [`ShellBuilder`]
     pub fn builder(stores: &Stores) -> ShellBuilder {
         ShellBuilder { stores }
     }

--- a/crates/fj-kernel/src/objects/sketch.rs
+++ b/crates/fj-kernel/src/objects/sketch.rs
@@ -15,7 +15,7 @@ pub struct Sketch {
 
 impl Sketch {
     /// Build a sketch using [`SketchBuilder`]
-    pub fn build(stores: &Stores, surface: Surface) -> SketchBuilder {
+    pub fn builder(stores: &Stores, surface: Surface) -> SketchBuilder {
         SketchBuilder { stores, surface }
     }
 

--- a/crates/fj-kernel/src/objects/sketch.rs
+++ b/crates/fj-kernel/src/objects/sketch.rs
@@ -14,7 +14,7 @@ pub struct Sketch {
 }
 
 impl Sketch {
-    /// Build a sketch using [`SketchBuilder`]
+    /// Build a `Sketch` using [`SketchBuilder`]
     pub fn builder(stores: &Stores, surface: Surface) -> SketchBuilder {
         SketchBuilder { stores, surface }
     }

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -16,7 +16,7 @@ pub struct Solid {
 }
 
 impl Solid {
-    /// Build a solid using [`SolidBuilder`]
+    /// Build a `Solid` using [`SolidBuilder`]
     pub fn builder(stores: &Stores) -> SolidBuilder {
         SolidBuilder { stores }
     }

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -17,7 +17,7 @@ pub struct Solid {
 
 impl Solid {
     /// Build a solid using [`SolidBuilder`]
-    pub fn build(stores: &Stores) -> SolidBuilder {
+    pub fn builder(stores: &Stores) -> SolidBuilder {
         SolidBuilder { stores }
     }
 

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -20,7 +20,7 @@ pub struct Vertex {
 
 impl Vertex {
     /// Build a vertex using [`VertexBuilder`]
-    pub fn build(curve: Curve) -> VertexBuilder {
+    pub fn builder(curve: Curve) -> VertexBuilder {
         VertexBuilder { curve }
     }
 

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -19,7 +19,7 @@ pub struct Vertex {
 }
 
 impl Vertex {
-    /// Build a vertex using [`VertexBuilder`]
+    /// Build a `Vertex` using [`VertexBuilder`]
     pub fn builder(curve: Curve) -> VertexBuilder {
         VertexBuilder { curve }
     }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -36,7 +36,7 @@ impl Shape for fj::Sketch {
                 let points =
                     poly_chain.to_points().into_iter().map(Point::from);
 
-                Face::build(stores, surface)
+                Face::builder(stores, surface)
                     .polygon_from_points(points)
                     .into_face()
                     .with_color(Color(self.color()))

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -26,7 +26,7 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let half_edge = HalfEdge::build(stores, surface)
+                let half_edge = HalfEdge::builder(stores, surface)
                     .circle_from_radius(Scalar::from_f64(circle.radius()));
                 let cycle = Cycle::new(surface, [half_edge]);
 


### PR DESCRIPTION
This is part of a larger refactoring of the builder API, to address the issues that are currently holding up #1079.