### PR TITLE
Add missing methods to `PartialGlobalEdge`

### DIFF
--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -220,6 +220,12 @@ impl PartialGlobalEdge {
         self
     }
 
+    /// Update the partial global edge with the given vertices
+    pub fn with_vertices(mut self, vertices: [GlobalVertex; 2]) -> Self {
+        self.vertices = Some(vertices);
+        self
+    }
+
     /// Update partial global edge from the given curve and vertices
     pub fn from_curve_and_vertices(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -214,6 +214,12 @@ pub struct PartialGlobalEdge {
 }
 
 impl PartialGlobalEdge {
+    /// Update the partial global edge with the given curve
+    pub fn with_curve(mut self, curve: Handle<GlobalCurve>) -> Self {
+        self.curve = Some(curve);
+        self
+    }
+
     /// Update partial global edge from the given curve and vertices
     pub fn from_curve_and_vertices(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -228,15 +228,12 @@ impl PartialGlobalEdge {
 
     /// Update partial global edge from the given curve and vertices
     pub fn from_curve_and_vertices(
-        mut self,
+        self,
         curve: &Curve,
         vertices: &[Vertex; 2],
     ) -> Self {
-        self.curve = Some(curve.global_form().clone());
-        self.vertices =
-            Some(vertices.clone().map(|vertex| *vertex.global_form()));
-
-        self
+        self.with_curve(curve.global_form().clone())
+            .with_vertices(vertices.clone().map(|vertex| *vertex.global_form()))
     }
 
     /// Build a full [`GlobalEdge`] from the partial global edge


### PR DESCRIPTION
I seem to have missed those when I originally migrated `PartialGlobalEdge` from the builder API.