### PR TITLE
Fix more `SurfaceVertex` duplication issues

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -90,9 +90,9 @@ impl Sweep for (HalfEdge, Color) {
         let top_edge = {
             let bottom_vertices = bottom_edge.vertices();
 
-            let global_vertices = side_edges.clone().map(|edge| {
+            let surface_vertices = side_edges.clone().map(|edge| {
                 let [_, vertex] = edge.vertices();
-                vertex.global_form().clone()
+                vertex.surface_form().clone()
             });
 
             let points_curve_and_surface =
@@ -120,30 +120,19 @@ impl Sweep for (HalfEdge, Color) {
 
             let global = GlobalEdge::new(
                 curve.global_form().clone(),
-                global_vertices.clone(),
+                surface_vertices
+                    .clone()
+                    .map(|surface_vertex| surface_vertex.global_form().clone()),
             );
 
             let vertices = {
-                let surface_points = points_curve_and_surface
-                    .map(|(_, point_surface)| point_surface);
-
                 // Can be cleaned up, once `zip` is stable:
                 // https://doc.rust-lang.org/std/primitive.array.html#method.zip
                 let [a_vertex, b_vertex] = bottom_vertices;
-                let [a_surface, b_surface] = surface_points;
-                let [a_global, b_global] = global_vertices;
-                let vertices = [
-                    (a_vertex, a_surface, a_global),
-                    (b_vertex, b_surface, b_global),
-                ];
+                let [a_surface, b_surface] = surface_vertices;
+                let vertices = [(a_vertex, a_surface), (b_vertex, b_surface)];
 
-                vertices.map(|(vertex, point_surface, global_form)| {
-                    let surface_form = SurfaceVertex::new(
-                        point_surface,
-                        surface.clone(),
-                        global_form,
-                        objects,
-                    );
+                vertices.map(|(vertex, surface_form)| {
                     Vertex::new(vertex.position(), curve.clone(), surface_form)
                 })
             };

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -141,18 +141,12 @@ impl<'a> ShellBuilder<'a> {
                 .clone()
                 .into_iter()
                 .zip(sides_down.clone())
-                .zip(&surfaces)
-                .map(|((side_up, side_down), surface)| {
+                .map(|(side_up, side_down)| {
                     let [_, from] = side_up.vertices();
                     let [to, _] = side_down.vertices();
 
                     let from = from.surface_form().clone();
-                    let to = Handle::<SurfaceVertex>::partial()
-                        .with_position(Some(
-                            from.position() + [-edge_length, Z],
-                        ))
-                        .with_surface(Some(surface.clone()))
-                        .with_global_form(Some(to.global_form().clone()));
+                    let to = to.surface_form().clone();
 
                     let from = Vertex::partial().with_surface_form(Some(from));
                     let to = Vertex::partial().with_surface_form(Some(to));


### PR DESCRIPTION
These were found by stricter validation code that I have in a local branch. This stricter validation was made possible by the advancements in #1021.

This pull request doesn't include the stricter validation code yet, as there's still problematic code left that causes test failures.