### PR TITLE
Fix `Face` transform code creating duplicate `Surface`s

### DIFF
--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -1,24 +1,12 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{Curve, GlobalCurve},
+    objects::GlobalCurve,
     partial::PartialCurve,
     stores::{Handle, Stores},
 };
 
 use super::TransformObject;
-
-impl TransformObject for Curve {
-    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let surface = self.surface().clone().transform(transform, stores);
-        let global_form =
-            self.global_form().clone().transform(transform, stores);
-
-        // Don't need to transform `self.path`, as that's defined in surface
-        // coordinates, and thus transforming `surface` takes care of it.
-        Self::new(surface, self.path(), global_form)
-    }
-}
 
 impl TransformObject for Handle<GlobalCurve> {
     fn transform(self, _: &Transform, stores: &Stores) -> Self {

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -1,6 +1,6 @@
 use fj_math::Transform;
 
-use crate::{objects::Cycle, stores::Stores};
+use crate::{objects::Cycle, partial::PartialCycle, stores::Stores};
 
 use super::TransformObject;
 
@@ -12,5 +12,24 @@ impl TransformObject for Cycle {
             .map(|edge| edge.transform(transform, stores));
 
         Self::new(surface, half_edges)
+    }
+}
+
+impl TransformObject for PartialCycle {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let surface = self
+            .surface
+            .clone()
+            .map(|surface| surface.transform(transform, stores));
+        let half_edges = self
+            .half_edges
+            .into_iter()
+            .map(|edge| edge.transform(transform, stores))
+            .collect();
+
+        Self {
+            surface,
+            half_edges,
+        }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -6,10 +6,11 @@ use super::TransformObject;
 
 impl TransformObject for Cycle {
     fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        Self::new(
-            self.surface().clone().transform(transform, stores),
-            self.into_half_edges()
-                .map(|edge| edge.transform(transform, stores)),
-        )
+        let surface = self.surface().clone().transform(transform, stores);
+        let half_edges = self
+            .into_half_edges()
+            .map(|edge| edge.transform(transform, stores));
+
+        Self::new(surface, half_edges)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -1,19 +1,8 @@
 use fj_math::Transform;
 
-use crate::{objects::Cycle, partial::PartialCycle, stores::Stores};
+use crate::{partial::PartialCycle, stores::Stores};
 
 use super::TransformObject;
-
-impl TransformObject for Cycle {
-    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let surface = self.surface().clone().transform(transform, stores);
-        let half_edges = self
-            .into_half_edges()
-            .map(|edge| edge.transform(transform, stores));
-
-        Self::new(surface, half_edges)
-    }
-}
 
 impl TransformObject for PartialCycle {
     fn transform(self, transform: &Transform, stores: &Stores) -> Self {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -1,49 +1,11 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{GlobalEdge, HalfEdge},
-    partial::{HasPartial, PartialGlobalEdge, PartialHalfEdge},
+    partial::{PartialGlobalEdge, PartialHalfEdge},
     stores::Stores,
 };
 
 use super::TransformObject;
-
-impl TransformObject for HalfEdge {
-    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let curve = self.curve().clone().transform(transform, stores);
-        let vertices = self
-            .vertices()
-            // The `clone` can be replaced with `each_ref`, once that is stable:
-            // https://doc.rust-lang.org/std/primitive.array.html#method.each_ref
-            .clone()
-            .map(|vertex| {
-                vertex
-                    .to_partial()
-                    .transform(transform, stores)
-                    .with_curve(curve.clone())
-                    .build(stores)
-            });
-        let global_form = self
-            .global_form()
-            .to_partial()
-            .transform(transform, stores)
-            .with_curve(curve.global_form().clone())
-            .build(stores);
-
-        Self::new(curve, vertices, global_form)
-    }
-}
-
-impl TransformObject for GlobalEdge {
-    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let curve = self.curve().clone().transform(transform, stores);
-        let vertices = self
-            .vertices_in_normalized_order()
-            .map(|vertex| vertex.transform(transform, stores));
-
-        Self::new(curve, vertices)
-    }
-}
 
 impl TransformObject for PartialHalfEdge {
     fn transform(self, transform: &Transform, stores: &Stores) -> Self {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{GlobalEdge, HalfEdge},
-    partial::{HasPartial, PartialGlobalEdge},
+    partial::{HasPartial, PartialGlobalEdge, PartialHalfEdge},
     stores::Stores,
 };
 
@@ -42,6 +42,43 @@ impl TransformObject for GlobalEdge {
             .map(|vertex| vertex.transform(transform, stores));
 
         Self::new(curve, vertices)
+    }
+}
+
+impl TransformObject for PartialHalfEdge {
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let curve = self
+            .curve
+            .clone()
+            .map(|curve| curve.transform(transform, stores));
+        let vertices = self.vertices.clone().map(|vertices| {
+            vertices.map(|vertex| {
+                let vertex = vertex.into_partial().transform(transform, stores);
+                let vertex = match &curve {
+                    Some(curve) => vertex.with_curve(curve.clone()),
+                    None => vertex,
+                };
+                vertex.into()
+            })
+        });
+        let global_form = self.global_form.map(|global_form| {
+            let global_form =
+                global_form.into_partial().transform(transform, stores);
+
+            let curve = curve.as_ref().and_then(|curve| curve.global_form());
+            let global_form = match curve {
+                Some(curve) => global_form.with_curve(curve),
+                None => global_form,
+            };
+
+            global_form.into()
+        });
+
+        Self {
+            curve,
+            vertices,
+            global_form,
+        }
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Face, Faces},
+    partial::HasPartial,
     stores::Stores,
 };
 
