### PR TITLE
Change naming convention of builder methods

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -210,7 +210,7 @@ mod tests {
 
         let surface = Surface::new(GlobalPath::x_axis(), [0., 0., 1.]);
         let curve = Curve::builder(&stores, surface)
-            .line_from_points([[1., 1.], [2., 1.]]);
+            .build_line_from_points([[1., 1.], [2., 1.]]);
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -225,7 +225,7 @@ mod tests {
         let surface =
             Surface::new(GlobalPath::circle_from_radius(1.), [0., 0., 1.]);
         let curve = Curve::builder(&stores, surface)
-            .line_from_points([[1., 1.], [1., 2.]]);
+            .build_line_from_points([[1., 1.], [1., 2.]]);
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -240,7 +240,7 @@ mod tests {
         let path = GlobalPath::circle_from_radius(1.);
         let surface = Surface::new(path, [0., 0., 1.]);
         let curve = Curve::builder(&stores, surface)
-            .line_from_points([[0., 1.], [1., 1.]]);
+            .build_line_from_points([[0., 1.], [1., 1.]]);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -266,7 +266,8 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::new(GlobalPath::x_axis(), [0., 0., 1.]);
-        let curve = Curve::builder(&stores, surface).circle_from_radius(1.);
+        let curve =
+            Curve::builder(&stores, surface).build_circle_from_radius(1.);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -86,7 +86,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::builder(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[1., -1.], [1., 1.]]);
 
@@ -105,7 +105,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::builder(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[-1., -1.], [-1., 1.]]);
 
@@ -124,7 +124,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::builder(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[-1., -1.], [1., -1.]]);
 
