### PR TITLE
Make partial vertex API more flexible

### DIFF
--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -63,7 +63,7 @@ impl<'a> HalfEdgeBuilder<'a> {
                 [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
             let global_vertex = GlobalVertex::partial()
-                .from_curve_and_position(&curve, a_curve)
+                .from_curve_and_position(curve.clone(), a_curve)
                 .build(self.stores);
 
             let surface_vertices = [a_curve, b_curve].map(|point_curve| {

--- a/crates/fj-kernel/src/partial/vertex.rs
+++ b/crates/fj-kernel/src/partial/vertex.rs
@@ -5,6 +5,8 @@ use crate::{
     stores::Stores,
 };
 
+use super::MaybePartial;
+
 /// A partial [`Vertex`]
 ///
 /// See [`crate::partial`] for more information.
@@ -194,11 +196,20 @@ impl PartialGlobalVertex {
     /// Update partial global vertex from the given curve and position on it
     pub fn from_curve_and_position(
         self,
-        curve: &Curve,
+        curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
     ) -> Self {
-        let position_surface = curve.path().point_from_path_coords(position);
-        self.from_surface_and_position(curve.surface(), position_surface)
+        let curve = curve.into().into_partial();
+
+        let path = curve.path.expect(
+            "Need path to create `GlobalVertex` from curve and position",
+        );
+        let surface = curve.surface.expect(
+            "Need surface to create `GlobalVertex` from curve and position",
+        );
+
+        let position_surface = path.point_from_path_coords(position);
+        self.from_surface_and_position(&surface, position_surface)
     }
 
     /// Update partial global vertex from the given surface and position on it

--- a/crates/fj-kernel/src/partial/vertex.rs
+++ b/crates/fj-kernel/src/partial/vertex.rs
@@ -32,7 +32,7 @@ pub struct PartialVertex {
     ///
     /// Can be provided, if already available, or acquired through the surface
     /// form.
-    pub global_form: Option<GlobalVertex>,
+    pub global_form: Option<MaybePartial<GlobalVertex>>,
 }
 
 impl PartialVertex {
@@ -55,8 +55,11 @@ impl PartialVertex {
     }
 
     /// Provide a global form for the partial vertex
-    pub fn with_global_form(mut self, global_form: GlobalVertex) -> Self {
-        self.global_form = Some(global_form);
+    pub fn with_global_form(
+        mut self,
+        global_form: impl Into<MaybePartial<GlobalVertex>>,
+    ) -> Self {
+        self.global_form = Some(global_form.into());
         self
     }
 
@@ -80,7 +83,7 @@ impl PartialVertex {
             PartialSurfaceVertex {
                 position: Some(curve.path().point_from_path_coords(position)),
                 surface: Some(*curve.surface()),
-                global_form: self.global_form.map(Into::into),
+                global_form: self.global_form,
             }
             .build(stores)
         });
@@ -97,7 +100,7 @@ impl From<Vertex> for PartialVertex {
             position: Some(vertex.position()),
             curve: Some(vertex.curve().clone().into()),
             surface_form: Some(*vertex.surface_form()),
-            global_form: Some(*vertex.global_form()),
+            global_form: Some((*vertex.global_form()).into()),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/vertex.rs
+++ b/crates/fj-kernel/src/partial/vertex.rs
@@ -20,7 +20,7 @@ pub struct PartialVertex {
     /// The curve that the [`Vertex`] is defined in
     ///
     /// Must be provided before [`PartialVertex::build`] is called.
-    pub curve: Option<Curve>,
+    pub curve: Option<MaybePartial<Curve>>,
 
     /// The surface form of the [`Vertex`]
     ///
@@ -43,8 +43,8 @@ impl PartialVertex {
     }
 
     /// Provide a curve for the partial vertex
-    pub fn with_curve(mut self, curve: Curve) -> Self {
-        self.curve = Some(curve);
+    pub fn with_curve(mut self, curve: impl Into<MaybePartial<Curve>>) -> Self {
+        self.curve = Some(curve.into());
         self
     }
 
@@ -71,7 +71,10 @@ impl PartialVertex {
         let position = self
             .position
             .expect("Cant' build `Vertex` without position");
-        let curve = self.curve.expect("Can't build `Vertex` without `Curve`");
+        let curve = self
+            .curve
+            .expect("Can't build `Vertex` without `Curve`")
+            .into_full(stores);
 
         let surface_form = self.surface_form.unwrap_or_else(|| {
             PartialSurfaceVertex {
@@ -92,7 +95,7 @@ impl From<Vertex> for PartialVertex {
     fn from(vertex: Vertex) -> Self {
         Self {
             position: Some(vertex.position()),
-            curve: Some(vertex.curve().clone()),
+            curve: Some(vertex.curve().clone().into()),
             surface_form: Some(*vertex.surface_form()),
             global_form: Some(*vertex.global_form()),
         }


### PR DESCRIPTION
This makes use of the new capabilities introduced in #1133, making the partial vertex API more flexible, which should help address the object identity issues that are holding up #1079.