### PR TITLE
Simplify `fj_window::run` arguments

### DIFF
--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, Context as _};
 use fj_export::export;
-use fj_host::{Model, Parameters, Watcher};
+use fj_host::{Model, Parameters};
 use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_window::run::run;
@@ -90,8 +90,7 @@ fn main() -> anyhow::Result<()> {
 
     let invert_zoom = config.invert_zoom.unwrap_or(false);
 
-    let watcher = Watcher::watch_model(model)?;
-    run(watcher, shape_processor, status, invert_zoom)?;
+    run(model, shape_processor, status, invert_zoom)?;
 
     Ok(())
 }

--- a/crates/fj-app/src/main.rs
+++ b/crates/fj-app/src/main.rs
@@ -20,7 +20,6 @@ use std::path::PathBuf;
 use anyhow::{anyhow, Context as _};
 use fj_export::export;
 use fj_host::{Model, Parameters};
-use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_window::run::run;
 use tracing_subscriber::fmt::format;
@@ -29,7 +28,6 @@ use tracing_subscriber::EnvFilter;
 use crate::{args::Args, config::Config};
 
 fn main() -> anyhow::Result<()> {
-    let status = StatusReport::new();
     // Respect `RUST_LOG`. If that's not defined or erroneous, log warnings and
     // above.
     //
@@ -90,7 +88,7 @@ fn main() -> anyhow::Result<()> {
 
     let invert_zoom = config.invert_zoom.unwrap_or(false);
 
-    run(model, shape_processor, status, invert_zoom)?;
+    run(model, shape_processor, invert_zoom)?;
 
     Ok(())
 }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -29,9 +29,9 @@ use crate::window::{self, Window};
 pub fn run(
     model: Model,
     shape_processor: ShapeProcessor,
-    mut status: StatusReport,
     invert_zoom: bool,
 ) -> Result<(), Error> {
+    let mut status = StatusReport::new();
     let watcher = Watcher::watch_model(model)?;
 
     let event_loop = EventLoop::new();

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -5,7 +5,7 @@
 
 use std::error;
 
-use fj_host::{Watcher, WatcherEvent};
+use fj_host::{Model, Watcher, WatcherEvent};
 use fj_interop::status_report::StatusReport;
 use fj_operations::shape_processor::ShapeProcessor;
 use fj_viewer::{
@@ -27,11 +27,13 @@ use crate::window::{self, Window};
 
 /// Initializes a model viewer for a given model and enters its process loop.
 pub fn run(
-    watcher: Watcher,
+    model: Model,
     shape_processor: ShapeProcessor,
     mut status: StatusReport,
     invert_zoom: bool,
 ) -> Result<(), Error> {
+    let watcher = Watcher::watch_model(model)?;
+
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop)?;
     let mut viewer = block_on(Viewer::new(&window))?;
@@ -289,6 +291,10 @@ fn input_event<T>(
 /// Error in main loop
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Error loading model
+    #[error("Error loading model")]
+    Model(#[from] fj_host::Error),
+
     /// Error initializing window
     #[error("Error initializing window")]
     WindowInit(#[from] window::Error),


### PR DESCRIPTION
These are some cleanups that have become possible thanks to #1244.