### PR TITLE
Always require watcher in `fj_window::run`

### DIFF
--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> anyhow::Result<()> {
     let invert_zoom = config.invert_zoom.unwrap_or(false);
 
     let watcher = model.load_and_watch(parameters)?;
-    run(Some(watcher), shape_processor, status, invert_zoom)?;
+    run(watcher, shape_processor, status, invert_zoom)?;
 
     Ok(())
 }

--- a/crates/fj-interop/src/status_report.rs
+++ b/crates/fj-interop/src/status_report.rs
@@ -3,6 +3,7 @@
 use std::collections::VecDeque;
 
 /// Struct to store and update status messages
+#[derive(Default)]
 pub struct StatusReport {
     status: VecDeque<String>,
 }
@@ -10,9 +11,7 @@ pub struct StatusReport {
 impl StatusReport {
     /// Create a new ``StatusReport`` instance with a blank status
     pub fn new() -> Self {
-        Self {
-            status: VecDeque::new(),
-        }
+        Self::default()
     }
 
     /// Update the status
@@ -37,11 +36,5 @@ impl StatusReport {
     /// Reset status
     pub fn clear_status(&mut self) {
         self.status.clear();
-    }
-}
-
-impl Default for StatusReport {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -171,6 +171,8 @@ pub fn run(
                 window.window().request_redraw();
             }
             Event::RedrawRequested(_) => {
+                // Only do a screen resize once per frame. This protects against
+                // spurious resize events that cause issues with the renderer.
                 if let Some(size) = new_size.take() {
                     viewer.handle_screen_resize(size);
                 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -200,8 +200,8 @@ pub fn run(
     });
 }
 
-fn input_event(
-    event: &Event<()>,
+fn input_event<T>(
+    event: &Event<T>,
     window: &Window,
     held_mouse_button: &Option<MouseButton>,
     previous_cursor: &mut Option<NormalizedScreenPosition>,

--- a/crates/fj-window/src/window.rs
+++ b/crates/fj-window/src/window.rs
@@ -8,7 +8,7 @@ pub struct Window(winit::window::Window);
 
 impl Window {
     /// Returns a new window with the given `EventLoop`.
-    pub fn new(event_loop: &EventLoop<()>) -> Result<Self, Error> {
+    pub fn new<T>(event_loop: &EventLoop<T>) -> Result<Self, Error> {
         let window = WindowBuilder::new()
             .with_title("Fornjot")
             .with_maximized(true)


### PR DESCRIPTION
This is a simplification that was made possible by #1242. Also contains some random cleanups.