### PR TITLE
Fix more surface duplication issues in transform code

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -92,7 +92,8 @@ mod tests {
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
-            .as_line_segment_from_points(surface, [[1., -1.], [1., 1.]])
+            .with_surface(Some(surface))
+            .as_line_segment_from_points([[1., -1.], [1., 1.]])
             .build(&stores);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -115,7 +116,8 @@ mod tests {
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
-            .as_line_segment_from_points(surface, [[-1., -1.], [-1., 1.]])
+            .with_surface(Some(surface))
+            .as_line_segment_from_points([[-1., -1.], [-1., 1.]])
             .build(&stores);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -138,7 +140,8 @@ mod tests {
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
-            .as_line_segment_from_points(surface, [[-1., -1.], [1., -1.]])
+            .with_surface(Some(surface))
+            .as_line_segment_from_points([[-1., -1.], [1., -1.]])
             .build(&stores);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -156,7 +159,8 @@ mod tests {
             .as_u_axis()
             .build(&stores);
         let half_edge = HalfEdge::partial()
-            .as_line_segment_from_points(surface, [[-1., 0.], [1., 0.]])
+            .with_surface(Some(surface))
+            .as_line_segment_from_points([[-1., 0.], [1., 0.]])
             .build(&stores);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -197,10 +197,8 @@ mod tests {
         let stores = Stores::new();
 
         let half_edge = HalfEdge::partial()
-            .as_line_segment_from_points(
-                stores.surfaces.insert(Surface::xy_plane()),
-                [[0., 0.], [1., 0.]],
-            )
+            .with_surface(Some(stores.surfaces.insert(Surface::xy_plane())))
+            .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&stores);
 
         let face = (half_edge, Color::default()).sweep([0., 0., 1.], &stores);
@@ -209,30 +207,22 @@ mod tests {
             let surface = stores.surfaces.insert(Surface::xz_plane());
 
             let bottom = HalfEdge::partial()
-                .as_line_segment_from_points(
-                    surface.clone(),
-                    [[0., 0.], [1., 0.]],
-                )
+                .with_surface(Some(surface.clone()))
+                .as_line_segment_from_points([[0., 0.], [1., 0.]])
                 .build(&stores);
             let top = HalfEdge::partial()
-                .as_line_segment_from_points(
-                    surface.clone(),
-                    [[0., 1.], [1., 1.]],
-                )
+                .with_surface(Some(surface.clone()))
+                .as_line_segment_from_points([[0., 1.], [1., 1.]])
                 .build(&stores)
                 .reverse();
             let left = HalfEdge::partial()
-                .as_line_segment_from_points(
-                    surface.clone(),
-                    [[0., 0.], [0., 1.]],
-                )
+                .with_surface(Some(surface.clone()))
+                .as_line_segment_from_points([[0., 0.], [0., 1.]])
                 .build(&stores)
                 .reverse();
             let right = HalfEdge::partial()
-                .as_line_segment_from_points(
-                    surface.clone(),
-                    [[1., 0.], [1., 1.]],
-                )
+                .with_surface(Some(surface.clone()))
+                .as_line_segment_from_points([[1., 0.], [1., 1.]])
                 .build(&stores);
 
             let cycle = Cycle::new(surface, [bottom, right, top, left]);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -117,10 +117,8 @@ mod tests {
             let [a, b] = [window[0], window[1]];
 
             let half_edge = HalfEdge::partial()
-                .as_line_segment_from_points(
-                    stores.surfaces.insert(Surface::xy_plane()),
-                    [a, b],
-                )
+                .with_surface(Some(stores.surfaces.insert(Surface::xy_plane())))
+                .as_line_segment_from_points([a, b])
                 .build(&stores);
             (half_edge, Color::default()).sweep(UP, &stores)
         });
@@ -157,10 +155,8 @@ mod tests {
             let [a, b] = [window[0], window[1]];
 
             let half_edge = HalfEdge::partial()
-                .as_line_segment_from_points(
-                    stores.surfaces.insert(Surface::xy_plane()),
-                    [a, b],
-                )
+                .with_surface(Some(stores.surfaces.insert(Surface::xy_plane())))
+                .as_line_segment_from_points([a, b])
                 .build(&stores)
                 .reverse();
             (half_edge, Color::default()).sweep(DOWN, &stores)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -172,7 +172,8 @@ mod tests {
         let half_edge = (vertex, surface.clone()).sweep([0., 0., 1.], &stores);
 
         let expected_half_edge = HalfEdge::partial()
-            .as_line_segment_from_points(surface, [[0., 0.], [0., 1.]])
+            .with_surface(Some(surface))
+            .as_line_segment_from_points([[0., 0.], [0., 1.]])
             .build(&stores);
         assert_eq!(half_edge, expected_half_edge);
     }

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -13,7 +13,12 @@ impl TransformObject for PartialCycle {
         let half_edges = self
             .half_edges
             .into_iter()
-            .map(|edge| edge.transform(transform, stores))
+            .map(|edge| {
+                edge.into_partial()
+                    .transform(transform, stores)
+                    .with_surface(surface.clone())
+                    .into()
+            })
             .collect();
 
         Self {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -9,6 +9,9 @@ use super::TransformObject;
 
 impl TransformObject for PartialHalfEdge {
     fn transform(self, transform: &Transform, stores: &Stores) -> Self {
+        let surface = self
+            .surface
+            .map(|surface| surface.transform(transform, stores));
         let curve = self
             .curve
             .clone()
@@ -33,6 +36,7 @@ impl TransformObject for PartialHalfEdge {
         });
 
         Self {
+            surface,
             curve,
             vertices,
             global_form,

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -1,7 +1,8 @@
 use fj_math::Transform;
 
 use crate::{
-    partial::{PartialGlobalEdge, PartialHalfEdge},
+    objects::Curve,
+    partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
     stores::Stores,
 };
 
@@ -12,10 +13,13 @@ impl TransformObject for PartialHalfEdge {
         let surface = self
             .surface
             .map(|surface| surface.transform(transform, stores));
-        let curve = self
-            .curve
-            .clone()
-            .map(|curve| curve.transform(transform, stores));
+        let curve = self.curve.clone().map(|curve| {
+            curve
+                .into_partial()
+                .transform(transform, stores)
+                .with_surface(surface.clone())
+                .into()
+        });
         let vertices = self.vertices.clone().map(|vertices| {
             vertices.map(|vertex| {
                 vertex
@@ -29,9 +33,9 @@ impl TransformObject for PartialHalfEdge {
             global_form
                 .into_partial()
                 .transform(transform, stores)
-                .with_curve(
-                    curve.as_ref().and_then(|curve| curve.global_form()),
-                )
+                .with_curve(curve.as_ref().and_then(
+                    |curve: &MaybePartial<Curve>| curve.global_form(),
+                ))
                 .into()
         });
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -69,11 +69,9 @@ impl<'a> ShellBuilder<'a> {
                 .zip(&surfaces)
                 .map(|(half_edge, surface)| {
                     HalfEdge::partial()
+                        .with_surface(Some(surface.clone()))
                         .with_global_form(Some(half_edge.global_form().clone()))
-                        .as_line_segment_from_points(
-                            surface.clone(),
-                            [[Z, Z], [edge_length, Z]],
-                        )
+                        .as_line_segment_from_points([[Z, Z], [edge_length, Z]])
                         .build(self.stores)
                 })
                 .collect::<Vec<_>>();

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -480,10 +480,8 @@ mod tests {
         let stores = Stores::new();
 
         let object = HalfEdge::partial()
-            .as_line_segment_from_points(
-                stores.surfaces.insert(Surface::xy_plane()),
-                [[0., 0.], [1., 0.]],
-            )
+            .with_surface(Some(stores.surfaces.insert(Surface::xy_plane())))
+            .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&stores);
 
         assert_eq!(1, object.curve_iter().count());

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -30,7 +30,7 @@ impl Cycle {
         for edge in &half_edges {
             assert_eq!(
                 &surface,
-                edge.curve().surface(),
+                edge.surface(),
                 "Edges in cycle not defined in same surface"
             );
         }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -4,11 +4,12 @@ use pretty_assertions::{assert_eq, assert_ne};
 
 use crate::stores::{Handle, HandleWrapper};
 
-use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
+use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
+    surface: Handle<Surface>,
     curve: Curve,
     vertices: [Vertex; 2],
     global_form: GlobalEdge,
@@ -69,10 +70,16 @@ impl HalfEdge {
         );
 
         Self {
+            surface: curve.surface().clone(),
             curve,
             vertices,
             global_form,
         }
+    }
+
+    /// Access the surface that the half-edge's [`Curve`] is defined on
+    pub fn surface(&self) -> &Handle<Surface> {
+        &self.surface
     }
 
     /// Access the curve that defines the half-edge's geometry

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -189,10 +189,12 @@ mod tests {
         let b = [1., 0.];
 
         let a_to_b = HalfEdge::partial()
-            .as_line_segment_from_points(surface.clone(), [a, b])
+            .with_surface(Some(surface.clone()))
+            .as_line_segment_from_points([a, b])
             .build(&stores);
         let b_to_a = HalfEdge::partial()
-            .as_line_segment_from_points(surface, [b, a])
+            .with_surface(Some(surface))
+            .as_line_segment_from_points([b, a])
             .build(&stores);
 
         assert_eq!(a_to_b.global_form(), b_to_a.global_form());

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -144,7 +144,8 @@ impl PartialCycle {
 
             self.half_edges.push(
                 HalfEdge::partial()
-                    .as_line_segment_from_points(surface, vertices)
+                    .with_surface(Some(surface))
+                    .as_line_segment_from_points(vertices)
                     .into(),
             );
         }

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -156,10 +156,14 @@ impl PartialCycle {
     /// Build a full [`Cycle`] from the partial cycle
     pub fn build(self, stores: &Stores) -> Cycle {
         let surface = self.surface.expect("Need surface to build `Cycle`");
-        let half_edges = self
-            .half_edges
-            .into_iter()
-            .map(|half_edge| half_edge.into_full(stores));
+        let surface_for_edges = surface.clone();
+        let half_edges = self.half_edges.into_iter().map(|half_edge| {
+            half_edge
+                .update_partial(|half_edge| {
+                    half_edge.with_surface(Some(surface_for_edges.clone()))
+                })
+                .into_full(stores)
+        });
 
         Cycle::new(surface, half_edges)
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -182,9 +182,11 @@ impl PartialHalfEdge {
 
     /// Build a full [`HalfEdge`] from the partial half-edge
     pub fn build(self, stores: &Stores) -> HalfEdge {
+        let surface = self.surface;
         let curve = self
             .curve
             .expect("Can't build `HalfEdge` without curve")
+            .update_partial(|curve| curve.with_surface(surface))
             .into_full(stores);
         let vertices = self
             .vertices

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -146,11 +146,13 @@ impl PartialHalfEdge {
                 .expect("Can't infer line segment without two surface vertices")
         });
 
-        let surface = from_surface
-            .surface()
-            .cloned()
-            .or_else(|| to_surface.surface().cloned())
-            .expect("Can't infer line segment without a surface");
+        let surface = self
+            .surface
+            .as_ref()
+            .or_else(|| from_surface.surface())
+            .or_else(|| to_surface.surface())
+            .expect("Can't infer line segment without a surface")
+            .clone();
         let points = [&from_surface, &to_surface].map(|vertex| {
             vertex
                 .position()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -101,13 +101,13 @@ impl PartialHalfEdge {
     /// Update partial half-edge as a line segment, from the given points
     pub fn as_line_segment_from_points(
         self,
-        surface: Handle<Surface>,
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
+        let surface = self.surface.clone();
         self.with_vertices(Some(points.map(|point| {
             Vertex::partial().with_surface_form(Some(
                 SurfaceVertex::partial()
-                    .with_surface(Some(surface.clone()))
+                    .with_surface(surface.clone())
                     .with_position(Some(point)),
             ))
         })))

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -72,13 +72,9 @@ impl PartialHalfEdge {
     }
 
     /// Update partial half-edge as a circle, from the given radius
-    pub fn as_circle_from_radius(
-        mut self,
-        surface: Handle<Surface>,
-        radius: impl Into<Scalar>,
-    ) -> Self {
+    pub fn as_circle_from_radius(mut self, radius: impl Into<Scalar>) -> Self {
         let curve = Curve::partial()
-            .with_surface(Some(surface))
+            .with_surface(self.surface.clone())
             .as_circle_from_radius(radius);
 
         let vertices = {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -14,6 +14,9 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialHalfEdge {
+    /// The surface that the [`HalfEdge`]'s [`Curve`] is defined in
+    pub surface: Option<Handle<Surface>>,
+
     /// The curve that the [`HalfEdge`] is defined in
     pub curve: Option<MaybePartial<Curve>>,
 
@@ -27,6 +30,14 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
+    /// Update the partial half-edge with the given surface
+    pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
+        if let Some(surface) = surface {
+            self.surface = Some(surface);
+        }
+        self
+    }
+
     /// Update the partial half-edge with the given curve
     pub fn with_curve(
         mut self,
@@ -204,6 +215,7 @@ impl PartialHalfEdge {
 impl From<&HalfEdge> for PartialHalfEdge {
     fn from(half_edge: &HalfEdge) -> Self {
         Self {
+            surface: Some(half_edge.surface().clone()),
             curve: Some(half_edge.curve().clone().into()),
             vertices: Some(half_edge.vertices().clone().map(Into::into)),
             global_form: Some(half_edge.global_form().clone().into()),

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -31,7 +31,8 @@ impl Shape for fj::Sketch {
                 // none need to be added here.
 
                 let half_edge = HalfEdge::partial()
-                    .as_circle_from_radius(surface.clone(), circle.radius())
+                    .with_surface(Some(surface.clone()))
+                    .as_circle_from_radius(circle.radius())
                     .build(stores);
                 let cycle = Cycle::new(surface, [half_edge]);
 


### PR DESCRIPTION
These are some more issues that I found in a local branch.  This local branch makes use of the progress in #1021, to tighten the validation code by using surface identity, as opposed to surface equality.