### PR TITLE
Simplify `Curve` construction

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -58,9 +58,8 @@ impl SurfaceSurfaceIntersection {
         let curves = surfaces_and_planes.map(|(surface, plane)| {
             let path = SurfacePath::Line(plane.project_line(&line));
             let global_form = GlobalCurve::new(stores);
-            let curve = Curve::new(surface, path, global_form);
 
-            stores.curves.insert(curve)
+            Curve::new(surface, path, global_form, stores)
         });
 
         Some(Self {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -40,13 +40,12 @@ impl Sweep for (HalfEdge, Color) {
                         points_curve_and_surface,
                     ));
 
-                let curve = Curve::new(
+                Curve::new(
                     surface.clone(),
                     path,
                     edge.curve().global_form().clone(),
-                );
-
-                stores.curves.insert(curve)
+                    stores,
+                )
             };
 
             let vertices = {
@@ -111,9 +110,7 @@ impl Sweep for (HalfEdge, Color) {
                         points_curve_and_surface,
                     ));
 
-                let curve = Curve::new(surface.clone(), path, global);
-
-                stores.curves.insert(curve)
+                Curve::new(surface.clone(), path, global, stores)
             };
 
             let global =

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -79,12 +79,13 @@ impl Sweep for (Vertex, Handle<Surface>) {
         // `Edge` is straight-forward.
         let curve = {
             let line = Line::from_points(points_surface);
-            let curve = Curve::new(
+
+            Curve::new(
                 surface.clone(),
                 SurfacePath::Line(line),
                 edge_global.curve().clone(),
-            );
-            stores.curves.insert(curve)
+                stores,
+            )
         };
 
         // And now the vertices. Again, nothing wild here.

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -177,8 +177,8 @@ mod tests {
         let curve = {
             let path = SurfacePath::line_from_points(points_surface);
             let global_form = GlobalCurve::new(&stores);
-            let curve = Curve::new(surface.clone(), path, global_form);
-            stores.curves.insert(curve)
+
+            Curve::new(surface.clone(), path, global_form, &stores)
         };
 
         let [a_global, b_global] =

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -21,11 +21,10 @@ impl Curve {
         global_form: impl Into<HandleWrapper<GlobalCurve>>,
         stores: &Stores,
     ) -> Handle<Self> {
-        let global_form = global_form.into();
         stores.curves.insert(Self {
             surface,
             path,
-            global_form,
+            global_form: global_form.into(),
         })
     }
 

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -19,14 +19,14 @@ impl Curve {
         surface: Handle<Surface>,
         path: SurfacePath,
         global_form: impl Into<HandleWrapper<GlobalCurve>>,
-    ) -> Self {
+        stores: &Stores,
+    ) -> Handle<Self> {
         let global_form = global_form.into();
-
-        Self {
+        stores.curves.insert(Self {
             surface,
             path,
             global_form,
-        }
+        })
     }
 
     /// Access the path that defines this curve

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -92,9 +92,7 @@ impl PartialCurve {
             .global_form
             .unwrap_or_else(|| GlobalCurve::new(stores).into());
 
-        let curve = Curve::new(surface, path, global_form);
-
-        stores.curves.insert(curve)
+        Curve::new(surface, path, global_form, stores)
     }
 }
 

--- a/crates/fj-kernel/src/stores/handle.rs
+++ b/crates/fj-kernel/src/stores/handle.rs
@@ -56,7 +56,7 @@ impl<T> Deref for Handle<T> {
         //    has at least been reserved.
         // 2. That the memory objects live in is never deallocated.
         //
-        // That means that as long as a `Handle` exists, the object is
+        // That means that as long as a `Handle` exists, the object it
         // references has at least been reserved, and has not been deallocated.
         //
         // Given all this, we know that the following must be true:
@@ -71,7 +71,7 @@ impl<T> Deref for Handle<T> {
         // the reference we return here are enforced.
         //
         // Furthermore, all of the code mentioned here is covered by unit tests,
-        // which I've run successfully run under Miri.
+        // which I've run successfully under Miri.
         let cell = unsafe { &*self.ptr };
 
         // Can only happen, if the object has been reserved, but the reservation


### PR DESCRIPTION
This introduces a new style for object constructors, one where the `&Stores` are passed into the constructor. This doesn't make a whole lot of difference for `Curve`, but it's a big convenience win with more widely-used objects (as I've seen in a local branch that's not ready yet).