### PR TITLE
Added Nix build and dev-shell support via Nix flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,110 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665356181,
+        "narHash": "sha256-ONEzlKL5LN4Y1TRfFY6C39G2Am1YFEjArwMYJONFhhs=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d78cb0453b9823d2102f7b22bb98686215462416",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1665431855,
+        "narHash": "sha256-/z4/QjPQ5g4Y4mQ5HJPn8siqqE1bjtEcmmkBUU0MqrQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f77a8a1df0cb83542be93f7d7ae962ab5a3ee78b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665398664,
+        "narHash": "sha256-y/UcVB5k0Wdc0j+7whJE2+vko8m296wZYX37b2lFSpI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "af29a900f10dd6e467622202fb4f6d944d72a3a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "Fornjot is an early-stage project to create a next-generation, code-first CAD application";
+  inputs = {
+    flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = { url = "github:oxalica/rust-overlay"; inputs = { nixpkgs.follows = "nixpkgs"; flake-utils.follows = "flake-utils"; }; };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-compat.follows = "flake-compat";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ (import rust-overlay) ]; };
+        rustToolchain = pkgs.rust-bin.fromRustupToolchain (
+          # extend toolchain with rust-analyzer for better IDE support
+          let toolchainToml = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain; in
+          {
+            channel = toolchainToml.channel;
+            components = toolchainToml.components ++ [ "rust-analyzer" ];
+          }
+        );
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+        # Only keeps assets in crates/ (currently shaders and fonts)
+        assetsFilter = path: _type: (builtins.match ".*(:?wgsl|ttf)$" path) != null;
+        filter = path: type: (assetsFilter path type) || (craneLib.filterCargoSources path type);
+        buildInputs = with pkgs; [
+          pkg-config
+          fontconfig
+          cmake
+          wayland
+          libGL
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libXrandr
+        ];
+
+        fornjot = craneLib.buildPackage {
+          pname = "fj-app";
+          src = nixpkgs.lib.cleanSourceWith { src = ./.; inherit filter; };
+          inherit buildInputs;
+        };
+
+        wrappedFornjot = pkgs.symlinkJoin {
+          name = "fj-app";
+          paths = [ fornjot ];
+
+          buildInputs = [ pkgs.makeWrapper ];
+
+          postBuild = ''
+            wrapProgram $out/bin/fj-app \
+              --prefix LD_LIBRARY_PATH : ${nixpkgs.lib.makeLibraryPath [ pkgs.vulkan-loader ]}
+          '';
+        };
+      in
+      {
+        checks = { inherit fornjot; };
+
+        packages.default = wrappedFornjot;
+
+        apps.default = flake-utils.lib.mkApp { drv = wrappedFornjot; };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.checks;
+
+          inherit buildInputs;
+          nativeBuildInputs = [ rustToolchain ];
+
+          LD_LIBRARY_PATH = "${nixpkgs.lib.makeLibraryPath [ pkgs.vulkan-loader ]}";
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
This PR adds support for Nix flakes (and the legacy nix build system via `flake-compat`).

Tested on NixOS, it may or not may run on other (linux/osx?) distributions.

I hacked this together to run and (likely) package Fornjot on NixOS, FWIW it may be helpful for other Nix users as well.

I can extend the `README` as well if it's helpful (Where would it fit best, in case?)

This can be run with (nix flakes enabled):

```bash
nix run github:Philipp-M/Fornjot/nix-flakes
```

or (without nix flakes enabled, in repo):

```bash
nix-build .
./result/bin/fj-app
```

Also supports a devshell environment, via `nix shell`