### PR TITLE
Improve error message, if model can't be loaded

### DIFF
--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -76,7 +76,20 @@ pub fn run(
                     }
                 }
                 Err(err) => {
+                    // Can be cleaned up, once `Report` is stable:
+                    // https://doc.rust-lang.org/std/error/struct.Report.html
+
                     println!("Error receiving updated shape: {}", err);
+
+                    let mut current_err = &err as &dyn error::Error;
+                    while let Some(err) = current_err.source() {
+                        println!();
+                        println!("Caused by:");
+                        println!("    {}", err);
+
+                        current_err = err;
+                    }
+
                     *control_flow = ControlFlow::Exit;
                     return;
                 }


### PR DESCRIPTION
Here's the old error message, as of before #1234 

```
thread 'main' panicked at 'Error reloading model: LibLoading(DlOpen { desc: "/home/hanno/Projects/main/fornjot/target/debug/libspacer.so: cannot open shared object file: No such file or directory" })', /home/hanno/.cargo/registry/src/github.com-1ecc6299db9ec823/fj-host-0.19.0/src/lib.rs:322:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

And this is the new one, as of this pull request:

```
Error receiving updated shape: Error loading model from dynamic library

Caused by:
    /home/hanno/Projects/main/fornjot/target/debug/libspacer.so: cannot open shared object file: No such file or directory
```