### PR TITLE
Improve partial object API

### DIFF
--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -124,7 +124,7 @@ impl PartialHalfEdge {
             .copied()
             .or_else(|| to.surface().copied())
             .expect("Can't infer line segment without a surface");
-        let points = [from, to].map(|vertex| {
+        let points = [&from, &to].map(|vertex| {
             vertex
                 .position()
                 .expect("Can't infer line segment without surface position")

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -137,13 +137,16 @@ impl PartialHalfEdge {
         .with_surface(surface)
         .as_line_from_points(points);
 
-        let vertices = [from, to].map(|vertex| match vertex {
-            MaybePartial::Partial(vertex) => {
-                let vertex = vertex.with_curve(curve.clone());
-                MaybePartial::from(vertex)
-            }
-            _ => vertex,
-        });
+        let vertices =
+            [(from, 0.), (to, 1.)].map(|(vertex, position)| match vertex {
+                MaybePartial::Partial(vertex) => {
+                    let vertex = vertex
+                        .with_position([position])
+                        .with_curve(curve.clone());
+                    MaybePartial::from(vertex)
+                }
+                _ => vertex,
+            });
 
         self.curve = Some(curve.into());
         self.vertices = Some(vertices);

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -137,7 +137,16 @@ impl PartialHalfEdge {
         .with_surface(surface)
         .as_line_from_points(points);
 
+        let vertices = [from, to].map(|vertex| match vertex {
+            MaybePartial::Partial(vertex) => {
+                let vertex = vertex.with_curve(curve.clone());
+                MaybePartial::from(vertex)
+            }
+            _ => vertex,
+        });
+
         self.curve = Some(curve.into());
+        self.vertices = Some(vertices);
 
         self
     }

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -109,7 +109,7 @@ impl PartialHalfEdge {
 
     /// Update partial half-edge as a line segment, reusing existing vertices
     pub fn as_line_segment(mut self) -> Self {
-        let [from, to] = self
+        let [from_surface, to_surface] = self
             .vertices
             .clone()
             .expect("Can't infer line segment without vertices")
@@ -119,12 +119,12 @@ impl PartialHalfEdge {
                 )
             });
 
-        let surface = from
+        let surface = from_surface
             .surface()
             .copied()
-            .or_else(|| to.surface().copied())
+            .or_else(|| to_surface.surface().copied())
             .expect("Can't infer line segment without a surface");
-        let points = [&from, &to].map(|vertex| {
+        let points = [&from_surface, &to_surface].map(|vertex| {
             vertex
                 .position()
                 .expect("Can't infer line segment without surface position")

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -148,16 +148,11 @@ impl PartialHalfEdge {
         .with_surface(surface)
         .as_line_from_points(points);
 
-        let vertices =
-            [(from, 0.), (to, 1.)].map(|(vertex, position)| match vertex {
-                MaybePartial::Partial(vertex) => {
-                    let vertex = vertex
-                        .with_position([position])
-                        .with_curve(curve.clone());
-                    MaybePartial::from(vertex)
-                }
-                _ => vertex,
-            });
+        let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {
+            vertex.update_partial(|vertex| {
+                vertex.with_position([position]).with_curve(curve.clone())
+            })
+        });
 
         self.curve = Some(curve.into());
         self.vertices = Some(vertices);

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -169,7 +169,11 @@ impl PartialHalfEdge {
         let vertices = self
             .vertices
             .expect("Can't build `HalfEdge` without vertices")
-            .map(|vertex| vertex.into_full(stores));
+            .map(|vertex| {
+                vertex
+                    .update_partial(|vertex| vertex.with_curve(curve.clone()))
+                    .into_full(stores)
+            });
 
         let global_form = self
             .global_form

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -2,7 +2,8 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{
-        Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface, Vertex,
+        Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Surface,
+        SurfaceVertex, Vertex,
     },
     stores::{Handle, Stores},
 };
@@ -84,27 +85,18 @@ impl PartialHalfEdge {
 
     /// Update partial half-edge as a line segment, from the given points
     pub fn as_line_segment_from_points(
-        mut self,
+        self,
         surface: Surface,
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
-        let curve = PartialCurve {
-            global_form: self.extract_global_curve(),
-            ..PartialCurve::default()
-        }
-        .with_surface(surface)
-        .as_line_from_points(points);
-
-        let vertices = [0., 1.].map(|position| {
-            Vertex::partial()
-                .with_position([position])
-                .with_curve(curve.clone())
-        });
-
-        self.curve = Some(curve.into());
-        self.vertices = Some(vertices.map(Into::into));
-
-        self
+        self.with_vertices(points.map(|point| {
+            Vertex::partial().with_surface_form(
+                SurfaceVertex::partial()
+                    .with_surface(surface)
+                    .with_position(point),
+            )
+        }))
+        .as_line_segment()
     }
 
     /// Update partial half-edge as a line segment, reusing existing vertices

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -109,15 +109,15 @@ impl PartialHalfEdge {
 
     /// Update partial half-edge as a line segment, reusing existing vertices
     pub fn as_line_segment(mut self) -> Self {
-        let [from_surface, to_surface] = self
+        let [from, to] = self
             .vertices
             .clone()
-            .expect("Can't infer line segment without vertices")
-            .map(|vertex| {
-                vertex.surface_form().expect(
-                    "Can't infer line segment without two surface vertices",
-                )
-            });
+            .expect("Can't infer line segment without vertices");
+        let [from_surface, to_surface] = [&from, &to].map(|vertex| {
+            vertex
+                .surface_form()
+                .expect("Can't infer line segment without two surface vertices")
+        });
 
         let surface = from_surface
             .surface()

--- a/crates/fj-kernel/src/partial/edge.rs
+++ b/crates/fj-kernel/src/partial/edge.rs
@@ -177,8 +177,20 @@ impl PartialHalfEdge {
     fn extract_global_curve(
         &self,
     ) -> Option<MaybePartial<Handle<GlobalCurve>>> {
-        let global_curve = self.global_form.as_ref()?.curve()?.clone();
-        Some(global_curve.into())
+        fn extract_global_curve_from_curve(
+            partial: &PartialHalfEdge,
+        ) -> Option<MaybePartial<Handle<GlobalCurve>>> {
+            partial.curve.as_ref()?.global_form()
+        }
+
+        fn extract_global_curve_from_global_form(
+            partial: &PartialHalfEdge,
+        ) -> Option<MaybePartial<Handle<GlobalCurve>>> {
+            Some(partial.global_form.as_ref()?.curve()?.clone().into())
+        }
+
+        extract_global_curve_from_curve(self)
+            .or_else(|| extract_global_curve_from_global_form(self))
     }
 }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -18,6 +18,17 @@ pub enum MaybePartial<T: HasPartialForm> {
 }
 
 impl<T: HasPartialForm> MaybePartial<T> {
+    /// If this is a partial object, update it
+    pub fn update_partial(
+        self,
+        f: impl FnOnce(T::PartialForm) -> T::PartialForm,
+    ) -> Self {
+        match self {
+            Self::Partial(partial) => Self::Partial(f(partial)),
+            _ => self,
+        }
+    }
+
     /// Return the full object, either directly or by building it
     pub fn into_full(self, stores: &Stores) -> T {
         match self {

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{GlobalCurve, GlobalEdge, Surface, SurfaceVertex, Vertex},
+    objects::{Curve, GlobalCurve, GlobalEdge, Surface, SurfaceVertex, Vertex},
     stores::{Handle, Stores},
 };
 
@@ -31,6 +31,16 @@ impl<T: HasPartialForm> MaybePartial<T> {
         match self {
             Self::Partial(partial) => partial,
             Self::Full(full) => full.into(),
+        }
+    }
+}
+
+impl MaybePartial<Curve> {
+    /// Access the global form
+    pub fn global_form(&self) -> Option<MaybePartial<Handle<GlobalCurve>>> {
+        match self {
+            Self::Full(full) => Some(full.global_form().clone().into()),
+            Self::Partial(partial) => partial.global_form.clone(),
         }
     }
 }


### PR DESCRIPTION
This is a collection of small changes, mainly to `PartialHalfEdge`, that came out of my work on #1079. These changes make the partial object API more flexible, more correct, and more useful overall.