### PR TITLE
Change `with_*` methods of partial objects to accept `Option`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -213,7 +213,7 @@ mod tests {
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]));
         let curve = Curve::partial()
-            .with_surface(surface)
+            .with_surface(Some(surface))
             .as_line_from_points([[1., 1.], [2., 1.]])
             .build(&stores);
         let range = RangeOnPath::from([[0.], [1.]]);
@@ -232,7 +232,7 @@ mod tests {
             [0., 0., 1.],
         ));
         let curve = Curve::partial()
-            .with_surface(surface)
+            .with_surface(Some(surface))
             .as_line_from_points([[1., 1.], [1., 2.]])
             .build(&stores);
         let range = RangeOnPath::from([[0.], [1.]]);
@@ -249,7 +249,7 @@ mod tests {
         let path = GlobalPath::circle_from_radius(1.);
         let surface = stores.surfaces.insert(Surface::new(path, [0., 0., 1.]));
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_line_from_points([[0., 1.], [1., 1.]])
             .build(&stores);
 
@@ -280,7 +280,7 @@ mod tests {
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]));
         let curve = Curve::partial()
-            .with_surface(surface)
+            .with_surface(Some(surface))
             .as_circle_from_radius(1.)
             .build(&stores);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -88,7 +88,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
@@ -111,7 +111,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
@@ -134,7 +134,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
@@ -152,7 +152,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -170,7 +170,7 @@ mod tests {
         let surface = stores.surfaces.insert(Surface::xy_plane());
 
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_line_from_points([[-3., 0.], [-2., 0.]])
             .build(&stores);
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -118,7 +118,7 @@ mod tests {
 
         let expected_curves = surfaces.map(|surface| {
             Curve::partial()
-                .with_surface(surface)
+                .with_surface(Some(surface))
                 .as_line_from_points([[0., 0.], [1., 0.]])
                 .build(&stores)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -118,11 +118,11 @@ mod tests {
         );
 
         let expected_xy = Curve::partial()
-            .with_surface(xy.clone())
+            .with_surface(Some(xy.clone()))
             .as_u_axis()
             .build(&stores);
         let expected_xz = Curve::partial()
-            .with_surface(xz.clone())
+            .with_surface(Some(xz.clone()))
             .as_u_axis()
             .build(&stores);
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -161,7 +161,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xz_plane());
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&stores);
         let vertex = Vertex::partial()

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -166,7 +166,7 @@ mod tests {
             .build(&stores);
         let vertex = Vertex::partial()
             .with_position(Some([0.]))
-            .with_curve(curve)
+            .with_curve(Some(curve))
             .build(&stores);
 
         let half_edge = (vertex, surface.clone()).sweep([0., 0., 1.], &stores);

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -165,7 +165,7 @@ mod tests {
             .as_u_axis()
             .build(&stores);
         let vertex = Vertex::partial()
-            .with_position([0.])
+            .with_position(Some([0.]))
             .with_curve(curve)
             .build(&stores);
 

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -27,10 +27,7 @@ impl TransformObject for PartialHalfEdge {
                 global_form.into_partial().transform(transform, stores);
 
             let curve = curve.as_ref().and_then(|curve| curve.global_form());
-            let global_form = match curve {
-                Some(curve) => global_form.with_curve(curve),
-                None => global_form,
-            };
+            let global_form = global_form.with_curve(curve);
 
             global_form.into()
         });

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -15,9 +15,11 @@ impl TransformObject for PartialHalfEdge {
             .map(|curve| curve.transform(transform, stores));
         let vertices = self.vertices.clone().map(|vertices| {
             vertices.map(|vertex| {
-                let vertex = vertex.into_partial().transform(transform, stores);
-                let vertex = vertex.with_curve(curve.clone());
-                vertex.into()
+                vertex
+                    .into_partial()
+                    .transform(transform, stores)
+                    .with_curve(curve.clone())
+                    .into()
             })
         });
         let global_form = self.global_form.map(|global_form| {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -23,13 +23,13 @@ impl TransformObject for PartialHalfEdge {
             })
         });
         let global_form = self.global_form.map(|global_form| {
-            let global_form =
-                global_form.into_partial().transform(transform, stores);
-
-            let curve = curve.as_ref().and_then(|curve| curve.global_form());
-            let global_form = global_form.with_curve(curve);
-
-            global_form.into()
+            global_form
+                .into_partial()
+                .transform(transform, stores)
+                .with_curve(
+                    curve.as_ref().and_then(|curve| curve.global_form()),
+                )
+                .into()
         });
 
         Self {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -16,10 +16,7 @@ impl TransformObject for PartialHalfEdge {
         let vertices = self.vertices.clone().map(|vertices| {
             vertices.map(|vertex| {
                 let vertex = vertex.into_partial().transform(transform, stores);
-                let vertex = match &curve {
-                    Some(curve) => vertex.with_curve(curve.clone()),
-                    None => vertex,
-                };
+                let vertex = vertex.with_curve(curve.clone());
                 vertex.into()
             })
         });

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -15,13 +15,13 @@ impl TransformObject for Face {
             .exterior()
             .to_partial()
             .transform(transform, stores)
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .build(stores);
         let interiors = self.interiors().map(|cycle| {
             cycle
                 .to_partial()
                 .transform(transform, stores)
-                .with_surface(surface.clone())
+                .with_surface(Some(surface.clone()))
                 .build(stores)
         });
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -34,7 +34,7 @@ impl<'a> FaceBuilder<'a> {
     ) -> Self {
         self.exterior = Some(
             Cycle::partial()
-                .with_surface(self.surface.clone())
+                .with_surface(Some(self.surface.clone()))
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()
                 .build(self.stores),
@@ -49,7 +49,7 @@ impl<'a> FaceBuilder<'a> {
     ) -> Self {
         self.interiors.push(
             Cycle::partial()
-                .with_surface(self.surface.clone())
+                .with_surface(Some(self.surface.clone()))
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()
                 .build(self.stores),

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -87,7 +87,7 @@ impl<'a> ShellBuilder<'a> {
 
                     let from = from.surface_form().clone();
                     let to = SurfaceVertex::partial()
-                        .with_position(from.position() + [Z, edge_length])
+                        .with_position(Some(from.position() + [Z, edge_length]))
                         .with_surface(surface.clone());
 
                     HalfEdge::partial()
@@ -115,7 +115,9 @@ impl<'a> ShellBuilder<'a> {
 
                         let to = to.surface_form().clone();
                         let from = SurfaceVertex::partial()
-                            .with_position(to.position() + [Z, edge_length])
+                            .with_position(Some(
+                                to.position() + [Z, edge_length],
+                            ))
                             .with_surface(surface.clone())
                             .with_global_form(*from.global_form());
 
@@ -146,7 +148,9 @@ impl<'a> ShellBuilder<'a> {
 
                     let from = from.surface_form().clone();
                     let to = SurfaceVertex::partial()
-                        .with_position(from.position() + [-edge_length, Z])
+                        .with_position(Some(
+                            from.position() + [-edge_length, Z],
+                        ))
                         .with_surface(surface.clone())
                         .with_global_form(*to.global_form());
 
@@ -203,7 +207,7 @@ impl<'a> ShellBuilder<'a> {
                 let vertices = [(point_a, vertex_a), (point_b, vertex_b)].map(
                     |(point, vertex)| {
                         let surface_form = SurfaceVertex::partial()
-                            .with_position(point)
+                            .with_position(Some(point))
                             .with_surface(surface.clone())
                             .with_global_form(*vertex.global_form())
                             .build(self.stores);

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -92,8 +92,8 @@ impl<'a> ShellBuilder<'a> {
 
                     HalfEdge::partial()
                         .with_vertices([
-                            Vertex::partial().with_surface_form(from),
-                            Vertex::partial().with_surface_form(to),
+                            Vertex::partial().with_surface_form(Some(from)),
+                            Vertex::partial().with_surface_form(Some(to)),
                         ])
                         .as_line_segment()
                         .build(self.stores)
@@ -126,8 +126,8 @@ impl<'a> ShellBuilder<'a> {
                         HalfEdge::partial()
                             .with_curve(curve)
                             .with_vertices([
-                                Vertex::partial().with_surface_form(from),
-                                Vertex::partial().with_surface_form(to),
+                                Vertex::partial().with_surface_form(Some(from)),
+                                Vertex::partial().with_surface_form(Some(to)),
                             ])
                             .as_line_segment()
                             .build(self.stores)
@@ -150,8 +150,8 @@ impl<'a> ShellBuilder<'a> {
                         .with_surface(surface.clone())
                         .with_global_form(*to.global_form());
 
-                    let from = Vertex::partial().with_surface_form(from);
-                    let to = Vertex::partial().with_surface_form(to);
+                    let from = Vertex::partial().with_surface_form(Some(from));
+                    let to = Vertex::partial().with_surface_form(Some(to));
 
                     HalfEdge::partial()
                         .with_vertices([from, to])
@@ -209,7 +209,7 @@ impl<'a> ShellBuilder<'a> {
                             .build(self.stores);
                         Vertex::partial()
                             .with_position(Some(vertex.position()))
-                            .with_surface_form(surface_form)
+                            .with_surface_form(Some(surface_form))
                     },
                 );
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -208,7 +208,7 @@ impl<'a> ShellBuilder<'a> {
                             .with_global_form(*vertex.global_form())
                             .build(self.stores);
                         Vertex::partial()
-                            .with_position(vertex.position())
+                            .with_position(Some(vertex.position()))
                             .with_surface_form(surface_form)
                     },
                 );

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -91,10 +91,10 @@ impl<'a> ShellBuilder<'a> {
                         .with_surface(Some(surface.clone()));
 
                     HalfEdge::partial()
-                        .with_vertices([
+                        .with_vertices(Some([
                             Vertex::partial().with_surface_form(Some(from)),
                             Vertex::partial().with_surface_form(Some(to)),
-                        ])
+                        ]))
                         .as_line_segment()
                         .build(self.stores)
                 })
@@ -127,10 +127,10 @@ impl<'a> ShellBuilder<'a> {
 
                         HalfEdge::partial()
                             .with_curve(Some(curve))
-                            .with_vertices([
+                            .with_vertices(Some([
                                 Vertex::partial().with_surface_form(Some(from)),
                                 Vertex::partial().with_surface_form(Some(to)),
-                            ])
+                            ]))
                             .as_line_segment()
                             .build(self.stores)
                     })
@@ -158,7 +158,7 @@ impl<'a> ShellBuilder<'a> {
                     let to = Vertex::partial().with_surface_form(Some(to));
 
                     HalfEdge::partial()
-                        .with_vertices([from, to])
+                        .with_vertices(Some([from, to]))
                         .as_line_segment()
                         .build(self.stores)
                 })
@@ -219,7 +219,7 @@ impl<'a> ShellBuilder<'a> {
 
                 edges.push(
                     HalfEdge::partial()
-                        .with_vertices(vertices)
+                        .with_vertices(Some(vertices))
                         .with_global_form(edge.global_form().clone())
                         .as_line_segment()
                         .build(self.stores),

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -168,7 +168,7 @@ impl<'a> ShellBuilder<'a> {
                 .zip(surfaces)
                 .map(|((((bottom, side_up), top), side_down), surface)| {
                     let cycle = Cycle::partial()
-                        .with_surface(surface)
+                        .with_surface(Some(surface))
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(self.stores);
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -126,7 +126,7 @@ impl<'a> ShellBuilder<'a> {
                         ));
 
                         HalfEdge::partial()
-                            .with_curve(curve)
+                            .with_curve(Some(curve))
                             .with_vertices([
                                 Vertex::partial().with_surface_form(Some(from)),
                                 Vertex::partial().with_surface_form(Some(to)),

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -119,9 +119,9 @@ impl<'a> ShellBuilder<'a> {
                             .with_surface(surface.clone())
                             .with_global_form(*from.global_form());
 
-                        let curve = Curve::partial().with_global_form(
+                        let curve = Curve::partial().with_global_form(Some(
                             side_up_prev.curve().global_form().clone(),
-                        );
+                        ));
 
                         HalfEdge::partial()
                             .with_curve(curve)

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -119,7 +119,7 @@ impl<'a> ShellBuilder<'a> {
                                 to.position() + [Z, edge_length],
                             ))
                             .with_surface(Some(surface.clone()))
-                            .with_global_form(*from.global_form());
+                            .with_global_form(Some(*from.global_form()));
 
                         let curve = Curve::partial().with_global_form(Some(
                             side_up_prev.curve().global_form().clone(),
@@ -152,7 +152,7 @@ impl<'a> ShellBuilder<'a> {
                             from.position() + [-edge_length, Z],
                         ))
                         .with_surface(Some(surface.clone()))
-                        .with_global_form(*to.global_form());
+                        .with_global_form(Some(*to.global_form()));
 
                     let from = Vertex::partial().with_surface_form(Some(from));
                     let to = Vertex::partial().with_surface_form(Some(to));
@@ -209,7 +209,7 @@ impl<'a> ShellBuilder<'a> {
                         let surface_form = SurfaceVertex::partial()
                             .with_position(Some(point))
                             .with_surface(Some(surface.clone()))
-                            .with_global_form(*vertex.global_form())
+                            .with_global_form(Some(*vertex.global_form()))
                             .build(self.stores);
                         Vertex::partial()
                             .with_position(Some(vertex.position()))

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -69,7 +69,7 @@ impl<'a> ShellBuilder<'a> {
                 .zip(&surfaces)
                 .map(|(half_edge, surface)| {
                     HalfEdge::partial()
-                        .with_global_form(half_edge.global_form().clone())
+                        .with_global_form(Some(half_edge.global_form().clone()))
                         .as_line_segment_from_points(
                             surface.clone(),
                             [[Z, Z], [edge_length, Z]],
@@ -220,7 +220,7 @@ impl<'a> ShellBuilder<'a> {
                 edges.push(
                     HalfEdge::partial()
                         .with_vertices(Some(vertices))
-                        .with_global_form(edge.global_form().clone())
+                        .with_global_form(Some(edge.global_form().clone()))
                         .as_line_segment()
                         .build(self.stores),
                 );

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -88,7 +88,7 @@ impl<'a> ShellBuilder<'a> {
                     let from = from.surface_form().clone();
                     let to = SurfaceVertex::partial()
                         .with_position(Some(from.position() + [Z, edge_length]))
-                        .with_surface(surface.clone());
+                        .with_surface(Some(surface.clone()));
 
                     HalfEdge::partial()
                         .with_vertices([
@@ -118,7 +118,7 @@ impl<'a> ShellBuilder<'a> {
                             .with_position(Some(
                                 to.position() + [Z, edge_length],
                             ))
-                            .with_surface(surface.clone())
+                            .with_surface(Some(surface.clone()))
                             .with_global_form(*from.global_form());
 
                         let curve = Curve::partial().with_global_form(Some(
@@ -151,7 +151,7 @@ impl<'a> ShellBuilder<'a> {
                         .with_position(Some(
                             from.position() + [-edge_length, Z],
                         ))
-                        .with_surface(surface.clone())
+                        .with_surface(Some(surface.clone()))
                         .with_global_form(*to.global_form());
 
                     let from = Vertex::partial().with_surface_form(Some(from));
@@ -208,7 +208,7 @@ impl<'a> ShellBuilder<'a> {
                     |(point, vertex)| {
                         let surface_form = SurfaceVertex::partial()
                             .with_position(Some(point))
-                            .with_surface(surface.clone())
+                            .with_surface(Some(surface.clone()))
                             .with_global_form(*vertex.global_form())
                             .build(self.stores);
                         Vertex::partial()

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -376,7 +376,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let object = Curve::partial()
-            .with_surface(surface)
+            .with_surface(Some(surface))
             .as_u_axis()
             .build(&stores);
 
@@ -585,7 +585,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let curve = Curve::partial()
-            .with_surface(surface.clone())
+            .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&stores);
         let global_vertex = GlobalVertex::from_position([0., 0., 0.]);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -399,7 +399,7 @@ mod tests {
 
         let surface = stores.surfaces.insert(Surface::xy_plane());
         let object = Cycle::partial()
-            .with_surface(surface)
+            .with_surface(Some(surface))
             .with_poly_chain_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .close_with_line_segment()
             .build(&stores);

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -48,9 +48,11 @@ impl PartialCurve {
     /// Provide a global form for the partial curve
     pub fn with_global_form(
         mut self,
-        global_form: impl Into<HandleWrapper<GlobalCurve>>,
+        global_form: Option<impl Into<HandleWrapper<GlobalCurve>>>,
     ) -> Self {
-        self.global_form = Some(global_form.into());
+        if let Some(global_form) = global_form {
+            self.global_form = Some(global_form.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -30,8 +30,10 @@ pub struct PartialCurve {
 
 impl PartialCurve {
     /// Provide a path for the partial curve
-    pub fn with_path(mut self, path: SurfacePath) -> Self {
-        self.path = Some(path);
+    pub fn with_path(mut self, path: Option<SurfacePath>) -> Self {
+        if let Some(path) = path {
+            self.path = Some(path);
+        }
         self
     }
 
@@ -68,12 +70,12 @@ impl PartialCurve {
 
     /// Update partial curve as a circle, from the provided radius
     pub fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
-        self.with_path(SurfacePath::circle_from_radius(radius))
+        self.with_path(Some(SurfacePath::circle_from_radius(radius)))
     }
 
     /// Update partial curve as a line, from the provided points
     pub fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self {
-        self.with_path(SurfacePath::line_from_points(points))
+        self.with_path(Some(SurfacePath::line_from_points(points)))
     }
 
     /// Build a full [`Curve`] from the partial curve

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -38,8 +38,10 @@ impl PartialCurve {
     }
 
     /// Provide a surface for the partial curve
-    pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
-        self.surface = Some(surface);
+    pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
+        if let Some(surface) = surface {
+            self.surface = Some(surface);
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -20,8 +20,10 @@ pub struct PartialCycle {
 
 impl PartialCycle {
     /// Update the partial cycle with the given surface
-    pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
-        self.surface = Some(surface);
+    pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
+        if let Some(surface) = surface {
+            self.surface = Some(surface);
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -78,13 +78,13 @@ impl PartialCycle {
                 let from = previous_vertex.unwrap_or_else(|| {
                     SurfaceVertex::partial()
                         .with_surface(surface.clone())
-                        .with_position(previous_position)
+                        .with_position(Some(previous_position))
                         .into()
                 });
                 let to = vertex.unwrap_or_else(|| {
                     SurfaceVertex::partial()
                         .with_surface(surface.clone())
-                        .with_position(position)
+                        .with_position(Some(position))
                         .into()
                 });
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -99,7 +99,7 @@ impl PartialCycle {
                         Vertex::partial()
                             .with_curve(Some(curve.clone()))
                             .with_position(Some([position]))
-                            .with_surface_form(surface_form)
+                            .with_surface_form(Some(surface_form))
                     });
 
                 self.half_edges.push(

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -105,7 +105,7 @@ impl PartialCycle {
                 self.half_edges.push(
                     HalfEdge::partial()
                         .with_curve(Some(curve))
-                        .with_vertices([from, to])
+                        .with_vertices(Some([from, to]))
                         .into(),
                 );
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -104,7 +104,7 @@ impl PartialCycle {
 
                 self.half_edges.push(
                     HalfEdge::partial()
-                        .with_curve(curve)
+                        .with_curve(Some(curve))
                         .with_vertices([from, to])
                         .into(),
                 );

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -98,7 +98,7 @@ impl PartialCycle {
                     [(0., from), (1., to)].map(|(position, surface_form)| {
                         Vertex::partial()
                             .with_curve(curve.clone())
-                            .with_position([position])
+                            .with_position(Some([position]))
                             .with_surface_form(surface_form)
                     });
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -97,7 +97,7 @@ impl PartialCycle {
                 let [from, to] =
                     [(0., from), (1., to)].map(|(position, surface_form)| {
                         Vertex::partial()
-                            .with_curve(curve.clone())
+                            .with_curve(Some(curve.clone()))
                             .with_position(Some([position]))
                             .with_surface_form(surface_form)
                     });

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -77,13 +77,13 @@ impl PartialCycle {
 
                 let from = previous_vertex.unwrap_or_else(|| {
                     SurfaceVertex::partial()
-                        .with_surface(surface.clone())
+                        .with_surface(Some(surface.clone()))
                         .with_position(Some(previous_position))
                         .into()
                 });
                 let to = vertex.unwrap_or_else(|| {
                     SurfaceVertex::partial()
-                        .with_surface(surface.clone())
+                        .with_surface(Some(surface.clone()))
                         .with_position(Some(position))
                         .into()
                 });

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -89,7 +89,7 @@ impl PartialCycle {
                 previous = Some((position, Some(to.clone())));
 
                 let curve = Curve::partial()
-                    .with_surface(surface.clone())
+                    .with_surface(Some(surface.clone()))
                     .as_line_from_points([previous_position, position]);
 
                 let [from, to] =

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -89,11 +89,11 @@ impl PartialHalfEdge {
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
         self.with_vertices(points.map(|point| {
-            Vertex::partial().with_surface_form(
+            Vertex::partial().with_surface_form(Some(
                 SurfaceVertex::partial()
                     .with_surface(surface.clone())
                     .with_position(point),
-            )
+            ))
         }))
         .as_line_segment()
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -237,8 +237,13 @@ impl PartialGlobalEdge {
     }
 
     /// Update the partial global edge with the given vertices
-    pub fn with_vertices(mut self, vertices: [GlobalVertex; 2]) -> Self {
-        self.vertices = Some(vertices);
+    pub fn with_vertices(
+        mut self,
+        vertices: Option<[GlobalVertex; 2]>,
+    ) -> Self {
+        if let Some(vertices) = vertices {
+            self.vertices = Some(vertices);
+        }
         self
     }
 
@@ -249,7 +254,9 @@ impl PartialGlobalEdge {
         vertices: &[Vertex; 2],
     ) -> Self {
         self.with_curve(Some(curve.global_form().clone()))
-            .with_vertices(vertices.clone().map(|vertex| *vertex.global_form()))
+            .with_vertices(Some(
+                vertices.clone().map(|vertex| *vertex.global_form()),
+            ))
     }
 
     /// Build a full [`GlobalEdge`] from the partial global edge

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -58,7 +58,7 @@ impl PartialHalfEdge {
         radius: impl Into<Scalar>,
     ) -> Self {
         let curve = Curve::partial()
-            .with_surface(surface)
+            .with_surface(Some(surface))
             .as_circle_from_radius(radius);
 
         let vertices = {
@@ -145,7 +145,7 @@ impl PartialHalfEdge {
             global_form: extract_global_curve(&self),
             ..PartialCurve::default()
         }
-        .with_surface(surface)
+        .with_surface(Some(surface))
         .as_line_from_points(points);
 
         let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -71,7 +71,7 @@ impl PartialHalfEdge {
             [a_curve, b_curve].map(|point_curve| {
                 Vertex::partial()
                     .with_position(Some(point_curve))
-                    .with_curve(curve.clone())
+                    .with_curve(Some(curve.clone()))
                     .with_global_form(global_vertex.clone())
             })
         };
@@ -152,7 +152,7 @@ impl PartialHalfEdge {
             vertex.update_partial(|vertex| {
                 vertex
                     .with_position(Some([position]))
-                    .with_curve(curve.clone())
+                    .with_curve(Some(curve.clone()))
             })
         });
 
@@ -173,7 +173,9 @@ impl PartialHalfEdge {
             .expect("Can't build `HalfEdge` without vertices")
             .map(|vertex| {
                 vertex
-                    .update_partial(|vertex| vertex.with_curve(curve.clone()))
+                    .update_partial(|vertex| {
+                        vertex.with_curve(Some(curve.clone()))
+                    })
                     .into_full(stores)
             });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -28,8 +28,13 @@ pub struct PartialHalfEdge {
 
 impl PartialHalfEdge {
     /// Update the partial half-edge with the given curve
-    pub fn with_curve(mut self, curve: impl Into<MaybePartial<Curve>>) -> Self {
-        self.curve = Some(curve.into());
+    pub fn with_curve(
+        mut self,
+        curve: Option<impl Into<MaybePartial<Curve>>>,
+    ) -> Self {
+        if let Some(curve) = curve {
+            self.curve = Some(curve.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -229,8 +229,10 @@ pub struct PartialGlobalEdge {
 
 impl PartialGlobalEdge {
     /// Update the partial global edge with the given curve
-    pub fn with_curve(mut self, curve: Handle<GlobalCurve>) -> Self {
-        self.curve = Some(curve.into());
+    pub fn with_curve(mut self, curve: Option<Handle<GlobalCurve>>) -> Self {
+        if let Some(curve) = curve {
+            self.curve = Some(curve.into());
+        }
         self
     }
 
@@ -246,7 +248,7 @@ impl PartialGlobalEdge {
         curve: &Curve,
         vertices: &[Vertex; 2],
     ) -> Self {
-        self.with_curve(curve.global_form().clone())
+        self.with_curve(Some(curve.global_form().clone()))
             .with_vertices(vertices.clone().map(|vertex| *vertex.global_form()))
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -41,9 +41,11 @@ impl PartialHalfEdge {
     /// Update the partial half-edge with the given vertices
     pub fn with_vertices(
         mut self,
-        vertices: [impl Into<MaybePartial<Vertex>>; 2],
+        vertices: Option<[impl Into<MaybePartial<Vertex>>; 2]>,
     ) -> Self {
-        self.vertices = Some(vertices.map(Into::into));
+        if let Some(vertices) = vertices {
+            self.vertices = Some(vertices.map(Into::into));
+        }
         self
     }
 
@@ -93,13 +95,13 @@ impl PartialHalfEdge {
         surface: Handle<Surface>,
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
-        self.with_vertices(points.map(|point| {
+        self.with_vertices(Some(points.map(|point| {
             Vertex::partial().with_surface_form(Some(
                 SurfaceVertex::partial()
                     .with_surface(Some(surface.clone()))
                     .with_position(Some(point)),
             ))
-        }))
+        })))
         .as_line_segment()
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -72,7 +72,7 @@ impl PartialHalfEdge {
                 Vertex::partial()
                     .with_position(Some(point_curve))
                     .with_curve(Some(curve.clone()))
-                    .with_global_form(global_vertex.clone())
+                    .with_global_form(Some(global_vertex.clone()))
             })
         };
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -70,7 +70,7 @@ impl PartialHalfEdge {
 
             [a_curve, b_curve].map(|point_curve| {
                 Vertex::partial()
-                    .with_position(point_curve)
+                    .with_position(Some(point_curve))
                     .with_curve(curve.clone())
                     .with_global_form(global_vertex.clone())
             })
@@ -150,7 +150,9 @@ impl PartialHalfEdge {
 
         let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {
             vertex.update_partial(|vertex| {
-                vertex.with_position([position]).with_curve(curve.clone())
+                vertex
+                    .with_position(Some([position]))
+                    .with_curve(curve.clone())
             })
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -92,7 +92,7 @@ impl PartialHalfEdge {
             Vertex::partial().with_surface_form(Some(
                 SurfaceVertex::partial()
                     .with_surface(surface.clone())
-                    .with_position(point),
+                    .with_position(Some(point)),
             ))
         }))
         .as_line_segment()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -52,9 +52,11 @@ impl PartialHalfEdge {
     /// Update the partial half-edge with the given global form
     pub fn with_global_form(
         mut self,
-        global_form: impl Into<MaybePartial<GlobalEdge>>,
+        global_form: Option<impl Into<MaybePartial<GlobalEdge>>>,
     ) -> Self {
-        self.global_form = Some(global_form.into());
+        if let Some(global_form) = global_form {
+            self.global_form = Some(global_form.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -91,7 +91,7 @@ impl PartialHalfEdge {
         self.with_vertices(points.map(|point| {
             Vertex::partial().with_surface_form(Some(
                 SurfaceVertex::partial()
-                    .with_surface(surface.clone())
+                    .with_surface(Some(surface.clone()))
                     .with_position(Some(point)),
             ))
         }))

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -47,8 +47,13 @@ impl PartialVertex {
     }
 
     /// Provide a curve for the partial vertex
-    pub fn with_curve(mut self, curve: impl Into<MaybePartial<Curve>>) -> Self {
-        self.curve = Some(curve.into());
+    pub fn with_curve(
+        mut self,
+        curve: Option<impl Into<MaybePartial<Curve>>>,
+    ) -> Self {
+        if let Some(curve) = curve {
+            self.curve = Some(curve.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -230,8 +230,13 @@ pub struct PartialGlobalVertex {
 
 impl PartialGlobalVertex {
     /// Provide a position for the partial global vertex
-    pub fn with_position(mut self, position: impl Into<Point<3>>) -> Self {
-        self.position = Some(position.into());
+    pub fn with_position(
+        mut self,
+        position: Option<impl Into<Point<3>>>,
+    ) -> Self {
+        if let Some(position) = position {
+            self.position = Some(position.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -161,8 +161,10 @@ impl PartialSurfaceVertex {
     }
 
     /// Provide a surface for the partial surface vertex
-    pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
-        self.surface = Some(surface);
+    pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
+        if let Some(surface) = surface {
+            self.surface = Some(surface);
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -71,9 +71,11 @@ impl PartialVertex {
     /// Provide a global form for the partial vertex
     pub fn with_global_form(
         mut self,
-        global_form: impl Into<MaybePartial<GlobalVertex>>,
+        global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
     ) -> Self {
-        self.global_form = Some(global_form.into());
+        if let Some(global_form) = global_form {
+            self.global_form = Some(global_form.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -171,9 +171,11 @@ impl PartialSurfaceVertex {
     /// Provide a global form for the partial surface vertex
     pub fn with_global_form(
         mut self,
-        global_form: impl Into<MaybePartial<GlobalVertex>>,
+        global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
     ) -> Self {
-        self.global_form = Some(global_form.into());
+        if let Some(global_form) = global_form {
+            self.global_form = Some(global_form.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -36,8 +36,13 @@ pub struct PartialVertex {
 
 impl PartialVertex {
     /// Provide a position for the partial vertex
-    pub fn with_position(mut self, position: impl Into<Point<1>>) -> Self {
-        self.position = Some(position.into());
+    pub fn with_position(
+        mut self,
+        position: Option<impl Into<Point<1>>>,
+    ) -> Self {
+        if let Some(position) = position {
+            self.position = Some(position.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -60,9 +60,11 @@ impl PartialVertex {
     /// Provide a surface form for the partial vertex
     pub fn with_surface_form(
         mut self,
-        surface_form: impl Into<MaybePartial<SurfaceVertex>>,
+        surface_form: Option<impl Into<MaybePartial<SurfaceVertex>>>,
     ) -> Self {
-        self.surface_form = Some(surface_form.into());
+        if let Some(surface_form) = surface_form {
+            self.surface_form = Some(surface_form.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -150,8 +150,13 @@ pub struct PartialSurfaceVertex {
 
 impl PartialSurfaceVertex {
     /// Provide a position for the partial surface vertex
-    pub fn with_position(mut self, position: impl Into<Point<2>>) -> Self {
-        self.position = Some(position.into());
+    pub fn with_position(
+        mut self,
+        position: Option<impl Into<Point<2>>>,
+    ) -> Self {
+        if let Some(position) = position {
+            self.position = Some(position.into());
+        }
         self
     }
 

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -46,6 +46,10 @@ pub trait HasPartial {
 ///   object structs, but all fields are optional.
 /// - Partial object structs have `with_*` methods to provide values for each of
 ///   their fields.
+/// - Values provided to `with_*` are usually wrapped in an `Option`, and only a
+///   `Some(...)` value has any effect. This is a trade-off that makes most use
+///   cases slightly more verbose, while significantly simplifying more complex
+///   use cases.
 /// - Partial object structs may have other methods with prefixes like `as_*`,
 ///   `from_*`, or similar, if one or more of their fields can be initialized by
 ///   providing alternative data.


### PR DESCRIPTION
From the documentation:
> Values provided to `with_*` are usually wrapped in an `Option`, and only a `Some(...)` value has any effect. This is a trade-off that makes most use cases slightly more verbose, while significantly simplifying more complex use cases.