### PR TITLE
Fix some `wgpu`/`egui-winit` errors and warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,23 +99,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arboard"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc120354d1b5ec6d7aaf4876b602def75595937b5e15d356eb554ab5177e08bb"
-dependencies = [
- "clipboard-win",
- "log",
- "objc",
- "objc-foundation",
- "objc_id",
- "parking_lot",
- "thiserror",
- "winapi",
- "x11rb",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,7 +300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22a6a8f622f797120d452c630b0ab12e1331a1a753e2039ce7868d4ac77b4ee"
 dependencies = [
  "log",
- "nix 0.24.2",
+ "nix",
  "slotmap",
  "thiserror",
  "vec_map",
@@ -359,12 +342,6 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -429,17 +406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "clipboard-win"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
-dependencies = [
- "error-code",
- "str-buf",
- "winapi",
 ]
 
 [[package]]
@@ -515,16 +481,6 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
 ]
 
 [[package]]
@@ -864,12 +820,9 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ddc525334c416e11580123e147b970f738507f427c9fb1cd09ea2dd7416a3a"
 dependencies = [
- "arboard",
  "egui",
  "instant",
- "smithay-clipboard",
  "tracing",
- "webbrowser",
  "winit",
 ]
 
@@ -923,16 +876,6 @@ dependencies = [
  "emath",
  "nohash-hasher",
  "parking_lot",
-]
-
-[[package]]
-name = "error-code"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
-dependencies = [
- "libc",
- "str-buf",
 ]
 
 [[package]]
@@ -1336,16 +1279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,20 +1635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
-name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys",
- "log",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,26 +1939,13 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
-dependencies = [
- "bitflags",
- "jni-sys",
- "ndk-sys 0.3.0",
- "num_enum",
- "thiserror",
-]
-
-[[package]]
-name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags",
  "jni-sys",
- "ndk-sys 0.4.0",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle 0.5.0",
  "thiserror",
@@ -2053,31 +1959,16 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0c4a7b83860226e6b4183edac21851f05d5a51756e97a1144b7f5a6b63e65f"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "ndk 0.6.0",
- "ndk-context",
- "ndk-macro",
- "ndk-sys 0.3.0",
-]
-
-[[package]]
-name = "ndk-glue"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
 dependencies = [
  "libc",
  "log",
- "ndk 0.7.0",
+ "ndk",
  "ndk-context",
  "ndk-macro",
- "ndk-sys 0.4.0",
+ "ndk-sys",
  "once_cell",
  "parking_lot",
 ]
@@ -2097,33 +1988,11 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
-dependencies = [
- "jni-sys",
-]
-
-[[package]]
-name = "ndk-sys"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -2295,32 +2164,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]
@@ -3198,21 +3047,11 @@ dependencies = [
  "lazy_static",
  "log",
  "memmap2",
- "nix 0.24.2",
+ "nix",
  "pkg-config",
  "wayland-client",
  "wayland-cursor",
  "wayland-protocols",
-]
-
-[[package]]
-name = "smithay-clipboard"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8"
-dependencies = [
- "smithay-client-toolkit",
- "wayland-client",
 ]
 
 [[package]]
@@ -3304,12 +3143,6 @@ checksum = "466e72b3a9258f51f0562a01f2aea3717fb71d9997f4050c65c251a623926e12"
 dependencies = [
  "byteorder 0.4.2",
 ]
