### PR TITLE
Clean up `fj-viewer` API

### DIFF
--- a/crates/fj-interop/src/debug.rs
+++ b/crates/fj-interop/src/debug.rs
@@ -7,7 +7,7 @@
 use fj_math::{Point, Segment};
 
 /// Debug info from the CAD kernel that can be visualized
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct DebugInfo {
     /// Rays being used during face triangulation
     pub triangle_edge_checks: Vec<TriangleEdgeCheck>,
@@ -30,6 +30,7 @@ impl DebugInfo {
 }
 
 /// Record of a check to determine if a triangle edge is within a face
+#[derive(Clone)]
 pub struct TriangleEdgeCheck {
     /// The origin of the ray used to perform the check
     pub origin: Point<3>,

--- a/crates/fj-interop/src/mesh.rs
+++ b/crates/fj-interop/src/mesh.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, hash::Hash};
 use fj_math::Point;
 
 /// A triangle mesh
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Mesh<V> {
     vertices: Vec<V>,
     indices: Vec<Index>,

--- a/crates/fj-interop/src/processed_shape.rs
+++ b/crates/fj-interop/src/processed_shape.rs
@@ -5,6 +5,7 @@ use fj_math::{Aabb, Point};
 use crate::{debug::DebugInfo, mesh::Mesh};
 
 /// A processed shape
+#[derive(Clone)]
 pub struct ProcessedShape {
     /// The axis-aligned bounding box of the shape
     pub aabb: Aabb<3>,

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -4,7 +4,7 @@ use std::f64::consts::FRAC_PI_2;
 use fj_interop::processed_shape::ProcessedShape;
 use fj_math::{Aabb, Point, Scalar, Transform, Vector};
 
-use crate::screen::NormalizedPosition;
+use crate::screen::NormalizedScreenPosition;
 
 /// The camera abstraction
 ///
@@ -73,7 +73,7 @@ impl Camera {
     /// Transform a normalized cursor position on the near plane to model space.
     pub fn cursor_to_model_space(
         &self,
-        cursor: NormalizedPosition,
+        cursor: NormalizedScreenPosition,
     ) -> Point<3> {
         // Cursor position in camera space.
         let f = (self.field_of_view_in_x() / 2.).tan() * self.near_plane();
@@ -86,7 +86,7 @@ impl Camera {
     /// Compute the point on the model, that the cursor currently points to.
     pub fn focus_point(
         &self,
-        cursor: Option<NormalizedPosition>,
+        cursor: Option<NormalizedScreenPosition>,
         shape: &ProcessedShape,
     ) -> FocusPoint {
         self.calculate_focus_point(cursor, shape)
@@ -95,7 +95,7 @@ impl Camera {
 
     fn calculate_focus_point(
         &self,
-        cursor: Option<NormalizedPosition>,
+        cursor: Option<NormalizedScreenPosition>,
         shape: &ProcessedShape,
     ) -> Option<FocusPoint> {
         // Transform camera and cursor positions to model space.

--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -1,7 +1,7 @@
 //! Viewer camera module
 use std::f64::consts::FRAC_PI_2;
 
-use fj_interop::processed_shape::ProcessedShape;
+use fj_interop::{mesh::Mesh, processed_shape::ProcessedShape};
 use fj_math::{Aabb, Point, Scalar, Transform, Vector};
 
 use crate::screen::NormalizedScreenPosition;
@@ -89,14 +89,14 @@ impl Camera {
         cursor: Option<NormalizedScreenPosition>,
         shape: &ProcessedShape,
     ) -> FocusPoint {
-        self.calculate_focus_point(cursor, shape)
+        self.calculate_focus_point(cursor, &shape.mesh)
             .unwrap_or_else(|| FocusPoint(shape.aabb.center()))
     }
 
     fn calculate_focus_point(
         &self,
         cursor: Option<NormalizedScreenPosition>,
-        shape: &ProcessedShape,
+        mesh: &Mesh<Point<3>>,
     ) -> Option<FocusPoint> {
         // Transform camera and cursor positions to model space.
         let origin = self.position();
@@ -105,7 +105,7 @@ impl Camera {
 
         let mut min_t = None;
 
-        for triangle in shape.mesh.triangles() {
+        for triangle in mesh.triangles() {
             let t =
                 triangle
                     .inner

--- a/crates/fj-viewer/src/graphics/draw_config.rs
+++ b/crates/fj-viewer/src/graphics/draw_config.rs
@@ -5,8 +5,10 @@
 pub struct DrawConfig {
     /// Toggle for displaying the shaded model
     pub draw_model: bool,
+
     /// Toggle for displaying the wireframe model
     pub draw_mesh: bool,
+
     /// Toggle for displaying model debug information
     pub draw_debug: bool,
 }

--- a/crates/fj-viewer/src/graphics/draw_config.rs
+++ b/crates/fj-viewer/src/graphics/draw_config.rs
@@ -1,5 +1,3 @@
-//! High level configuration for graphics rendering
-
 /// High level configuration for rendering the active model
 #[derive(Debug)]
 pub struct DrawConfig {

--- a/crates/fj-viewer/src/graphics/geometries.rs
+++ b/crates/fj-viewer/src/graphics/geometries.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 
-use fj_math::Aabb;
 use wgpu::util::DeviceExt;
 
 use super::vertices::{Vertex, Vertices};
@@ -9,7 +8,6 @@ use super::vertices::{Vertex, Vertices};
 pub struct Geometries {
     pub mesh: Geometry,
     pub lines: Geometry,
-    pub aabb: Aabb<3>,
 }
 
 impl Geometries {
@@ -17,13 +15,12 @@ impl Geometries {
         device: &wgpu::Device,
         mesh: &Vertices,
         debug_info: &Vertices,
-        aabb: Aabb<3>,
     ) -> Self {
         let mesh = Geometry::new(device, mesh.vertices(), mesh.indices());
         let lines =
             Geometry::new(device, debug_info.vertices(), debug_info.indices());
 
-        Self { mesh, lines, aabb }
+        Self { mesh, lines }
     }
 }
 

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -12,7 +12,7 @@ mod vertices;
 
 pub use self::{
     draw_config::DrawConfig,
-    renderer::{DrawError, InitError, Renderer},
+    renderer::{DrawError, Renderer, RendererInitError},
 };
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -42,7 +42,7 @@ pub struct Renderer {
 
 impl Renderer {
     /// Returns a new `Renderer`.
-    pub async fn new(screen: &impl Screen) -> Result<Self, InitError> {
+    pub async fn new(screen: &impl Screen) -> Result<Self, RendererInitError> {
         let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
 
         // This is sound, as `window` is an object to create a surface upon.
@@ -55,7 +55,7 @@ impl Renderer {
                 compatible_surface: Some(&surface),
             })
             .await
-            .ok_or(InitError::RequestAdapter)?;
+            .ok_or(RendererInitError::RequestAdapter)?;
 
         let features = {
             let desired_features = wgpu::Features::POLYGON_MODE_LINE;
@@ -361,7 +361,7 @@ impl Renderer {
 
 /// Error describing the set of render surface initialization errors
 #[derive(Error, Debug)]
-pub enum InitError {
+pub enum RendererInitError {
     /// General IO error
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -184,7 +184,7 @@ impl Renderer {
     pub fn draw(
         &mut self,
         camera: &Camera,
-        config: &mut DrawConfig,
+        config: &DrawConfig,
         scale_factor: f32,
         gui: &mut Gui,
     ) -> Result<(), DrawError> {

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -1,6 +1,5 @@
 use std::{io, mem::size_of};
 
-use fj_math::{Aabb, Point};
 use thiserror::Error;
 use tracing::debug;
 use wgpu::util::DeviceExt as _;
@@ -135,15 +134,8 @@ impl Renderer {
             label: None,
         });
 
-        let geometries = Geometries::new(
-            &device,
-            &Vertices::empty(),
-            &Vertices::empty(),
-            Aabb {
-                min: Point::from([0.0, 0.0, 0.0]),
-                max: Point::from([0.0, 0.0, 0.0]),
-            },
-        );
+        let geometries =
+            Geometries::new(&device, &Vertices::empty(), &Vertices::empty());
         let pipelines =
             Pipelines::new(&device, &bind_group_layout, color_format);
 
@@ -169,13 +161,8 @@ impl Renderer {
     }
 
     /// Updates the geometry of the model being rendered.
-    pub fn update_geometry(
-        &mut self,
-        mesh: Vertices,
-        lines: Vertices,
-        aabb: Aabb<3>,
-    ) {
-        self.geometries = Geometries::new(&self.device, &mesh, &lines, aabb);
+    pub fn update_geometry(&mut self, mesh: Vertices, lines: Vertices) {
+        self.geometries = Geometries::new(&self.device, &mesh, &lines);
     }
 
     /// Resizes the render surface.

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -1,6 +1,5 @@
 use std::{io, mem::size_of};
 
-use fj_interop::status_report::StatusReport;
 use fj_math::{Aabb, Point};
 use thiserror::Error;
 use tracing::debug;
@@ -200,8 +199,6 @@ impl Renderer {
         camera: &Camera,
         config: &mut DrawConfig,
         scale_factor: f32,
-        status: &mut StatusReport,
-        egui_input: egui::RawInput,
         gui: &mut Gui,
     ) -> Result<(), DrawError> {
         let aspect_ratio = self.surface_config.width as f64
@@ -271,13 +268,6 @@ impl Renderer {
             }
         }
 
-        gui.update(
-            egui_input,
-            config,
-            &self.geometries.aabb,
-            status,
-            self.is_line_drawing_available(),
-        );
         gui.draw(
             &self.device,
             &self.queue,

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -10,7 +10,7 @@ use wgpu_glyph::ab_glyph::InvalidFont;
 use crate::{
     camera::Camera,
     gui::Gui,
-    screen::{Screen, Size},
+    screen::{Screen, ScreenSize},
 };
 
 use super::{
@@ -89,7 +89,7 @@ impl Renderer {
             .copied()
             .expect("Error determining preferred color format");
 
-        let Size { width, height } = screen.size();
+        let ScreenSize { width, height } = screen.size();
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: color_format,
@@ -186,7 +186,7 @@ impl Renderer {
     ///
     /// # Arguments
     /// - `size`: The target size for the render surface.
-    pub fn handle_resize(&mut self, size: Size) {
+    pub fn handle_resize(&mut self, size: ScreenSize) {
         self.surface_config.width = size.width;
         self.surface_config.height = size.height;
 

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -35,9 +35,6 @@ pub struct Renderer {
 
     geometries: Geometries,
     pipelines: Pipelines,
-
-    /// State required for integration with `egui`.
-    pub gui: Gui,
 }
 
 impl Renderer {
@@ -151,8 +148,6 @@ impl Renderer {
         let pipelines =
             Pipelines::new(&device, &bind_group_layout, color_format);
 
-        let gui = Gui::new(&device, surface_config.format);
-
         Ok(Self {
             surface,
             features,
@@ -167,9 +162,11 @@ impl Renderer {
 
             geometries,
             pipelines,
-
-            gui,
         })
+    }
+
+    pub(crate) fn init_gui(&self) -> Gui {
+        Gui::new(&self.device, self.surface_config.format)
     }
 
     /// Updates the geometry of the model being rendered.
@@ -205,6 +202,7 @@ impl Renderer {
         scale_factor: f32,
         status: &mut StatusReport,
         egui_input: egui::RawInput,
+        gui: &mut Gui,
     ) -> Result<(), DrawError> {
         let aspect_ratio = self.surface_config.width as f64
             / self.surface_config.height as f64;
@@ -273,14 +271,14 @@ impl Renderer {
             }
         }
 
-        self.gui.update(
+        gui.update(
             egui_input,
             config,
             &self.geometries.aabb,
             status,
             self.is_line_drawing_available(),
         );
-        self.gui.draw(
+        gui.draw(
             &self.device,
             &self.queue,
             &mut encoder,

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -20,9 +20,9 @@ use fj_math::Aabb;
 use crate::graphics::DrawConfig;
 
 pub struct Gui {
-    pub context: egui::Context,
-    pub render_pass: egui_wgpu::renderer::RenderPass,
-    pub options: Options,
+    context: egui::Context,
+    render_pass: egui_wgpu::renderer::RenderPass,
+    options: Options,
 }
 
 impl Gui {
@@ -69,6 +69,11 @@ impl Gui {
             render_pass,
             options: Default::default(),
         }
+    }
+
+    /// Access the egui context
+    pub fn context(&self) -> &egui::Context {
+        &self.context
     }
 
     pub fn update(

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -26,7 +26,7 @@ pub struct Gui {
 }
 
 impl Gui {
-    pub fn new(
+    pub(crate) fn new(
         device: &wgpu::Device,
         texture_format: wgpu::TextureFormat,
     ) -> Self {
@@ -76,7 +76,7 @@ impl Gui {
         &self.context
     }
 
-    pub fn update(
+    pub(crate) fn update(
         &mut self,
         egui_input: egui::RawInput,
         config: &mut DrawConfig,
@@ -247,7 +247,7 @@ impl Gui {
         });
     }
 
-    pub fn draw(
+    pub(crate) fn draw(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -19,6 +19,7 @@ use fj_math::Aabb;
 
 use crate::graphics::DrawConfig;
 
+/// The GUI
 pub struct Gui {
     context: egui::Context,
     render_pass: egui_wgpu::renderer::RenderPass,

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -1,7 +1,7 @@
 use crate::screen::NormalizedPosition;
 
 /// An input event
-pub enum Event {
+pub enum InputEvent {
     /// Move the model up, down, left or right
     Translate {
         /// The normalized position of the cursor before input

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -1,13 +1,13 @@
-use crate::screen::NormalizedPosition;
+use crate::screen::NormalizedScreenPosition;
 
 /// An input event
 pub enum InputEvent {
     /// Move the model up, down, left or right
     Translation {
         /// The normalized position of the cursor before input
-        previous: NormalizedPosition,
+        previous: NormalizedScreenPosition,
         /// The normalized position of the cursor after input
-        current: NormalizedPosition,
+        current: NormalizedScreenPosition,
     },
 
     /// Rotate the model around the focus point

--- a/crates/fj-viewer/src/input/event.rs
+++ b/crates/fj-viewer/src/input/event.rs
@@ -3,7 +3,7 @@ use crate::screen::NormalizedPosition;
 /// An input event
 pub enum InputEvent {
     /// Move the model up, down, left or right
-    Translate {
+    Translation {
         /// The normalized position of the cursor before input
         previous: NormalizedPosition,
         /// The normalized position of the cursor after input

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -19,7 +19,7 @@ impl InputHandler {
         camera: &mut Camera,
     ) {
         match event {
-            InputEvent::Translate { previous, current } => {
+            InputEvent::Translation { previous, current } => {
                 self.movement.apply(previous, current, focus_point, camera)
             }
             InputEvent::Rotation { angle_x, angle_y } => {

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -4,13 +4,13 @@ use crate::camera::{Camera, FocusPoint};
 /// Input handling abstraction
 ///
 /// Takes user input and applies them to application state.
-pub struct Handler {
+pub struct InputHandler {
     movement: Movement,
     rotation: Rotation,
     zoom: Zoom,
 }
 
-impl Handler {
+impl InputHandler {
     /// Handle an input event
     pub fn handle_event(
         &mut self,
@@ -32,7 +32,7 @@ impl Handler {
     }
 }
 
-impl Default for Handler {
+impl Default for InputHandler {
     fn default() -> Self {
         Self {
             movement: Movement,

--- a/crates/fj-viewer/src/input/handler.rs
+++ b/crates/fj-viewer/src/input/handler.rs
@@ -1,4 +1,4 @@
-use super::{movement::Movement, rotation::Rotation, zoom::Zoom, Event};
+use super::{movement::Movement, rotation::Rotation, zoom::Zoom, InputEvent};
 use crate::camera::{Camera, FocusPoint};
 
 /// Input handling abstraction
@@ -14,18 +14,18 @@ impl InputHandler {
     /// Handle an input event
     pub fn handle_event(
         &mut self,
-        event: Event,
+        event: InputEvent,
         focus_point: FocusPoint,
         camera: &mut Camera,
     ) {
         match event {
-            Event::Translate { previous, current } => {
+            InputEvent::Translate { previous, current } => {
                 self.movement.apply(previous, current, focus_point, camera)
             }
-            Event::Rotation { angle_x, angle_y } => {
+            InputEvent::Rotation { angle_x, angle_y } => {
                 self.rotation.apply(angle_x, angle_y, focus_point, camera)
             }
-            Event::Zoom(zoom_delta) => {
+            InputEvent::Zoom(zoom_delta) => {
                 self.zoom.apply(zoom_delta, focus_point, camera)
             }
         }

--- a/crates/fj-viewer/src/input/mod.rs
+++ b/crates/fj-viewer/src/input/mod.rs
@@ -6,4 +6,4 @@ mod movement;
 mod rotation;
 mod zoom;
 
-pub use self::{event::Event, handler::Handler};
+pub use self::{event::Event, handler::InputHandler};

--- a/crates/fj-viewer/src/input/mod.rs
+++ b/crates/fj-viewer/src/input/mod.rs
@@ -6,4 +6,4 @@ mod movement;
 mod rotation;
 mod zoom;
 
-pub use self::{event::Event, handler::InputHandler};
+pub use self::{event::InputEvent, handler::InputHandler};

--- a/crates/fj-viewer/src/input/movement.rs
+++ b/crates/fj-viewer/src/input/movement.rs
@@ -2,7 +2,7 @@ use fj_math::{Point, Scalar, Transform, Vector};
 
 use crate::{
     camera::{Camera, FocusPoint},
-    screen::NormalizedPosition,
+    screen::NormalizedScreenPosition,
 };
 
 pub struct Movement;
@@ -10,8 +10,8 @@ pub struct Movement;
 impl Movement {
     pub fn apply(
         &mut self,
-        previous: NormalizedPosition,
-        current: NormalizedPosition,
+        previous: NormalizedScreenPosition,
+        current: NormalizedScreenPosition,
         focus_point: FocusPoint,
         camera: &mut Camera,
     ) {

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -24,6 +24,7 @@ mod viewer;
 pub use self::{
     camera::Camera,
     graphics::{DrawConfig, Renderer, RendererInitError},
+    gui::Gui,
     input::{InputEvent, InputHandler},
     screen::{NormalizedScreenPosition, Screen, ScreenSize},
     viewer::Viewer,

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -14,12 +14,11 @@
 
 #![warn(missing_docs)]
 
-pub mod camera;
-pub mod graphics;
-pub mod input;
-pub mod screen;
-
+mod camera;
+mod graphics;
 mod gui;
+mod input;
+mod screen;
 
 pub use self::{
     camera::Camera,

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -19,10 +19,12 @@ mod graphics;
 mod gui;
 mod input;
 mod screen;
+mod viewer;
 
 pub use self::{
     camera::Camera,
     graphics::{DrawConfig, Renderer, RendererInitError},
     input::{InputEvent, InputHandler},
     screen::{NormalizedScreenPosition, Screen, ScreenSize},
+    viewer::Viewer,
 };

--- a/crates/fj-viewer/src/lib.rs
+++ b/crates/fj-viewer/src/lib.rs
@@ -20,3 +20,10 @@ pub mod input;
 pub mod screen;
 
 mod gui;
+
+pub use self::{
+    camera::Camera,
+    graphics::{DrawConfig, Renderer, RendererInitError},
+    input::{InputEvent, InputHandler},
+    screen::{NormalizedScreenPosition, Screen, ScreenSize},
+};

--- a/crates/fj-viewer/src/screen.rs
+++ b/crates/fj-viewer/src/screen.rs
@@ -19,7 +19,7 @@ pub trait Screen {
 /// The center of the screen is at (0, 0). The aspect ratio is taken into
 /// account.
 #[derive(Clone, Copy, Debug)]
-pub struct NormalizedPosition {
+pub struct NormalizedScreenPosition {
     /// The x coordinate of the position [-1, 1]
     pub x: f64,
 

--- a/crates/fj-viewer/src/screen.rs
+++ b/crates/fj-viewer/src/screen.rs
@@ -8,7 +8,7 @@ pub trait Screen {
     type Window: HasRawWindowHandle;
 
     /// Access the size of the screen
-    fn size(&self) -> Size;
+    fn size(&self) -> ScreenSize;
 
     /// Access the window
     fn window(&self) -> &Self::Window;
@@ -29,7 +29,7 @@ pub struct NormalizedScreenPosition {
 
 /// The size of the screen
 #[derive(Clone, Copy, Debug)]
-pub struct Size {
+pub struct ScreenSize {
     /// The width of the screen
     pub width: u32,
 
@@ -37,7 +37,7 @@ pub struct Size {
     pub height: u32,
 }
 
-impl Size {
+impl ScreenSize {
     /// Convert size to `f64`
     pub fn as_f64(&self) -> [f64; 2] {
         [self.width, self.height].map(Into::into)

--- a/crates/fj-viewer/src/screen.rs
+++ b/crates/fj-viewer/src/screen.rs
@@ -14,8 +14,10 @@ pub trait Screen {
     fn window(&self) -> &Self::Window;
 }
 
-/// Cursor position in normalized coordinates (-1 to +1) with aspect ratio taken into account.
-/// i.e. the center of the screen is at (0, 0)
+/// Cursor position in normalized coordinates (-1 to +1)
+///
+/// The center of the screen is at (0, 0). The aspect ratio is taken into
+/// account.
 #[derive(Clone, Copy, Debug)]
 pub struct NormalizedPosition {
     /// The x coordinate of the position [-1, 1]

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -5,14 +5,17 @@ use fj_math::Aabb;
 use tracing::warn;
 
 use crate::{
-    gui::Gui, Camera, DrawConfig, InputHandler, Renderer, RendererInitError,
-    Screen, ScreenSize,
+    gui::Gui, Camera, DrawConfig, InputHandler, NormalizedScreenPosition,
+    Renderer, RendererInitError, Screen, ScreenSize,
 };
 
 /// The Fornjot model viewer
 pub struct Viewer {
     /// The camera
     pub camera: Camera,
+
+    /// The cursor
+    pub cursor: Option<NormalizedScreenPosition>,
 
     /// The draw config
     pub draw_config: DrawConfig,
@@ -38,6 +41,7 @@ impl Viewer {
 
         Ok(Self {
             camera: Camera::default(),
+            cursor: None,
             draw_config: DrawConfig::default(),
             gui,
             input_handler: InputHandler::default(),

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -5,7 +5,7 @@ use fj_math::Aabb;
 use tracing::warn;
 
 use crate::{
-    camera::FocusPoint, gui::Gui, Camera, DrawConfig, InputHandler,
+    camera::FocusPoint, gui::Gui, Camera, DrawConfig, InputEvent, InputHandler,
     NormalizedScreenPosition, Renderer, RendererInitError, Screen, ScreenSize,
 };
 
@@ -80,6 +80,17 @@ impl Viewer {
         self.camera.update_planes(&shape.aabb);
 
         self.shape = Some(shape);
+    }
+
+    /// Handle an input event
+    pub fn handle_input_event(&mut self, event: InputEvent) {
+        if let Some(focus_point) = self.focus_point {
+            self.input_handler.handle_event(
+                event,
+                focus_point,
+                &mut self.camera,
+            );
+        }
     }
 
     /// Handle the screen being resized

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -1,3 +1,5 @@
+use fj_interop::processed_shape::ProcessedShape;
+
 use crate::{
     Camera, DrawConfig, InputHandler, Renderer, RendererInitError, Screen,
 };
@@ -15,6 +17,9 @@ pub struct Viewer {
 
     /// The renderer
     pub renderer: Renderer,
+
+    /// The shape
+    pub shape: Option<ProcessedShape>,
 }
 
 impl Viewer {
@@ -25,6 +30,19 @@ impl Viewer {
             draw_config: DrawConfig::default(),
             input_handler: InputHandler::default(),
             renderer: Renderer::new(screen).await?,
+            shape: None,
         })
+    }
+
+    /// Handle the shape being updated
+    pub fn handle_shape_update(&mut self, shape: ProcessedShape) {
+        self.renderer.update_geometry(
+            (&shape.mesh).into(),
+            (&shape.debug_info).into(),
+            shape.aabb,
+        );
+        self.camera.update_planes(&shape.aabb);
+
+        self.shape = Some(shape);
     }
 }

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -67,11 +67,8 @@ impl Viewer {
 
     /// Handle the shape being updated
     pub fn handle_shape_update(&mut self, shape: ProcessedShape) {
-        self.renderer.update_geometry(
-            (&shape.mesh).into(),
-            (&shape.debug_info).into(),
-            shape.aabb,
-        );
+        self.renderer
+            .update_geometry((&shape.mesh).into(), (&shape.debug_info).into());
         self.camera.update_planes(&shape.aabb);
 
         self.shape = Some(shape);

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -34,6 +34,25 @@ impl Viewer {
         })
     }
 
+    /// Toggle the "draw model" setting
+    pub fn toggle_draw_model(&mut self) {
+        self.draw_config.draw_model = !self.draw_config.draw_model
+    }
+
+    /// Toggle the "draw mesh" setting
+    pub fn toggle_draw_mesh(&mut self) {
+        if self.renderer.is_line_drawing_available() {
+            self.draw_config.draw_mesh = !self.draw_config.draw_mesh
+        }
+    }
+
+    /// Toggle the "draw debug" setting
+    pub fn toggle_draw_debug(&mut self) {
+        if self.renderer.is_line_drawing_available() {
+            self.draw_config.draw_debug = !self.draw_config.draw_debug
+        }
+    }
+
     /// Handle the shape being updated
     pub fn handle_shape_update(&mut self, shape: ProcessedShape) {
         self.renderer.update_geometry(

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -1,6 +1,7 @@
 use fj_interop::{
     processed_shape::ProcessedShape, status_report::StatusReport,
 };
+use fj_math::Aabb;
 use tracing::warn;
 
 use crate::{
@@ -83,12 +84,24 @@ impl Viewer {
         status: &mut StatusReport,
         egui_input: egui::RawInput,
     ) {
+        let aabb = self
+            .shape
+            .as_ref()
+            .map(|shape| shape.aabb)
+            .unwrap_or_else(Aabb::default);
+
+        self.gui.update(
+            egui_input,
+            &mut self.draw_config,
+            &aabb,
+            status,
+            self.renderer.is_line_drawing_available(),
+        );
+
         if let Err(err) = self.renderer.draw(
             &self.camera,
             &mut self.draw_config,
             scale_factor,
-            status,
-            egui_input,
             &mut self.gui,
         ) {
             warn!("Draw error: {}", err);

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -1,7 +1,8 @@
 use fj_interop::processed_shape::ProcessedShape;
 
 use crate::{
-    Camera, DrawConfig, InputHandler, Renderer, RendererInitError, Screen,
+    gui::Gui, Camera, DrawConfig, InputHandler, Renderer, RendererInitError,
+    Screen,
 };
 
 /// The Fornjot model viewer
@@ -11,6 +12,9 @@ pub struct Viewer {
 
     /// The draw config
     pub draw_config: DrawConfig,
+
+    /// The GUI
+    pub gui: Gui,
 
     /// The input handler
     pub input_handler: InputHandler,
@@ -25,11 +29,15 @@ pub struct Viewer {
 impl Viewer {
     /// Construct a new instance of `Viewer`
     pub async fn new(screen: &impl Screen) -> Result<Self, RendererInitError> {
+        let renderer = Renderer::new(screen).await?;
+        let gui = renderer.init_gui();
+
         Ok(Self {
             camera: Camera::default(),
             draw_config: DrawConfig::default(),
+            gui,
             input_handler: InputHandler::default(),
-            renderer: Renderer::new(screen).await?,
+            renderer,
             shape: None,
         })
     }

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 
 use crate::{
     gui::Gui, Camera, DrawConfig, InputHandler, Renderer, RendererInitError,
-    Screen,
+    Screen, ScreenSize,
 };
 
 /// The Fornjot model viewer
@@ -72,6 +72,11 @@ impl Viewer {
         self.camera.update_planes(&shape.aabb);
 
         self.shape = Some(shape);
+    }
+
+    /// Handle the screen being resized
+    pub fn handle_screen_resize(&mut self, screen_size: ScreenSize) {
+        self.renderer.handle_resize(screen_size)
     }
 
     /// Draw the graphics

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -97,7 +97,7 @@ impl Viewer {
 
         if let Err(err) = self.renderer.draw(
             &self.camera,
-            &mut self.draw_config,
+            &self.draw_config,
             scale_factor,
             &mut self.gui,
         ) {

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -77,8 +77,6 @@ impl Viewer {
     pub fn handle_shape_update(&mut self, shape: ProcessedShape) {
         self.renderer
             .update_geometry((&shape.mesh).into(), (&shape.debug_info).into());
-        self.camera.update_planes(&shape.aabb);
-
         self.shape = Some(shape);
     }
 
@@ -126,6 +124,8 @@ impl Viewer {
             .as_ref()
             .map(|shape| shape.aabb)
             .unwrap_or_else(Aabb::default);
+
+        self.camera.update_planes(&aabb);
 
         self.gui.update(
             egui_input,

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -1,0 +1,30 @@
+use crate::{
+    Camera, DrawConfig, InputHandler, Renderer, RendererInitError, Screen,
+};
+
+/// The Fornjot model viewer
+pub struct Viewer {
+    /// The camera
+    pub camera: Camera,
+
+    /// The draw config
+    pub draw_config: DrawConfig,
+
+    /// The input handler
+    pub input_handler: InputHandler,
+
+    /// The renderer
+    pub renderer: Renderer,
+}
+
+impl Viewer {
+    /// Construct a new instance of `Viewer`
+    pub async fn new(screen: &impl Screen) -> Result<Self, RendererInitError> {
+        Ok(Self {
+            camera: Camera::default(),
+            draw_config: DrawConfig::default(),
+            input_handler: InputHandler::default(),
+            renderer: Renderer::new(screen).await?,
+        })
+    }
+}

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -1,4 +1,7 @@
-use fj_interop::processed_shape::ProcessedShape;
+use fj_interop::{
+    processed_shape::ProcessedShape, status_report::StatusReport,
+};
+use tracing::warn;
 
 use crate::{
     gui::Gui, Camera, DrawConfig, InputHandler, Renderer, RendererInitError,
@@ -71,5 +74,24 @@ impl Viewer {
         self.camera.update_planes(&shape.aabb);
 
         self.shape = Some(shape);
+    }
+
+    /// Draw the graphics
+    pub fn draw(
+        &mut self,
+        scale_factor: f32,
+        status: &mut StatusReport,
+        egui_input: egui::RawInput,
+    ) {
+        if let Err(err) = self.renderer.draw(
+            &self.camera,
+            &mut self.draw_config,
+            scale_factor,
+            status,
+            egui_input,
+            &mut self.gui,
+        ) {
+            warn!("Draw error: {}", err);
+        }
     }
 }

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -5,8 +5,8 @@ use fj_math::Aabb;
 use tracing::warn;
 
 use crate::{
-    gui::Gui, Camera, DrawConfig, InputHandler, NormalizedScreenPosition,
-    Renderer, RendererInitError, Screen, ScreenSize,
+    camera::FocusPoint, gui::Gui, Camera, DrawConfig, InputHandler,
+    NormalizedScreenPosition, Renderer, RendererInitError, Screen, ScreenSize,
 };
 
 /// The Fornjot model viewer
@@ -19,6 +19,9 @@ pub struct Viewer {
 
     /// The draw config
     pub draw_config: DrawConfig,
+
+    /// The focus point
+    pub focus_point: Option<FocusPoint>,
 
     /// The GUI
     pub gui: Gui,
@@ -43,6 +46,7 @@ impl Viewer {
             camera: Camera::default(),
             cursor: None,
             draw_config: DrawConfig::default(),
+            focus_point: None,
             gui,
             input_handler: InputHandler::default(),
             renderer,

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -87,6 +87,22 @@ impl Viewer {
         self.renderer.handle_resize(screen_size)
     }
 
+    /// Compute and store a focus point, unless one is already stored
+    pub fn add_focus_point(&mut self) {
+        // Don't recompute the focus point unnecessarily.
+        if let Some(shape) = &self.shape {
+            if self.focus_point.is_none() {
+                self.focus_point =
+                    Some(self.camera.focus_point(self.cursor, shape));
+            }
+        }
+    }
+
+    /// Remove the stored focus point
+    pub fn remove_focus_point(&mut self) {
+        self.focus_point = None;
+    }
+
     /// Draw the graphics
     pub fn draw(
         &mut self,

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -36,7 +36,6 @@ pub fn run(
     let window = Window::new(&event_loop)?;
     let mut viewer = block_on(Viewer::new(&window))?;
 
-    let mut previous_cursor = None;
     let mut held_mouse_button = None;
     let mut focus_point = None;
 
@@ -166,7 +165,7 @@ pub fn run(
                 // Don't unnecessarily recalculate focus point
                 if focus_point.is_none() {
                     focus_point =
-                        Some(viewer.camera.focus_point(previous_cursor, shape));
+                        Some(viewer.camera.focus_point(viewer.cursor, shape));
                 }
             } else {
                 focus_point = None;
@@ -177,7 +176,7 @@ pub fn run(
             &event,
             &window,
             &held_mouse_button,
-            &mut previous_cursor,
+            &mut viewer.cursor,
             invert_zoom,
         );
         if let (Some(input_event), Some(focus_point)) =

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -42,8 +42,6 @@ pub fn run(
 
     let mut egui_winit_state = egui_winit::State::new(&event_loop);
 
-    let mut shape = None;
-
     // Only handle resize events once every frame. This filters out spurious
     // resize events that can lead to wgpu warnings. See this issue for some
     // context:
@@ -57,14 +55,7 @@ pub fn run(
             if let Some(new_shape) = watcher.receive(&mut status) {
                 match shape_processor.process(&new_shape) {
                     Ok(new_shape) => {
-                        viewer.renderer.update_geometry(
-                            (&new_shape.mesh).into(),
-                            (&new_shape.debug_info).into(),
-                            new_shape.aabb,
-                        );
-
-                        viewer.camera.update_planes(&new_shape.aabb);
-                        shape = Some(new_shape);
+                        viewer.handle_shape_update(new_shape);
                     }
                     Err(err) => {
                         // Can be cleaned up, once `Report` is stable:
@@ -184,7 +175,8 @@ pub fn run(
             _ => {}
         }
 
-        if let (Some(shape), Some(should_focus)) = (&shape, focus_event(&event))
+        if let (Some(shape), Some(should_focus)) =
+            (&viewer.shape, focus_event(&event))
         {
             if should_focus {
                 // Don't unnecessarily recalculate focus point

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -209,8 +209,10 @@ pub fn run(
             &mut previous_cursor,
             invert_zoom,
         );
-        if let (Some(input_event), Some(fp)) = (input_event, focus_point) {
-            input_handler.handle_event(input_event, fp, &mut camera);
+        if let (Some(input_event), Some(focus_point)) =
+            (input_event, focus_point)
+        {
+            input_handler.handle_event(input_event, focus_point, &mut camera);
         }
     });
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -90,7 +90,7 @@ pub fn run(
             // a title bar that overlaps the model then both the model & window
             // get moved.
             egui_winit_state
-                .on_event(&viewer.renderer.gui.context, window_event);
+                .on_event(viewer.renderer.gui.context(), window_event);
         }
 
         // fj-window events

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -49,7 +49,6 @@ pub fn run(
 
     let mut shape = None;
     let mut camera = Camera::new();
-    let mut camera_update_once = watcher.is_some();
 
     // Only handle resize events once every frame. This filters out spurious
     // resize events that can lead to wgpu warnings. See this issue for some
@@ -70,12 +69,7 @@ pub fn run(
                             new_shape.aabb,
                         );
 
-                        if camera_update_once {
-                            camera_update_once = false;
-                            camera = Camera::new();
-                            camera.update_planes(&new_shape.aabb);
-                        }
-
+                        camera.update_planes(&new_shape.aabb);
                         shape = Some(new_shape);
                     }
                     Err(err) => {
@@ -172,9 +166,6 @@ pub fn run(
                 window.window().request_redraw();
             }
             Event::RedrawRequested(_) => {
-                if let Some(shape) = &shape {
-                    camera.update_planes(&shape.aabb);
-                }
                 if let Some(size) = new_size.take() {
                     renderer.handle_resize(size);
                 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -309,7 +309,7 @@ pub enum Error {
 
     /// Error initializing graphics
     #[error("Error initializing graphics")]
-    GraphicsInit(#[from] graphics::InitError),
+    GraphicsInit(#[from] graphics::RendererInitError),
 }
 
 /// Affects the speed of zoom movement given a scroll wheel input in lines.

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -12,7 +12,7 @@ use fj_viewer::{
     camera::Camera,
     graphics::{self, DrawConfig, Renderer},
     input::{InputEvent, InputHandler},
-    screen::{NormalizedScreenPosition, Screen as _, Size},
+    screen::{NormalizedScreenPosition, Screen as _, ScreenSize},
 };
 use futures::executor::block_on;
 use tracing::{trace, warn};
@@ -148,7 +148,7 @@ pub fn run(
                 event: WindowEvent::Resized(size),
                 ..
             } => {
-                new_size = Some(Size {
+                new_size = Some(ScreenSize {
                     width: size.width,
                     height: size.height,
                 });

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -89,8 +89,7 @@ pub fn run(
             // The primary visible impact of this currently is that if you drag
             // a title bar that overlaps the model then both the model & window
             // get moved.
-            egui_winit_state
-                .on_event(viewer.renderer.gui.context(), window_event);
+            egui_winit_state.on_event(viewer.gui.context(), window_event);
         }
 
         // fj-window events
@@ -161,6 +160,7 @@ pub fn run(
                     window.window().scale_factor() as f32,
                     &mut status,
                     egui_input,
+                    &mut viewer.gui,
                 ) {
                     warn!("Draw error: {}", err);
                 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -131,12 +131,20 @@ pub fn run(
             Event::WindowEvent {
                 event: WindowEvent::MouseInput { state, button, .. },
                 ..
-            } => {
-                match state {
-                    ElementState::Pressed => held_mouse_button = Some(button),
-                    ElementState::Released => held_mouse_button = None,
-                };
-            }
+            } => match state {
+                ElementState::Pressed => {
+                    held_mouse_button = Some(button);
+                    viewer.add_focus_point();
+                }
+                ElementState::Released => {
+                    held_mouse_button = None;
+                    viewer.remove_focus_point();
+                }
+            },
+            Event::WindowEvent {
+                event: WindowEvent::MouseWheel { .. },
+                ..
+            } => viewer.add_focus_point(),
             Event::MainEventsCleared => {
                 window.window().request_redraw();
             }
@@ -155,14 +163,6 @@ pub fn run(
                 );
             }
             _ => {}
-        }
-
-        if let Some(should_focus) = focus_event(&event) {
-            if should_focus {
-                viewer.add_focus_point();
-            } else {
-                viewer.remove_focus_point();
-            }
         }
 
         let input_event = input_event(
@@ -242,30 +242,6 @@ fn input_event(
 
             Some(InputEvent::Zoom(delta))
         }
-        _ => None,
-    }
-}
-
-/// Returns true/false if focus point point should be created/removed
-/// None means no change to focus point is needed
-fn focus_event(event: &Event<()>) -> Option<bool> {
-    match event {
-        Event::WindowEvent {
-            event:
-                WindowEvent::MouseInput {
-                    state,
-                    button: MouseButton::Left | MouseButton::Right,
-                    ..
-                },
-            ..
-        } => match state {
-            ElementState::Pressed => Some(true),
-            ElementState::Released => Some(false),
-        },
-        Event::WindowEvent {
-            event: WindowEvent::MouseWheel { .. },
-            ..
-        } => Some(true),
         _ => None,
     }
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -41,7 +41,7 @@ pub fn run(
     let mut held_mouse_button = None;
     let mut focus_point = None;
 
-    let mut input_handler = input::Handler::default();
+    let mut input_handler = input::InputHandler::default();
     let mut renderer = block_on(Renderer::new(&window))?;
     let mut egui_winit_state = egui_winit::State::new(&event_loop);
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -116,20 +116,13 @@ pub fn run(
             } => match virtual_key_code {
                 VirtualKeyCode::Escape => *control_flow = ControlFlow::Exit,
                 VirtualKeyCode::Key1 => {
-                    viewer.draw_config.draw_model =
-                        !viewer.draw_config.draw_model
+                    viewer.toggle_draw_model();
                 }
                 VirtualKeyCode::Key2 => {
-                    if viewer.renderer.is_line_drawing_available() {
-                        viewer.draw_config.draw_mesh =
-                            !viewer.draw_config.draw_mesh
-                    }
+                    viewer.toggle_draw_mesh();
                 }
                 VirtualKeyCode::Key3 => {
-                    if viewer.renderer.is_line_drawing_available() {
-                        viewer.draw_config.draw_debug =
-                            !viewer.draw_config.draw_debug
-                    }
+                    viewer.toggle_draw_debug();
                 }
                 _ => {}
             },

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -9,10 +9,8 @@ use fj_host::Watcher;
 use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_viewer::{
-    camera::Camera,
-    graphics::{DrawConfig, Renderer, RendererInitError},
-    input::{InputEvent, InputHandler},
-    screen::{NormalizedScreenPosition, Screen as _, ScreenSize},
+    Camera, DrawConfig, InputEvent, InputHandler, NormalizedScreenPosition,
+    Renderer, RendererInitError, Screen, ScreenSize,
 };
 use futures::executor::block_on;
 use tracing::{trace, warn};

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -13,7 +13,7 @@ use fj_viewer::{
     ScreenSize, Viewer,
 };
 use futures::executor::block_on;
-use tracing::{trace, warn};
+use tracing::trace;
 use winit::{
     dpi::PhysicalPosition,
     event::{
@@ -154,16 +154,11 @@ pub fn run(
                 let egui_input =
                     egui_winit_state.take_egui_input(window.window());
 
-                if let Err(err) = viewer.renderer.draw(
-                    &viewer.camera,
-                    &mut viewer.draw_config,
+                viewer.draw(
                     window.window().scale_factor() as f32,
                     &mut status,
                     egui_input,
-                    &mut viewer.gui,
-                ) {
-                    warn!("Draw error: {}", err);
-                }
+                );
             }
             _ => {}
         }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -172,14 +172,8 @@ pub fn run(
             &mut viewer.cursor,
             invert_zoom,
         );
-        if let (Some(input_event), Some(focus_point)) =
-            (input_event, viewer.focus_point)
-        {
-            viewer.input_handler.handle_event(
-                input_event,
-                focus_point,
-                &mut viewer.camera,
-            );
+        if let Some(input_event) = input_event {
+            viewer.handle_input_event(input_event);
         }
     });
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -48,7 +48,7 @@ pub fn run(
     let mut draw_config = DrawConfig::default();
 
     let mut shape = None;
-    let mut camera = Camera::new(&Default::default());
+    let mut camera = Camera::new();
     let mut camera_update_once = watcher.is_some();
 
     // Only handle resize events once every frame. This filters out spurious
@@ -72,7 +72,8 @@ pub fn run(
 
                         if camera_update_once {
                             camera_update_once = false;
-                            camera = Camera::new(&new_shape.aabb);
+                            camera = Camera::new();
+                            camera.update_planes(&new_shape.aabb);
                         }
 
                         shape = Some(new_shape);

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -246,7 +246,7 @@ fn input_event(
                         Some(InputEvent::Rotation { angle_x, angle_y })
                     }
                     MouseButton::Right => {
-                        Some(InputEvent::Translate { previous, current })
+                        Some(InputEvent::Translation { previous, current })
                     }
                     _ => None,
                 },

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -11,7 +11,7 @@ use fj_operations::shape_processor::ShapeProcessor;
 use fj_viewer::{
     camera::Camera,
     graphics::{self, DrawConfig, Renderer},
-    input,
+    input::{InputEvent, InputHandler},
     screen::{NormalizedPosition, Screen as _, Size},
 };
 use futures::executor::block_on;
@@ -41,7 +41,7 @@ pub fn run(
     let mut held_mouse_button = None;
     let mut focus_point = None;
 
-    let mut input_handler = input::InputHandler::default();
+    let mut input_handler = InputHandler::default();
     let mut renderer = block_on(Renderer::new(&window))?;
     let mut egui_winit_state = egui_winit::State::new(&event_loop);
 
@@ -220,7 +220,7 @@ fn input_event(
     held_mouse_button: &Option<MouseButton>,
     previous_cursor: &mut Option<NormalizedPosition>,
     invert_zoom: bool,
-) -> Option<input::InputEvent> {
+) -> Option<InputEvent> {
     match event {
         Event::WindowEvent {
             event: WindowEvent::CursorMoved { position, .. },
@@ -243,10 +243,10 @@ fn input_event(
                         let angle_x = -diff_y * ROTATION_SENSITIVITY;
                         let angle_y = diff_x * ROTATION_SENSITIVITY;
 
-                        Some(input::InputEvent::Rotation { angle_x, angle_y })
+                        Some(InputEvent::Rotation { angle_x, angle_y })
                     }
                     MouseButton::Right => {
-                        Some(input::InputEvent::Translate { previous, current })
+                        Some(InputEvent::Translate { previous, current })
                     }
                     _ => None,
                 },
@@ -270,7 +270,7 @@ fn input_event(
 
             let delta = if invert_zoom { -delta } else { delta };
 
-            Some(input::InputEvent::Zoom(delta))
+            Some(InputEvent::Zoom(delta))
         }
         _ => None,
     }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -186,9 +186,6 @@ pub fn run(
             _ => {}
         }
 
-        // fj-viewer input events
-        // These can fire multiple times per frame
-
         if let (Some(shape), Some(should_focus)) = (&shape, focus_event(&event))
         {
             if should_focus {

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -157,17 +157,11 @@ pub fn run(
             _ => {}
         }
 
-        if let (Some(shape), Some(should_focus)) =
-            (&viewer.shape, focus_event(&event))
-        {
+        if let Some(should_focus) = focus_event(&event) {
             if should_focus {
-                // Don't unnecessarily recalculate focus point
-                if viewer.focus_point.is_none() {
-                    viewer.focus_point =
-                        Some(viewer.camera.focus_point(viewer.cursor, shape));
-                }
+                viewer.add_focus_point();
             } else {
-                viewer.focus_point = None;
+                viewer.remove_focus_point();
             }
         }
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -10,7 +10,7 @@ use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_viewer::{
     camera::Camera,
-    graphics::{self, DrawConfig, Renderer},
+    graphics::{DrawConfig, Renderer, RendererInitError},
     input::{InputEvent, InputHandler},
     screen::{NormalizedScreenPosition, Screen as _, ScreenSize},
 };
@@ -309,7 +309,7 @@ pub enum Error {
 
     /// Error initializing graphics
     #[error("Error initializing graphics")]
-    GraphicsInit(#[from] graphics::RendererInitError),
+    GraphicsInit(#[from] RendererInitError),
 }
 
 /// Affects the speed of zoom movement given a scroll wheel input in lines.

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -148,7 +148,7 @@ pub fn run(
             }
             Event::RedrawRequested(_) => {
                 if let Some(size) = new_size.take() {
-                    viewer.renderer.handle_resize(size);
+                    viewer.handle_screen_resize(size);
                 }
 
                 let egui_input =

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -76,11 +76,7 @@ pub fn run(
             }
         }
 
-        if let Event::WindowEvent {
-            event: window_event,
-            ..
-        } = &event
-        {
+        if let Event::WindowEvent { event, .. } = &event {
             // In theory we could/should check if `egui` wants "exclusive" use
             // of this event here. But with the current integration with Fornjot
             // we're kinda blurring the lines between "app" and "platform", so
@@ -89,7 +85,7 @@ pub fn run(
             // The primary visible impact of this currently is that if you drag
             // a title bar that overlaps the model then both the model & window
             // get moved.
-            egui_winit_state.on_event(viewer.gui.context(), window_event);
+            egui_winit_state.on_event(viewer.gui.context(), event);
         }
 
         // fj-window events

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -12,7 +12,7 @@ use fj_viewer::{
     camera::Camera,
     graphics::{self, DrawConfig, Renderer},
     input::{InputEvent, InputHandler},
-    screen::{NormalizedPosition, Screen as _, Size},
+    screen::{NormalizedScreenPosition, Screen as _, Size},
 };
 use futures::executor::block_on;
 use tracing::{trace, warn};
@@ -218,7 +218,7 @@ fn input_event(
     event: &Event<()>,
     window: &Window,
     held_mouse_button: &Option<MouseButton>,
-    previous_cursor: &mut Option<NormalizedPosition>,
+    previous_cursor: &mut Option<NormalizedScreenPosition>,
     invert_zoom: bool,
 ) -> Option<InputEvent> {
     match event {
@@ -231,7 +231,7 @@ fn input_event(
 
             // Cursor position in normalized coordinates (-1 to +1) with
             // aspect ratio taken into account.
-            let current = NormalizedPosition {
+            let current = NormalizedScreenPosition {
                 x: position.x / width * 2. - 1.,
                 y: -(position.y / height * 2. - 1.) / aspect_ratio,
             };

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -220,7 +220,7 @@ fn input_event(
     held_mouse_button: &Option<MouseButton>,
     previous_cursor: &mut Option<NormalizedPosition>,
     invert_zoom: bool,
-) -> Option<input::Event> {
+) -> Option<input::InputEvent> {
     match event {
         Event::WindowEvent {
             event: WindowEvent::CursorMoved { position, .. },
@@ -243,10 +243,10 @@ fn input_event(
                         let angle_x = -diff_y * ROTATION_SENSITIVITY;
                         let angle_y = diff_x * ROTATION_SENSITIVITY;
 
-                        Some(input::Event::Rotation { angle_x, angle_y })
+                        Some(input::InputEvent::Rotation { angle_x, angle_y })
                     }
                     MouseButton::Right => {
-                        Some(input::Event::Translate { previous, current })
+                        Some(input::InputEvent::Translate { previous, current })
                     }
                     _ => None,
                 },
@@ -270,7 +270,7 @@ fn input_event(
 
             let delta = if invert_zoom { -delta } else { delta };
 
-            Some(input::Event::Zoom(delta))
+            Some(input::InputEvent::Zoom(delta))
         }
         _ => None,
     }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -37,7 +37,6 @@ pub fn run(
     let mut viewer = block_on(Viewer::new(&window))?;
 
     let mut held_mouse_button = None;
-    let mut focus_point = None;
 
     let mut egui_winit_state = egui_winit::State::new(&event_loop);
 
@@ -163,12 +162,12 @@ pub fn run(
         {
             if should_focus {
                 // Don't unnecessarily recalculate focus point
-                if focus_point.is_none() {
-                    focus_point =
+                if viewer.focus_point.is_none() {
+                    viewer.focus_point =
                         Some(viewer.camera.focus_point(viewer.cursor, shape));
                 }
             } else {
-                focus_point = None;
+                viewer.focus_point = None;
             }
         }
 
@@ -180,7 +179,7 @@ pub fn run(
             invert_zoom,
         );
         if let (Some(input_event), Some(focus_point)) =
-            (input_event, focus_point)
+            (input_event, viewer.focus_point)
         {
             viewer.input_handler.handle_event(
                 input_event,

--- a/crates/fj-window/src/window.rs
+++ b/crates/fj-window/src/window.rs
@@ -1,6 +1,6 @@
 //! CAD viewer utility windowing abstraction
 
-use fj_viewer::screen::{Screen, Size};
+use fj_viewer::screen::{Screen, ScreenSize};
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 /// Window abstraction providing details such as the width or height and easing initialization.
@@ -23,10 +23,10 @@ impl Window {
 impl Screen for Window {
     type Window = winit::window::Window;
 
-    fn size(&self) -> Size {
+    fn size(&self) -> ScreenSize {
         let size = self.0.inner_size();
 
-        Size {
+        ScreenSize {
             width: size.width,
             height: size.height,
         }

--- a/crates/fj-window/src/window.rs
+++ b/crates/fj-window/src/window.rs
@@ -1,6 +1,6 @@
 //! CAD viewer utility windowing abstraction
 
-use fj_viewer::screen::{Screen, ScreenSize};
+use fj_viewer::{Screen, ScreenSize};
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 /// Window abstraction providing details such as the width or height and easing initialization.


### PR DESCRIPTION
This pull request combines many cleanups of the `fj-viewer` API, large and small. The main attraction is the introduction of a `Viewer` trait that combines `fj-viewer`'s data into one struct, and provides (for the most part) a unified API to work with. This is certainly not the end of the line for `fj-viewer`, but it should provide a nicer foundation to build upon.