### PR TITLE
Fix another object duplication issue

### DIFF
--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -105,6 +105,28 @@ impl MaybePartial<GlobalEdge> {
 }
 
 impl MaybePartial<HalfEdge> {
+    /// Access the back vertex
+    pub fn back(&self) -> Option<MaybePartial<Vertex>> {
+        match self {
+            Self::Full(full) => Some(full.back().clone().into()),
+            Self::Partial(partial) => {
+                let [back, _] = &partial.vertices;
+                back.clone()
+            }
+        }
+    }
+
+    /// Access the front vertex
+    pub fn front(&self) -> Option<MaybePartial<Vertex>> {
+        match self {
+            Self::Full(full) => Some(full.front().clone().into()),
+            Self::Partial(partial) => {
+                let [_, front] = &partial.vertices;
+                front.clone()
+            }
+        }
+    }
+
     /// Access the vertices
     pub fn vertices(&self) -> [Option<MaybePartial<Vertex>>; 2] {
         match self {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -166,14 +166,7 @@ impl PartialCycle {
         let half_edges = {
             let (half_edges, _) = self.half_edges.into_iter().fold(
                 (Vec::new(), None),
-                |(mut half_edges, previous), next| {
-                    let previous_half_edge: Option<HalfEdge> = previous;
-
-                    let previous_vertex = previous_half_edge.map(|half_edge| {
-                        let [_, vertex] = half_edge.vertices().clone();
-                        vertex.surface_form().clone()
-                    });
-
+                |(mut half_edges, previous_vertex), next| {
                     let next = next
                         .update_partial(|half_edge| {
                             let [from, _] = half_edge.vertices.clone();
@@ -189,9 +182,10 @@ impl PartialCycle {
                         })
                         .into_full(objects);
 
-                    half_edges.push(next.clone());
+                    let front = next.front().surface_form().clone();
+                    half_edges.push(next);
 
-                    (half_edges, Some(next))
+                    (half_edges, Some(front))
                 },
             );
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -166,8 +166,8 @@ impl PartialCycle {
         let half_edges = {
             let (half_edges, _) = self.half_edges.into_iter().fold(
                 (Vec::new(), None),
-                |(mut half_edges, previous_vertex), next| {
-                    let next = next
+                |(mut half_edges, previous_vertex), half_edge| {
+                    let half_edge = half_edge
                         .update_partial(|half_edge| {
                             let [from, _] = half_edge.vertices.clone();
                             let from = from.map(|vertex| {
@@ -182,8 +182,8 @@ impl PartialCycle {
                         })
                         .into_full(objects);
 
-                    let front = next.front().surface_form().clone();
-                    half_edges.push(next);
+                    let front = half_edge.front().surface_form().clone();
+                    half_edges.push(half_edge);
 
                     (half_edges, Some(front))
                 },


### PR DESCRIPTION
Fix the creation of duplicate `SurfaceVertex` instances when building a cycle. This problem was found by making the cycle validation code more strict, which was enabled by the progress of #1021. This stricter validation code is not included in this pull request, as there is at least one more object validation issue in the code that triggers it.