### PR TITLE
Fix `SurfaceVertex` duplication when creating circle

### DIFF
--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -53,19 +53,19 @@ impl Cycle {
                     "Edges in cycle do not connect"
                 );
             }
+        }
 
-            // Verify that the edges form a cycle
-            if let Some(first) = half_edges.first() {
-                if let Some(last) = half_edges.last() {
-                    let [first, _] = first.vertices();
-                    let [_, last] = last.vertices();
+        // Verify that the edges form a cycle
+        if let Some(first) = half_edges.first() {
+            if let Some(last) = half_edges.last() {
+                let [first, _] = first.vertices();
+                let [_, last] = last.vertices();
 
-                    assert_eq!(
-                        first.surface_form(),
-                        last.surface_form(),
-                        "Edges do not form a cycle"
-                    );
-                }
+                assert_eq!(
+                    first.surface_form(),
+                    last.surface_form(),
+                    "Edges do not form a cycle"
+                );
             }
         }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -93,14 +93,14 @@ impl PartialHalfEdge {
             let [a_curve, b_curve] =
                 [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-            let global_vertex = Handle::<GlobalVertex>::partial()
+            let global_form = Handle::<GlobalVertex>::partial()
                 .from_curve_and_position(curve.clone(), a_curve);
 
             [a_curve, b_curve].map(|point_curve| {
                 Vertex::partial()
                     .with_position(Some(point_curve))
                     .with_curve(Some(curve.clone()))
-                    .with_global_form(Some(global_vertex.clone()))
+                    .with_global_form(Some(global_form.clone()))
             })
         };
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -96,11 +96,16 @@ impl PartialHalfEdge {
             let global_form = Handle::<GlobalVertex>::partial()
                 .from_curve_and_position(curve.clone(), a_curve);
 
+            let path = curve.path.expect("Expected path that was just created");
+            let surface_form = SurfaceVertex::partial()
+                .with_position(Some(path.point_from_path_coords(a_curve)))
+                .with_global_form(Some(global_form));
+
             [a_curve, b_curve].map(|point_curve| {
                 Vertex::partial()
                     .with_position(Some(point_curve))
                     .with_curve(Some(curve.clone()))
-                    .with_global_form(Some(global_form.clone()))
+                    .with_surface_form(Some(surface_form.clone()))
             })
         };
 


### PR DESCRIPTION
This could slip through, because a validation check in `Cycle` wasn't executed for circles. Fixed that too.