### PR TITLE
Fix last known `SurfaceVertex` duplication issue

### DIFF
--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -62,8 +62,8 @@ impl Cycle {
                 let [_, last] = last.vertices();
 
                 assert_eq!(
-                    first.surface_form(),
-                    last.surface_form(),
+                    first.surface_form().id(),
+                    last.surface_form().id(),
                     "Edges do not form a cycle"
                 );
             }

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -201,8 +201,8 @@ impl PartialCycle {
                 |(mut half_edges, previous_vertex), half_edge| {
                     let half_edge = half_edge
                         .update_partial(|half_edge| {
-                            let [from, _] = half_edge.vertices.clone();
-                            let from = from.map(|vertex| {
+                            let [back, _] = half_edge.vertices.clone();
+                            let back = back.map(|vertex| {
                                 vertex.update_partial(|partial| {
                                     partial.with_surface_form(previous_vertex)
                                 })
@@ -210,7 +210,7 @@ impl PartialCycle {
 
                             half_edge
                                 .with_surface(Some(surface_for_edges.clone()))
-                                .with_back_vertex(from)
+                                .with_back_vertex(back)
                         })
                         .into_full(objects);
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -229,12 +229,13 @@ impl PartialHalfEdge {
 
 impl From<&HalfEdge> for PartialHalfEdge {
     fn from(half_edge: &HalfEdge) -> Self {
-        let [a, b] = half_edge.vertices().clone().map(Into::into);
+        let [back_vertex, front_vertex] =
+            half_edge.vertices().clone().map(Into::into);
 
         Self {
             surface: Some(half_edge.curve().surface().clone()),
             curve: Some(half_edge.curve().clone().into()),
-            vertices: [Some(a), Some(b)],
+            vertices: [Some(back_vertex), Some(front_vertex)],
             global_form: Some(half_edge.global_form().clone().into()),
         }
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -90,8 +90,8 @@ impl PartialHalfEdge {
         vertices: Option<[impl Into<MaybePartial<Vertex>>; 2]>,
     ) -> Self {
         let vertices = vertices.map(|vertices| vertices.map(Into::into));
-        if let Some([a, b]) = vertices {
-            self.vertices = [Some(a), Some(b)];
+        if let Some([back, front]) = vertices {
+            self.vertices = [Some(back), Some(front)];
         }
         self
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -114,7 +114,7 @@ impl PartialHalfEdge {
             .with_surface(self.surface.clone())
             .as_circle_from_radius(radius);
 
-        let [a, b] = {
+        let [back, front] = {
             let [a_curve, b_curve] =
                 [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
@@ -136,7 +136,7 @@ impl PartialHalfEdge {
         };
 
         self.curve = Some(curve.into());
-        self.vertices = [Some(a), Some(b)];
+        self.vertices = [Some(back), Some(front)];
 
         self
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -186,7 +186,7 @@ impl PartialHalfEdge {
             .with_surface(Some(surface))
             .as_line_from_points(points);
 
-        let [a, b] = [(from, 0.), (to, 1.)].map(|(vertex, position)| {
+        let [back, front] = [(from, 0.), (to, 1.)].map(|(vertex, position)| {
             vertex.update_partial(|vertex| {
                 vertex
                     .with_position(Some([position]))
@@ -195,7 +195,7 @@ impl PartialHalfEdge {
         });
 
         self.curve = Some(curve.into());
-        self.vertices = [Some(a), Some(b)];
+        self.vertices = [Some(back), Some(front)];
 
         self
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -108,7 +108,17 @@ impl PartialHalfEdge {
     }
 
     /// Update partial half-edge as a circle, from the given radius
-    pub fn as_circle_from_radius(mut self, radius: impl Into<Scalar>) -> Self {
+    ///
+    /// # Implementation Note
+    ///
+    /// In principle, only the `build` method should take a reference to
+    /// [`Objects`]. As of this writing, this method is the only one that
+    /// deviates from that. I couldn't think of a way to do it better.
+    pub fn as_circle_from_radius(
+        mut self,
+        radius: impl Into<Scalar>,
+        objects: &Objects,
+    ) -> Self {
         let curve = Handle::<Curve>::partial()
             .with_global_form(self.extract_global_curve())
             .with_surface(self.surface.clone())
@@ -124,7 +134,9 @@ impl PartialHalfEdge {
             let path = curve.path.expect("Expected path that was just created");
             let surface_form = Handle::<SurfaceVertex>::partial()
                 .with_position(Some(path.point_from_path_coords(a_curve)))
-                .with_global_form(Some(global_form));
+                .with_surface(self.surface.clone())
+                .with_global_form(Some(global_form))
+                .build(objects);
 
             [a_curve, b_curve].map(|point_curve| {
                 Vertex::partial()

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -28,7 +28,7 @@ impl Shape for fj::Sketch {
 
                 let half_edge = HalfEdge::partial()
                     .with_surface(Some(surface.clone()))
-                    .as_circle_from_radius(circle.radius())
+                    .as_circle_from_radius(circle.radius(), objects)
                     .build(objects);
                 let cycle = Cycle::new(surface, [half_edge]);
 


### PR DESCRIPTION
Make use of the inclusion of `SurfaceVertex` in the centralized object storage (#1021) to make the cycle validation code stricter (by comparing based on [identity instead of equality](https://docs.rs/fj-kernel/0.20.0/fj_kernel/objects/index.html#object-identity-vs-object-equality)). This surfaced a few object duplication issues, some of which were already fixed. This takes care of the last known one.