### PR TITLE
Add methods to access single `HalfEdge` vertices

### DIFF
--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -79,6 +79,18 @@ impl HalfEdge {
         &self.vertices
     }
 
+    /// Access the vertex at the back of the half-edge
+    pub fn back(&self) -> &Vertex {
+        let [back, _] = self.vertices();
+        back
+    }
+
+    /// Access the vertex at the front of the half-edge
+    pub fn front(&self) -> &Vertex {
+        let [_, front] = self.vertices();
+        front
+    }
+
     /// Access the global form of this half-edge
     pub fn global_form(&self) -> &GlobalEdge {
         &self.global_form

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -185,7 +185,7 @@ impl PartialCycle {
 
                             half_edge
                                 .with_surface(Some(surface_for_edges.clone()))
-                                .with_from_vertex(from)
+                                .with_back_vertex(from)
                         })
                         .into_full(objects);
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -73,7 +73,7 @@ impl PartialHalfEdge {
     }
 
     /// Update the partial half-edge with the given from vertex
-    pub fn with_to_vertex(
+    pub fn with_front_vertex(
         mut self,
         vertex: Option<impl Into<MaybePartial<Vertex>>>,
     ) -> Self {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -61,7 +61,7 @@ impl PartialHalfEdge {
     }
 
     /// Update the partial half-edge with the given from vertex
-    pub fn with_from_vertex(
+    pub fn with_back_vertex(
         mut self,
         vertex: Option<impl Into<MaybePartial<Vertex>>>,
     ) -> Self {


### PR DESCRIPTION
Also update some `PartialHalfEdge` methods to follow the nomenclature of these new methods: "back" and "front", instead of "from" and "to".