### PR TITLE
Remove need to specify `crate-type` in `Cargo.toml`

### DIFF
--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -90,7 +90,7 @@ impl Model {
         let mut command_root = Command::new("cargo");
 
         let command = command_root
-            .arg("build")
+            .arg("rustc")
             .args(["--manifest-path", &manifest_path]);
 
         let cargo_output = command.output()?;

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -91,7 +91,8 @@ impl Model {
 
         let command = command_root
             .arg("rustc")
-            .args(["--manifest-path", &manifest_path]);
+            .args(["--manifest-path", &manifest_path])
+            .args(["--crate-type", "cdylib"]);
 
         let cargo_output = command.output()?;
         let exit_status = cargo_output.status;

--- a/models/cuboid/Cargo.toml
+++ b/models/cuboid/Cargo.toml
@@ -3,8 +3,5 @@ name = "cuboid"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies.fj]
 path = "../../crates/fj"

--- a/models/spacer/Cargo.toml
+++ b/models/spacer/Cargo.toml
@@ -3,8 +3,5 @@ name = "spacer"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies.fj]
 path = "../../crates/fj"

--- a/models/star/Cargo.toml
+++ b/models/star/Cargo.toml
@@ -3,8 +3,5 @@ name = "star"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies.fj]
 path = "../../crates/fj"

--- a/models/test/Cargo.toml
+++ b/models/test/Cargo.toml
@@ -7,8 +7,5 @@ homepage = "https://www.fornjot.app/"
 repository = "https://github.com/hannobraun/fornjot"
 license = "0BSD"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies.fj]
 path = "../../crates/fj"


### PR DESCRIPTION
Specify the crate type through a command-line argument when compiling the model, removing the need for the user to specify it in `Cargo.toml`.

Close #938