### PR TITLE
Integrate `GlobalEdge` into centralized object storage

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -125,6 +125,7 @@ impl Sweep for (HalfEdge, Color) {
                 surface_vertices
                     .clone()
                     .map(|surface_vertex| surface_vertex.global_form().clone()),
+                objects,
             );
 
             let vertices = {

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -122,7 +122,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 }
 
 impl Sweep for Handle<GlobalVertex> {
-    type Swept = (GlobalEdge, [Handle<GlobalVertex>; 2]);
+    type Swept = (Handle<GlobalEdge>, [Handle<GlobalVertex>; 2]);
 
     fn sweep_with_cache(
         self,
@@ -145,7 +145,7 @@ impl Sweep for Handle<GlobalVertex> {
             .clone();
 
         let vertices = [a, b];
-        let global_edge = GlobalEdge::new(curve, vertices.clone());
+        let global_edge = GlobalEdge::new(curve, vertices.clone(), objects);
 
         // The vertices of the returned `GlobalEdge` are in normalized order,
         // which means the order can't be relied upon by the caller. Return the

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -171,6 +171,7 @@ mod tests {
         },
         partial::HasPartial,
         path::SurfacePath,
+        storage::Handle,
     };
 
     #[test]
@@ -224,7 +225,7 @@ mod tests {
         );
         let vertices = [a, b];
 
-        let global_edge = GlobalEdge::partial()
+        let global_edge = Handle::<GlobalEdge>::partial()
             .from_curve_and_vertices(&curve, &vertices)
             .build(&objects);
         let half_edge = HalfEdge::new(vertices, global_edge);

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -4,13 +4,13 @@ use pretty_assertions::{assert_eq, assert_ne};
 
 use crate::storage::{Handle, HandleWrapper};
 
-use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
+use super::{Curve, GlobalCurve, GlobalVertex, Objects, Vertex};
 
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
     vertices: [Handle<Vertex>; 2],
-    global_form: GlobalEdge,
+    global_form: Handle<GlobalEdge>,
 }
 
 impl HalfEdge {
@@ -29,7 +29,10 @@ impl HalfEdge {
     /// were, the edge would have no length, and thus not be valid. (It is
     /// perfectly fine for global forms of the the vertices to be coincident.
     /// That would just mean, that ends of the edge connect to each other.)
-    pub fn new([a, b]: [Handle<Vertex>; 2], global_form: GlobalEdge) -> Self {
+    pub fn new(
+        [a, b]: [Handle<Vertex>; 2],
+        global_form: Handle<GlobalEdge>,
+    ) -> Self {
         // Make sure `curve` and `vertices` match.
         assert_eq!(
             a.curve().id(),
@@ -101,7 +104,7 @@ impl HalfEdge {
     }
 
     /// Access the global form of this half-edge
-    pub fn global_form(&self) -> &GlobalEdge {
+    pub fn global_form(&self) -> &Handle<GlobalEdge> {
         &self.global_form
     }
 }
@@ -137,10 +140,12 @@ impl GlobalEdge {
     pub fn new(
         curve: impl Into<HandleWrapper<GlobalCurve>>,
         vertices: [Handle<GlobalVertex>; 2],
-    ) -> Self {
+        objects: &Objects,
+    ) -> Handle<Self> {
         let curve = curve.into();
         let (vertices, _) = VerticesInNormalizedOrder::new(vertices);
-        Self { curve, vertices }
+
+        objects.global_edges.insert(Self { curve, vertices })
     }
 
     /// Access the curve that defines the edge's geometry

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -118,6 +118,9 @@ pub struct Objects {
     /// Store for global curves
     pub global_curves: Store<GlobalCurve>,
 
+    /// Store for global edges
+    pub global_edges: Store<GlobalEdge>,
+
     /// Store for global vertices
     pub global_vertices: Store<GlobalVertex>,
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -92,7 +92,7 @@ impl MaybePartial<Handle<Curve>> {
     }
 }
 
-impl MaybePartial<GlobalEdge> {
+impl MaybePartial<Handle<GlobalEdge>> {
     /// Access the curve
     pub fn curve(&self) -> Option<&Handle<GlobalCurve>> {
         match self {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -26,7 +26,7 @@ pub struct PartialHalfEdge {
     /// The global form of the [`HalfEdge`]
     ///
     /// Can be computed by [`PartialHalfEdge::build`], if not available.
-    pub global_form: Option<MaybePartial<GlobalEdge>>,
+    pub global_form: Option<MaybePartial<Handle<GlobalEdge>>>,
 }
 
 impl PartialHalfEdge {
@@ -104,7 +104,7 @@ impl PartialHalfEdge {
     /// Update the partial half-edge with the given global form
     pub fn with_global_form(
         mut self,
-        global_form: Option<impl Into<MaybePartial<GlobalEdge>>>,
+        global_form: Option<impl Into<MaybePartial<Handle<GlobalEdge>>>>,
     ) -> Self {
         if let Some(global_form) = global_form {
             self.global_form = Some(global_form.into());
@@ -282,7 +282,7 @@ impl PartialHalfEdge {
 
         let global_form = self
             .global_form
-            .unwrap_or_else(|| GlobalEdge::partial().into())
+            .unwrap_or_else(|| Handle::<GlobalEdge>::partial().into())
             .update_partial(|partial| {
                 partial.from_curve_and_vertices(&curve, &vertices)
             })
@@ -355,7 +355,7 @@ impl PartialGlobalEdge {
     }
 
     /// Build a full [`GlobalEdge`] from the partial global edge
-    pub fn build(self, _: &Objects) -> GlobalEdge {
+    pub fn build(self, objects: &Objects) -> Handle<GlobalEdge> {
         let curve = self
             .curve
             .expect("Can't build `GlobalEdge` without `GlobalCurve`");
@@ -363,12 +363,12 @@ impl PartialGlobalEdge {
             .vertices
             .expect("Can't build `GlobalEdge` without vertices");
 
-        GlobalEdge::new(curve, vertices)
+        GlobalEdge::new(curve, vertices, objects)
     }
 }
 
-impl From<&GlobalEdge> for PartialGlobalEdge {
-    fn from(global_edge: &GlobalEdge) -> Self {
+impl From<&Handle<GlobalEdge>> for PartialGlobalEdge {
+    fn from(global_edge: &Handle<GlobalEdge>) -> Self {
         Self {
             curve: Some(global_edge.curve().clone().into()),
             vertices: Some(

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -44,7 +44,7 @@ macro_rules! impl_traits {
 impl_traits!(
     Handle<Curve>, PartialCurve;
     Cycle, PartialCycle;
-    GlobalEdge, PartialGlobalEdge;
+    Handle<GlobalEdge>, PartialGlobalEdge;
     Handle<GlobalVertex>, PartialGlobalVertex;
     HalfEdge, PartialHalfEdge;
     Handle<SurfaceVertex>, PartialSurfaceVertex;


### PR DESCRIPTION
This is another step towards addressing #1021. This was another easy one, although I suspect that in this case, this is due to the lack of much validation code that *could* catch issues with `GlobalEdge`s.