### PR TITLE
Remove `HalfEdge::from_curve_and_vertices`

### DIFF
--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -1,4 +1,4 @@
-use crate::objects::HalfEdge;
+use crate::objects::{GlobalEdge, HalfEdge};
 
 use super::Reverse;
 
@@ -9,6 +9,21 @@ impl Reverse for HalfEdge {
             [b, a]
         };
 
-        HalfEdge::from_curve_and_vertices(self.curve().clone(), vertices)
+        HalfEdge::new(
+            self.curve().clone(),
+            vertices,
+            self.global_form().clone().reverse(),
+        )
+    }
+}
+
+impl Reverse for GlobalEdge {
+    fn reverse(self) -> Self {
+        let vertices = {
+            let &[a, b] = self.vertices();
+            [b, a]
+        };
+
+        GlobalEdge::new(self.curve().clone(), vertices)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform.rs
+++ b/crates/fj-kernel/src/algorithms/transform.rs
@@ -4,8 +4,8 @@ use fj_math::{Transform, Vector};
 
 use crate::{
     objects::{
-        Curve, Cycle, Face, Faces, GlobalCurve, GlobalVertex, HalfEdge, Shell,
-        Sketch, Solid, Surface, SurfaceVertex, Vertex,
+        Curve, Cycle, Face, Faces, GlobalCurve, GlobalEdge, GlobalVertex,
+        HalfEdge, Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
     },
     path::GlobalPath,
     stores::{Handle, Stores},
@@ -122,6 +122,23 @@ impl TransformObject for GlobalCurve {
     }
 }
 
+impl TransformObject for GlobalEdge {
+    type Transformed = Self;
+
+    fn transform(
+        self,
+        transform: &Transform,
+        stores: &Stores,
+    ) -> Self::Transformed {
+        let curve = self.curve().clone().transform(transform, stores);
+        let vertices = self
+            .vertices()
+            .map(|vertex| vertex.transform(transform, stores));
+
+        Self::new(curve, vertices)
+    }
+}
+
 impl TransformObject for GlobalPath {
     type Transformed = Self;
 
@@ -153,8 +170,10 @@ impl TransformObject for HalfEdge {
             .vertices()
             .clone()
             .map(|vertex| vertex.transform(transform, stores));
+        let global_form =
+            self.global_form().clone().transform(transform, stores);
 
-        Self::from_curve_and_vertices(curve, vertices)
+        Self::new(curve, vertices, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -161,8 +161,8 @@ mod tests {
     use crate::{
         algorithms::validate::{Validate, ValidationConfig, ValidationError},
         objects::{
-            Curve, GlobalCurve, GlobalVertex, HalfEdge, Surface, SurfaceVertex,
-            Vertex,
+            Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface,
+            SurfaceVertex, Vertex,
         },
         path::{GlobalPath, SurfacePath},
         stores::Stores,
@@ -236,7 +236,9 @@ mod tests {
         );
         let vertices = [a, b];
 
-        let half_edge = HalfEdge::from_curve_and_vertices(curve, vertices);
+        let global_edge = GlobalEdge::builder()
+            .build_from_curve_and_vertices(&curve, &vertices);
+        let half_edge = HalfEdge::new(curve, vertices, global_edge);
 
         let result =
             half_edge.clone().validate_with_config(&ValidationConfig {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -2,8 +2,8 @@ use fj_math::{Line, Point, Scalar};
 
 use crate::{
     objects::{
-        Curve, GlobalCurve, GlobalVertex, HalfEdge, Surface, SurfaceVertex,
-        Vertex,
+        Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface,
+        SurfaceVertex, Vertex,
     },
     path::{GlobalPath, SurfacePath},
     stores::Stores,
@@ -129,3 +129,17 @@ impl<'a> HalfEdgeBuilder<'a> {
 ///
 /// Also see [`GlobalEdge::builder`].
 pub struct GlobalEdgeBuilder;
+
+impl GlobalEdgeBuilder {
+    /// Build a [`GlobalEdge`] from the provided curve and vertices
+    pub fn build_from_curve_and_vertices(
+        self,
+        curve: &Curve,
+        vertices: &[Vertex; 2],
+    ) -> GlobalEdge {
+        GlobalEdge::new(
+            curve.global_form().clone(),
+            vertices.clone().map(|vertex| *vertex.global_form()),
+        )
+    }
+}

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -57,7 +57,10 @@ impl<'a> HalfEdgeBuilder<'a> {
             )
         };
 
-        HalfEdge::from_curve_and_vertices(curve, vertices)
+        let global_form = GlobalEdge::builder()
+            .build_from_curve_and_vertices(&curve, &vertices);
+
+        HalfEdge::new(curve, vertices, global_form)
     }
 
     /// Build a line segment from two points
@@ -121,7 +124,10 @@ impl<'a> HalfEdgeBuilder<'a> {
             ]
         };
 
-        HalfEdge::from_curve_and_vertices(curve, vertices)
+        let global_form = GlobalEdge::builder()
+            .build_from_curve_and_vertices(&curve, &vertices);
+
+        HalfEdge::new(curve, vertices, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -124,3 +124,8 @@ impl<'a> HalfEdgeBuilder<'a> {
         HalfEdge::from_curve_and_vertices(curve, vertices)
     }
 }
+
+/// API for building a [`GlobalEdge`]
+///
+/// Also see [`GlobalEdge::builder`].
+pub struct GlobalEdgeBuilder;

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -12,7 +12,7 @@ mod vertex;
 pub use self::{
     curve::{CurveBuilder, GlobalCurveBuilder},
     cycle::CycleBuilder,
-    edge::HalfEdgeBuilder,
+    edge::{GlobalEdgeBuilder, HalfEdgeBuilder},
     face::FaceBuilder,
     shell::ShellBuilder,
     sketch::SketchBuilder,

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -85,10 +85,8 @@ impl HalfEdge {
         curve: Curve,
         vertices: [Vertex; 2],
     ) -> Self {
-        let global = GlobalEdge::new(
-            curve.global_form().clone(),
-            vertices.clone().map(|vertex| *vertex.global_form()),
-        );
+        let global = GlobalEdge::builder()
+            .build_from_curve_and_vertices(&curve, &vertices);
         Self::new(curve, vertices, global)
     }
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::{
-    builder::HalfEdgeBuilder,
+    builder::{GlobalEdgeBuilder, HalfEdgeBuilder},
     stores::{Handle, Stores},
 };
 
@@ -134,6 +134,11 @@ pub struct GlobalEdge {
 }
 
 impl GlobalEdge {
+    /// Build a `GlobalEdge` using [`GlobalEdgeBuilder`]
+    pub fn builder() -> GlobalEdgeBuilder {
+        GlobalEdgeBuilder
+    }
+
     /// Create a new instance
     pub fn new(
         curve: Handle<GlobalCurve>,

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -23,10 +23,6 @@ impl HalfEdge {
 
     /// Create a new instance of `HalfEdge`
     ///
-    /// If you only have a curve and the edge vertices, please check out
-    /// [`HalfEdge::from_curve_and_vertices`], which is a convenience wrapper
-    /// around this method, which creates an instance of [`GlobalEdge`].
-    ///
     /// # Panics
     ///
     /// Panics, if the provided `vertices` are not defined on the same curve as
@@ -74,20 +70,6 @@ impl HalfEdge {
             vertices,
             global_form,
         }
-    }
-
-    /// Create a new instance of `HalfEdge` from a curve and vertices
-    ///
-    /// The [`GlobalEdge`] instance is created from the provided curve and
-    /// vertices. Please refer to [`HalfEdge::new`], if you already have a
-    /// [`GlobalEdge`] instance that you can provide.
-    pub fn from_curve_and_vertices(
-        curve: Curve,
-        vertices: [Vertex; 2],
-    ) -> Self {
-        let global = GlobalEdge::builder()
-            .build_from_curve_and_vertices(&curve, &vertices);
-        Self::new(curve, vertices, global)
     }
 
     /// Access the curve that defines the half-edge's geometry


### PR DESCRIPTION
This constructor is problematic. Citing one of the commit messages:

> - It fulfills a role that is better fitted for the builder API.
> - It takes away control over the `GlobalVertex` construction from the caller.
> 
> That second point is a problem, due to the work that needs to happen to address https://github.com/hannobraun/Fornjot/issues/1079. This commit doesn't solve that, but the builder API provides a better framework to do so than this constructor did.