### PR TITLE
Fix all known `GlobalVertex` duplication issues

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -6,14 +6,15 @@ use crate::{
     storage::Handle,
 };
 
-use super::Sweep;
+use super::{Sweep, SweepCache};
 
 impl Sweep for Handle<Curve> {
     type Swept = Handle<Surface>;
 
-    fn sweep(
+    fn sweep_with_cache(
         self,
         path: impl Into<Vector<3>>,
+        _: &mut SweepCache,
         objects: &Objects,
     ) -> Self::Swept {
         match self.surface().u() {

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -6,14 +6,15 @@ use crate::{
     path::GlobalPath,
 };
 
-use super::Sweep;
+use super::{Sweep, SweepCache};
 
 impl Sweep for Face {
     type Swept = Shell;
 
-    fn sweep(
+    fn sweep_with_cache(
         self,
         path: impl Into<Vector<3>>,
+        cache: &mut SweepCache,
         objects: &Objects,
     ) -> Self::Swept {
         let path = path.into();
@@ -64,7 +65,8 @@ impl Sweep for Face {
                     half_edge.clone()
                 };
 
-                let face = (half_edge, self.color()).sweep(path, objects);
+                let face = (half_edge, self.color())
+                    .sweep_with_cache(path, cache, objects);
 
                 faces.push(face);
             }

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -20,5 +20,22 @@ pub trait Sweep: Sized {
         self,
         path: impl Into<Vector<3>>,
         objects: &Objects,
+    ) -> Self::Swept {
+        let mut cache = SweepCache::default();
+        self.sweep_with_cache(path, &mut cache, objects)
+    }
+
+    /// Sweep the object along the given path, using the provided cache
+    fn sweep_with_cache(
+        self,
+        path: impl Into<Vector<3>>,
+        cache: &mut SweepCache,
+        objects: &Objects,
     ) -> Self::Swept;
 }
+
+/// A cache used for sweeping
+///
+/// See [`Sweep`].
+#[derive(Default)]
+pub struct SweepCache;

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -6,9 +6,14 @@ mod face;
 mod sketch;
 mod vertex;
 
+use std::collections::BTreeMap;
+
 use fj_math::Vector;
 
-use crate::objects::Objects;
+use crate::{
+    objects::{GlobalVertex, Objects},
+    storage::{Handle, ObjectId},
+};
 
 /// Sweep an object along a path to create another object
 pub trait Sweep: Sized {
@@ -38,4 +43,7 @@ pub trait Sweep: Sized {
 ///
 /// See [`Sweep`].
 #[derive(Default)]
-pub struct SweepCache;
+pub struct SweepCache {
+    /// Cache for global vertices
+    pub global_vertex: BTreeMap<ObjectId, Handle<GlobalVertex>>,
+}

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -11,7 +11,7 @@ use fj_math::Vector;
 use crate::objects::Objects;
 
 /// Sweep an object along a path to create another object
-pub trait Sweep {
+pub trait Sweep: Sized {
     /// The object that is created by sweeping the implementing object
     type Swept;
 

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -2,21 +2,22 @@ use fj_math::Vector;
 
 use crate::objects::{Objects, Sketch, Solid};
 
-use super::Sweep;
+use super::{Sweep, SweepCache};
 
 impl Sweep for Sketch {
     type Swept = Solid;
 
-    fn sweep(
+    fn sweep_with_cache(
         self,
         path: impl Into<Vector<3>>,
+        cache: &mut SweepCache,
         objects: &Objects,
     ) -> Self::Swept {
         let path = path.into();
 
         let mut shells = Vec::new();
         for face in self.into_faces() {
-            let shell = face.sweep(path, objects);
+            let shell = face.sweep_with_cache(path, cache, objects);
             shells.push(shell);
         }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -9,14 +9,15 @@ use crate::{
     storage::Handle,
 };
 
-use super::Sweep;
+use super::{Sweep, SweepCache};
 
 impl Sweep for (Vertex, Handle<Surface>) {
     type Swept = HalfEdge;
 
-    fn sweep(
+    fn sweep_with_cache(
         self,
         path: impl Into<Vector<3>>,
+        cache: &mut SweepCache,
         objects: &Objects,
     ) -> Self::Swept {
         let (vertex, surface) = self;
@@ -57,8 +58,10 @@ impl Sweep for (Vertex, Handle<Surface>) {
         // With that out of the way, let's start by creating the `GlobalEdge`,
         // as that is the most straight-forward part of this operations, and
         // we're going to need it soon anyway.
-        let (edge_global, vertices_global) =
-            vertex.global_form().clone().sweep(path, objects);
+        let (edge_global, vertices_global) = vertex
+            .global_form()
+            .clone()
+            .sweep_with_cache(path, cache, objects);
 
         // Next, let's compute the surface coordinates of the two vertices of
         // the output `Edge`, as we're going to need these for the rest of this
@@ -120,9 +123,10 @@ impl Sweep for (Vertex, Handle<Surface>) {
 impl Sweep for Handle<GlobalVertex> {
     type Swept = (GlobalEdge, [Handle<GlobalVertex>; 2]);
 
-    fn sweep(
+    fn sweep_with_cache(
         self,
         path: impl Into<Vector<3>>,
+        _: &mut SweepCache,
         objects: &Objects,
     ) -> Self::Swept {
         let curve = GlobalCurve::new(objects);

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -126,14 +126,22 @@ impl Sweep for Handle<GlobalVertex> {
     fn sweep_with_cache(
         self,
         path: impl Into<Vector<3>>,
-        _: &mut SweepCache,
+        cache: &mut SweepCache,
         objects: &Objects,
     ) -> Self::Swept {
         let curve = GlobalCurve::new(objects);
 
         let a = self.clone();
-        let b =
-            GlobalVertex::from_position(self.position() + path.into(), objects);
+        let b = cache
+            .global_vertex
+            .entry(self.id())
+            .or_insert_with(|| {
+                GlobalVertex::from_position(
+                    self.position() + path.into(),
+                    objects,
+                )
+            })
+            .clone();
 
         let vertices = [a, b];
         let global_edge = GlobalEdge::new(curve, vertices.clone());

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -51,8 +51,15 @@ impl HalfEdge {
             the half-edge's global form"
         );
         assert_eq!(
-            &vertices_in_normalized_order,
-            global_form.vertices(),
+            vertices_in_normalized_order
+                .access_in_normalized_order()
+                .clone()
+                .map(|global_vertex| global_vertex.id()),
+            global_form
+                .vertices()
+                .access_in_normalized_order()
+                .clone()
+                .map(|global_vertex| global_vertex.id()),
             "The global forms of a half-edge's vertices must match the \
             vertices of the half-edge's global form"
         );

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -39,6 +39,10 @@ impl HalfEdge {
 
         let curve = a.curve();
 
+        let (vertices_in_normalized_order, _) = VerticesInNormalizedOrder::new(
+            [&a, &b].map(|vertex| vertex.global_form().clone()),
+        );
+
         // Make sure `curve` and `vertices` match `global_form`.
         assert_eq!(
             curve.global_form().id(),
@@ -47,9 +51,7 @@ impl HalfEdge {
             the half-edge's global form"
         );
         assert_eq!(
-            &VerticesInNormalizedOrder::new(
-                [&a, &b].map(|vertex| vertex.global_form().clone())
-            ),
+            &vertices_in_normalized_order,
             global_form.vertices(),
             "The global forms of a half-edge's vertices must match the \
             vertices of the half-edge's global form"
@@ -130,7 +132,7 @@ impl GlobalEdge {
         vertices: [Handle<GlobalVertex>; 2],
     ) -> Self {
         let curve = curve.into();
-        let vertices = VerticesInNormalizedOrder::new(vertices);
+        let (vertices, _) = VerticesInNormalizedOrder::new(vertices);
         Self { curve, vertices }
     }
 
@@ -166,10 +168,14 @@ pub struct VerticesInNormalizedOrder([Handle<GlobalVertex>; 2]);
 impl VerticesInNormalizedOrder {
     /// Construct a new instance of `VerticesInNormalizedOrder`
     ///
-    /// The provided vertices can be in any order.
-    pub fn new([a, b]: [Handle<GlobalVertex>; 2]) -> Self {
-        let vertices = if a < b { [a, b] } else { [b, a] };
-        Self(vertices)
+    /// The provided vertices can be in any order. The returned `bool` value
+    /// indicates whether the normalization changed the order of the vertices.
+    pub fn new([a, b]: [Handle<GlobalVertex>; 2]) -> (Self, bool) {
+        if a < b {
+            (Self([a, b]), false)
+        } else {
+            (Self([b, a]), true)
+        }
     }
 
     /// Access the vertices

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -2,8 +2,8 @@ use fj_math::Point;
 
 use crate::{
     objects::{
-        Curve, GlobalCurve, GlobalEdge, HalfEdge, Objects, Surface,
-        SurfaceVertex, Vertex,
+        Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
+        Surface, SurfaceVertex, Vertex,
     },
     storage::Handle,
 };
@@ -100,6 +100,16 @@ impl MaybePartial<GlobalEdge> {
             Self::Partial(partial) => {
                 partial.curve.as_ref().map(|wrapper| &wrapper.0)
             }
+        }
+    }
+
+    /// Access the vertices
+    pub fn vertices(&self) -> Option<&[Handle<GlobalVertex>; 2]> {
+        match self {
+            Self::Full(full) => {
+                Some(full.vertices().access_in_normalized_order())
+            }
+            Self::Partial(partial) => partial.vertices.as_ref(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -174,6 +174,7 @@ impl PartialHalfEdge {
             let surface_form = Handle::<SurfaceVertex>::partial()
                 .with_surface(surface.clone())
                 .with_position(Some(point));
+
             Vertex::partial().with_surface_form(Some(surface_form))
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -143,7 +143,7 @@ impl PartialHalfEdge {
                     .into()
             });
 
-        let surface_form = Handle::<SurfaceVertex>::partial()
+        let surface_vertex = Handle::<SurfaceVertex>::partial()
             .with_position(Some(path.point_from_path_coords(a_curve)))
             .with_surface(self.surface.clone())
             .with_global_form(Some(global_vertex))
@@ -153,7 +153,7 @@ impl PartialHalfEdge {
             Vertex::partial()
                 .with_position(Some(point_curve))
                 .with_curve(Some(curve.clone()))
-                .with_surface_form(Some(surface_form.clone()))
+                .with_surface_form(Some(surface_vertex.clone()))
                 .into()
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -129,6 +129,8 @@ impl PartialHalfEdge {
             .with_surface(self.surface.clone())
             .as_circle_from_radius(radius);
 
+        let path = curve.path.expect("Expected path that was just created");
+
         let [back, front] = {
             let [a_curve, b_curve] =
                 [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
@@ -142,7 +144,6 @@ impl PartialHalfEdge {
                         .into()
                 });
 
-            let path = curve.path.expect("Expected path that was just created");
             let surface_form = Handle::<SurfaceVertex>::partial()
                 .with_position(Some(path.point_from_path_coords(a_curve)))
                 .with_surface(self.surface.clone())

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -134,7 +134,7 @@ impl PartialHalfEdge {
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        let global_form = self
+        let global_vertex = self
             .extract_global_vertices()
             .map(|[global_form, _]| MaybePartial::from(global_form))
             .unwrap_or_else(|| {
@@ -146,7 +146,7 @@ impl PartialHalfEdge {
         let surface_form = Handle::<SurfaceVertex>::partial()
             .with_position(Some(path.point_from_path_coords(a_curve)))
             .with_surface(self.surface.clone())
-            .with_global_form(Some(global_form))
+            .with_global_form(Some(global_vertex))
             .build(objects);
 
         let [back, front] = [a_curve, b_curve].map(|point_curve| {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -133,8 +133,14 @@ impl PartialHalfEdge {
             let [a_curve, b_curve] =
                 [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-            let global_form = Handle::<GlobalVertex>::partial()
-                .from_curve_and_position(curve.clone(), a_curve);
+            let global_form = self
+                .extract_global_vertices()
+                .map(|[global_form, _]| MaybePartial::from(global_form))
+                .unwrap_or_else(|| {
+                    Handle::<GlobalVertex>::partial()
+                        .from_curve_and_position(curve.clone(), a_curve)
+                        .into()
+                });
 
             let path = curve.path.expect("Expected path that was just created");
             let surface_form = Handle::<SurfaceVertex>::partial()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -131,33 +131,31 @@ impl PartialHalfEdge {
 
         let path = curve.path.expect("Expected path that was just created");
 
-        let [back, front] = {
-            let [a_curve, b_curve] =
-                [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
+        let [a_curve, b_curve] =
+            [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-            let global_form = self
-                .extract_global_vertices()
-                .map(|[global_form, _]| MaybePartial::from(global_form))
-                .unwrap_or_else(|| {
-                    Handle::<GlobalVertex>::partial()
-                        .from_curve_and_position(curve.clone(), a_curve)
-                        .into()
-                });
-
-            let surface_form = Handle::<SurfaceVertex>::partial()
-                .with_position(Some(path.point_from_path_coords(a_curve)))
-                .with_surface(self.surface.clone())
-                .with_global_form(Some(global_form))
-                .build(objects);
-
-            [a_curve, b_curve].map(|point_curve| {
-                Vertex::partial()
-                    .with_position(Some(point_curve))
-                    .with_curve(Some(curve.clone()))
-                    .with_surface_form(Some(surface_form.clone()))
+        let global_form = self
+            .extract_global_vertices()
+            .map(|[global_form, _]| MaybePartial::from(global_form))
+            .unwrap_or_else(|| {
+                Handle::<GlobalVertex>::partial()
+                    .from_curve_and_position(curve.clone(), a_curve)
                     .into()
-            })
-        };
+            });
+
+        let surface_form = Handle::<SurfaceVertex>::partial()
+            .with_position(Some(path.point_from_path_coords(a_curve)))
+            .with_surface(self.surface.clone())
+            .with_global_form(Some(global_form))
+            .build(objects);
+
+        let [back, front] = [a_curve, b_curve].map(|point_curve| {
+            Vertex::partial()
+                .with_position(Some(point_curve))
+                .with_curve(Some(curve.clone()))
+                .with_surface_form(Some(surface_form.clone()))
+                .into()
+        });
 
         self.curve = Some(curve.into());
         self.vertices = [Some(back), Some(front)];

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -36,7 +36,7 @@ impl PartialHalfEdge {
     pub fn extract_global_curve(&self) -> Option<Handle<GlobalCurve>> {
         let global_curve_from_curve = || self.curve.as_ref()?.global_form();
         let global_curve_from_global_form =
-            || Some(self.global_form.as_ref()?.curve()?.clone());
+            || self.global_form.as_ref()?.curve().cloned();
 
         global_curve_from_curve().or_else(global_curve_from_global_form)
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -41,6 +41,11 @@ impl PartialHalfEdge {
         global_curve_from_curve().or_else(global_curve_from_global_form)
     }
 
+    /// Access the vertices of the global form, if available
+    pub fn extract_global_vertices(&self) -> Option<[Handle<GlobalVertex>; 2]> {
+        self.global_form.as_ref()?.vertices().cloned()
+    }
+
     /// Update the partial half-edge with the given surface
     pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
         if let Some(surface) = surface {


### PR DESCRIPTION
Fix all known  `GlobalVertex` duplication issues, i.e. the creation of equal but not identical `GlobalVertex` instances. These issues were found using stricter validation code, which is based on comparing [object identity instead of object equality](https://docs.rs/fj-kernel/0.20.0/fj_kernel/objects/index.html#object-identity-vs-object-equality). This was made possible by the inclusion of `GlobalVertex` in the centralized object storage (#1021).