-
-[[package]]
-name = "str-buf"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
@@ -3837,7 +3670,7 @@ dependencies = [
  "bitflags",
  "downcast-rs",
  "libc",
- "nix 0.24.2",
+ "nix",
  "scoped-tls",
  "wayland-commons",
  "wayland-scanner",
@@ -3850,7 +3683,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
 dependencies = [
- "nix 0.24.2",
+ "nix",
  "once_cell",
  "smallvec",
  "wayland-sys",
@@ -3862,7 +3695,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
 dependencies = [
- "nix 0.24.2",
+ "nix",
  "wayland-client",
  "xcursor",
 ]
@@ -3909,20 +3742,6 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webbrowser"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a3cffdb686fbb24d9fb8f03a213803277ed2300f11026a3afe1f108dc021b"
-dependencies = [
- "jni",
- "ndk-glue 0.6.2",
- "url",
- "web-sys",
- "widestring",
- "winapi",
 ]
 
 [[package]]
@@ -4042,12 +3861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4068,15 +3881,6 @@ name = "winapi-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
 dependencies = [
  "winapi",
 ]
@@ -4145,8 +3949,8 @@ dependencies = [
  "libc",
  "log",
  "mio",
- "ndk 0.7.0",
- "ndk-glue 0.7.0",
+ "ndk",
+ "ndk-glue",
  "objc",
  "once_cell",
  "parking_lot",
@@ -4190,18 +3994,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "x11rb"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e99be55648b3ae2a52342f9a870c0e138709a3493261ce9b469afe6e4df6d8a"
-dependencies = [
- "gethostname",
- "nix 0.22.3",
- "winapi",
- "winapi-wsapoll",
 ]
 
 [[package]]

--- a/crates/fj-viewer/src/graphics/shader.wgsl
+++ b/crates/fj-viewer/src/graphics/shader.wgsl
@@ -1,3 +1,11 @@
+struct Uniforms {
+    transform: mat4x4<f32>,
+    transform_normals: mat4x4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: Uniforms;
+
 struct VertexInput {
     @location(0) position: vec3<f32>,
     @location(1) normal: vec3<f32>,
@@ -9,14 +17,6 @@ struct VertexOutput {
     @location(0) normal: vec3<f32>,
     @location(1) color: vec4<f32>,
 };
-
-struct Uniforms {
-    transform: mat4x4<f32>,
-    transform_normals: mat4x4<f32>,
-};
-
-@group(0) @binding(0)
-var<uniform> uniforms: Uniforms;
 
 @vertex
 fn vertex(in: VertexInput) -> VertexOutput {

--- a/crates/fj-viewer/src/graphics/shader.wgsl
+++ b/crates/fj-viewer/src/graphics/shader.wgsl
@@ -1,3 +1,9 @@
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    @location(2) color: vec4<f32>,
+}
+
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) normal: vec3<f32>,
@@ -13,18 +19,12 @@ struct Uniforms {
 var<uniform> uniforms: Uniforms;
 
 @vertex
-fn vertex(
-    @location(0) position: vec3<f32>,
-    @location(1) normal: vec3<f32>,
-    @location(2) color: vec4<f32>,
-)
-    -> VertexOutput
-{
+fn vertex(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
-    out.normal = (uniforms.transform_normals * vec4<f32>(normal, 0.0)).xyz;
-    out.position = uniforms.transform * vec4<f32>(position, 1.0);
+    out.normal = (uniforms.transform_normals * vec4<f32>(in.normal, 0.0)).xyz;
+    out.position = uniforms.transform * vec4<f32>(in.position, 1.0);
     // We use premultiplied alpha blending.
-    out.color = vec4<f32>(color.rgb * color.a, color.a);
+    out.color = vec4<f32>(in.color.rgb * in.color.a, in.color.a);
 
     return out;
 }

--- a/crates/fj-viewer/src/graphics/shader.wgsl
+++ b/crates/fj-viewer/src/graphics/shader.wgsl
@@ -18,6 +18,10 @@ struct VertexOutput {
     @location(1) color: vec4<f32>,
 };
 
+struct FragmentOutput {
+    @location(0) color: vec4<f32>,
+}
+
 @vertex
 fn vertex(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
@@ -32,7 +36,7 @@ fn vertex(in: VertexInput) -> VertexOutput {
 let pi: f32 = 3.14159265359;
 
 @fragment
-fn frag_model(in: VertexOutput) -> @location(0) vec4<f32> {
+fn frag_model(in: VertexOutput) -> FragmentOutput {
     let light = vec3<f32>(0.0, 0.0, -1.0);
 
     let angle = acos(dot(light, -in.normal));
@@ -40,17 +44,22 @@ fn frag_model(in: VertexOutput) -> @location(0) vec4<f32> {
 
     let f_normal = max(1.0 - f_angle, 0.0);
 
-    let color = vec4<f32>(in.color.rgb * f_normal, in.color.a);
+    var out: FragmentOutput;
+    out.color = vec4<f32>(in.color.rgb * f_normal, in.color.a);
 
-    return color;
+    return out;
 }
 
 @fragment
-fn frag_mesh(in: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(1.0 - in.color.rgb, in.color.a);
+fn frag_mesh(in: VertexOutput) -> FragmentOutput {
+    var out: FragmentOutput;
+    out.color = vec4<f32>(1.0 - in.color.rgb, in.color.a);
+    return out;
 }
 
 @fragment
-fn frag_lines(in: VertexOutput) -> @location(0) vec4<f32> {
-    return vec4<f32>(in.color.rgb, in.color.a);
+fn frag_lines(in: VertexOutput) -> FragmentOutput {
+    var out: FragmentOutput;
+    out.color = vec4<f32>(in.color.rgb, in.color.a);
+    return out;
 }

--- a/crates/fj-window/Cargo.toml
+++ b/crates/fj-window/Cargo.toml
@@ -15,8 +15,11 @@ fj-host.workspace = true
 fj-operations.workspace = true
 fj-viewer.workspace = true
 fj-interop.workspace = true
-egui-winit = "0.19.0"
 futures = "0.3.24"
 thiserror = "1.0.35"
 tracing = "0.1.37"
 winit = "0.27.4"
+
+[dependencies.egui-winit]
+version = "0.19.0"
+default-features = false

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -51,6 +51,12 @@ pub fn run(
     let mut camera = Camera::new(&Default::default());
     let mut camera_update_once = watcher.is_some();
 
+    // Only handle resize events once every frame. This filters out spurious
+    // resize events that can lead to wgpu warnings. See this issue for some
+    // context:
+    // https://github.com/rust-windowing/winit/issues/2094
+    let mut new_size = None;
+
     event_loop.run(move |event, _, control_flow| {
         trace!("Handling event: {:?}", event);
 
@@ -147,11 +153,10 @@ pub fn run(
                 event: WindowEvent::Resized(size),
                 ..
             } => {
-                let size = Size {
+                new_size = Some(Size {
                     width: size.width,
                     height: size.height,
-                };
-                renderer.handle_resize(size);
+                });
             }
             Event::WindowEvent {
                 event: WindowEvent::MouseInput { state, button, .. },
@@ -168,6 +173,9 @@ pub fn run(
             Event::RedrawRequested(_) => {
                 if let Some(shape) = &shape {
                     camera.update_planes(&shape.aabb);
+                }
+                if let Some(size) = new_size.take() {
+                    renderer.handle_resize(size);
                 }
 
                 let egui_input =

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -90,8 +90,6 @@ pub fn run(
             }
         }
 
-        //
-
         if let Event::WindowEvent {
             event: window_event,
             ..


### PR DESCRIPTION
`wgpu` and `egui-winit` emits quite a few warnings! Here's what I'm seeing as of before this pull request:

```
  2022-10-13T11:10:11.381181Z ERROR wgpu_hal::vulkan::instance: VALIDATION [UNASSIGNED-CoreValidation-Shader-InconsistentSpirv (0x6bbb14)]
        Validation Error: [ UNASSIGNED-CoreValidation-Shader-InconsistentSpirv ] Object 0: handle = 0x55e13b1add70, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x6bbb14 | SPIR-V module not valid: [VUID-StandaloneSpirv-Flat-06202] OpEntryPoint interfaces variable must not be vertex execution model with an input storage class for Entry Point id 107.
  %a_color = OpVariable %_ptr_Input_uint Input

    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.13.2/src/vulkan/instance.rs:48

  2022-10-13T11:10:11.381248Z ERROR wgpu_hal::vulkan::instance:         objects: (type: DEVICE, hndl: 0x55e13b1add70, name: ?)
    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.13.2/src/vulkan/instance.rs:111

  2022-10-13T11:10:11.382990Z ERROR egui_winit::clipboard: Cannot initialize smithay clipboard without a display handle!
    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/egui-winit-0.19.0/src/clipboard.rs:139

  2022-10-13T11:10:12.303601Z  WARN wgpu_core::device: Requested size 800x600 is outside of the supported range: Extent3d { width: 3840, height: 2022, depth_or_array_layers: 1 }..=Extent3d { width: 3840, height: 2022, depth_or_array_layers: 1 }
    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-core-0.13.2/src/device/mod.rs:4974

  2022-10-13T11:10:12.303839Z ERROR wgpu_hal::vulkan::instance: VALIDATION [VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 (0x7cd0911d)]
        Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 ] Object 0: handle = 0x55e13b1add70, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7cd0911d | vkCreateSwapchainKHR() called with imageExtent = (800,600), which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (3840,2022), minImageExtent = (3840,2022), maxImageExtent = (3840,2022). The Vulkan spec states: imageExtent must be between minImageExtent and maxImageExtent, inclusive, where minImageExtent and maxImageExtent are members of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01274)
    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.13.2/src/vulkan/instance.rs:48

  2022-10-13T11:10:12.303880Z ERROR wgpu_hal::vulkan::instance:         objects: (type: DEVICE, hndl: 0x55e13b1add70, name: ?)
    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.13.2/src/vulkan/instance.rs:111
```

With the fixes from this pull request, I'm down to this:
```
  2022-10-13T11:11:39.523521Z ERROR wgpu_hal::vulkan::instance: VALIDATION [UNASSIGNED-CoreValidation-Shader-InconsistentSpirv (0x6bbb14)]
        Validation Error: [ UNASSIGNED-CoreValidation-Shader-InconsistentSpirv ] Object 0: handle = 0x55cbf113afb0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x6bbb14 | SPIR-V module not valid: [VUID-StandaloneSpirv-Flat-06202] OpEntryPoint interfaces variable must not be vertex execution model with an input storage class for Entry Point id 107.
  %a_color = OpVariable %_ptr_Input_uint Input

    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.13.2/src/vulkan/instance.rs:48

  2022-10-13T11:11:39.523642Z ERROR wgpu_hal::vulkan::instance:         objects: (type: DEVICE, hndl: 0x55cbf113afb0, name: ?)
    at /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-hal-0.13.2/src/vulkan/instance.rs:111
```

Both of those remaining errors seem to be caused by https://github.com/gfx-rs/naga/issues/2036. This is already fixed, so they should disappear too, once we upgrade to the latest wgpu (https://github.com/hannobraun/Fornjot/issues/976).