### PR TITLE
Integrate `Vertex` into centralized object storage

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -2,7 +2,10 @@
 
 use fj_math::Point;
 
-use crate::objects::{Face, HalfEdge, Vertex};
+use crate::{
+    objects::{Face, HalfEdge, Vertex},
+    storage::Handle,
+};
 
 use super::{
     ray_segment::RaySegmentIntersection, HorizontalRayToTheRight, Intersect,
@@ -123,7 +126,7 @@ pub enum FacePointIntersection {
     PointIsOnEdge(HalfEdge),
 
     /// The point is coincident with a vertex
-    PointIsOnVertex(Vertex),
+    PointIsOnVertex(Handle<Vertex>),
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -6,6 +6,7 @@ use crate::{
     algorithms::intersect::face_point::FacePointIntersection,
     objects::{Face, HalfEdge, Vertex},
     path::GlobalPath,
+    storage::Handle,
 };
 
 use super::{HorizontalRayToTheRight, Intersect};
@@ -136,7 +137,7 @@ pub enum RayFaceIntersection {
     RayHitsEdge(HalfEdge),
 
     /// The ray hits a vertex
-    RayHitsVertex(Vertex),
+    RayHitsVertex(Handle<Vertex>),
 }
 
 #[cfg(test)]

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -77,6 +77,7 @@ impl Sweep for (HalfEdge, Color) {
                         vertex.position(),
                         curve.clone(),
                         surface_vertex,
+                        objects,
                     )
                 })
             };
@@ -134,7 +135,12 @@ impl Sweep for (HalfEdge, Color) {
                 let vertices = [(a_vertex, a_surface), (b_vertex, b_surface)];
 
                 vertices.map(|(vertex, surface_form)| {
-                    Vertex::new(vertex.position(), curve.clone(), surface_form)
+                    Vertex::new(
+                        vertex.position(),
+                        curve.clone(),
+                        surface_form,
+                        objects,
+                    )
                 })
             };
 
