### PR TITLE
Rename `Watcher::receive`; improve its error handling

### DIFF
--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -310,7 +310,7 @@ impl Watcher {
     pub fn receive_shape(
         &self,
         status: &mut StatusReport,
-    ) -> Option<fj::Shape> {
+    ) -> Result<Option<fj::Shape>, Error> {
         match self.channel.try_recv() {
             Ok(()) => {
                 let shape = match self.model.load_once(&self.parameters, status)
@@ -320,18 +320,18 @@ impl Watcher {
                         // An error is being displayed to the user via the
                         // `StatusReport that is passed to `load_once` above, so
                         // no need to do anything else here.
-                        return None;
+                        return Ok(None);
                     }
                     Err(err) => {
                         panic!("Error reloading model: {:?}", err);
                     }
                 };
 
-                Some(shape)
+                Ok(Some(shape))
             }
             Err(mpsc::TryRecvError::Empty) => {
                 // Nothing to receive from the channel.
-                None
+                Ok(None)
             }
             Err(mpsc::TryRecvError::Disconnected) => {
                 // The other end has disconnected. This is probably the result

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -323,7 +323,7 @@ impl Watcher {
                         return Ok(None);
                     }
                     Err(err) => {
-                        panic!("Error reloading model: {:?}", err);
+                        return Err(err);
                     }
                 };
 

--- a/crates/fj-host/src/lib.rs
+++ b/crates/fj-host/src/lib.rs
@@ -307,7 +307,10 @@ impl Watcher {
     ///
     /// Returns `None`, if the model has not changed since the last time this
     /// method was called.
-    pub fn receive(&self, status: &mut StatusReport) -> Option<fj::Shape> {
+    pub fn receive_shape(
+        &self,
+        status: &mut StatusReport,
+    ) -> Option<fj::Shape> {
         match self.channel.try_recv() {
             Ok(()) => {
                 let shape = match self.model.load_once(&self.parameters, status)

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -50,8 +50,8 @@ pub fn run(
         trace!("Handling event: {:?}", event);
 
         if let Some(watcher) = &watcher {
-            if let Some(new_shape) = watcher.receive_shape(&mut status) {
-                match shape_processor.process(&new_shape) {
+            if let Some(shape) = watcher.receive_shape(&mut status) {
+                match shape_processor.process(&shape) {
                     Ok(shape) => {
                         viewer.handle_shape_update(shape);
                     }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -52,8 +52,8 @@ pub fn run(
         if let Some(watcher) = &watcher {
             if let Some(new_shape) = watcher.receive_shape(&mut status) {
                 match shape_processor.process(&new_shape) {
-                    Ok(new_shape) => {
-                        viewer.handle_shape_update(new_shape);
+                    Ok(shape) => {
+                        viewer.handle_shape_update(shape);
                     }
                     Err(err) => {
                         // Can be cleaned up, once `Report` is stable:

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -50,7 +50,7 @@ pub fn run(
         trace!("Handling event: {:?}", event);
 
         if let Some(watcher) = &watcher {
-            if let Some(new_shape) = watcher.receive(&mut status) {
+            if let Some(new_shape) = watcher.receive_shape(&mut status) {
                 match shape_processor.process(&new_shape) {
                     Ok(new_shape) => {
                         viewer.handle_shape_update(new_shape);


### PR DESCRIPTION
Make the method name more explicit by renaming it to `receive_shape` and update it to return `Result`.