### PR TITLE
Make it possible to abstract over partial objects

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -168,7 +168,7 @@ mod tests {
         let vertex = Vertex::partial()
             .with_position([0.])
             .with_curve(curve)
-            .build();
+            .build(&stores);
 
         let half_edge = (vertex, surface).sweep([0., 0., 1.], &stores);
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -64,7 +64,7 @@ impl<'a> HalfEdgeBuilder<'a> {
 
             let global_vertex = GlobalVertex::partial()
                 .from_curve_and_position(&curve, a_curve)
-                .build();
+                .build(self.stores);
 
             let surface_vertices = [a_curve, b_curve].map(|point_curve| {
                 let point_surface =
@@ -103,7 +103,7 @@ impl<'a> HalfEdgeBuilder<'a> {
         let global_vertices = points.map(|position| {
             GlobalVertex::partial()
                 .from_surface_and_position(&self.surface, position)
-                .build()
+                .build(self.stores)
         });
 
         let surface_vertices = {

--- a/crates/fj-kernel/src/partial/curve.rs
+++ b/crates/fj-kernel/src/partial/curve.rs
@@ -100,6 +100,16 @@ impl PartialCurve {
     }
 }
 
+impl From<Curve> for PartialCurve {
+    fn from(curve: Curve) -> Self {
+        Self {
+            path: Some(curve.path()),
+            surface: Some(*curve.surface()),
+            global_form: Some(curve.global_form().clone()),
+        }
+    }
+}
+
 /// A partial [`GlobalCurve`]
 ///
 /// See [`crate::partial`] for more information.
@@ -151,5 +161,13 @@ impl PartialGlobalCurve {
     pub fn build(self, stores: &Stores) -> Handle<GlobalCurve> {
         let path = self.path.expect("Can't build `GlobalCurve` without a path");
         stores.global_curves.insert(GlobalCurve::from_path(path))
+    }
+}
+
+impl From<Handle<GlobalCurve>> for PartialGlobalCurve {
+    fn from(global_curve: Handle<GlobalCurve>) -> Self {
+        Self {
+            path: Some(global_curve.path()),
+        }
     }
 }

--- a/crates/fj-kernel/src/partial/curve.rs
+++ b/crates/fj-kernel/src/partial/curve.rs
@@ -9,7 +9,7 @@ use crate::{
 /// A partial [`Curve`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialCurve {
     /// The path that defines the [`Curve`]
     ///
@@ -104,7 +104,7 @@ impl PartialCurve {
 /// A partial [`GlobalCurve`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialGlobalCurve {
     /// The path that defines the [`GlobalCurve`]
     ///

--- a/crates/fj-kernel/src/partial/mod.rs
+++ b/crates/fj-kernel/src/partial/mod.rs
@@ -38,6 +38,34 @@ use crate::{
     stores::{Handle, Stores},
 };
 
+/// Either a partial object or a full one
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum MaybePartial<T: HasPartialForm> {
+    /// A full object
+    Full(T),
+
+    /// A partial object
+    Partial(T::PartialForm),
+}
+
+impl<T: HasPartialForm> MaybePartial<T> {
+    /// Return the full object, either directly or by building it
+    pub fn into_full(self, stores: &Stores) -> T {
+        match self {
+            Self::Partial(partial) => T::from_partial(partial, stores),
+            Self::Full(full) => full,
+        }
+    }
+
+    /// Return the partial object, either directly or via conversion
+    pub fn into_partial(self) -> T::PartialForm {
+        match self {
+            Self::Partial(partial) => partial,
+            Self::Full(full) => full.into(),
+        }
+    }
+}
+
 /// Implemented for types that are partial objects
 ///
 /// # Implementation Note
@@ -65,6 +93,18 @@ macro_rules! impl_traits {
                     -> Self
                 {
                     partial.build(stores)
+                }
+            }
+
+            impl From<$full> for MaybePartial<$full> {
+                fn from(full: $full) -> Self {
+                    Self::Full(full)
+                }
+            }
+
+            impl From<$partial> for MaybePartial<$full> {
+                fn from(partial: $partial) -> Self {
+                    Self::Partial(partial)
                 }
             }
         )*

--- a/crates/fj-kernel/src/partial/vertex.rs
+++ b/crates/fj-kernel/src/partial/vertex.rs
@@ -86,6 +86,17 @@ impl PartialVertex {
     }
 }
 
+impl From<Vertex> for PartialVertex {
+    fn from(vertex: Vertex) -> Self {
+        Self {
+            position: Some(vertex.position()),
+            curve: Some(vertex.curve().clone()),
+            surface_form: Some(*vertex.surface_form()),
+            global_form: Some(*vertex.global_form()),
+        }
+    }
+}
+
 /// A partial [`SurfaceVertex`]
 ///
 /// See [`crate::partial`] for more information.
@@ -152,6 +163,16 @@ impl PartialSurfaceVertex {
     }
 }
 
+impl From<SurfaceVertex> for PartialSurfaceVertex {
+    fn from(surface_vertex: SurfaceVertex) -> Self {
+        Self {
+            position: Some(surface_vertex.position()),
+            surface: Some(*surface_vertex.surface()),
+            global_form: Some(*surface_vertex.global_form()),
+        }
+    }
+}
+
 /// A partial [`GlobalVertex`]
 ///
 /// See [`crate::partial`] for more information.
@@ -197,5 +218,13 @@ impl PartialGlobalVertex {
             .expect("Can't build a `GlobalVertex` without a position");
 
         GlobalVertex::from_position(position)
+    }
+}
+
+impl From<GlobalVertex> for PartialGlobalVertex {
+    fn from(global_vertex: GlobalVertex) -> Self {
+        Self {
+            position: Some(global_vertex.position()),
+        }
     }
 }

--- a/crates/fj-kernel/src/partial/vertex.rs
+++ b/crates/fj-kernel/src/partial/vertex.rs
@@ -5,7 +5,7 @@ use crate::objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex};
 /// A partial [`Vertex`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialVertex {
     /// The position of the [`Vertex`] on the [`Curve`]
     ///
@@ -86,7 +86,7 @@ impl PartialVertex {
 /// A partial [`SurfaceVertex`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialSurfaceVertex {
     /// The position of the [`SurfaceVertex`] in the [`Surface`]
     ///
@@ -152,7 +152,7 @@ impl PartialSurfaceVertex {
 /// A partial [`GlobalVertex`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialGlobalVertex {
     /// The position of the [`GlobalVertex`]
     ///

--- a/crates/fj-kernel/src/partial/vertex.rs
+++ b/crates/fj-kernel/src/partial/vertex.rs
@@ -1,6 +1,9 @@
 use fj_math::Point;
 
-use crate::objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex};
+use crate::{
+    objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex},
+    stores::Stores,
+};
 
 /// A partial [`Vertex`]
 ///
@@ -62,7 +65,7 @@ impl PartialVertex {
     /// Panics, if no position has been provided.
     ///
     /// Panics, if no curve has been provided.
-    pub fn build(self) -> Vertex {
+    pub fn build(self, stores: &Stores) -> Vertex {
         let position = self
             .position
             .expect("Cant' build `Vertex` without position");
@@ -74,7 +77,7 @@ impl PartialVertex {
                 surface: Some(*curve.surface()),
                 global_form: self.global_form,
             }
-            .build()
+            .build(stores)
         });
 
         let global_form = *surface_form.global_form();
@@ -131,7 +134,7 @@ impl PartialSurfaceVertex {
     /// Panics, if no position has been provided.
     ///
     /// Panics, if no surface has been provided.
-    pub fn build(self) -> SurfaceVertex {
+    pub fn build(self, stores: &Stores) -> SurfaceVertex {
         let position = self
             .position
             .expect("Can't build `SurfaceVertex` without position");
@@ -142,7 +145,7 @@ impl PartialSurfaceVertex {
         let global_form = self.global_form.unwrap_or_else(|| {
             GlobalVertex::partial()
                 .from_surface_and_position(&surface, position)
-                .build()
+                .build(stores)
         });
 
         SurfaceVertex::new(position, surface, global_form)
@@ -188,7 +191,7 @@ impl PartialGlobalVertex {
     }
 
     /// Build a full [`GlobalVertex`] from the partial global vertex
-    pub fn build(self) -> GlobalVertex {
+    pub fn build(self, _: &Stores) -> GlobalVertex {
         let position = self
             .position
             .expect("Can't build a `GlobalVertex` without a position");


### PR DESCRIPTION
Add infrastructure that makes it possible to build abstractions on top of partial objects. This is required to address the object identity problems that currently prevent #1079 from being finished.