@@ -207,11 +213,13 @@ mod tests {
                 .build(&objects);
             let side_up = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .with_back_vertex(Some(Vertex::partial().with_surface_form(
-                    Some(bottom.front().surface_form().clone()),
-                )))
+                .with_back_vertex(Some(
+                    Handle::<Vertex>::partial().with_surface_form(Some(
+                        bottom.front().surface_form().clone(),
+                    )),
+                ))
                 .with_front_vertex(Some(
-                    Vertex::partial().with_surface_form(Some(
+                    Handle::<Vertex>::partial().with_surface_form(Some(
                         Handle::<SurfaceVertex>::partial()
                             .with_position(Some([1., 1.])),
                     )),
@@ -221,25 +229,31 @@ mod tests {
             let top = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
                 .with_back_vertex(Some(
-                    Vertex::partial().with_surface_form(Some(
+                    Handle::<Vertex>::partial().with_surface_form(Some(
                         Handle::<SurfaceVertex>::partial()
                             .with_position(Some([0., 1.])),
                     )),
                 ))
-                .with_front_vertex(Some(Vertex::partial().with_surface_form(
-                    Some(side_up.front().surface_form().clone()),
-                )))
+                .with_front_vertex(Some(
+                    Handle::<Vertex>::partial().with_surface_form(Some(
+                        side_up.front().surface_form().clone(),
+                    )),
+                ))
                 .as_line_segment()
                 .build(&objects)
                 .reverse();
             let side_down = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .with_back_vertex(Some(Vertex::partial().with_surface_form(
-                    Some(bottom.back().surface_form().clone()),
-                )))
-                .with_front_vertex(Some(Vertex::partial().with_surface_form(
-                    Some(top.front().surface_form().clone()),
-                )))
+                .with_back_vertex(Some(
+                    Handle::<Vertex>::partial().with_surface_form(Some(
+                        bottom.back().surface_form().clone(),
+                    )),
+                ))
+                .with_front_vertex(Some(
+                    Handle::<Vertex>::partial().with_surface_form(Some(
+                        top.front().surface_form().clone(),
+                    )),
+                ))
                 .as_line_segment()
                 .build(&objects)
                 .reverse();

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for (Vertex, Handle<Surface>) {
+impl Sweep for (Handle<Vertex>, Handle<Surface>) {
     type Swept = HalfEdge;
 
     fn sweep_with_cache(
@@ -111,6 +111,7 @@ impl Sweep for (Vertex, Handle<Surface>) {
                 [surface_form.position().v],
                 curve.clone(),
                 surface_form,
+                objects,
             )
         });
 
@@ -173,7 +174,7 @@ mod tests {
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let vertex = Vertex::partial()
+        let vertex = Handle::<Vertex>::partial()
             .with_position(Some([0.]))
             .with_curve(Some(curve))
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -214,9 +214,14 @@ mod tests {
             Point::from([Scalar::ZERO + deviation]),
             curve.clone(),
             a_surface,
+            &objects,
         );
-        let b =
-            Vertex::new(Point::from([Scalar::ONE]), curve.clone(), b_surface);
+        let b = Vertex::new(
+            Point::from([Scalar::ONE]),
+            curve.clone(),
+            b_surface,
+            &objects,
+        );
         let vertices = [a, b];
 
         let global_edge = GlobalEdge::partial()

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -91,8 +91,10 @@ impl<'a> ShellBuilder<'a> {
 
                     HalfEdge::partial()
                         .with_vertices(Some([
-                            Vertex::partial().with_surface_form(Some(from)),
-                            Vertex::partial().with_surface_form(Some(to)),
+                            Handle::<Vertex>::partial()
+                                .with_surface_form(Some(from)),
+                            Handle::<Vertex>::partial()
+                                .with_surface_form(Some(to)),
                         ]))
                         .as_line_segment()
                         .build(self.objects)
@@ -128,8 +130,10 @@ impl<'a> ShellBuilder<'a> {
                         HalfEdge::partial()
                             .with_curve(Some(curve))
                             .with_vertices(Some([
-                                Vertex::partial().with_surface_form(Some(from)),
-                                Vertex::partial().with_surface_form(Some(to)),
+                                Handle::<Vertex>::partial()
+                                    .with_surface_form(Some(from)),
+                                Handle::<Vertex>::partial()
+                                    .with_surface_form(Some(to)),
                             ]))
                             .as_line_segment()
                             .build(self.objects)
@@ -148,8 +152,10 @@ impl<'a> ShellBuilder<'a> {
                     let from = from.surface_form().clone();
                     let to = to.surface_form().clone();
 
-                    let from = Vertex::partial().with_surface_form(Some(from));
-                    let to = Vertex::partial().with_surface_form(Some(to));
+                    let from = Handle::<Vertex>::partial()
+                        .with_surface_form(Some(from));
+                    let to =
+                        Handle::<Vertex>::partial().with_surface_form(Some(to));
 
                     HalfEdge::partial()
                         .with_vertices(Some([from, to]))
@@ -231,7 +237,7 @@ impl<'a> ShellBuilder<'a> {
                     (vertex_b, surface_vertex_b),
                 ]
                 .map(|(vertex, surface_form)| {
-                    Vertex::partial()
+                    Handle::<Vertex>::partial()
                         .with_position(Some(vertex.position()))
                         .with_surface_form(Some(surface_form))
                 });

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -129,7 +129,7 @@ pub trait ObjectIters<'r> {
     }
 
     /// Iterator over all vertices
-    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Handle<Vertex>> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
@@ -276,7 +276,7 @@ impl<'r> ObjectIters<'r> for Handle<Surface> {
     }
 }
 
-impl<'r> ObjectIters<'r> for Vertex {
+impl<'r> ObjectIters<'r> for Handle<Vertex> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         vec![
             self.curve() as &dyn ObjectIters,
@@ -284,7 +284,7 @@ impl<'r> ObjectIters<'r> for Vertex {
         ]
     }
 
-    fn vertex_iter(&'r self) -> Iter<&'r Vertex> {
+    fn vertex_iter(&'r self) -> Iter<&'r Handle<Vertex>> {
         Iter::from_object(self)
     }
 }
@@ -591,7 +591,7 @@ mod tests {
         let global_vertex = GlobalVertex::from_position([0., 0., 0.], &objects);
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex, &objects);
-        let object = Vertex::new([0.], curve, surface_vertex);
+        let object = Vertex::new([0.], curve, surface_vertex, &objects);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -9,7 +9,7 @@ use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
-    vertices: [Vertex; 2],
+    vertices: [Handle<Vertex>; 2],
     global_form: GlobalEdge,
 }
 
@@ -29,7 +29,7 @@ impl HalfEdge {
     /// were, the edge would have no length, and thus not be valid. (It is
     /// perfectly fine for global forms of the the vertices to be coincident.
     /// That would just mean, that ends of the edge connect to each other.)
-    pub fn new([a, b]: [Vertex; 2], global_form: GlobalEdge) -> Self {
+    pub fn new([a, b]: [Handle<Vertex>; 2], global_form: GlobalEdge) -> Self {
         // Make sure `curve` and `vertices` match.
         assert_eq!(
             a.curve().id(),
@@ -84,18 +84,18 @@ impl HalfEdge {
     }
 
     /// Access the vertices that bound the half-edge on the curve
-    pub fn vertices(&self) -> &[Vertex; 2] {
+    pub fn vertices(&self) -> &[Handle<Vertex>; 2] {
         &self.vertices
     }
 
     /// Access the vertex at the back of the half-edge
-    pub fn back(&self) -> &Vertex {
+    pub fn back(&self) -> &Handle<Vertex> {
         let [back, _] = self.vertices();
         back
     }
 
     /// Access the vertex at the front of the half-edge
-    pub fn front(&self) -> &Vertex {
+    pub fn front(&self) -> &Handle<Vertex> {
         let [_, front] = self.vertices();
         front
     }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -126,6 +126,9 @@ pub struct Objects {
 
     /// Store for surfaces
     pub surfaces: Surfaces,
+
+    /// Store for vertices
+    pub vertices: Store<Vertex>,
 }
 
 impl Objects {

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -26,7 +26,8 @@ impl Vertex {
         position: impl Into<Point<1>>,
         curve: Handle<Curve>,
         surface_form: Handle<SurfaceVertex>,
-    ) -> Self {
+        objects: &Objects,
+    ) -> Handle<Self> {
         let position = position.into();
 
         assert_eq!(
@@ -35,11 +36,11 @@ impl Vertex {
             "Surface form of vertex must be defined on same surface as curve",
         );
 
-        Self {
+        objects.vertices.insert(Self {
             position,
             curve,
             surface_form,
-        }
+        })
     }
 
     /// Access the position of the vertex on the curve

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -116,7 +116,7 @@ impl MaybePartial<GlobalEdge> {
 
 impl MaybePartial<HalfEdge> {
     /// Access the back vertex
-    pub fn back(&self) -> Option<MaybePartial<Vertex>> {
+    pub fn back(&self) -> Option<MaybePartial<Handle<Vertex>>> {
         match self {
             Self::Full(full) => Some(full.back().clone().into()),
             Self::Partial(partial) => {
@@ -127,7 +127,7 @@ impl MaybePartial<HalfEdge> {
     }
 
     /// Access the front vertex
-    pub fn front(&self) -> Option<MaybePartial<Vertex>> {
+    pub fn front(&self) -> Option<MaybePartial<Handle<Vertex>>> {
         match self {
             Self::Full(full) => Some(full.front().clone().into()),
             Self::Partial(partial) => {
@@ -138,7 +138,7 @@ impl MaybePartial<HalfEdge> {
     }
 
     /// Access the vertices
-    pub fn vertices(&self) -> [Option<MaybePartial<Vertex>>; 2] {
+    pub fn vertices(&self) -> [Option<MaybePartial<Handle<Vertex>>>; 2] {
         match self {
             Self::Full(full) => {
                 full.vertices().clone().map(|vertex| Some(vertex.into()))
@@ -166,7 +166,7 @@ impl MaybePartial<Handle<SurfaceVertex>> {
     }
 }
 
-impl MaybePartial<Vertex> {
+impl MaybePartial<Handle<Vertex>> {
     /// Access the surface form
     pub fn surface_form(&self) -> Option<MaybePartial<Handle<SurfaceVertex>>> {
         match self {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -88,7 +88,7 @@ impl PartialCycle {
 
                 let [from, to] =
                     [(0., from), (1., to)].map(|(position, surface_form)| {
-                        Vertex::partial()
+                        Handle::<Vertex>::partial()
                             .with_curve(Some(curve.clone()))
                             .with_position(Some([position]))
                             .with_surface_form(Some(surface_form))

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -21,7 +21,7 @@ pub struct PartialHalfEdge {
     pub curve: Option<MaybePartial<Handle<Curve>>>,
 
     /// The vertices that bound this [`HalfEdge`] in the [`Curve`]
-    pub vertices: [Option<MaybePartial<Vertex>>; 2],
+    pub vertices: [Option<MaybePartial<Handle<Vertex>>>; 2],
 
     /// The global form of the [`HalfEdge`]
     ///
@@ -68,7 +68,7 @@ impl PartialHalfEdge {
     /// Update the partial half-edge with the given from vertex
     pub fn with_back_vertex(
         mut self,
-        vertex: Option<impl Into<MaybePartial<Vertex>>>,
+        vertex: Option<impl Into<MaybePartial<Handle<Vertex>>>>,
     ) -> Self {
         if let Some(vertex) = vertex {
             let [from, _] = &mut self.vertices;
@@ -80,7 +80,7 @@ impl PartialHalfEdge {
     /// Update the partial half-edge with the given from vertex
     pub fn with_front_vertex(
         mut self,
-        vertex: Option<impl Into<MaybePartial<Vertex>>>,
+        vertex: Option<impl Into<MaybePartial<Handle<Vertex>>>>,
     ) -> Self {
         if let Some(vertex) = vertex {
             let [_, to] = &mut self.vertices;
@@ -92,7 +92,7 @@ impl PartialHalfEdge {
     /// Update the partial half-edge with the given vertices
     pub fn with_vertices(
         mut self,
-        vertices: Option<[impl Into<MaybePartial<Vertex>>; 2]>,
+        vertices: Option<[impl Into<MaybePartial<Handle<Vertex>>>; 2]>,
     ) -> Self {
         let vertices = vertices.map(|vertices| vertices.map(Into::into));
         if let Some([back, front]) = vertices {
@@ -150,7 +150,7 @@ impl PartialHalfEdge {
             .build(objects);
 
         let [back, front] = [a_curve, b_curve].map(|point_curve| {
-            Vertex::partial()
+            Handle::<Vertex>::partial()
                 .with_position(Some(point_curve))
                 .with_curve(Some(curve.clone()))
                 .with_surface_form(Some(surface_vertex.clone()))
@@ -174,7 +174,7 @@ impl PartialHalfEdge {
                 .with_surface(surface.clone())
                 .with_position(Some(point));
 
-            Vertex::partial().with_surface_form(Some(surface_form))
+            Handle::<Vertex>::partial().with_surface_form(Some(surface_form))
         });
 
         self.with_vertices(Some(vertices)).as_line_segment()
@@ -346,7 +346,7 @@ impl PartialGlobalEdge {
     pub fn from_curve_and_vertices(
         self,
         curve: &Curve,
-        vertices: &[Vertex; 2],
+        vertices: &[Handle<Vertex>; 2],
     ) -> Self {
         self.with_curve(Some(curve.global_form().clone()))
             .with_vertices(Some(

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -48,5 +48,5 @@ impl_traits!(
     Handle<GlobalVertex>, PartialGlobalVertex;
     HalfEdge, PartialHalfEdge;
     Handle<SurfaceVertex>, PartialSurfaceVertex;
-    Vertex, PartialVertex;
+    Handle<Vertex>, PartialVertex;
 );

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -86,7 +86,7 @@ impl PartialVertex {
     /// Panics, if no position has been provided.
     ///
     /// Panics, if no curve has been provided.
-    pub fn build(self, objects: &Objects) -> Vertex {
+    pub fn build(self, objects: &Objects) -> Handle<Vertex> {
         let position = self
             .position
             .expect("Cant' build `Vertex` without position");
@@ -110,12 +110,12 @@ impl PartialVertex {
             })
             .into_full(objects);
 
-        Vertex::new(position, curve, surface_form)
+        Vertex::new(position, curve, surface_form, objects)
     }
 }
 
-impl From<&Vertex> for PartialVertex {
-    fn from(vertex: &Vertex) -> Self {
+impl From<&Handle<Vertex>> for PartialVertex {
+    fn from(vertex: &Handle<Vertex>) -> Self {
         Self {
             position: Some(vertex.position()),
             curve: Some(vertex.curve().clone().into()),


### PR DESCRIPTION
This is another step towards addressing #1021. This one was pretty easy, as `Vertex` isn't shared much between objects, and thus there isn't much room for object duplication issues.