### PR TITLE
Make `PartialHalfEdge` more flexible

### DIFF
--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -111,11 +111,7 @@ impl MaybePartial<HalfEdge> {
             Self::Full(full) => {
                 full.vertices().clone().map(|vertex| Some(vertex.into()))
             }
-            Self::Partial(partial) => partial
-                .vertices
-                .clone()
-                .map(|vertices| vertices.map(Some))
-                .unwrap_or([None, None]),
+            Self::Partial(partial) => partial.vertices.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -106,10 +106,16 @@ impl MaybePartial<GlobalEdge> {
 
 impl MaybePartial<HalfEdge> {
     /// Access the vertices
-    pub fn vertices(&self) -> Option<[MaybePartial<Vertex>; 2]> {
+    pub fn vertices(&self) -> [Option<MaybePartial<Vertex>>; 2] {
         match self {
-            Self::Full(full) => Some(full.vertices().clone().map(Into::into)),
-            Self::Partial(partial) => partial.vertices.clone(),
+            Self::Full(full) => {
+                full.vertices().clone().map(|vertex| Some(vertex.into()))
+            }
+            Self::Partial(partial) => partial
+                .vertices
+                .clone()
+                .map(|vertices| vertices.map(Some))
+                .unwrap_or([None, None]),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -48,17 +48,17 @@ impl PartialCycle {
             .half_edges
             .last()
             .map(|half_edge| {
-                let [_, last] = half_edge.vertices().expect(
-                    "Need half-edge vertices to extend cycle with poly-chain",
-                );
-                let last = last.surface_form().expect(
-                    "Need surface vertex to extend cycle with poly-chain",
-                );
+                let [_, last] = half_edge
+                    .vertices()
+                    .expect("Need half-edge vertices to extend cycle");
+                let last = last
+                    .surface_form()
+                    .expect("Need surface vertex to extend cycle");
 
                 let vertex = last.clone();
-                let position = last.position().expect(
-                    "Need surface position to extend cycle with poly-chain",
-                );
+                let position = last
+                    .position()
+                    .expect("Need surface position to extend cycle");
 
                 (position, Some(vertex))
             })

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -48,9 +48,9 @@ impl PartialCycle {
             .half_edges
             .last()
             .map(|half_edge| {
-                let [_, last] = half_edge
-                    .vertices()
-                    .expect("Need half-edge vertices to extend cycle");
+                let [_, last] = half_edge.vertices().map(|vertex| {
+                    vertex.expect("Need half-edge vertices to extend cycle")
+                });
                 let last = last
                     .surface_form()
                     .expect("Need surface vertex to extend cycle");
@@ -129,7 +129,9 @@ impl PartialCycle {
 
         let vertices = [first, last].map(|option| {
             option.map(|half_edge| {
-                half_edge.vertices().expect("Need vertices to close cycle")
+                half_edge
+                    .vertices()
+                    .map(|vertex| vertex.expect("Need vertices to close cycle"))
             })
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -60,6 +60,30 @@ impl PartialHalfEdge {
         self
     }
 
+    /// Update the partial half-edge with the given from vertex
+    pub fn with_from_vertex(
+        mut self,
+        vertex: Option<impl Into<MaybePartial<Vertex>>>,
+    ) -> Self {
+        if let Some(vertex) = vertex {
+            let [from, _] = &mut self.vertices;
+            *from = Some(vertex.into());
+        }
+        self
+    }
+
+    /// Update the partial half-edge with the given from vertex
+    pub fn with_to_vertex(
+        mut self,
+        vertex: Option<impl Into<MaybePartial<Vertex>>>,
+    ) -> Self {
+        if let Some(vertex) = vertex {
+            let [_, to] = &mut self.vertices;
+            *to = Some(vertex.into());
+        }
+        self
+    }
+
     /// Update the partial half-edge with the given vertices
     pub fn with_vertices(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -65,8 +65,9 @@ impl PartialHalfEdge {
         mut self,
         vertices: Option<[impl Into<MaybePartial<Vertex>>; 2]>,
     ) -> Self {
+        let vertices = vertices.map(|vertices| vertices.map(Into::into));
         if let Some(vertices) = vertices {
-            self.vertices = Some(vertices.map(Into::into));
+            self.vertices = Some(vertices);
         }
         self
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -107,11 +107,12 @@ impl PartialHalfEdge {
                     .with_position(Some(point_curve))
                     .with_curve(Some(curve.clone()))
                     .with_surface_form(Some(surface_form.clone()))
+                    .into()
             })
         };
 
         self.curve = Some(curve.into());
-        self.vertices = Some(vertices.map(Into::into));
+        self.vertices = Some(vertices);
 
         self
     }


### PR DESCRIPTION
Makes it possible to override only one vertex of a `PartialHalfEdge`. I'm already using this capability in a local branch.