### PR TITLE
Fix more `SurfaceVertex` duplication issues

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -208,7 +208,7 @@ mod tests {
                 .as_line_segment_from_points([[0., 1.], [1., 1.]])
                 .build(&objects)
                 .reverse();
-            let left = HalfEdge::partial()
+            let side_down = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
                 .as_line_segment_from_points([[0., 0.], [0., 1.]])
                 .build(&objects)
@@ -218,7 +218,7 @@ mod tests {
                 .as_line_segment_from_points([[1., 0.], [1., 1.]])
                 .build(&objects);
 
-            let cycle = Cycle::new(surface, [bottom, right, top, left]);
+            let cycle = Cycle::new(surface, [bottom, right, top, side_down]);
 
             Face::from_exterior(cycle)
         };

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -213,12 +213,12 @@ mod tests {
                 .as_line_segment_from_points([[0., 0.], [0., 1.]])
                 .build(&objects)
                 .reverse();
-            let right = HalfEdge::partial()
+            let side_up = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
                 .as_line_segment_from_points([[1., 0.], [1., 1.]])
                 .build(&objects);
 
-            let cycle = Cycle::new(surface, [bottom, right, top, side_down]);
+            let cycle = Cycle::new(surface, [bottom, side_up, top, side_down]);
 
             Face::from_exterior(cycle)
         };

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -203,6 +203,10 @@ mod tests {
                 .with_surface(Some(surface.clone()))
                 .as_line_segment_from_points([[0., 0.], [1., 0.]])
                 .build(&objects);
+            let side_up = HalfEdge::partial()
+                .with_surface(Some(surface.clone()))
+                .as_line_segment_from_points([[1., 0.], [1., 1.]])
+                .build(&objects);
             let top = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
                 .as_line_segment_from_points([[0., 1.], [1., 1.]])
@@ -213,10 +217,6 @@ mod tests {
                 .as_line_segment_from_points([[0., 0.], [0., 1.]])
                 .build(&objects)
                 .reverse();
-            let side_up = HalfEdge::partial()
-                .with_surface(Some(surface.clone()))
-                .as_line_segment_from_points([[1., 0.], [1., 1.]])
-                .build(&objects);
 
             let cycle = Cycle::new(surface, [bottom, side_up, top, side_down]);
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -181,8 +181,9 @@ mod tests {
 
     use crate::{
         algorithms::{reverse::Reverse, sweep::Sweep},
-        objects::{Cycle, Face, HalfEdge, Objects},
+        objects::{Cycle, Face, HalfEdge, Objects, SurfaceVertex, Vertex},
         partial::HasPartial,
+        storage::Handle,
     };
 
     #[test]
@@ -205,16 +206,40 @@ mod tests {
                 .build(&objects);
             let side_up = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .as_line_segment_from_points([[1., 0.], [1., 1.]])
+                .with_back_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(bottom.front().surface_form().clone()),
+                )))
+                .with_front_vertex(Some(
+                    Vertex::partial().with_surface_form(Some(
+                        Handle::<SurfaceVertex>::partial()
+                            .with_position(Some([1., 1.])),
+                    )),
+                ))
+                .as_line_segment()
                 .build(&objects);
             let top = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .as_line_segment_from_points([[0., 1.], [1., 1.]])
+                .with_back_vertex(Some(
+                    Vertex::partial().with_surface_form(Some(
+                        Handle::<SurfaceVertex>::partial()
+                            .with_position(Some([0., 1.])),
+                    )),
+                ))
+                .with_front_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(side_up.front().surface_form().clone()),
+                )))
+                .as_line_segment()
                 .build(&objects)
                 .reverse();
             let side_down = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .as_line_segment_from_points([[0., 0.], [0., 1.]])
+                .with_back_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(bottom.back().surface_form().clone()),
+                )))
+                .with_front_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(top.front().surface_form().clone()),
+                )))
+                .as_line_segment()
                 .build(&objects)
                 .reverse();
 

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -48,8 +48,8 @@ impl Cycle {
                 let [next, _] = b.vertices();
 
                 assert_eq!(
-                    prev.surface_form(),
-                    next.surface_form(),
+                    prev.surface_form().id(),
+                    next.surface_form().id(),
                     "Edges in cycle do not connect"
                 );
             }


### PR DESCRIPTION
This fixes more `SurfaceVertex` duplication issues that were discovered using the enhanced cycle validation code, which is also included in this pull request. This enhanced validation code was made possible thanks to the advancements of #1021.

More enhancements to the cycle validation code are possible, but those currently trigger more test failures.