### PR TITLE
Extend vertex builder API

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let surface = Surface::xz_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let vertex = Vertex::builder(curve).from_point([0.]);
+        let vertex = Vertex::builder(curve).build([0.]);
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let surface = Surface::xz_plane();
         let curve = Curve::builder(&stores, surface).u_axis();
-        let vertex = Vertex::builder(curve).build([0.]);
+        let vertex = Vertex::builder([0.], curve).build();
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -31,7 +31,7 @@ impl<'a> HalfEdgeBuilder<'a> {
                 [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
             let global_vertex = GlobalVertex::builder()
-                .from_curve_and_position(&curve, a_curve);
+                .build_from_curve_and_position(&curve, a_curve);
 
             let surface_vertices = [a_curve, b_curve].map(|point_curve| {
                 let point_surface =

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -66,7 +66,7 @@ impl<'a> HalfEdgeBuilder<'a> {
 
         let global_vertices = points.map(|position| {
             GlobalVertex::builder()
-                .from_surface_and_position(&self.surface, position)
+                .build_from_surface_and_position(&self.surface, position)
         });
 
         let surface_vertices = {

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -17,5 +17,5 @@ pub use self::{
     shell::ShellBuilder,
     sketch::SketchBuilder,
     solid::SolidBuilder,
-    vertex::{GlobalVertexBuilder, VertexBuilder},
+    vertex::{GlobalVertexBuilder, SurfaceVertexBuilder, VertexBuilder},
 };

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -12,7 +12,7 @@ pub struct VertexBuilder {
 
 impl VertexBuilder {
     /// Build a vertex from a curve position
-    pub fn from_point(self, position: impl Into<Point<1>>) -> Vertex {
+    pub fn build(self, position: impl Into<Point<1>>) -> Vertex {
         let position = position.into();
 
         let surface_form = SurfaceVertexBuilder {

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -29,6 +29,41 @@ impl VertexBuilder {
     }
 }
 
+/// API for building a [`SurfaceVertex`]
+///
+/// Also see [`SurfaceVertex::builder`].
+pub struct SurfaceVertexBuilder {
+    /// The position of the [`SurfaceVertex`] on the [`Surface`]
+    pub position: Point<2>,
+
+    /// The surface that the [`SurfaceVertex`] is defined in
+    pub surface: Surface,
+
+    /// The global form of the [`SurfaceVertex`]
+    ///
+    /// Can be provided to the builder, if already available, or computed from
+    /// the position on the [`Surface`].
+    pub global_form: Option<GlobalVertex>,
+}
+
+impl SurfaceVertexBuilder {
+    /// Build the [`SurfaceVertex`] with the provided global form
+    pub fn with_global_form(mut self, global_form: GlobalVertex) -> Self {
+        self.global_form = Some(global_form);
+        self
+    }
+
+    /// Finish building the [`SurfaceVertex`]
+    pub fn build(self) -> SurfaceVertex {
+        let global_form = self.global_form.unwrap_or_else(|| {
+            GlobalVertex::builder()
+                .from_surface_and_position(&self.surface, self.position)
+        });
+
+        SurfaceVertex::new(self.position, self.surface, global_form)
+    }
+}
+
 /// API for building a [`GlobalVertex`]
 ///
 /// Also see [`GlobalVertex::builder`].

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -100,7 +100,7 @@ pub struct GlobalVertexBuilder;
 
 impl GlobalVertexBuilder {
     /// Build a [`GlobalVertex`] from a curve and a position on that curve
-    pub fn from_curve_and_position(
+    pub fn build_from_curve_and_position(
         &self,
         curve: &Curve,
         position: impl Into<Point<1>>,

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -6,17 +6,18 @@ use crate::objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex};
 ///
 /// Also see [`Vertex::builder`].
 pub struct VertexBuilder {
+    /// The position of the [`Vertex`] on the [`Curve`]
+    pub position: Point<1>,
+
     /// The curve that the [`Vertex`] is defined in
     pub curve: Curve,
 }
 
 impl VertexBuilder {
     /// Build a vertex from a curve position
-    pub fn build(self, position: impl Into<Point<1>>) -> Vertex {
-        let position = position.into();
-
+    pub fn build(self) -> Vertex {
         let surface_form = SurfaceVertexBuilder {
-            position: self.curve.path().point_from_path_coords(position),
+            position: self.curve.path().point_from_path_coords(self.position),
             surface: *self.curve.surface(),
             global_form: None,
         }
@@ -24,7 +25,7 @@ impl VertexBuilder {
 
         let global_form = *surface_form.global_form();
 
-        Vertex::new(position, self.curve, surface_form, global_form)
+        Vertex::new(self.position, self.curve, surface_form, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -11,17 +11,34 @@ pub struct VertexBuilder {
 
     /// The curve that the [`Vertex`] is defined in
     pub curve: Curve,
+
+    /// The surface form of the [`Vertex`]
+    ///
+    /// Can be provided to the builder, if already available, or computed from
+    /// the position on the [`Curve`].
+    pub surface_form: Option<SurfaceVertex>,
 }
 
 impl VertexBuilder {
+    /// Build the [`Vertex`] with the provided surface form
+    pub fn with_surface_form(mut self, surface_form: SurfaceVertex) -> Self {
+        self.surface_form = Some(surface_form);
+        self
+    }
+
     /// Build a vertex from a curve position
     pub fn build(self) -> Vertex {
-        let surface_form = SurfaceVertexBuilder {
-            position: self.curve.path().point_from_path_coords(self.position),
-            surface: *self.curve.surface(),
-            global_form: None,
-        }
-        .build();
+        let surface_form = self.surface_form.unwrap_or_else(|| {
+            SurfaceVertexBuilder {
+                position: self
+                    .curve
+                    .path()
+                    .point_from_path_coords(self.position),
+                surface: *self.curve.surface(),
+                global_form: None,
+            }
+            .build()
+        });
 
         let global_form = *surface_form.global_form();
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -86,7 +86,7 @@ impl SurfaceVertexBuilder {
     pub fn build(self) -> SurfaceVertex {
         let global_form = self.global_form.unwrap_or_else(|| {
             GlobalVertex::builder()
-                .from_surface_and_position(&self.surface, self.position)
+                .build_from_surface_and_position(&self.surface, self.position)
         });
 
         SurfaceVertex::new(self.position, self.surface, global_form)
@@ -106,11 +106,11 @@ impl GlobalVertexBuilder {
         position: impl Into<Point<1>>,
     ) -> GlobalVertex {
         let position_surface = curve.path().point_from_path_coords(position);
-        self.from_surface_and_position(curve.surface(), position_surface)
+        self.build_from_surface_and_position(curve.surface(), position_surface)
     }
 
     /// Build a [`GlobalVertex`] from a surface and a position on that surface
-    pub fn from_surface_and_position(
+    pub fn build_from_surface_and_position(
         &self,
         surface: &Surface,
         position: impl Into<Point<2>>,

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -12,7 +12,7 @@ pub struct VertexBuilder {
 
 impl VertexBuilder {
     /// Build a vertex from a curve position
-    pub fn from_point(&self, position: impl Into<Point<1>>) -> Vertex {
+    pub fn from_point(self, position: impl Into<Point<1>>) -> Vertex {
         let position = position.into();
 
         let surface_form = SurfaceVertexBuilder {
@@ -24,7 +24,7 @@ impl VertexBuilder {
 
         let global_form = *surface_form.global_form();
 
-        Vertex::new(position, self.curve.clone(), surface_form, global_form)
+        Vertex::new(position, self.curve, surface_form, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -14,11 +14,10 @@ impl VertexBuilder {
     /// Build a vertex from a curve position
     pub fn from_point(&self, point: impl Into<Point<1>>) -> Vertex {
         let point = point.into();
-        let &surface = self.curve.surface();
 
         let surface_form = SurfaceVertexBuilder {
             position: self.curve.path().point_from_path_coords(point),
-            surface,
+            surface: *self.curve.surface(),
             global_form: None,
         }
         .build();

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -12,11 +12,11 @@ pub struct VertexBuilder {
 
 impl VertexBuilder {
     /// Build a vertex from a curve position
-    pub fn from_point(&self, point: impl Into<Point<1>>) -> Vertex {
-        let point = point.into();
+    pub fn from_point(&self, position: impl Into<Point<1>>) -> Vertex {
+        let position = position.into();
 
         let surface_form = SurfaceVertexBuilder {
-            position: self.curve.path().point_from_path_coords(point),
+            position: self.curve.path().point_from_path_coords(position),
             surface: *self.curve.surface(),
             global_form: None,
         }
@@ -24,7 +24,7 @@ impl VertexBuilder {
 
         let global_form = *surface_form.global_form();
 
-        Vertex::new(point, self.curve.clone(), surface_form, global_form)
+        Vertex::new(position, self.curve.clone(), surface_form, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -25,7 +25,7 @@ impl VertexBuilder {
             global_form,
         );
 
-        Vertex::new([0.], self.curve.clone(), surface_form, global_form)
+        Vertex::new(point, self.curve.clone(), surface_form, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -17,12 +17,24 @@ pub struct VertexBuilder {
     /// Can be provided to the builder, if already available, or computed from
     /// the position on the [`Curve`].
     pub surface_form: Option<SurfaceVertex>,
+
+    /// The global form of the [`Vertex`]
+    ///
+    /// Can be provided to the builder, if already available, or acquired
+    /// through the surface form.
+    pub global_form: Option<GlobalVertex>,
 }
 
 impl VertexBuilder {
     /// Build the [`Vertex`] with the provided surface form
     pub fn with_surface_form(mut self, surface_form: SurfaceVertex) -> Self {
         self.surface_form = Some(surface_form);
+        self
+    }
+
+    /// Build the [`Vertex`] with the provided global form
+    pub fn with_global_form(mut self, global_form: GlobalVertex) -> Self {
+        self.global_form = Some(global_form);
         self
     }
 
@@ -35,7 +47,7 @@ impl VertexBuilder {
                     .path()
                     .point_from_path_coords(self.position),
                 surface: *self.curve.surface(),
-                global_form: None,
+                global_form: self.global_form,
             }
             .build()
         });

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -16,14 +16,14 @@ impl VertexBuilder {
         let point = point.into();
         let &surface = self.curve.surface();
 
-        let global_form =
-            GlobalVertex::builder().from_curve_and_position(&self.curve, point);
-
-        let surface_form = SurfaceVertex::new(
-            self.curve.path().point_from_path_coords(point),
+        let surface_form = SurfaceVertexBuilder {
+            position: self.curve.path().point_from_path_coords(point),
             surface,
-            global_form,
-        );
+            global_form: None,
+        }
+        .build();
+
+        let global_form = *surface_form.global_form();
 
         Vertex::new(point, self.curve.clone(), surface_form, global_form)
     }

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -22,8 +22,14 @@ pub struct Vertex {
 
 impl Vertex {
     /// Build a `Vertex` using [`VertexBuilder`]
-    pub fn builder(curve: Curve) -> VertexBuilder {
-        VertexBuilder { curve }
+    pub fn builder(
+        position: impl Into<Point<1>>,
+        curve: Curve,
+    ) -> VertexBuilder {
+        VertexBuilder {
+            position: position.into(),
+            curve,
+        }
     }
 
     /// Construct an instance of `Vertex`

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -29,6 +29,7 @@ impl Vertex {
         VertexBuilder {
             position: position.into(),
             curve,
+            surface_form: None,
         }
     }
 

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -30,6 +30,7 @@ impl Vertex {
             position: position.into(),
             curve,
             surface_form: None,
+            global_form: None,
         }
     }
 

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -1,7 +1,9 @@
 use fj_math::Point;
 use pretty_assertions::assert_eq;
 
-use crate::builder::{GlobalVertexBuilder, VertexBuilder};
+use crate::builder::{
+    GlobalVertexBuilder, SurfaceVertexBuilder, VertexBuilder,
+};
 
 use super::{Curve, Surface};
 
@@ -80,6 +82,18 @@ pub struct SurfaceVertex {
 }
 
 impl SurfaceVertex {
+    /// Build a `SurfaceVertex` using [`SurfaceVertexBuilder`]
+    pub fn builder(
+        position: impl Into<Point<2>>,
+        surface: Surface,
+    ) -> SurfaceVertexBuilder {
+        SurfaceVertexBuilder {
+            position: position.into(),
+            surface,
+            global_form: None,
+        }
+    }
+
     /// Construct a new instance of `SurfaceVertex`
     pub fn new(
         position: impl Into<Point<2>>,


### PR DESCRIPTION
Clean it up and make it more flexible. This is kind of a prototype for what the other builder APIs will need to be like, so we can address the issues that currently hold up #1079.