@@ -9,10 +10,20 @@ use super::TransformObject;
 
 impl TransformObject for Face {
     fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let exterior = self.exterior().clone().transform(transform, stores);
-        let interiors = self
-            .interiors()
-            .map(|cycle| cycle.clone().transform(transform, stores));
+        let surface = self.surface().clone().transform(transform, stores);
+        let exterior = self
+            .exterior()
+            .to_partial()
+            .transform(transform, stores)
+            .with_surface(surface.clone())
+            .build(stores);
+        let interiors = self.interiors().map(|cycle| {
+            cycle
+                .to_partial()
+                .transform(transform, stores)
+                .with_surface(surface.clone())
+                .build(stores)
+        });
 
         let color = self.color();
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -14,7 +14,7 @@ mod vertex;
 use fj_math::{Transform, Vector};
 
 use crate::{
-    partial::{HasPartial, MaybePartial},
+    partial::{HasPartial, MaybePartial, Partial},
     stores::Stores,
 };
 
@@ -46,6 +46,16 @@ pub trait TransformObject: Sized {
     #[must_use]
     fn rotate(self, axis_angle: impl Into<Vector<3>>, stores: &Stores) -> Self {
         self.transform(&Transform::rotation(axis_angle), stores)
+    }
+}
+
+impl<T> TransformObject for T
+where
+    T: HasPartial,
+    T::Partial: TransformObject,
+{
+    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        self.to_partial().transform(transform, stores).build(stores)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -1,43 +1,11 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{GlobalVertex, SurfaceVertex, Vertex},
     partial::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     stores::Stores,
 };
 
 use super::TransformObject;
-
-impl TransformObject for Vertex {
-    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let curve = self.curve().clone().transform(transform, stores);
-        let surface_form =
-            self.surface_form().clone().transform(transform, stores);
-        let global_form = self.global_form().transform(transform, stores);
-
-        // Don't need to transform `self.position`, as that is in curve
-        // coordinates and thus transforming the curve takes care of it.
-        Self::new(self.position(), curve, surface_form, global_form)
-    }
-}
-
-impl TransformObject for SurfaceVertex {
-    fn transform(self, transform: &Transform, stores: &Stores) -> Self {
-        let surface = self.surface().clone().transform(transform, stores);
-        let global_form = self.global_form().transform(transform, stores);
-
-        // Don't need to transform `self.position`, as that is in surface
-        // coordinates and thus transforming the surface takes care of it.
-        Self::new(self.position(), surface, global_form)
-    }
-}
-
-impl TransformObject for GlobalVertex {
-    fn transform(self, transform: &Transform, _: &Stores) -> Self {
-        let position = transform.transform_point(&self.position());
-        Self::from_position(position)
-    }
-}
 
 impl TransformObject for PartialVertex {
     fn transform(self, transform: &Transform, stores: &Stores) -> Self {


### PR DESCRIPTION
I have a local branch that changes validation that uses surface equality to use surface identity instead, which is stricter and should help prevent bug (or possible uncover existing ones). This is possible thanks to `Surface` being managed within the centralized object storage (#1021).

This pull request addresses one source of duplicate surfaces that this work uncovered.