### PR TITLE
Integrate `HalfEdge` into centralized object storage

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -91,7 +91,7 @@ mod tests {
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = HalfEdge::partial()
+        let half_edge = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[1., -1.], [1., 1.]])
             .build(&objects);
@@ -115,7 +115,7 @@ mod tests {
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = HalfEdge::partial()
+        let half_edge = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[-1., -1.], [-1., 1.]])
             .build(&objects);
@@ -139,7 +139,7 @@ mod tests {
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = HalfEdge::partial()
+        let half_edge = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[-1., -1.], [1., -1.]])
             .build(&objects);
@@ -158,7 +158,7 @@ mod tests {
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = HalfEdge::partial()
+        let half_edge = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[-1., 0.], [1., 0.]])
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -123,7 +123,7 @@ pub enum FacePointIntersection {
     PointIsInsideFace,
 
     /// The point is coincident with an edge
-    PointIsOnEdge(HalfEdge),
+    PointIsOnEdge(Handle<HalfEdge>),
 
     /// The point is coincident with a vertex
     PointIsOnVertex(Handle<Vertex>),

--- a/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_edge.rs
@@ -6,11 +6,12 @@ use crate::{
     algorithms::intersect::{HorizontalRayToTheRight, Intersect},
     objects::HalfEdge,
     path::SurfacePath,
+    storage::Handle,
 };
 
 use super::ray_segment::RaySegmentIntersection;
 
-impl Intersect for (&HorizontalRayToTheRight<2>, &HalfEdge) {
+impl Intersect for (&HorizontalRayToTheRight<2>, &Handle<HalfEdge>) {
     type Intersection = RaySegmentIntersection;
 
     fn intersect(self) -> Option<Self::Intersection> {

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -134,7 +134,7 @@ pub enum RayFaceIntersection {
     RayHitsFaceAndAreParallel,
 
     /// The ray hits an edge
-    RayHitsEdge(HalfEdge),
+    RayHitsEdge(Handle<HalfEdge>),
 
     /// The ray hits a vertex
     RayHitsVertex(Handle<Vertex>),

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -1,14 +1,14 @@
-use crate::objects::Cycle;
+use crate::objects::{Cycle, Objects};
 
 use super::Reverse;
 
 impl Reverse for Cycle {
-    fn reverse(self) -> Self {
+    fn reverse(self, objects: &Objects) -> Self {
         let surface = self.surface().clone();
 
         let mut edges = self
             .into_half_edges()
-            .map(|edge| edge.reverse())
+            .map(|edge| edge.reverse(objects))
             .collect::<Vec<_>>();
 
         edges.reverse();

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -1,14 +1,17 @@
-use crate::objects::{HalfEdge, Objects};
+use crate::{
+    objects::{HalfEdge, Objects},
+    storage::Handle,
+};
 
 use super::Reverse;
 
-impl Reverse for HalfEdge {
-    fn reverse(self, _: &Objects) -> Self {
+impl Reverse for Handle<HalfEdge> {
+    fn reverse(self, objects: &Objects) -> Self {
         let vertices = {
             let [a, b] = self.vertices().clone();
             [b, a]
         };
 
-        HalfEdge::new(vertices, self.global_form().clone())
+        HalfEdge::new(vertices, self.global_form().clone(), objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -1,9 +1,9 @@
-use crate::objects::HalfEdge;
+use crate::objects::{HalfEdge, Objects};
 
 use super::Reverse;
 
 impl Reverse for HalfEdge {
-    fn reverse(self) -> Self {
+    fn reverse(self, _: &Objects) -> Self {
         let vertices = {
             let [a, b] = self.vertices().clone();
             [b, a]

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -1,11 +1,12 @@
-use crate::objects::Face;
+use crate::objects::{Face, Objects};
 
 use super::Reverse;
 
 impl Reverse for Face {
-    fn reverse(self) -> Self {
-        let exterior = self.exterior().clone().reverse();
-        let interiors = self.interiors().map(|cycle| cycle.clone().reverse());
+    fn reverse(self, objects: &Objects) -> Self {
+        let exterior = self.exterior().clone().reverse(objects);
+        let interiors =
+            self.interiors().map(|cycle| cycle.clone().reverse(objects));
 
         Face::from_exterior(exterior)
             .with_interiors(interiors)

--- a/crates/fj-kernel/src/algorithms/reverse/mod.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/mod.rs
@@ -1,5 +1,7 @@
 //! Reverse the direction/orientation of objects
 
+use crate::objects::Objects;
+
 mod cycle;
 mod edge;
 mod face;
@@ -8,5 +10,5 @@ mod face;
 pub trait Reverse {
     /// Reverse the direction/orientation of the object
     #[must_use]
-    fn reverse(self) -> Self;
+    fn reverse(self, objects: &Objects) -> Self;
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -169,7 +169,7 @@ impl Sweep for (HalfEdge, Color) {
                 if prev_last.surface_form().id()
                     != next_first.surface_form().id()
                 {
-                    edges[j] = edges[j].clone().reverse();
+                    edges[j] = edges[j].clone().reverse(objects);
                 }
 
                 i += 1;
@@ -242,7 +242,7 @@ mod tests {
                 ))
                 .as_line_segment()
                 .build(&objects)
-                .reverse();
+                .reverse(&objects);
             let side_down = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
                 .with_back_vertex(Some(
@@ -257,7 +257,7 @@ mod tests {
                 ))
                 .as_line_segment()
                 .build(&objects)
-                .reverse();
+                .reverse(&objects);
 
             let cycle = Cycle::new(surface, [bottom, side_up, top, side_down]);
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -8,11 +8,12 @@ use crate::{
         Vertex,
     },
     path::SurfacePath,
+    storage::Handle,
 };
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for (HalfEdge, Color) {
+impl Sweep for (Handle<HalfEdge>, Color) {
     type Swept = Face;
 
     fn sweep_with_cache(
@@ -82,7 +83,7 @@ impl Sweep for (HalfEdge, Color) {
                 })
             };
 
-            HalfEdge::new(vertices, edge.global_form().clone())
+            HalfEdge::new(vertices, edge.global_form().clone(), objects)
         };
 
         let side_edges = bottom_edge.vertices().clone().map(|vertex| {
@@ -145,7 +146,7 @@ impl Sweep for (HalfEdge, Color) {
                 })
             };
 
-            HalfEdge::new(vertices, global)
+            HalfEdge::new(vertices, global, objects)
         };
 
         let cycle = {
@@ -198,7 +199,7 @@ mod tests {
     fn sweep() {
         let objects = Objects::new();
 
-        let half_edge = HalfEdge::partial()
+        let half_edge = Handle::<HalfEdge>::partial()
             .with_surface(Some(objects.surfaces.xy_plane()))
             .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&objects);
@@ -208,11 +209,11 @@ mod tests {
         let expected_face = {
             let surface = objects.surfaces.xz_plane();
 
-            let bottom = HalfEdge::partial()
+            let bottom = Handle::<HalfEdge>::partial()
                 .with_surface(Some(surface.clone()))
                 .as_line_segment_from_points([[0., 0.], [1., 0.]])
                 .build(&objects);
-            let side_up = HalfEdge::partial()
+            let side_up = Handle::<HalfEdge>::partial()
                 .with_surface(Some(surface.clone()))
                 .with_back_vertex(Some(
                     Handle::<Vertex>::partial().with_surface_form(Some(
@@ -227,7 +228,7 @@ mod tests {
                 ))
                 .as_line_segment()
                 .build(&objects);
-            let top = HalfEdge::partial()
+            let top = Handle::<HalfEdge>::partial()
                 .with_surface(Some(surface.clone()))
                 .with_back_vertex(Some(
                     Handle::<Vertex>::partial().with_surface_form(Some(
@@ -243,7 +244,7 @@ mod tests {
                 .as_line_segment()
                 .build(&objects)
                 .reverse(&objects);
-            let side_down = HalfEdge::partial()
+            let side_down = Handle::<HalfEdge>::partial()
                 .with_surface(Some(surface.clone()))
                 .with_back_vertex(Some(
                     Handle::<Vertex>::partial().with_surface_form(Some(

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -84,6 +84,7 @@ mod tests {
         algorithms::{reverse::Reverse, transform::TransformObject},
         objects::{Face, HalfEdge, Objects, Sketch},
         partial::HasPartial,
+        storage::Handle,
     };
 
     use super::Sweep;
@@ -120,7 +121,7 @@ mod tests {
             // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
             let [a, b] = [window[0], window[1]];
 
-            let half_edge = HalfEdge::partial()
+            let half_edge = Handle::<HalfEdge>::partial()
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects);
@@ -158,7 +159,7 @@ mod tests {
             // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
             let [a, b] = [window[0], window[1]];
 
-            let half_edge = HalfEdge::partial()
+            let half_edge = Handle::<HalfEdge>::partial()
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects)

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -40,7 +40,7 @@ impl Sweep for Face {
             if is_negative_sweep {
                 self.clone()
             } else {
-                self.clone().reverse()
+                self.clone().reverse(objects)
             }
         };
         faces.push(bottom_face);
@@ -49,7 +49,7 @@ impl Sweep for Face {
             let mut face = self.clone().translate(path, objects);
 
             if is_negative_sweep {
-                face = face.reverse();
+                face = face.reverse(objects);
             };
 
             face
@@ -60,7 +60,7 @@ impl Sweep for Face {
         for cycle in self.all_cycles() {
             for half_edge in cycle.half_edges() {
                 let half_edge = if is_negative_sweep {
-                    half_edge.clone().reverse()
+                    half_edge.clone().reverse(objects)
                 } else {
                     half_edge.clone()
                 };
@@ -105,7 +105,7 @@ mod tests {
         let bottom = Face::builder(&objects, surface.clone())
             .with_exterior_polygon_from_points(TRIANGLE)
             .build()
-            .reverse();
+            .reverse(&objects);
         let top = Face::builder(&objects, surface.translate(UP, &objects))
             .with_exterior_polygon_from_points(TRIANGLE)
             .build();
@@ -143,7 +143,7 @@ mod tests {
             Face::builder(&objects, surface.clone().translate(DOWN, &objects))
                 .with_exterior_polygon_from_points(TRIANGLE)
                 .build()
-                .reverse();
+                .reverse(&objects);
         let top = Face::builder(&objects, surface)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build();
@@ -162,7 +162,7 @@ mod tests {
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects)
-                .reverse();
+                .reverse(&objects);
             (half_edge, Color::default()).sweep(DOWN, &objects)
         });
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{Sweep, SweepCache};
 
 impl Sweep for (Handle<Vertex>, Handle<Surface>) {
-    type Swept = HalfEdge;
+    type Swept = Handle<HalfEdge>;
 
     fn sweep_with_cache(
         self,
@@ -117,7 +117,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.
-        HalfEdge::new(vertices, edge_global)
+        HalfEdge::new(vertices, edge_global, objects)
     }
 }
 
@@ -181,7 +181,7 @@ mod tests {
 
         let half_edge = (vertex, surface.clone()).sweep([0., 0., 1.], &objects);
 
-        let expected_half_edge = HalfEdge::partial()
+        let expected_half_edge = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[0., 0.], [0., 1.]])
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -228,7 +228,7 @@ mod tests {
         let global_edge = Handle::<GlobalEdge>::partial()
             .from_curve_and_vertices(&curve, &vertices)
             .build(&objects);
-        let half_edge = HalfEdge::new(vertices, global_edge);
+        let half_edge = HalfEdge::new(vertices, global_edge, &objects);
 
         let result =
             half_edge.clone().validate_with_config(&ValidationConfig {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -69,7 +69,7 @@ impl<'a> ShellBuilder<'a> {
                 .half_edges()
                 .zip(&surfaces)
                 .map(|(half_edge, surface)| {
-                    HalfEdge::partial()
+                    Handle::<HalfEdge>::partial()
                         .with_surface(Some(surface.clone()))
                         .with_global_form(Some(half_edge.global_form().clone()))
                         .as_line_segment_from_points([[Z, Z], [edge_length, Z]])
@@ -89,7 +89,7 @@ impl<'a> ShellBuilder<'a> {
                         .with_position(Some(from.position() + [Z, edge_length]))
                         .with_surface(Some(surface.clone()));
 
-                    HalfEdge::partial()
+                    Handle::<HalfEdge>::partial()
                         .with_vertices(Some([
                             Handle::<Vertex>::partial()
                                 .with_surface_form(Some(from)),
@@ -127,7 +127,7 @@ impl<'a> ShellBuilder<'a> {
                                 side_up_prev.curve().global_form().clone(),
                             ));
 
-                        HalfEdge::partial()
+                        Handle::<HalfEdge>::partial()
                             .with_curve(Some(curve))
                             .with_vertices(Some([
                                 Handle::<Vertex>::partial()
@@ -157,7 +157,7 @@ impl<'a> ShellBuilder<'a> {
                     let to =
                         Handle::<Vertex>::partial().with_surface_form(Some(to));
 
-                    HalfEdge::partial()
+                    Handle::<HalfEdge>::partial()
                         .with_vertices(Some([from, to]))
                         .as_line_segment()
                         .build(self.objects)
@@ -243,7 +243,7 @@ impl<'a> ShellBuilder<'a> {
                 });
 
                 edges.push(
-                    HalfEdge::partial()
+                    Handle::<HalfEdge>::partial()
                         .with_vertices(Some(vertices))
                         .with_global_form(Some(edge.global_form().clone()))
                         .as_line_segment()

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -74,7 +74,7 @@ pub trait ObjectIters<'r> {
     }
 
     /// Iterate over all half-edges
-    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
+    fn half_edge_iter(&'r self) -> Iter<&'r Handle<HalfEdge>> {
         let mut iter = Iter::empty();
 
         for object in self.referenced_objects() {
@@ -202,7 +202,7 @@ impl<'r> ObjectIters<'r> for Handle<GlobalVertex> {
     }
 }
 
-impl<'r> ObjectIters<'r> for HalfEdge {
+impl<'r> ObjectIters<'r> for Handle<HalfEdge> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         let mut objects = vec![self.curve() as &dyn ObjectIters];
 
@@ -213,7 +213,7 @@ impl<'r> ObjectIters<'r> for HalfEdge {
         objects
     }
 
-    fn half_edge_iter(&'r self) -> Iter<&'r HalfEdge> {
+    fn half_edge_iter(&'r self) -> Iter<&'r Handle<HalfEdge>> {
         Iter::from_object(self)
     }
 }
@@ -481,7 +481,7 @@ mod tests {
     fn half_edge() {
         let objects = Objects::new();
 
-        let object = HalfEdge::partial()
+        let object = Handle::<HalfEdge>::partial()
             .with_surface(Some(objects.surfaces.xy_plane()))
             .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&objects);

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -9,7 +9,7 @@ use super::{HalfEdge, Surface};
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
     surface: Handle<Surface>,
-    half_edges: Vec<HalfEdge>,
+    half_edges: Vec<Handle<HalfEdge>>,
 }
 
 impl Cycle {
@@ -21,7 +21,7 @@ impl Cycle {
     /// the next one.
     pub fn new(
         surface: Handle<Surface>,
-        half_edges: impl IntoIterator<Item = HalfEdge>,
+        half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
     ) -> Self {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
 
@@ -81,7 +81,7 @@ impl Cycle {
     }
 
     /// Access the half-edges that make up the cycle
-    pub fn half_edges(&self) -> impl Iterator<Item = &HalfEdge> + '_ {
+    pub fn half_edges(&self) -> impl Iterator<Item = &Handle<HalfEdge>> + '_ {
         self.half_edges.iter()
     }
 
@@ -150,7 +150,7 @@ impl Cycle {
     }
 
     /// Consume the cycle and return its half-edges
-    pub fn into_half_edges(self) -> impl Iterator<Item = HalfEdge> {
+    pub fn into_half_edges(self) -> impl Iterator<Item = Handle<HalfEdge>> {
         self.half_edges.into_iter()
     }
 }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -32,7 +32,8 @@ impl HalfEdge {
     pub fn new(
         [a, b]: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
-    ) -> Self {
+        objects: &Objects,
+    ) -> Handle<Self> {
         // Make sure `curve` and `vertices` match.
         assert_eq!(
             a.curve().id(),
@@ -74,10 +75,10 @@ impl HalfEdge {
             "Vertices of an edge must not be coincident on curve"
         );
 
-        Self {
+        objects.half_edges.insert(Self {
             vertices: [a, b],
             global_form,
-        }
+        })
     }
 
     /// Access the curve that defines the half-edge's geometry
@@ -202,7 +203,7 @@ impl VerticesInNormalizedOrder {
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use crate::{objects::Objects, partial::HasPartial};
+    use crate::{objects::Objects, partial::HasPartial, storage::Handle};
 
     use super::HalfEdge;
 
@@ -215,11 +216,11 @@ mod tests {
         let a = [0., 0.];
         let b = [1., 0.];
 
-        let a_to_b = HalfEdge::partial()
+        let a_to_b = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface.clone()))
             .as_line_segment_from_points([a, b])
             .build(&objects);
-        let b_to_a = HalfEdge::partial()
+        let b_to_a = Handle::<HalfEdge>::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([b, a])
             .build(&objects);

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -124,6 +124,9 @@ pub struct Objects {
     /// Store for global vertices
     pub global_vertices: Store<GlobalVertex>,
 
+    /// Store for half-edges
+    pub half_edges: Store<HalfEdge>,
+
     /// Store for surface vertices
     pub surface_vertices: Store<SurfaceVertex>,
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -114,7 +114,7 @@ impl MaybePartial<Handle<GlobalEdge>> {
     }
 }
 
-impl MaybePartial<HalfEdge> {
+impl MaybePartial<Handle<HalfEdge>> {
     /// Access the back vertex
     pub fn back(&self) -> Option<MaybePartial<Handle<Vertex>>> {
         match self {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -17,7 +17,7 @@ pub struct PartialCycle {
     pub surface: Option<Handle<Surface>>,
 
     /// The half-edges that make up the [`Cycle`]
-    pub half_edges: Vec<MaybePartial<HalfEdge>>,
+    pub half_edges: Vec<MaybePartial<Handle<HalfEdge>>>,
 }
 
 impl PartialCycle {
@@ -32,7 +32,9 @@ impl PartialCycle {
     /// Update the partial cycle with the given half-edges
     pub fn with_half_edges(
         mut self,
-        half_edge: impl IntoIterator<Item = impl Into<MaybePartial<HalfEdge>>>,
+        half_edge: impl IntoIterator<
+            Item = impl Into<MaybePartial<Handle<HalfEdge>>>,
+        >,
     ) -> Self {
         self.half_edges
             .extend(half_edge.into_iter().map(Into::into));
@@ -95,7 +97,7 @@ impl PartialCycle {
                     });
 
                 self.half_edges.push(
-                    HalfEdge::partial()
+                    Handle::<HalfEdge>::partial()
                         .with_curve(Some(curve))
                         .with_vertices(Some([from, to]))
                         .into(),
@@ -149,7 +151,7 @@ impl PartialCycle {
                 self.surface.clone().expect("Need surface to close cycle");
 
             self.half_edges.push(
-                HalfEdge::partial()
+                Handle::<HalfEdge>::partial()
                     .with_surface(Some(surface))
                     .as_line_segment_from_points(vertices)
                     .into(),

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -266,7 +266,7 @@ impl PartialHalfEdge {
     }
 
     /// Build a full [`HalfEdge`] from the partial half-edge
-    pub fn build(self, objects: &Objects) -> HalfEdge {
+    pub fn build(self, objects: &Objects) -> Handle<HalfEdge> {
         let surface = self.surface;
         let curve = self
             .curve
@@ -288,12 +288,12 @@ impl PartialHalfEdge {
             })
             .into_full(objects);
 
-        HalfEdge::new(vertices, global_form)
+        HalfEdge::new(vertices, global_form, objects)
     }
 }
 
-impl From<&HalfEdge> for PartialHalfEdge {
-    fn from(half_edge: &HalfEdge) -> Self {
+impl From<&Handle<HalfEdge>> for PartialHalfEdge {
+    fn from(half_edge: &Handle<HalfEdge>) -> Self {
         let [back_vertex, front_vertex] =
             half_edge.vertices().clone().map(Into::into);
 

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -46,7 +46,7 @@ impl_traits!(
     Cycle, PartialCycle;
     Handle<GlobalEdge>, PartialGlobalEdge;
     Handle<GlobalVertex>, PartialGlobalVertex;
-    HalfEdge, PartialHalfEdge;
+    Handle<HalfEdge>, PartialHalfEdge;
     Handle<SurfaceVertex>, PartialSurfaceVertex;
     Handle<Vertex>, PartialVertex;
 );

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -50,7 +50,7 @@ impl Shape for fj::Difference2d {
 
                 exteriors.push(face.exterior().clone());
                 for cycle in face.interiors() {
-                    interiors.push(cycle.clone().reverse());
+                    interiors.push(cycle.clone().reverse(objects));
                 }
             }
 
@@ -61,7 +61,7 @@ impl Shape for fj::Difference2d {
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                interiors.push(face.exterior().clone().reverse());
+                interiors.push(face.exterior().clone().reverse(objects));
             }
 
             // Faces only support one exterior, while the code here comes from

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,6 +5,7 @@ use fj_kernel::{
     },
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
     partial::HasPartial,
+    storage::Handle,
 };
 use fj_math::{Aabb, Point};
 
@@ -26,7 +27,7 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let half_edge = HalfEdge::partial()
+                let half_edge = Handle::<HalfEdge>::partial()
                     .with_surface(Some(surface.clone()))
                     .as_circle_from_radius(circle.radius(), objects)
                     .build(objects);


### PR DESCRIPTION
And another step towards addressing #1021. And yet another one that was relatively easy. In this case, I think it's again a case of `HalfEdge` not being shared much between other objects, so there's not much opportunity for object validation issues to spring up.