### PR TITLE
Invert default zoom direction; add config to override that

### DIFF
--- a/crates/fj-app/src/config.rs
+++ b/crates/fj-app/src/config.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 pub struct Config {
     pub default_path: Option<PathBuf>,
     pub default_model: Option<PathBuf>,
+    pub invert_zoom: Option<bool>,
 }
 
 impl Config {

--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -80,11 +80,13 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let invert_zoom = config.invert_zoom.unwrap_or(false);
+
     if let Some(model) = model {
         let watcher = model.load_and_watch(parameters)?;
-        run(Some(watcher), shape_processor, status)?;
+        run(Some(watcher), shape_processor, status, invert_zoom)?;
     } else {
-        run(None, shape_processor, status)?;
+        run(None, shape_processor, status, invert_zoom)?;
     }
 
     Ok(())

--- a/crates/fj-viewer/src/input/zoom.rs
+++ b/crates/fj-viewer/src/input/zoom.rs
@@ -14,6 +14,6 @@ impl Zoom {
         let distance = (focus_point.0 - camera.position()).magnitude();
         let displacement = zoom_delta * distance.into_f64();
         camera.translation = camera.translation
-            * Transform::translation(Vector::from([0.0, 0.0, -displacement]));
+            * Transform::translation(Vector::from([0.0, 0.0, displacement]));
     }
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -264,12 +264,18 @@ fn input_event(
         Event::WindowEvent {
             event: WindowEvent::MouseWheel { delta, .. },
             ..
-        } => Some(input::Event::Zoom(match delta {
-            MouseScrollDelta::LineDelta(_, y) => (*y as f64) * ZOOM_FACTOR_LINE,
-            MouseScrollDelta::PixelDelta(PhysicalPosition { y, .. }) => {
-                y * ZOOM_FACTOR_PIXEL
-            }
-        })),
+        } => {
+            let delta = match delta {
+                MouseScrollDelta::LineDelta(_, y) => {
+                    (*y as f64) * ZOOM_FACTOR_LINE
+                }
+                MouseScrollDelta::PixelDelta(PhysicalPosition {
+                    y, ..
+                }) => y * ZOOM_FACTOR_PIXEL,
+            };
+
+            Some(input::Event::Zoom(delta))
+        }
         _ => None,
     }
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -32,6 +32,7 @@ pub fn run(
     watcher: Option<Watcher>,
     shape_processor: ShapeProcessor,
     mut status: StatusReport,
+    invert_zoom: bool,
 ) -> Result<(), Error> {
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop)?;
@@ -214,6 +215,7 @@ pub fn run(
             &window,
             &held_mouse_button,
             &mut previous_cursor,
+            invert_zoom,
         );
         if let (Some(input_event), Some(fp)) = (input_event, focus_point) {
             input_handler.handle_event(input_event, fp, &mut camera);
@@ -226,6 +228,7 @@ fn input_event(
     window: &Window,
     held_mouse_button: &Option<MouseButton>,
     previous_cursor: &mut Option<NormalizedPosition>,
+    invert_zoom: bool,
 ) -> Option<input::Event> {
     match event {
         Event::WindowEvent {
@@ -273,6 +276,8 @@ fn input_event(
                     y, ..
                 }) => y * ZOOM_FACTOR_PIXEL,
             };
+
+            let delta = if invert_zoom { -delta } else { delta };
 
             Some(input::Event::Zoom(delta))
         }

--- a/fj.toml
+++ b/fj.toml
@@ -5,3 +5,7 @@ default_path = "models"
 # The default models that is loaded, if none is specified. If this is a relative
 # path, it should be relative to `default_path`.
 default_model = "test"
+
+# Indicate whether to invert the zoom direction. Can be used to override the
+# OS-level setting.
+invert_zoom = false


### PR DESCRIPTION
From one of the commit messages:

> The intent behind the original zoom direction was to provide a consistent metaphor: You manipulate the model, not an abstract camera.
>
> Unfortunately, it turned out to not be that simple. At least on Gnome, if you enable "natural scrolling" (which is the same metaphor, applied to the Gnome UI), you invert all mouse whell input, and so also the zoom direction in Fornjot.
>
> With this change, the zoom direction in Fornjot follows the "natural scrolling" configuration in Gnome. Unfortunately I don't have data from other platforms.

The new configuration has been added to this repository's `fj.toml`, as an example.

Close #829 