### PR TITLE
Fix some `SurfaceVertex` duplication issues

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -169,7 +169,9 @@ impl Sweep for (HalfEdge, Color) {
                 // Need to compare surface forms here, as the global forms might
                 // be coincident when sweeping circles, despite the vertices
                 // being different!
-                if prev_last.surface_form() != next_first.surface_form() {
+                if prev_last.surface_form().id()
+                    != next_first.surface_form().id()
+                {
                     edges[j] = edges[j].clone().reverse();
                 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -92,32 +92,24 @@ impl Sweep for (Vertex, Handle<Surface>) {
             )
         };
 
-        // And now the vertices. Again, nothing wild here.
-        let vertices = {
-            // Can be cleaned up, once `zip` is stable:
-            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-            let [a_surface, b_surface] = points_surface;
-            let [a_global, b_global] = vertices_global;
-            let vertices_surface =
-                [(a_surface, a_global), (b_surface, b_global)].map(
-                    |(point_surface, vertex_global)| {
-                        SurfaceVertex::new(
-                            point_surface,
-                            surface.clone(),
-                            vertex_global,
-                            objects,
-                        )
-                    },
-                );
+        let vertices_surface = {
+            let [_, position] = points_surface;
+            let [_, global_form] = vertices_global;
 
-            vertices_surface.map(|surface_form| {
-                Vertex::new(
-                    [surface_form.position().v],
-                    curve.clone(),
-                    surface_form,
-                )
-            })
+            [
+                vertex.surface_form().clone(),
+                SurfaceVertex::new(position, surface, global_form, objects),
+            ]
         };
+
+        // And now the vertices. Again, nothing wild here.
+        let vertices = vertices_surface.map(|surface_form| {
+            Vertex::new(
+                [surface_form.position().v],
+                curve.clone(),
+                surface_form,
+            )
+        });
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.


### PR DESCRIPTION
Fix some instances of `SurfaceVertex` being duplicated. These were found using stricter validation code, which was made possible by the progress of #1021.

There are more instances of these in the code, which is why this pull request doesn't include this stricter validation code. It still causes test failures.