### PR TITLE
Provide access to default planes through `Objects`

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -75,7 +75,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        objects::{Curve, HalfEdge, Objects, Surface},
+        objects::{Curve, HalfEdge, Objects},
         partial::HasPartial,
         storage::Handle,
     };
@@ -86,7 +86,7 @@ mod tests {
     fn compute_edge_in_front_of_curve_origin() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
@@ -110,7 +110,7 @@ mod tests {
     fn compute_edge_behind_curve_origin() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
@@ -134,7 +134,7 @@ mod tests {
     fn compute_edge_parallel_to_curve() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
@@ -153,7 +153,7 @@ mod tests {
     fn compute_edge_on_curve() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -156,7 +156,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        objects::{Curve, Face, Objects, Surface},
+        objects::{Curve, Face, Objects},
         partial::HasPartial,
         storage::Handle,
     };
@@ -167,7 +167,7 @@ mod tests {
     fn compute() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
 
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -64,7 +64,7 @@ mod tests {
 
     use crate::{
         algorithms::intersect::CurveFaceIntersection,
-        objects::{Curve, Face, Objects, Surface},
+        objects::{Curve, Face, Objects},
         partial::HasPartial,
         storage::Handle,
     };
@@ -82,9 +82,8 @@ mod tests {
             [2., 2.],
             [1., 2.],
         ];
-        let [a, b] =
-            [Surface::xy_plane(), Surface::xz_plane()].map(|surface| {
-                let surface = objects.surfaces.insert(surface);
+        let [a, b] = [objects.surfaces.xy_plane(), objects.surfaces.xz_plane()]
+            .map(|surface| {
                 Face::builder(&objects, surface)
                     .with_exterior_polygon_from_points(points)
                     .build()
@@ -106,8 +105,8 @@ mod tests {
             [ 1.,  1.],
             [-1.,  1.],
         ];
-        let surfaces = [Surface::xy_plane(), Surface::xz_plane()]
-            .map(|surface| objects.surfaces.insert(surface));
+        let surfaces =
+            [objects.surfaces.xy_plane(), objects.surfaces.xz_plane()];
         let [a, b] = surfaces.clone().map(|surface| {
             Face::builder(&objects, surface)
                 .with_exterior_polygon_from_points(points)

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -134,14 +134,14 @@ mod tests {
     use crate::{
         algorithms::intersect::{face_point::FacePointIntersection, Intersect},
         iter::ObjectIters,
-        objects::{Face, Objects, Surface},
+        objects::{Face, Objects},
     };
 
     #[test]
     fn point_is_outside_face() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
             .build();
@@ -155,7 +155,7 @@ mod tests {
     fn ray_hits_vertex_while_passing_outside() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
             .build();
@@ -172,7 +172,7 @@ mod tests {
     fn ray_hits_vertex_at_cycle_seam() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
             .build();
@@ -189,7 +189,7 @@ mod tests {
     fn ray_hits_vertex_while_staying_inside() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [0., 0.],
@@ -211,7 +211,7 @@ mod tests {
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [0., 0.],
@@ -233,7 +233,7 @@ mod tests {
     fn ray_hits_parallel_edge_and_does_not_leave_face_there() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [0., 0.],
@@ -256,7 +256,7 @@ mod tests {
     fn point_is_coincident_with_edge() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
             .build();
@@ -282,7 +282,7 @@ mod tests {
     fn point_is_coincident_with_vertex() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -152,7 +152,7 @@ mod tests {
             transform::TransformObject,
         },
         iter::ObjectIters,
-        objects::{Face, Objects, Surface},
+        objects::{Face, Objects},
     };
 
     #[test]
@@ -161,7 +161,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::yz_plane());
+        let surface = objects.surfaces.yz_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
@@ -181,7 +181,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::yz_plane());
+        let surface = objects.surfaces.yz_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
@@ -204,7 +204,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::yz_plane());
+        let surface = objects.surfaces.yz_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
@@ -224,7 +224,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::yz_plane());
+        let surface = objects.surfaces.yz_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
@@ -255,7 +255,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::yz_plane());
+        let surface = objects.surfaces.yz_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
@@ -284,7 +284,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
@@ -306,7 +306,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -88,7 +88,7 @@ mod tests {
 
     use crate::{
         algorithms::transform::TransformObject,
-        objects::{Curve, Objects, Surface},
+        objects::{Curve, Objects},
         partial::HasPartial,
         storage::Handle,
     };
@@ -99,8 +99,8 @@ mod tests {
     fn plane_plane() {
         let objects = Objects::new();
 
-        let xy = objects.surfaces.insert(Surface::xy_plane());
-        let xz = objects.surfaces.insert(Surface::xz_plane());
+        let xy = objects.surfaces.xy_plane();
+        let xz = objects.surfaces.xz_plane();
 
         // Coincident and parallel planes don't have an intersection curve.
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -188,7 +188,7 @@ mod tests {
 
     use crate::{
         algorithms::{reverse::Reverse, sweep::Sweep},
-        objects::{Cycle, Face, HalfEdge, Objects, Surface},
+        objects::{Cycle, Face, HalfEdge, Objects},
         partial::HasPartial,
     };
 
@@ -197,14 +197,14 @@ mod tests {
         let objects = Objects::new();
 
         let half_edge = HalfEdge::partial()
-            .with_surface(Some(objects.surfaces.insert(Surface::xy_plane())))
+            .with_surface(Some(objects.surfaces.xy_plane()))
             .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&objects);
 
         let face = (half_edge, Color::default()).sweep([0., 0., 1.], &objects);
 
         let expected_face = {
-            let surface = objects.surfaces.insert(Surface::xz_plane());
+            let surface = objects.surfaces.xz_plane();
 
             let bottom = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -80,7 +80,7 @@ mod tests {
 
     use crate::{
         algorithms::{reverse::Reverse, transform::TransformObject},
-        objects::{Face, HalfEdge, Objects, Sketch, Surface},
+        objects::{Face, HalfEdge, Objects, Sketch},
         partial::HasPartial,
     };
 
@@ -95,7 +95,7 @@ mod tests {
     fn sweep_up() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder(&objects, surface.clone())
             .build_polygon_from_points(TRIANGLE)
             .sweep(UP, &objects);
@@ -119,9 +119,7 @@ mod tests {
             let [a, b] = [window[0], window[1]];
 
             let half_edge = HalfEdge::partial()
-                .with_surface(Some(
-                    objects.surfaces.insert(Surface::xy_plane()),
-                ))
+                .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects);
             (half_edge, Color::default()).sweep(UP, &objects)
@@ -134,7 +132,7 @@ mod tests {
     fn sweep_down() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder(&objects, surface.clone())
             .build_polygon_from_points(TRIANGLE)
             .sweep(DOWN, &objects);
@@ -159,9 +157,7 @@ mod tests {
             let [a, b] = [window[0], window[1]];
 
             let half_edge = HalfEdge::partial()
-                .with_surface(Some(
-                    objects.surfaces.insert(Surface::xy_plane()),
-                ))
+                .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects)
                 .reverse();

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -154,7 +154,7 @@ mod tests {
 
     use crate::{
         algorithms::sweep::Sweep,
-        objects::{Curve, HalfEdge, Objects, Surface, Vertex},
+        objects::{Curve, HalfEdge, Objects, Vertex},
         partial::HasPartial,
         storage::Handle,
     };
@@ -163,7 +163,7 @@ mod tests {
     fn vertex_surface() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xz_plane());
+        let surface = objects.surfaces.xz_plane();
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -84,7 +84,7 @@ mod tests {
 
     use crate::{
         algorithms::approx::{Approx, Tolerance},
-        objects::{Face, Objects, Surface},
+        objects::{Face, Objects},
     };
 
     use super::Triangulate;
@@ -98,7 +98,7 @@ mod tests {
         let c = [2., 2.];
         let d = [0., 1.];
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([a, b, c, d])
             .build();
@@ -132,7 +132,7 @@ mod tests {
         let g = [3., 3.];
         let h = [3., 1.];
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
@@ -192,7 +192,7 @@ mod tests {
         let d = [0.1, 0.1];
         let e = [0., 0.8];
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d, e])
             .build();

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -167,7 +167,7 @@ mod tests {
         algorithms::validate::{Validate, ValidationConfig, ValidationError},
         objects::{
             Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
-            Surface, SurfaceVertex, Vertex,
+            SurfaceVertex, Vertex,
         },
         partial::HasPartial,
         path::SurfacePath,
@@ -177,7 +177,7 @@ mod tests {
     fn coherence_edge() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
 
         let points_surface = [[0., 0.], [1., 0.]];
         let points_global = [[0., 0., 0.], [1., 0., 0.]];

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -34,7 +34,7 @@ impl<'a> ShellBuilder<'a> {
             let surface = self
                 .objects
                 .surfaces
-                .insert(Surface::xy_plane())
+                .xy_plane()
                 .translate([Z, Z, -h], self.objects);
 
             Face::builder(self.objects, surface)
@@ -186,7 +186,7 @@ impl<'a> ShellBuilder<'a> {
             let surface = self
                 .objects
                 .surfaces
-                .insert(Surface::xy_plane())
+                .xy_plane()
                 .translate([Z, Z, h], self.objects);
 
             let points = [[-h, -h], [-h, h], [h, h], [h, -h], [-h, -h]];

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -362,7 +362,7 @@ mod tests {
     use crate::{
         objects::{
             Curve, Cycle, Face, GlobalCurve, GlobalVertex, HalfEdge, Objects,
-            Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
+            Shell, Sketch, Solid, SurfaceVertex, Vertex,
         },
         partial::HasPartial,
         storage::Handle,
@@ -374,7 +374,7 @@ mod tests {
     fn curve() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let object = Handle::<Curve>::partial()
             .with_surface(Some(surface))
             .as_u_axis()
@@ -397,7 +397,7 @@ mod tests {
     fn cycle() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let object = Cycle::partial()
             .with_surface(Some(surface))
             .with_poly_chain_from_points([[0., 0.], [1., 0.], [0., 1.]])
@@ -421,7 +421,7 @@ mod tests {
     fn face() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let object = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build();
@@ -482,7 +482,7 @@ mod tests {
         let objects = Objects::new();
 
         let object = HalfEdge::partial()
-            .with_surface(Some(objects.surfaces.insert(Surface::xy_plane())))
+            .with_surface(Some(objects.surfaces.xy_plane()))
             .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&objects);
 
@@ -522,7 +522,7 @@ mod tests {
     fn sketch() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let face = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build();
@@ -564,7 +564,7 @@ mod tests {
     fn surface() {
         let objects = Objects::new();
 
-        let object = objects.surfaces.insert(Surface::xy_plane());
+        let object = objects.surfaces.xy_plane();
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -583,7 +583,7 @@ mod tests {
     fn vertex() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
         let curve = Handle::<Curve>::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -172,10 +172,7 @@ impl VerticesInNormalizedOrder {
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use crate::{
-        objects::{Objects, Surface},
-        partial::HasPartial,
-    };
+    use crate::{objects::Objects, partial::HasPartial};
 
     use super::HalfEdge;
 
@@ -183,7 +180,7 @@ mod tests {
     fn global_edge_equality() {
         let objects = Objects::new();
 
-        let surface = objects.surfaces.insert(Surface::xy_plane());
+        let surface = objects.surfaces.xy_plane();
 
         let a = [0., 0.];
         let b = [1., 0.];

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -128,14 +128,50 @@ impl Objects {
 }
 
 /// The store for [`Surface`]s
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Surfaces {
     store: Store<Surface>,
+
+    xy_plane: Handle<Surface>,
+    xz_plane: Handle<Surface>,
+    yz_plane: Handle<Surface>,
 }
 
 impl Surfaces {
     /// Insert a surface into the store
     pub fn insert(&self, surface: Surface) -> Handle<Surface> {
         self.store.insert(surface)
+    }
+
+    /// Access the xy-plane
+    pub fn xy_plane(&self) -> Handle<Surface> {
+        self.xy_plane.clone()
+    }
+
+    /// Access the xz-plane
+    pub fn xz_plane(&self) -> Handle<Surface> {
+        self.xz_plane.clone()
+    }
+
+    /// Access the yz-plane
+    pub fn yz_plane(&self) -> Handle<Surface> {
+        self.yz_plane.clone()
+    }
+}
+
+impl Default for Surfaces {
+    fn default() -> Self {
+        let store = Store::new();
+
+        let xy_plane = store.insert(Surface::xy_plane());
+        let xz_plane = store.insert(Surface::xz_plane());
+        let yz_plane = store.insert(Surface::yz_plane());
+
+        Self {
+            store,
+            xy_plane,
+            xz_plane,
+            yz_plane,
+        }
     }
 }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -83,8 +83,6 @@ mod solid;
 mod surface;
 mod vertex;
 
-use crate::storage::Store;
-
 pub use self::{
     curve::{Curve, GlobalCurve},
     cycle::Cycle,
@@ -96,6 +94,8 @@ pub use self::{
     surface::Surface,
     vertex::{GlobalVertex, SurfaceVertex, Vertex},
 };
+
+use crate::storage::{Handle, Store};
 
 /// The available object stores
 ///
@@ -117,12 +117,25 @@ pub struct Objects {
     pub global_vertices: Store<GlobalVertex>,
 
     /// Store for surfaces
-    pub surfaces: Store<Surface>,
+    pub surfaces: Surfaces,
 }
 
 impl Objects {
     /// Construct a new instance of `Stores`
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// The store for [`Surface`]s
+#[derive(Debug, Default)]
+pub struct Surfaces {
+    store: Store<Surface>,
+}
+
+impl Surfaces {
+    /// Insert a surface into the store
+    pub fn insert(&self, surface: Surface) -> Handle<Surface> {
+        self.store.insert(surface)
     }
 }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -95,7 +95,12 @@ pub use self::{
     vertex::{GlobalVertex, SurfaceVertex, Vertex},
 };
 
-use crate::storage::{Handle, Store};
+use fj_math::Vector;
+
+use crate::{
+    path::GlobalPath,
+    storage::{Handle, Store},
+};
 
 /// The available object stores
 ///
@@ -163,9 +168,12 @@ impl Default for Surfaces {
     fn default() -> Self {
         let store = Store::new();
 
-        let xy_plane = store.insert(Surface::xy_plane());
-        let xz_plane = store.insert(Surface::xz_plane());
-        let yz_plane = store.insert(Surface::yz_plane());
+        let xy_plane =
+            store.insert(Surface::new(GlobalPath::x_axis(), Vector::unit_y()));
+        let xz_plane =
+            store.insert(Surface::new(GlobalPath::x_axis(), Vector::unit_z()));
+        let yz_plane =
+            store.insert(Surface::new(GlobalPath::y_axis(), Vector::unit_z()));
 
         Self {
             store,

--- a/crates/fj-kernel/src/objects/surface.rs
+++ b/crates/fj-kernel/src/objects/surface.rs
@@ -16,30 +16,6 @@ impl Surface {
         Self { u, v }
     }
 
-    /// Construct a `Surface` that represents the xy-plane
-    pub fn xy_plane() -> Self {
-        Self {
-            u: GlobalPath::x_axis(),
-            v: Vector::unit_y(),
-        }
-    }
-
-    /// Construct a `Surface` that represents the xz-plane
-    pub fn xz_plane() -> Self {
-        Self {
-            u: GlobalPath::x_axis(),
-            v: Vector::unit_z(),
-        }
-    }
-
-    /// Construct a `Surface` that represents the yz-plane
-    pub fn yz_plane() -> Self {
-        Self {
-            u: GlobalPath::y_axis(),
-            v: Vector::unit_z(),
-        }
-    }
-
     /// Construct a plane from 3 points
     pub fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Self {
         let [a, b, c] = points.map(Into::into);

--- a/crates/fj-operations/src/planes.rs
+++ b/crates/fj-operations/src/planes.rs
@@ -26,9 +26,9 @@ impl Planes {
     /// Create one instance of this struct, then share it everywhere it's
     /// needed.
     pub fn new(objects: &Objects) -> Self {
-        let xy = objects.surfaces.insert(Surface::xy_plane());
-        let xz = objects.surfaces.insert(Surface::xz_plane());
-        let yz = objects.surfaces.insert(Surface::yz_plane());
+        let xy = objects.surfaces.xy_plane();
+        let xz = objects.surfaces.xz_plane();
+        let yz = objects.surfaces.yz_plane();
 
         Self { xy, xz, yz }
     }


### PR DESCRIPTION
Provide access to the xy-, xz-, and yz-planes through `Objects`. This means code won't have to re-create those, reducing the risk of duplicated surfaces. It also paves the way for simplifying `fj_operations::Shape`, which already uses a similar mechanism.