@@ -138,7 +138,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::builder(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
             .line_segment_from_points([[-1., 0.], [1., 0.]]);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -88,7 +88,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
-            .line_segment_from_points([[1., -1.], [1., 1.]]);
+            .build_line_segment_from_points([[1., -1.], [1., 1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -107,7 +107,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
-            .line_segment_from_points([[-1., -1.], [-1., 1.]]);
+            .build_line_segment_from_points([[-1., -1.], [-1., 1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -126,7 +126,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
-            .line_segment_from_points([[-1., -1.], [1., -1.]]);
+            .build_line_segment_from_points([[-1., -1.], [1., -1.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -140,7 +140,7 @@ mod tests {
         let surface = Surface::xy_plane();
         let curve = Curve::builder(&stores, surface).build_u_axis();
         let half_edge = HalfEdge::builder(&stores, surface)
-            .line_segment_from_points([[-1., 0.], [1., 0.]]);
+            .build_line_segment_from_points([[-1., 0.], [1., 0.]]);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -187,7 +187,7 @@ mod tests {
         ];
 
         let face = Face::builder(&stores, surface)
-            .polygon_from_points(exterior)
+            .build_polygon_from_points(exterior)
             .with_hole(interior)
             .into_face();
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -169,7 +169,7 @@ mod tests {
         let surface = Surface::xy_plane();
 
         let curve = Curve::builder(&stores, surface)
-            .line_from_points([[-3., 0.], [-2., 0.]]);
+            .build_line_from_points([[-3., 0.], [-2., 0.]]);
 
         #[rustfmt::skip]
         let exterior = [

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -84,7 +84,7 @@ mod tests {
         let surfaces = [Surface::xy_plane(), Surface::xz_plane()];
         let [a, b] = surfaces.map(|surface| {
             Face::builder(&stores, surface)
-                .polygon_from_points(points)
+                .build_polygon_from_points(points)
                 .into_face()
         });
 
@@ -107,7 +107,7 @@ mod tests {
         let surfaces = [Surface::xy_plane(), Surface::xz_plane()];
         let [a, b] = surfaces.map(|surface| {
             Face::builder(&stores, surface)
-                .polygon_from_points(points)
+                .build_polygon_from_points(points)
                 .into_face()
         });
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -115,7 +115,7 @@ mod tests {
 
         let expected_curves = surfaces.map(|surface| {
             Curve::builder(&stores, surface)
-                .line_from_points([[0., 0.], [1., 0.]])
+                .build_line_from_points([[0., 0.], [1., 0.]])
         });
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -143,7 +143,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
+            .build_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
             .into_face();
         let point = Point::from([2., 1.]);
 
@@ -156,7 +156,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
+            .build_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
             .into_face();
         let point = Point::from([1., 1.]);
 
@@ -172,7 +172,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
+            .build_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
             .into_face();
         let point = Point::from([1., 2.]);
 
@@ -188,7 +188,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [2., 1.], [3., 0.], [3., 4.]])
+            .build_polygon_from_points([[0., 0.], [2., 1.], [3., 0.], [3., 4.]])
             .into_face();
         let point = Point::from([1., 1.]);
 
@@ -204,7 +204,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [2., 1.], [3., 1.], [0., 2.]])
+            .build_polygon_from_points([[0., 0.], [2., 1.], [3., 1.], [0., 2.]])
             .into_face();
         let point = Point::from([1., 1.]);
 
@@ -220,7 +220,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([
+            .build_polygon_from_points([
                 [0., 0.],
                 [2., 1.],
                 [3., 1.],
@@ -242,7 +242,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
+            .build_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
             .into_face();
         let point = Point::from([1., 0.]);
 
@@ -267,7 +267,7 @@ mod tests {
         let stores = Stores::new();
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
+            .build_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .into_face();
         let point = Point::from([1., 0.]);
 

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -169,7 +169,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::yz_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face()
             .translate([-1., 0., 0.], &stores);
 
@@ -183,7 +188,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::yz_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face()
             .translate([1., 0., 0.], &stores);
 
@@ -200,7 +210,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::yz_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face()
             .translate([0., 0., 2.], &stores);
 
@@ -214,7 +229,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::yz_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face()
             .translate([1., 1., 0.], &stores);
 
@@ -239,7 +259,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::yz_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face()
             .translate([1., 1., 1.], &stores);
 
@@ -262,7 +287,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face();
 
         assert_eq!(
@@ -278,7 +308,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let face = Face::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]])
+            .build_polygon_from_points([
+                [-1., -1.],
+                [1., -1.],
+                [1., 1.],
+                [-1., 1.],
+            ])
             .into_face()
             .translate([0., 0., 1.], &stores);
 

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -186,8 +186,8 @@ mod tests {
             None,
         );
 
-        let expected_xy = Curve::builder(&stores, xy).u_axis();
-        let expected_xz = Curve::builder(&stores, xz).u_axis();
+        let expected_xy = Curve::builder(&stores, xy).build_u_axis();
+        let expected_xz = Curve::builder(&stores, xz).build_u_axis();
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([&xy, &xz], &stores),

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -192,7 +192,7 @@ mod tests {
         let stores = Stores::new();
 
         let half_edge = HalfEdge::builder(&stores, Surface::xy_plane())
-            .line_segment_from_points([[0., 0.], [1., 0.]]);
+            .build_line_segment_from_points([[0., 0.], [1., 0.]]);
 
         let face = (half_edge, Color::default()).sweep([0., 0., 1.], &stores);
 
@@ -200,14 +200,16 @@ mod tests {
             let surface = Surface::xz_plane();
             let builder = HalfEdge::builder(&stores, surface);
 
-            let bottom = builder.line_segment_from_points([[0., 0.], [1., 0.]]);
+            let bottom =
+                builder.build_line_segment_from_points([[0., 0.], [1., 0.]]);
             let top = builder
-                .line_segment_from_points([[0., 1.], [1., 1.]])
+                .build_line_segment_from_points([[0., 1.], [1., 1.]])
                 .reverse();
             let left = builder
-                .line_segment_from_points([[0., 0.], [0., 1.]])
+                .build_line_segment_from_points([[0., 0.], [0., 1.]])
                 .reverse();
-            let right = builder.line_segment_from_points([[1., 0.], [1., 1.]]);
+            let right =
+                builder.build_line_segment_from_points([[1., 0.], [1., 1.]]);
 
             let cycle = Cycle::new(surface, [bottom, right, top, left]);
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -113,7 +113,7 @@ mod tests {
             let [a, b] = [window[0], window[1]];
 
             let half_edge = HalfEdge::builder(&stores, Surface::xy_plane())
-                .line_segment_from_points([a, b]);
+                .build_line_segment_from_points([a, b]);
             (half_edge, Color::default()).sweep(UP, &stores)
         });
 
@@ -148,7 +148,7 @@ mod tests {
             let [a, b] = [window[0], window[1]];
 
             let half_edge = HalfEdge::builder(&stores, Surface::xy_plane())
-                .line_segment_from_points([a, b])
+                .build_line_segment_from_points([a, b])
                 .reverse();
             (half_edge, Color::default()).sweep(DOWN, &stores)
         });

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -95,11 +95,11 @@ mod tests {
             .sweep(UP, &stores);
 
         let bottom = Face::builder(&stores, surface)
-            .polygon_from_points(TRIANGLE)
+            .build_polygon_from_points(TRIANGLE)
             .into_face()
             .reverse();
         let top = Face::builder(&stores, surface.translate(UP, &stores))
-            .polygon_from_points(TRIANGLE)
+            .build_polygon_from_points(TRIANGLE)
             .into_face();
 
         assert!(solid.find_face(&bottom).is_some());
@@ -130,11 +130,11 @@ mod tests {
             .sweep(DOWN, &stores);
 
         let bottom = Face::builder(&stores, surface.translate(DOWN, &stores))
-            .polygon_from_points(TRIANGLE)
+            .build_polygon_from_points(TRIANGLE)
             .into_face()
             .reverse();
         let top = Face::builder(&stores, surface)
-            .polygon_from_points(TRIANGLE)
+            .build_polygon_from_points(TRIANGLE)
             .into_face();
 
         assert!(solid.find_face(&bottom).is_some());

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -91,7 +91,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let solid = Sketch::builder(&stores, surface)
-            .polygon_from_points(TRIANGLE)
+            .build_polygon_from_points(TRIANGLE)
             .sweep(UP, &stores);
 
         let bottom = Face::builder(&stores, surface)
@@ -126,7 +126,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let solid = Sketch::builder(&stores, surface)
-            .polygon_from_points(TRIANGLE)
+            .build_polygon_from_points(TRIANGLE)
             .sweep(DOWN, &stores);
 
         let bottom = Face::builder(&stores, surface.translate(DOWN, &stores))

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -166,7 +166,7 @@ mod tests {
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);
 
         let expected_half_edge = HalfEdge::builder(&stores, surface)
-            .line_segment_from_points([[0., 0.], [0., 1.]]);
+            .build_line_segment_from_points([[0., 0.], [0., 1.]]);
         assert_eq!(half_edge, expected_half_edge);
     }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -160,7 +160,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xz_plane();
-        let curve = Curve::builder(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).build_u_axis();
         let vertex = Vertex::builder([0.], curve).build();
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -101,7 +101,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let face = Face::builder(&stores, surface)
-            .polygon_from_points([a, b, c, d])
+            .build_polygon_from_points([a, b, c, d])
             .into_face();
 
         let a = Point::from(a).to_xyz();
@@ -135,7 +135,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let face = Face::builder(&stores, surface)
-            .polygon_from_points([a, b, c, d])
+            .build_polygon_from_points([a, b, c, d])
             .with_hole([e, f, g, h])
             .into_face();
 
@@ -188,7 +188,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let face = Face::builder(&stores, surface)
-            .polygon_from_points([a, b, c, d, e])
+            .build_polygon_from_points([a, b, c, d, e])
             .into_face();
 
         let triangles = triangulate(face)?;

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -35,7 +35,7 @@ impl<'a> CurveBuilder<'a> {
     }
 
     /// Build a circle from the given radius
-    pub fn circle_from_radius(&self, radius: impl Into<Scalar>) -> Curve {
+    pub fn build_circle_from_radius(&self, radius: impl Into<Scalar>) -> Curve {
         let radius = radius.into();
 
         let path = SurfacePath::circle_from_radius(radius);

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -23,7 +23,7 @@ impl<'a> CurveBuilder<'a> {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 
-        self.line_from_points([a, b])
+        self.build_line_from_points([a, b])
     }
 
     /// Build a line that represents the v-axis on the surface
@@ -31,7 +31,7 @@ impl<'a> CurveBuilder<'a> {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 
-        self.line_from_points([a, b])
+        self.build_line_from_points([a, b])
     }
 
     /// Build a circle from the given radius
@@ -46,7 +46,10 @@ impl<'a> CurveBuilder<'a> {
     }
 
     /// Build a line from the given points
-    pub fn line_from_points(&self, points: [impl Into<Point<2>>; 2]) -> Curve {
+    pub fn build_line_from_points(
+        &self,
+        points: [impl Into<Point<2>>; 2],
+    ) -> Curve {
         let points = points.map(Into::into);
 
         let path = SurfacePath::Line(Line::from_points(points));

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -27,7 +27,7 @@ impl<'a> CurveBuilder<'a> {
     }
 
     /// Build a line that represents the v-axis on the surface
-    pub fn v_axis(&self) -> Curve {
+    pub fn build_v_axis(&self) -> Curve {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -19,7 +19,7 @@ pub struct CurveBuilder<'a> {
 
 impl<'a> CurveBuilder<'a> {
     /// Build a line that represents the u-axis on the surface
-    pub fn u_axis(&self) -> Curve {
+    pub fn build_u_axis(&self) -> Curve {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -18,7 +18,7 @@ pub struct CycleBuilder<'a> {
 
 impl<'a> CycleBuilder<'a> {
     /// Create a polygon from a list of points
-    pub fn polygon_from_points(
+    pub fn build_polygon_from_points(
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Cycle {

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -39,7 +39,7 @@ impl<'a> CycleBuilder<'a> {
 
             half_edges.push(
                 HalfEdge::builder(self.stores, self.surface)
-                    .line_segment_from_points(points),
+                    .build_line_segment_from_points(points),
             );
         }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -22,7 +22,10 @@ pub struct HalfEdgeBuilder<'a> {
 
 impl<'a> HalfEdgeBuilder<'a> {
     /// Build a circle from the given radius
-    pub fn circle_from_radius(&self, radius: impl Into<Scalar>) -> HalfEdge {
+    pub fn build_circle_from_radius(
+        &self,
+        radius: impl Into<Scalar>,
+    ) -> HalfEdge {
         let curve = Curve::builder(self.stores, self.surface)
             .build_circle_from_radius(radius);
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -61,7 +61,7 @@ impl<'a> HalfEdgeBuilder<'a> {
     }
 
     /// Build a line segment from two points
-    pub fn line_segment_from_points(
+    pub fn build_line_segment_from_points(
         &self,
         points: [impl Into<Point<2>>; 2],
     ) -> HalfEdge {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -24,7 +24,7 @@ impl<'a> HalfEdgeBuilder<'a> {
     /// Build a circle from the given radius
     pub fn circle_from_radius(&self, radius: impl Into<Scalar>) -> HalfEdge {
         let curve = Curve::builder(self.stores, self.surface)
-            .circle_from_radius(radius);
+            .build_circle_from_radius(radius);
 
         let vertices = {
             let [a_curve, b_curve] =

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -25,7 +25,7 @@ impl<'a> FaceBuilder<'a> {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> FacePolygon {
         let cycle = Cycle::builder(self.stores, self.surface)
-            .polygon_from_points(points);
+            .build_polygon_from_points(points);
         let face = Face::new(self.surface, cycle);
 
         FacePolygon {
@@ -52,7 +52,7 @@ impl FacePolygon<'_> {
         self.face =
             self.face
                 .with_interiors([Cycle::builder(self.stores, surface)
-                    .polygon_from_points(points)]);
+                    .build_polygon_from_points(points)]);
 
         self
     }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -20,7 +20,7 @@ pub struct FaceBuilder<'a> {
 
 impl<'a> FaceBuilder<'a> {
     /// Construct a polygon from a list of points
-    pub fn polygon_from_points(
+    pub fn build_polygon_from_points(
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> FacePolygon {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -38,7 +38,7 @@ impl<'a> ShellBuilder<'a> {
 
         let faces = planes.map(|plane| {
             Face::builder(self.stores, plane)
-                .polygon_from_points(points)
+                .build_polygon_from_points(points)
                 .into_face()
         });
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -16,7 +16,7 @@ pub struct ShellBuilder<'a> {
 
 impl<'a> ShellBuilder<'a> {
     /// Create a cube from the length of its edges
-    pub fn cube_from_edge_length(
+    pub fn build_cube_from_edge_length(
         &self,
         edge_length: impl Into<Scalar>,
     ) -> Shell {

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -18,7 +18,7 @@ pub struct SketchBuilder<'a> {
 
 impl<'a> SketchBuilder<'a> {
     /// Construct a polygon from a list of points
-    pub fn polygon_from_points(
+    pub fn build_polygon_from_points(
         &self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Sketch {

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -23,7 +23,7 @@ impl<'a> SketchBuilder<'a> {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Sketch {
         let face = Face::builder(self.stores, self.surface)
-            .polygon_from_points(points)
+            .build_polygon_from_points(points)
             .into_face();
         Sketch::new().with_faces([face])
     }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -15,7 +15,7 @@ pub struct SolidBuilder<'a> {
 
 impl<'a> SolidBuilder<'a> {
     /// Create a cube from the length of its edges
-    pub fn cube_from_edge_length(
+    pub fn build_cube_from_edge_length(
         &self,
         edge_length: impl Into<Scalar>,
     ) -> Solid {

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -19,8 +19,8 @@ impl<'a> SolidBuilder<'a> {
         &self,
         edge_length: impl Into<Scalar>,
     ) -> Solid {
-        let shell =
-            Shell::builder(self.stores).cube_from_edge_length(edge_length);
+        let shell = Shell::builder(self.stores)
+            .build_cube_from_edge_length(edge_length);
         Solid::new().with_shells([shell])
     }
 }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -382,7 +382,7 @@ mod tests {
         let stores = Stores::new();
 
         let object = Cycle::builder(&stores, Surface::xy_plane())
-            .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]]);
+            .build_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]]);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -521,7 +521,7 @@ mod tests {
     fn solid() {
         let stores = Stores::new();
 
-        let object = Solid::builder(&stores).cube_from_edge_length(1.);
+        let object = Solid::builder(&stores).build_cube_from_edge_length(1.);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -362,7 +362,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let object = Curve::builder(&stores, surface).u_axis();
+        let object = Curve::builder(&stores, surface).build_u_axis();
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -558,7 +558,7 @@ mod tests {
         let stores = Stores::new();
 
         let surface = Surface::xy_plane();
-        let curve = Curve::builder(&stores, surface).u_axis();
+        let curve = Curve::builder(&stores, surface).build_u_axis();
         let global_vertex = GlobalVertex::from_position([0., 0., 0.]);
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -403,7 +403,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let object = Face::builder(&stores, surface)
-            .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
+            .build_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .into_face();
 
         assert_eq!(3, object.curve_iter().count());
@@ -500,7 +500,7 @@ mod tests {
 
         let surface = Surface::xy_plane();
         let face = Face::builder(&stores, surface)
-            .polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
+            .build_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .into_face();
         let object = Sketch::new().with_faces([face]);
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -479,7 +479,7 @@ mod tests {
     fn shell() {
         let stores = Stores::new();
 
-        let object = Shell::builder(&stores).cube_from_edge_length(1.);
+        let object = Shell::builder(&stores).build_cube_from_edge_length(1.);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -460,7 +460,7 @@ mod tests {
         let stores = Stores::new();
 
         let object = HalfEdge::builder(&stores, Surface::xy_plane())
-            .line_segment_from_points([[0., 0.], [1., 0.]]);
+            .build_line_segment_from_points([[0., 0.], [1., 0.]]);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -37,7 +37,7 @@ impl Shape for fj::Sketch {
                     poly_chain.to_points().into_iter().map(Point::from);
 
                 Face::builder(stores, surface)
-                    .polygon_from_points(points)
+                    .build_polygon_from_points(points)
                     .into_face()
                     .with_color(Color(self.color()))
             }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -6,7 +6,7 @@ use fj_kernel::{
     objects::{Cycle, Face, HalfEdge, Sketch, Surface},
     stores::Stores,
 };
-use fj_math::{Aabb, Point, Scalar};
+use fj_math::{Aabb, Point};
 
 use super::Shape;
 
@@ -27,9 +27,7 @@ impl Shape for fj::Sketch {
                 // none need to be added here.
 
                 let half_edge = HalfEdge::builder(stores, surface)
-                    .build_circle_from_radius(Scalar::from_f64(
-                        circle.radius(),
-                    ));
+                    .build_circle_from_radius(circle.radius());
                 let cycle = Cycle::new(surface, [half_edge]);
 
                 Face::new(surface, cycle).with_color(Color(self.color()))

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -27,7 +27,9 @@ impl Shape for fj::Sketch {
                 // none need to be added here.
 
                 let half_edge = HalfEdge::builder(stores, surface)
-                    .circle_from_radius(Scalar::from_f64(circle.radius()));
+                    .build_circle_from_radius(Scalar::from_f64(
+                        circle.radius(),
+                    ));
                 let cycle = Cycle::new(surface, [half_edge]);
 
                 Face::new(surface, cycle).with_color(Color(self.color()))


### PR DESCRIPTION
Make it so that all methods that build a thing start with `build_`, to distinguish them from methods that modify the builder.