### PR TITLE
Add extension traits for arrays and slices

### DIFF
--- a/crates/fj-interop/src/ext.rs
+++ b/crates/fj-interop/src/ext.rs
@@ -7,6 +7,13 @@ pub trait ArrayExt<T, const N: usize> {
     /// <https://doc.rust-lang.org/std/primitive.array.html#method.each_ref>
     fn each_ref_ext(&self) -> [&T; N];
 
+    /// Stable replacement for `try_map`
+    ///
+    /// <https://doc.rust-lang.org/std/primitive.array.html#method.try_map>
+    fn try_map_ext<F, U, E>(self, f: F) -> Result<[U; N], E>
+    where
+        F: FnMut(T) -> Result<U, E>;
+
     /// Stable replacement for `zip`
     ///
     /// <https://doc.rust-lang.org/std/primitive.array.html#method.zip>
@@ -17,6 +24,14 @@ impl<T> ArrayExt<T, 2> for [T; 2] {
     fn each_ref_ext(&self) -> [&T; 2] {
         let [a, b] = self;
         [a, b]
+    }
+
+    fn try_map_ext<F, U, E>(self, f: F) -> Result<[U; 2], E>
+    where
+        F: FnMut(T) -> Result<U, E>,
+    {
+        let [a, b] = self.map(f);
+        Ok([a?, b?])
     }
 
     fn zip_ext<U>(self, rhs: [U; 2]) -> [(T, U); 2] {
@@ -31,6 +46,14 @@ impl<T> ArrayExt<T, 4> for [T; 4] {
     fn each_ref_ext(&self) -> [&T; 4] {
         let [a, b, c, d] = self;
         [a, b, c, d]
+    }
+
+    fn try_map_ext<F, U, E>(self, f: F) -> Result<[U; 4], E>
+    where
+        F: FnMut(T) -> Result<U, E>,
+    {
+        let [a, b, c, d] = self.map(f);
+        Ok([a?, b?, c?, d?])
     }
 
     fn zip_ext<U>(self, rhs: [U; 4]) -> [(T, U); 4] {

--- a/crates/fj-interop/src/ext.rs
+++ b/crates/fj-interop/src/ext.rs
@@ -63,3 +63,42 @@ impl<T> ArrayExt<T, 4> for [T; 4] {
         [(a, e), (b, f), (c, g), (d, h)]
     }
 }
+
+/// Extension trait for arrays
+pub trait SliceExt<T> {
+    /// Stable replacement for `array_chunks`
+    ///
+    /// <https://doc.rust-lang.org/std/primitive.slice.html#method.array_chunks>
+    fn array_chunks_ext<const N: usize>(&self) -> ArrayChunks<T, N>;
+}
+
+impl<T> SliceExt<T> for &[T] {
+    fn array_chunks_ext<const N: usize>(&self) -> ArrayChunks<T, N> {
+        ArrayChunks {
+            slice: self,
+            index: 0,
+        }
+    }
+}
+
+/// Returned by [`SliceExt::array_chunks_ext`]
+pub struct ArrayChunks<'a, T: 'a, const N: usize> {
+    slice: &'a [T],
+    index: usize,
+}
+
+impl<'a, T, const N: usize> Iterator for ArrayChunks<'a, T, N> {
+    type Item = &'a [T; N];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index + N > self.slice.len() {
+            return None;
+        }
+
+        let next = &self.slice[self.index..self.index + N];
+        self.index += N;
+
+        let next = next.try_into().unwrap();
+        Some(next)
+    }
+}

--- a/crates/fj-interop/src/ext.rs
+++ b/crates/fj-interop/src/ext.rs
@@ -1,0 +1,42 @@
+//! Extension traits for standard library types
+
+/// Extension trait for arrays
+pub trait ArrayExt<T, const N: usize> {
+    /// Stable replacement for `each_ref`
+    ///
+    /// <https://doc.rust-lang.org/std/primitive.array.html#method.each_ref>
+    fn each_ref_ext(&self) -> [&T; N];
+
+    /// Stable replacement for `zip`
+    ///
+    /// <https://doc.rust-lang.org/std/primitive.array.html#method.zip>
+    fn zip_ext<U>(self, rhs: [U; N]) -> [(T, U); N];
+}
+
+impl<T> ArrayExt<T, 2> for [T; 2] {
+    fn each_ref_ext(&self) -> [&T; 2] {
+        let [a, b] = self;
+        [a, b]
+    }
+
+    fn zip_ext<U>(self, rhs: [U; 2]) -> [(T, U); 2] {
+        let [a, b] = self;
+        let [c, d] = rhs;
+
+        [(a, c), (b, d)]
+    }
+}
+
+impl<T> ArrayExt<T, 4> for [T; 4] {
+    fn each_ref_ext(&self) -> [&T; 4] {
+        let [a, b, c, d] = self;
+        [a, b, c, d]
+    }
+
+    fn zip_ext<U>(self, rhs: [U; 4]) -> [(T, U); 4] {
+        let [a, b, c, d] = self;
+        let [e, f, g, h] = rhs;
+
+        [(a, e), (b, f), (c, g), (d, h)]
+    }
+}

--- a/crates/fj-interop/src/lib.rs
+++ b/crates/fj-interop/src/lib.rs
@@ -15,6 +15,7 @@
 #![warn(missing_docs)]
 
 pub mod debug;
+pub mod ext;
 pub mod mesh;
 pub mod processed_shape;
 pub mod status_report;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -1,5 +1,6 @@
 use std::vec;
 
+use fj_interop::ext::SliceExt;
 use fj_math::Point;
 
 use crate::objects::{Curve, Face};
@@ -51,17 +52,10 @@ impl CurveFaceIntersection {
 
         intersections.sort();
 
-        // Can be cleaned up, once `array_chunks` is stable:
-        // https://doc.rust-lang.org/std/primitive.slice.html#method.array_chunks
         let intervals = intersections
-            .chunks(2)
-            .map(|chunk| {
-                // Can't panic, as we passed `2` to `chunks`.
-                CurveFaceIntersectionInterval {
-                    start: chunk[0],
-                    end: chunk[1],
-                }
-            })
+            .as_slice()
+            .array_chunks_ext()
+            .map(|&[start, end]| CurveFaceIntersectionInterval { start, end })
             .collect();
 
         CurveFaceIntersection { intervals }

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -1,3 +1,5 @@
+use fj_interop::ext::ArrayExt;
+
 use crate::{
     objects::{Curve, Face, Objects},
     storage::Handle,
@@ -31,16 +33,10 @@ impl FaceFaceIntersection {
             SurfaceSurfaceIntersection::compute(surfaces, objects)?
                 .intersection_curves;
 
-        // Can be cleaned up, once `zip` is stable:
-        // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-        let curve_face_intersections = {
-            let [curve_a, curve_b] = &intersection_curves;
-            let [face_a, face_b] = faces;
-
-            [(curve_a, face_a), (curve_b, face_b)].map(|(curve, face)| {
-                CurveFaceIntersection::compute(curve, face)
-            })
-        };
+        let curve_face_intersections = intersection_curves
+            .each_ref_ext()
+            .zip_ext(faces)
+            .map(|(curve, face)| CurveFaceIntersection::compute(curve, face));
 
         let intersection_intervals = {
             let [a, b] = curve_face_intersections;

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -78,7 +78,7 @@ impl Sweep for Face {
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::mesh::Color;
+    use fj_interop::{ext::SliceExt, mesh::Color};
 
     use crate::{
         algorithms::{reverse::Reverse, transform::TransformObject},
@@ -114,13 +114,8 @@ mod tests {
         assert!(solid.find_face(&bottom).is_some());
         assert!(solid.find_face(&top).is_some());
 
-        let mut side_faces = TRIANGLE.windows(2).map(|window| {
-            // Can't panic, as we passed `2` to `windows`.
-            //
-            // Can be cleaned up, once `array_windows` is stable:
-            // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
-            let [a, b] = [window[0], window[1]];
-
+        let triangle = TRIANGLE.as_slice();
+        let mut side_faces = triangle.array_windows_ext().map(|&[a, b]| {
             let half_edge = Handle::<HalfEdge>::partial()
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
@@ -152,13 +147,8 @@ mod tests {
         assert!(solid.find_face(&bottom).is_some());
         assert!(solid.find_face(&top).is_some());
 
-        let mut side_faces = TRIANGLE.windows(2).map(|window| {
-            // Can't panic, as we passed `2` to `windows`.
-            //
-            // Can be cleaned up, once `array_windows` is stable:
-            // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
-            let [a, b] = [window[0], window[1]];
-
+        let triangle = TRIANGLE.as_slice();
+        let mut side_faces = triangle.array_windows_ext().map(|&[a, b]| {
             let half_edge = Handle::<HalfEdge>::partial()
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])

--- a/crates/fj-kernel/src/algorithms/triangulate/polygon.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/polygon.rs
@@ -1,3 +1,4 @@
+use fj_interop::ext::SliceExt;
 use fj_math::{Point, PolyChain, Segment, Triangle};
 
 use crate::algorithms::intersect::{
@@ -47,10 +48,8 @@ impl Polygon {
 
         let mut might_be_hole = true;
 
-        for edge in [a, b, c, a].windows(2) {
-            // This can't panic, as we passed `2` to `windows`. It can be
-            // cleaned up a bit, once `array_windows` is stable.
-            let edge = Segment::from([edge[0], edge[1]]);
+        for &edge in [a, b, c, a].as_slice().array_windows_ext() {
+            let edge = Segment::from(edge);
 
             let is_exterior_edge = self.contains_exterior_edge(edge);
             let is_interior_edge = self.contains_interior_edge(edge);

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -161,6 +161,7 @@ pub enum ValidationError {
 
 #[cfg(test)]
 mod tests {
+    use fj_interop::ext::ArrayExt;
     use fj_math::{Point, Scalar};
 
     use crate::{
@@ -190,24 +191,19 @@ mod tests {
             Curve::new(surface.clone(), path, global_form, &objects)
         };
 
-        let [a_global, b_global] = points_global
+        let vertices_global = points_global
             .map(|point| GlobalVertex::from_position(point, &objects));
 
-        let [a_surface, b_surface] = {
-            // Can be cleaned up, once `zip` is stable:
-            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-            let [a_surface, b_surface] = points_surface;
-            [(a_surface, a_global), (b_surface, b_global)].map(
-                |(point_surface, vertex_global)| {
-                    SurfaceVertex::new(
-                        point_surface,
-                        surface.clone(),
-                        vertex_global,
-                        &objects,
-                    )
-                },
-            )
-        };
+        let [a_surface, b_surface] = points_surface
+            .zip_ext(vertices_global)
+            .map(|(point_surface, vertex_global)| {
+                SurfaceVertex::new(
+                    point_surface,
+                    surface.clone(),
+                    vertex_global,
+                    &objects,
+                )
+            });
 
         let deviation = Scalar::from_f64(0.25);
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -1,6 +1,6 @@
 use std::array;
 
-use fj_interop::ext::ArrayExt;
+use fj_interop::ext::{ArrayExt, SliceExt};
 use fj_math::Scalar;
 
 use crate::{
@@ -218,18 +218,15 @@ impl<'a> ShellBuilder<'a> {
             };
 
             let mut edges = Vec::new();
-            for (surface_vertices, edge) in
-                surface_vertices.windows(2).zip(top_edges)
+            for (surface_vertices, edge) in surface_vertices
+                .as_slice()
+                .array_windows_ext()
+                .zip(top_edges)
             {
-                // This can't panic, as we passed `2` to `windows`. Can be
-                // cleaned up, once `array_windows` is stable.
-                let surface_vertices =
-                    [surface_vertices[0].clone(), surface_vertices[1].clone()];
-
                 let vertices = edge
                     .vertices()
                     .each_ref_ext()
-                    .zip_ext(surface_vertices)
+                    .zip_ext(surface_vertices.clone())
                     .map(|(vertex, surface_form)| {
                         Handle::<Vertex>::partial()
                             .with_position(Some(vertex.position()))

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -1,3 +1,4 @@
+use fj_interop::ext::SliceExt;
 use fj_math::{Scalar, Winding};
 use pretty_assertions::assert_eq;
 
@@ -37,13 +38,7 @@ impl Cycle {
 
         if half_edges.len() != 1 {
             // Verify that all edges connect.
-            for half_edges in half_edges.windows(2) {
-                // Can't panic, as we passed `2` to `windows`.
-                //
-                // Can be cleaned up, once `array_windows` is stable"
-                // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
-                let [a, b] = [&half_edges[0], &half_edges[1]];
-
+            for [a, b] in half_edges.as_slice().array_windows_ext() {
                 let [_, prev] = a.vertices();
                 let [next, _] = b.vertices();
 
@@ -124,13 +119,7 @@ impl Cycle {
 
         let mut sum = Scalar::ZERO;
 
-        for half_edge in self.half_edges.windows(2) {
-            // Can't panic, as we passed `2` to `windows`.
-            //
-            // Can be cleaned up, once `array_windows` is stable:
-            // https://doc.rust-lang.org/std/primitive.slice.html#method.array_windows
-            let [a, b] = [&half_edge[0], &half_edge[1]];
-
+        for [a, b] in self.half_edges.as_slice().array_windows_ext() {
             let [a, b] = [a, b].map(|half_edge| {
                 let [vertex, _] = half_edge.vertices();
                 vertex.surface_form().position()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -1,3 +1,4 @@
+use fj_interop::ext::ArrayExt;
 use fj_math::{Point, Scalar};
 
 use crate::{
@@ -248,11 +249,7 @@ impl PartialHalfEdge {
                     .unwrap_or([None, None])
             };
 
-            // Can be cleaned up, once `zip` is stable:
-            // https://doc.rust-lang.org/std/primitive.array.html#method.zip
-            let [a, b] = vertices;
-            let [a_global, b_global] = global_forms;
-            [(a, a_global), (b, b_global)].map(|(vertex, global_form)| {
+            vertices.zip_ext(global_forms).map(|(vertex, global_form)| {
                 vertex.update_partial(|partial| {
                     partial.with_global_form(global_form)
                 })

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -28,13 +28,9 @@ impl Shape for fj::Difference2d {
         let mut exteriors = Vec::new();
         let mut interiors = Vec::new();
 
-        // Can be cleaned up, once `try_map` is stable:
-        // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
-        let [a, b] = self
-            .shapes()
-            .each_ref_ext()
-            .map(|shape| shape.compute_brep(config, objects, debug_info));
-        let [a, b] = [a?, b?];
+        let [a, b] = self.shapes().each_ref_ext().try_map_ext(|shape| {
+            shape.compute_brep(config, objects, debug_info)
+        })?;
 
         if let Some(face) = a.face_iter().next() {
             // If there's at least one face to subtract from, we can proceed.

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -1,4 +1,4 @@
-use fj_interop::{debug::DebugInfo, mesh::Color};
+use fj_interop::{debug::DebugInfo, ext::ArrayExt, mesh::Color};
 use fj_kernel::{
     algorithms::{
         reverse::Reverse,
@@ -28,12 +28,12 @@ impl Shape for fj::Difference2d {
         let mut exteriors = Vec::new();
         let mut interiors = Vec::new();
 
-        // Can be cleaned up, once `each_ref` and `try_map` are stable:
-        // - https://doc.rust-lang.org/std/primitive.array.html#method.each_ref
-        // - https://doc.rust-lang.org/std/primitive.array.html#method.try_map
-        let [a, b] = self.shapes();
-        let [a, b] =
-            [a, b].map(|shape| shape.compute_brep(config, objects, debug_info));
+        // Can be cleaned up, once `try_map` is stable:
+        // https://doc.rust-lang.org/std/primitive.array.html#method.try_map
+        let [a, b] = self
+            .shapes()
+            .each_ref_ext()
+            .map(|shape| shape.compute_brep(config, objects, debug_info));
         let [a, b] = [a?, b?];
 
         if let Some(face) = a.face_iter().next() {


### PR DESCRIPTION
There are a number of methods defined on arrays and slices that aren't stable yet, meaning we can't use them in Fornjot. I've been working around that for a while, but today enough was enough.

This pull request introduces stable replacements for the missing methods that I need, simplifying the code that previously had workarounds. I still hope those become stable soon.