### PR TITLE
Integrate `Cycle` into centralized object storage

### DIFF
--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -7,7 +7,8 @@ impl Reverse for Cycle {
         let surface = self.surface().clone();
 
         let mut edges = self
-            .into_half_edges()
+            .half_edges()
+            .cloned()
             .map(|edge| edge.reverse(objects))
             .collect::<Vec<_>>();
 

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -1,8 +1,11 @@
-use crate::objects::{Cycle, Objects};
+use crate::{
+    objects::{Cycle, Objects},
+    storage::Handle,
+};
 
 use super::Reverse;
 
-impl Reverse for Cycle {
+impl Reverse for Handle<Cycle> {
     fn reverse(self, objects: &Objects) -> Self {
         let surface = self.surface().clone();
 
@@ -14,6 +17,6 @@ impl Reverse for Cycle {
 
         edges.reverse();
 
-        Cycle::new(surface, edges)
+        Cycle::new(surface, edges, objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -166,7 +166,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 i += 1;
             }
 
-            Cycle::new(surface, edges)
+            Cycle::new(surface, edges, objects)
         };
 
         Face::from_exterior(cycle).with_color(color)
@@ -250,7 +250,11 @@ mod tests {
                 .build(&objects)
                 .reverse(&objects);
 
-            let cycle = Cycle::new(surface, [bottom, side_up, top, side_down]);
+            let cycle = Cycle::new(
+                surface,
+                [bottom, side_up, top, side_down],
+                &objects,
+            );
 
             Face::from_exterior(cycle)
         };

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -20,10 +20,10 @@ pub struct FaceBuilder<'a> {
     ///
     /// Must be provided by the caller, directly or using one of the `with_`
     /// methods, before [`FaceBuilder::build`] is called.
-    pub exterior: Option<Cycle>,
+    pub exterior: Option<Handle<Cycle>>,
 
     /// The interior cycles that form holes in the [`Face`]
-    pub interiors: Vec<Cycle>,
+    pub interiors: Vec<Handle<Cycle>>,
 }
 
 impl<'a> FaceBuilder<'a> {
@@ -33,7 +33,7 @@ impl<'a> FaceBuilder<'a> {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         self.exterior = Some(
-            Cycle::partial()
+            Handle::<Cycle>::partial()
                 .with_surface(Some(self.surface.clone()))
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()
@@ -48,7 +48,7 @@ impl<'a> FaceBuilder<'a> {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         self.interiors.push(
-            Cycle::partial()
+            Handle::<Cycle>::partial()
                 .with_surface(Some(self.surface.clone()))
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -174,7 +174,7 @@ impl<'a> ShellBuilder<'a> {
                 .zip(sides_down)
                 .zip(surfaces)
                 .map(|((((bottom, side_up), top), side_down), surface)| {
-                    let cycle = Cycle::partial()
+                    let cycle = Handle::<Cycle>::partial()
                         .with_surface(Some(surface))
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(self.objects);
@@ -242,7 +242,7 @@ impl<'a> ShellBuilder<'a> {
                 );
             }
 
-            Face::from_exterior(Cycle::new(surface, edges))
+            Face::from_exterior(Cycle::new(surface, edges, self.objects))
         };
 
         let mut faces = Vec::new();

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -150,7 +150,7 @@ impl<'r> ObjectIters<'r> for Handle<Curve> {
     }
 }
 
-impl<'r> ObjectIters<'r> for Cycle {
+impl<'r> ObjectIters<'r> for Handle<Cycle> {
     fn referenced_objects(&'r self) -> Vec<&'r dyn ObjectIters> {
         let mut objects = Vec::new();
 
@@ -398,7 +398,7 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let object = Cycle::partial()
+        let object = Handle::<Cycle>::partial()
             .with_surface(Some(surface))
             .with_poly_chain_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .close_with_line_segment()

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 
 use crate::{path::SurfacePath, storage::Handle};
 
-use super::{HalfEdge, Surface};
+use super::{HalfEdge, Objects, Surface};
 
 /// A cycle of connected half-edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -23,7 +23,8 @@ impl Cycle {
     pub fn new(
         surface: Handle<Surface>,
         half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
-    ) -> Self {
+        objects: &Objects,
+    ) -> Handle<Self> {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
 
         // Verify, that the curves of all edges are defined in the correct
@@ -64,10 +65,10 @@ impl Cycle {
             }
         }
 
-        Self {
+        objects.cycles.insert(Self {
             surface,
             half_edges,
-        }
+        })
     }
 
     /// Access the surface that this cycle is in

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -137,9 +137,4 @@ impl Cycle {
 
         unreachable!("Encountered invalid cycle: {self:#?}");
     }
-
-    /// Consume the cycle and return its half-edges
-    pub fn into_half_edges(self) -> impl Iterator<Item = Handle<HalfEdge>> {
-        self.half_edges.into_iter()
-    }
 }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -34,8 +34,8 @@ use super::{Cycle, Objects, Surface};
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Face {
     surface: Handle<Surface>,
-    exterior: Cycle,
-    interiors: Vec<Cycle>,
+    exterior: Handle<Cycle>,
+    interiors: Vec<Handle<Cycle>>,
     color: Color,
 }
 
@@ -54,7 +54,7 @@ impl Face {
     ///
     /// Creates the face with no interiors and the default color. This can be
     /// overridden using the `with_` methods.
-    pub fn from_exterior(exterior: Cycle) -> Self {
+    pub fn from_exterior(exterior: Handle<Cycle>) -> Self {
         Self {
             surface: exterior.surface().clone(),
             exterior,
@@ -75,7 +75,7 @@ impl Face {
     /// the exterior cycle.
     pub fn with_interiors(
         mut self,
-        interiors: impl IntoIterator<Item = Cycle>,
+        interiors: impl IntoIterator<Item = Handle<Cycle>>,
     ) -> Self {
         for interior in interiors.into_iter() {
             assert_eq!(
@@ -109,19 +109,19 @@ impl Face {
     }
 
     /// Access the cycle that bounds the face on the outside
-    pub fn exterior(&self) -> &Cycle {
+    pub fn exterior(&self) -> &Handle<Cycle> {
         &self.exterior
     }
 
     /// Access the cycles that bound the face on the inside
     ///
     /// Each of these cycles defines a hole in the face.
-    pub fn interiors(&self) -> impl Iterator<Item = &Cycle> + '_ {
+    pub fn interiors(&self) -> impl Iterator<Item = &Handle<Cycle>> + '_ {
         self.interiors.iter()
     }
 
     /// Access all cycles of this face
-    pub fn all_cycles(&self) -> impl Iterator<Item = &Cycle> + '_ {
+    pub fn all_cycles(&self) -> impl Iterator<Item = &Handle<Cycle>> + '_ {
         [self.exterior()].into_iter().chain(self.interiors())
     }
 

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -115,6 +115,9 @@ pub struct Objects {
     /// Store for [`Curve`]s
     pub curves: Store<Curve>,
 
+    /// Store for [`Cycle`]s
+    pub cycles: Store<Cycle>,
+
     /// Store for [`GlobalCurve`]s
     pub global_curves: Store<GlobalCurve>,
 

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -112,28 +112,28 @@ use crate::{
 /// [#1021]: https://github.com/hannobraun/Fornjot/issues/1021
 #[derive(Debug, Default)]
 pub struct Objects {
-    /// Store for curves
+    /// Store for [`Curve`]s
     pub curves: Store<Curve>,
 
-    /// Store for global curves
+    /// Store for [`GlobalCurve`]s
     pub global_curves: Store<GlobalCurve>,
 
-    /// Store for global edges
+    /// Store for [`GlobalEdge`]s
     pub global_edges: Store<GlobalEdge>,
 
-    /// Store for global vertices
+    /// Store for [`GlobalVertex`] objects
     pub global_vertices: Store<GlobalVertex>,
 
-    /// Store for half-edges
+    /// Store for [`HalfEdge`]s
     pub half_edges: Store<HalfEdge>,
 
-    /// Store for surface vertices
+    /// Store for [`SurfaceVertex`] objects
     pub surface_vertices: Store<SurfaceVertex>,
 
-    /// Store for surfaces
+    /// Store for [`Surface`]s
     pub surfaces: Surfaces,
 
-    /// Store for vertices
+    /// Store for [`Vertex`] objects
     pub vertices: Store<Vertex>,
 }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -162,7 +162,7 @@ impl PartialCycle {
     }
 
     /// Build a full [`Cycle`] from the partial cycle
-    pub fn build(mut self, objects: &Objects) -> Cycle {
+    pub fn build(mut self, objects: &Objects) -> Handle<Cycle> {
         let surface = self.surface.expect("Need surface to build `Cycle`");
         let surface_for_edges = surface.clone();
         let half_edges = {
@@ -226,12 +226,12 @@ impl PartialCycle {
             half_edges
         };
 
-        Cycle::new(surface, half_edges)
+        Cycle::new(surface, half_edges, objects)
     }
 }
 
-impl From<&Cycle> for PartialCycle {
-    fn from(cycle: &Cycle) -> Self {
+impl From<&Handle<Cycle>> for PartialCycle {
+    fn from(cycle: &Handle<Cycle>) -> Self {
         Self {
             surface: Some(cycle.surface().clone()),
             half_edges: cycle.half_edges().cloned().map(Into::into).collect(),

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -43,7 +43,7 @@ macro_rules! impl_traits {
 
 impl_traits!(
     Handle<Curve>, PartialCurve;
-    Cycle, PartialCycle;
+    Handle<Cycle>, PartialCycle;
     Handle<GlobalEdge>, PartialGlobalEdge;
     Handle<GlobalVertex>, PartialGlobalVertex;
     Handle<HalfEdge>, PartialHalfEdge;

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -31,7 +31,7 @@ impl Shape for fj::Sketch {
                     .with_surface(Some(surface.clone()))
                     .as_circle_from_radius(circle.radius(), objects)
                     .build(objects);
-                let cycle = Cycle::new(surface, [half_edge]);
+                let cycle = Cycle::new(surface, [half_edge], objects);
 
                 Face::from_exterior(cycle).with_color(Color(self.color()))
             }


### PR DESCRIPTION
That `Cycle` wasn't part of the centralized object storage was causing some irregularity in the partial object infrastructure, which this pull request fixes. This paves the way for some cleanups of the partial object infrastructure.

This is another step towards addressing #1021.