### PR TITLE
Avoid creating duplicate `GlobalCurve`s when transforming half-edge

### DIFF
--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Curve, GlobalCurve},
+    partial::PartialGlobalCurve,
     stores::{Handle, Stores},
 };
 
@@ -24,5 +25,12 @@ impl TransformObject for Handle<GlobalCurve> {
         stores.global_curves.insert(GlobalCurve::from_path(
             self.path().transform(transform, stores),
         ))
+    }
+}
+
+impl TransformObject for PartialGlobalCurve {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let path = self.path.map(|path| path.transform(transform, stores));
+        Self { path }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Curve, GlobalCurve},
-    partial::PartialGlobalCurve,
+    partial::{PartialCurve, PartialGlobalCurve},
     stores::{Handle, Stores},
 };
 
@@ -25,6 +25,25 @@ impl TransformObject for Handle<GlobalCurve> {
         stores.global_curves.insert(GlobalCurve::from_path(
             self.path().transform(transform, stores),
         ))
+    }
+}
+
+impl TransformObject for PartialCurve {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let surface = self
+            .surface
+            .map(|surface| surface.transform(transform, stores));
+        let global_form = self
+            .global_form
+            .map(|global_form| global_form.transform(transform, stores));
+
+        // Don't need to transform `self.path`, as that's defined in surface
+        // coordinates, and thus transforming `surface` takes care of it.
+        Self {
+            surface,
+            path: self.path,
+            global_form,
+        }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{GlobalEdge, HalfEdge},
+    partial::HasPartial,
     stores::Stores,
 };
 
@@ -13,7 +14,13 @@ impl TransformObject for HalfEdge {
         let vertices = self
             .vertices()
             .clone()
-            .map(|vertex| vertex.transform(transform, stores));
+            .map(|vertex| {
+                vertex
+                    .to_partial()
+                    .transform(transform, stores)
+                    .with_curve(curve.clone())
+                    .build(stores)
+            });
         let global_form =
             self.global_form().clone().transform(transform, stores);
 

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{GlobalEdge, HalfEdge},
-    partial::HasPartial,
+    partial::{HasPartial, PartialGlobalEdge},
     stores::Stores,
 };
 
@@ -38,5 +38,16 @@ impl TransformObject for GlobalEdge {
             .map(|vertex| vertex.transform(transform, stores));
 
         Self::new(curve, vertices)
+    }
+}
+
+impl TransformObject for PartialGlobalEdge {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let curve = self.curve.map(|curve| curve.transform(transform, stores));
+        let vertices = self.vertices.map(|vertices| {
+            vertices.map(|vertex| vertex.transform(transform, stores))
+        });
+
+        Self { curve, vertices }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -13,6 +13,8 @@ impl TransformObject for HalfEdge {
         let curve = self.curve().clone().transform(transform, stores);
         let vertices = self
             .vertices()
+            // The `clone` can be replaced with `each_ref`, once that is stable:
+            // https://doc.rust-lang.org/std/primitive.array.html#method.each_ref
             .clone()
             .map(|vertex| {
                 vertex

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -23,8 +23,12 @@ impl TransformObject for HalfEdge {
                     .with_curve(curve.clone())
                     .build(stores)
             });
-        let global_form =
-            self.global_form().clone().transform(transform, stores);
+        let global_form = self
+            .global_form()
+            .to_partial()
+            .transform(transform, stores)
+            .with_curve(curve.global_form().clone())
+            .build(stores);
 
         Self::new(curve, vertices, global_form)
     }

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -13,7 +13,10 @@ mod vertex;
 
 use fj_math::{Transform, Vector};
 
-use crate::stores::Stores;
+use crate::{
+    partial::{HasPartial, MaybePartial},
+    stores::Stores,
+};
 
 /// Transform an object
 ///
@@ -43,5 +46,20 @@ pub trait TransformObject: Sized {
     #[must_use]
     fn rotate(self, axis_angle: impl Into<Vector<3>>, stores: &Stores) -> Self {
         self.transform(&Transform::rotation(axis_angle), stores)
+    }
+}
+
+impl<T> TransformObject for MaybePartial<T>
+where
+    T: HasPartial + TransformObject,
+    T::Partial: TransformObject,
+{
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        match self {
+            Self::Full(full) => Self::Full(full.transform(transform, stores)),
+            Self::Partial(partial) => {
+                Self::Partial(partial.transform(transform, stores))
+            }
+        }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{GlobalVertex, SurfaceVertex, Vertex},
-    partial::{PartialGlobalVertex, PartialSurfaceVertex},
+    partial::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     stores::Stores,
 };
 
@@ -35,6 +35,27 @@ impl TransformObject for GlobalVertex {
     fn transform(self, transform: &Transform, _: &Stores) -> Self {
         let position = transform.transform_point(&self.position());
         Self::from_position(position)
+    }
+}
+
+impl TransformObject for PartialVertex {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let curve = self.curve.map(|curve| curve.transform(transform, stores));
+        let surface_form = self
+            .surface_form
+            .map(|surface_form| surface_form.transform(transform, stores));
+        let global_form = self
+            .global_form
+            .map(|global_form| global_form.transform(transform, stores));
+
+        // Don't need to transform `self.position`, as that is in curve
+        // coordinates and thus transforming the curve takes care of it.
+        Self {
+            position: self.position,
+            curve,
+            surface_form,
+            global_form,
+        }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{GlobalVertex, SurfaceVertex, Vertex},
-    partial::PartialGlobalVertex,
+    partial::{PartialGlobalVertex, PartialSurfaceVertex},
     stores::Stores,
 };
 
@@ -35,6 +35,25 @@ impl TransformObject for GlobalVertex {
     fn transform(self, transform: &Transform, _: &Stores) -> Self {
         let position = transform.transform_point(&self.position());
         Self::from_position(position)
+    }
+}
+
+impl TransformObject for PartialSurfaceVertex {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let surface = self
+            .surface
+            .map(|surface| surface.transform(transform, stores));
+        let global_form = self
+            .global_form
+            .map(|global_form| global_form.transform(transform, stores));
+
+        // Don't need to transform `self.position`, as that is in surface
+        // coordinates and thus transforming the surface takes care of it.
+        Self {
+            position: self.position,
+            surface,
+            global_form,
+        }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{GlobalVertex, SurfaceVertex, Vertex},
+    partial::PartialGlobalVertex,
     stores::Stores,
 };
 
@@ -34,5 +35,15 @@ impl TransformObject for GlobalVertex {
     fn transform(self, transform: &Transform, _: &Stores) -> Self {
         let position = transform.transform_point(&self.position());
         Self::from_position(position)
+    }
+}
+
+impl TransformObject for PartialGlobalVertex {
+    fn transform(self, transform: &Transform, _: &Stores) -> Self {
+        let position = self
+            .position
+            .map(|position| transform.transform_point(&position));
+
+        Self { position }
     }
 }


### PR DESCRIPTION
As part of addressing #1079, `GlobalCurve` will no longer contain geometric data, but instead just be an empty trait that only exists to determine whether two curves are different, or map to the same `GlobalCurve`. This implies that `GlobalCurve` equality no longer has any meaning, but `GlobalCurve` identity does. I've [written about this in more detail](https://github.com/hannobraun/Fornjot/issues/1079#issuecomment-1252416096) before.

A lot of code created duplicate but equal `GlobalCurve`s. This happened to work, but is now turning into an error, as those duplicate `GlobalCurve`s have different identities, which is going to trigger validation errors going soon. This pull request removes one source of duplicate `GlobalCurve`s: the code that transforms half-edges. This is another step towards addressing #1079.

