### PR TITLE
Simplify use of `MaybePartial`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -200,7 +200,6 @@ mod tests {
         objects::{Curve, Objects, Surface},
         partial::HasPartial,
         path::GlobalPath,
-        storage::Handle,
     };
 
     use super::CurveApprox;
@@ -212,7 +211,7 @@ mod tests {
         let surface = objects
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]));
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface))
             .as_line_from_points([[1., 1.], [2., 1.]])
             .build(&objects);
@@ -231,7 +230,7 @@ mod tests {
             GlobalPath::circle_from_radius(1.),
             [0., 0., 1.],
         ));
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface))
             .as_line_from_points([[1., 1.], [1., 2.]])
             .build(&objects);
@@ -248,7 +247,7 @@ mod tests {
 
         let path = GlobalPath::circle_from_radius(1.);
         let surface = objects.surfaces.insert(Surface::new(path, [0., 0., 1.]));
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_line_from_points([[0., 1.], [1., 1.]])
             .build(&objects);
@@ -279,7 +278,7 @@ mod tests {
         let surface = objects
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]));
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface))
             .as_circle_from_radius(1.)
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -77,7 +77,6 @@ mod tests {
     use crate::{
         objects::{Curve, HalfEdge, Objects},
         partial::HasPartial,
-        storage::Handle,
     };
 
     use super::CurveEdgeIntersection;
@@ -87,11 +86,11 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = Handle::<HalfEdge>::partial()
+        let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[1., -1.], [1., 1.]])
             .build(&objects);
@@ -111,11 +110,11 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = Handle::<HalfEdge>::partial()
+        let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[-1., -1.], [-1., 1.]])
             .build(&objects);
@@ -135,11 +134,11 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = Handle::<HalfEdge>::partial()
+        let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[-1., -1.], [1., -1.]])
             .build(&objects);
@@ -154,11 +153,11 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let half_edge = Handle::<HalfEdge>::partial()
+        let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[-1., 0.], [1., 0.]])
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -152,7 +152,6 @@ mod tests {
     use crate::{
         objects::{Curve, Face, Objects},
         partial::HasPartial,
-        storage::Handle,
     };
 
     use super::CurveFaceIntersection;
@@ -163,7 +162,7 @@ mod tests {
 
         let surface = objects.surfaces.xy_plane();
 
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_line_from_points([[-3., 0.], [-2., 0.]])
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -62,7 +62,6 @@ mod tests {
         algorithms::intersect::CurveFaceIntersection,
         objects::{Curve, Face, Objects},
         partial::HasPartial,
-        storage::Handle,
     };
 
     use super::FaceFaceIntersection;
@@ -112,7 +111,7 @@ mod tests {
         let intersection = FaceFaceIntersection::compute([&a, &b], &objects);
 
         let expected_curves = surfaces.map(|surface| {
-            Handle::<Curve>::partial()
+            Curve::partial()
                 .with_surface(Some(surface))
                 .as_line_from_points([[0., 0.], [1., 0.]])
                 .build(&objects)

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -90,7 +90,6 @@ mod tests {
         algorithms::transform::TransformObject,
         objects::{Curve, Objects},
         partial::HasPartial,
-        storage::Handle,
     };
 
     use super::SurfaceSurfaceIntersection;
@@ -117,11 +116,11 @@ mod tests {
             None,
         );
 
-        let expected_xy = Handle::<Curve>::partial()
+        let expected_xy = Curve::partial()
             .with_surface(Some(xy.clone()))
             .as_u_axis()
             .build(&objects);
-        let expected_xz = Handle::<Curve>::partial()
+        let expected_xz = Curve::partial()
             .with_surface(Some(xz.clone()))
             .as_u_axis()
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -182,14 +182,13 @@ mod tests {
         algorithms::{reverse::Reverse, sweep::Sweep},
         objects::{Cycle, Face, HalfEdge, Objects, SurfaceVertex, Vertex},
         partial::HasPartial,
-        storage::Handle,
     };
 
     #[test]
     fn sweep() {
         let objects = Objects::new();
 
-        let half_edge = Handle::<HalfEdge>::partial()
+        let half_edge = HalfEdge::partial()
             .with_surface(Some(objects.surfaces.xy_plane()))
             .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&objects);
@@ -199,53 +198,43 @@ mod tests {
         let expected_face = {
             let surface = objects.surfaces.xz_plane();
 
-            let bottom = Handle::<HalfEdge>::partial()
+            let bottom = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
                 .as_line_segment_from_points([[0., 0.], [1., 0.]])
                 .build(&objects);
-            let side_up = Handle::<HalfEdge>::partial()
+            let side_up = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .with_back_vertex(Some(
-                    Handle::<Vertex>::partial().with_surface_form(Some(
-                        bottom.front().surface_form().clone(),
-                    )),
-                ))
-                .with_front_vertex(Some(
-                    Handle::<Vertex>::partial().with_surface_form(Some(
-                        Handle::<SurfaceVertex>::partial()
-                            .with_position(Some([1., 1.])),
-                    )),
-                ))
+                .with_back_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(bottom.front().surface_form().clone()),
+                )))
+                .with_front_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(
+                        SurfaceVertex::partial().with_position(Some([1., 1.])),
+                    ),
+                )))
                 .as_line_segment()
                 .build(&objects);
-            let top = Handle::<HalfEdge>::partial()
+            let top = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .with_back_vertex(Some(
-                    Handle::<Vertex>::partial().with_surface_form(Some(
-                        Handle::<SurfaceVertex>::partial()
-                            .with_position(Some([0., 1.])),
-                    )),
-                ))
-                .with_front_vertex(Some(
-                    Handle::<Vertex>::partial().with_surface_form(Some(
-                        side_up.front().surface_form().clone(),
-                    )),
-                ))
+                .with_back_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(
+                        SurfaceVertex::partial().with_position(Some([0., 1.])),
+                    ),
+                )))
+                .with_front_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(side_up.front().surface_form().clone()),
+                )))
                 .as_line_segment()
                 .build(&objects)
                 .reverse(&objects);
-            let side_down = Handle::<HalfEdge>::partial()
+            let side_down = HalfEdge::partial()
                 .with_surface(Some(surface.clone()))
-                .with_back_vertex(Some(
-                    Handle::<Vertex>::partial().with_surface_form(Some(
-                        bottom.back().surface_form().clone(),
-                    )),
-                ))
-                .with_front_vertex(Some(
-                    Handle::<Vertex>::partial().with_surface_form(Some(
-                        top.front().surface_form().clone(),
-                    )),
-                ))
+                .with_back_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(bottom.back().surface_form().clone()),
+                )))
+                .with_front_vertex(Some(Vertex::partial().with_surface_form(
+                    Some(top.front().surface_form().clone()),
+                )))
                 .as_line_segment()
                 .build(&objects)
                 .reverse(&objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -84,7 +84,6 @@ mod tests {
         algorithms::{reverse::Reverse, transform::TransformObject},
         objects::{Face, HalfEdge, Objects, Sketch},
         partial::HasPartial,
-        storage::Handle,
     };
 
     use super::Sweep;
@@ -116,7 +115,7 @@ mod tests {
 
         let triangle = TRIANGLE.as_slice();
         let mut side_faces = triangle.array_windows_ext().map(|&[a, b]| {
-            let half_edge = Handle::<HalfEdge>::partial()
+            let half_edge = HalfEdge::partial()
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects);
@@ -149,7 +148,7 @@ mod tests {
 
         let triangle = TRIANGLE.as_slice();
         let mut side_faces = triangle.array_windows_ext().map(|&[a, b]| {
-            let half_edge = Handle::<HalfEdge>::partial()
+            let half_edge = HalfEdge::partial()
                 .with_surface(Some(objects.surfaces.xy_plane()))
                 .as_line_segment_from_points([a, b])
                 .build(&objects)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -162,7 +162,6 @@ mod tests {
         algorithms::sweep::Sweep,
         objects::{Curve, HalfEdge, Objects, Vertex},
         partial::HasPartial,
-        storage::Handle,
     };
 
     #[test]
@@ -170,18 +169,18 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xz_plane();
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);
-        let vertex = Handle::<Vertex>::partial()
+        let vertex = Vertex::partial()
             .with_position(Some([0.]))
             .with_curve(Some(curve))
             .build(&objects);
 
         let half_edge = (vertex, surface.clone()).sweep([0., 0., 1.], &objects);
 
-        let expected_half_edge = Handle::<HalfEdge>::partial()
+        let expected_half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([[0., 0.], [0., 1.]])
             .build(&objects);

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -3,7 +3,6 @@ use fj_math::Transform;
 use crate::{
     objects::{Curve, Objects},
     partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
-    storage::Handle,
 };
 
 use super::TransformObject;
@@ -34,7 +33,7 @@ impl TransformObject for PartialHalfEdge {
                 .into_partial()
                 .transform(transform, objects)
                 .with_curve(curve.as_ref().and_then(
-                    |curve: &MaybePartial<Handle<Curve>>| curve.global_form(),
+                    |curve: &MaybePartial<Curve>| curve.global_form(),
                 ))
                 .into()
         });

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -16,6 +16,7 @@ use fj_math::{Transform, Vector};
 use crate::{
     objects::Objects,
     partial::{HasPartial, MaybePartial, Partial},
+    storage::Handle,
 };
 
 /// Transform an object
@@ -57,7 +58,7 @@ pub trait TransformObject: Sized {
     }
 }
 
-impl<T> TransformObject for T
+impl<T> TransformObject for Handle<T>
 where
     T: HasPartial,
     T::Partial: TransformObject,
@@ -71,7 +72,8 @@ where
 
 impl<T> TransformObject for MaybePartial<T>
 where
-    T: HasPartial + TransformObject,
+    T: HasPartial,
+    Handle<T>: TransformObject,
     T::Partial: TransformObject,
 {
     fn transform(self, transform: &Transform, objects: &Objects) -> Self {

--- a/crates/fj-kernel/src/algorithms/validate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/validate/mod.rs
@@ -172,7 +172,6 @@ mod tests {
         },
         partial::HasPartial,
         path::SurfacePath,
-        storage::Handle,
     };
 
     #[test]
@@ -221,7 +220,7 @@ mod tests {
         );
         let vertices = [a, b];
 
-        let global_edge = Handle::<GlobalEdge>::partial()
+        let global_edge = GlobalEdge::partial()
             .from_curve_and_vertices(&curve, &vertices)
             .build(&objects);
         let half_edge = HalfEdge::new(vertices, global_edge, &objects);

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -33,7 +33,7 @@ impl<'a> FaceBuilder<'a> {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         self.exterior = Some(
-            Handle::<Cycle>::partial()
+            Cycle::partial()
                 .with_surface(Some(self.surface.clone()))
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()
@@ -48,7 +48,7 @@ impl<'a> FaceBuilder<'a> {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         self.interiors.push(
-            Handle::<Cycle>::partial()
+            Cycle::partial()
                 .with_surface(Some(self.surface.clone()))
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -10,7 +10,6 @@ use crate::{
         Vertex,
     },
     partial::HasPartial,
-    storage::Handle,
 };
 
 /// API for building a [`Shell`]
@@ -72,7 +71,7 @@ impl<'a> ShellBuilder<'a> {
                 .half_edges()
                 .zip(&surfaces)
                 .map(|(half_edge, surface)| {
-                    Handle::<HalfEdge>::partial()
+                    HalfEdge::partial()
                         .with_surface(Some(surface.clone()))
                         .with_global_form(Some(half_edge.global_form().clone()))
                         .as_line_segment_from_points([[Z, Z], [edge_length, Z]])
@@ -88,16 +87,14 @@ impl<'a> ShellBuilder<'a> {
                     let [_, from] = bottom.vertices();
 
                     let from = from.surface_form().clone();
-                    let to = Handle::<SurfaceVertex>::partial()
+                    let to = SurfaceVertex::partial()
                         .with_position(Some(from.position() + [Z, edge_length]))
                         .with_surface(Some(surface.clone()));
 
-                    Handle::<HalfEdge>::partial()
+                    HalfEdge::partial()
                         .with_vertices(Some([
-                            Handle::<Vertex>::partial()
-                                .with_surface_form(Some(from)),
-                            Handle::<Vertex>::partial()
-                                .with_surface_form(Some(to)),
+                            Vertex::partial().with_surface_form(Some(from)),
+                            Vertex::partial().with_surface_form(Some(to)),
                         ]))
                         .as_line_segment()
                         .build(self.objects)
@@ -118,25 +115,22 @@ impl<'a> ShellBuilder<'a> {
                         let [to, _] = bottom.vertices();
 
                         let to = to.surface_form().clone();
-                        let from = Handle::<SurfaceVertex>::partial()
+                        let from = SurfaceVertex::partial()
                             .with_position(Some(
                                 to.position() + [Z, edge_length],
                             ))
                             .with_surface(Some(surface.clone()))
                             .with_global_form(Some(from.global_form().clone()));
 
-                        let curve = Handle::<Curve>::partial()
-                            .with_global_form(Some(
-                                side_up_prev.curve().global_form().clone(),
-                            ));
+                        let curve = Curve::partial().with_global_form(Some(
+                            side_up_prev.curve().global_form().clone(),
+                        ));
 
-                        Handle::<HalfEdge>::partial()
+                        HalfEdge::partial()
                             .with_curve(Some(curve))
                             .with_vertices(Some([
-                                Handle::<Vertex>::partial()
-                                    .with_surface_form(Some(from)),
-                                Handle::<Vertex>::partial()
-                                    .with_surface_form(Some(to)),
+                                Vertex::partial().with_surface_form(Some(from)),
+                                Vertex::partial().with_surface_form(Some(to)),
                             ]))
                             .as_line_segment()
                             .build(self.objects)
@@ -155,12 +149,10 @@ impl<'a> ShellBuilder<'a> {
                     let from = from.surface_form().clone();
                     let to = to.surface_form().clone();
 
-                    let from = Handle::<Vertex>::partial()
-                        .with_surface_form(Some(from));
-                    let to =
-                        Handle::<Vertex>::partial().with_surface_form(Some(to));
+                    let from = Vertex::partial().with_surface_form(Some(from));
+                    let to = Vertex::partial().with_surface_form(Some(to));
 
-                    Handle::<HalfEdge>::partial()
+                    HalfEdge::partial()
                         .with_vertices(Some([from, to]))
                         .as_line_segment()
                         .build(self.objects)
@@ -174,7 +166,7 @@ impl<'a> ShellBuilder<'a> {
                 .zip(sides_down)
                 .zip(surfaces)
                 .map(|((((bottom, side_up), top), side_down), surface)| {
-                    let cycle = Handle::<Cycle>::partial()
+                    let cycle = Cycle::partial()
                         .with_surface(Some(surface))
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(self.objects);
@@ -205,7 +197,7 @@ impl<'a> ShellBuilder<'a> {
                     points.zip_ext(half_edges).map(|(point, edge)| {
                         let vertex = edge.back();
 
-                        Handle::<SurfaceVertex>::partial()
+                        SurfaceVertex::partial()
                             .with_position(Some(point))
                             .with_surface(Some(surface.clone()))
                             .with_global_form(Some(
@@ -228,13 +220,13 @@ impl<'a> ShellBuilder<'a> {
                     .each_ref_ext()
                     .zip_ext(surface_vertices.clone())
                     .map(|(vertex, surface_form)| {
-                        Handle::<Vertex>::partial()
+                        Vertex::partial()
                             .with_position(Some(vertex.position()))
                             .with_surface_form(Some(surface_form))
                     });
 
                 edges.push(
-                    Handle::<HalfEdge>::partial()
+                    HalfEdge::partial()
                         .with_vertices(Some(vertices))
                         .with_global_form(Some(edge.global_form().clone()))
                         .as_line_segment()

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -365,7 +365,6 @@ mod tests {
             Shell, Sketch, Solid, SurfaceVertex, Vertex,
         },
         partial::HasPartial,
-        storage::Handle,
     };
 
     use super::ObjectIters as _;
@@ -375,7 +374,7 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let object = Handle::<Curve>::partial()
+        let object = Curve::partial()
             .with_surface(Some(surface))
             .as_u_axis()
             .build(&objects);
@@ -398,7 +397,7 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let object = Handle::<Cycle>::partial()
+        let object = Cycle::partial()
             .with_surface(Some(surface))
             .with_poly_chain_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .close_with_line_segment()
@@ -481,7 +480,7 @@ mod tests {
     fn half_edge() {
         let objects = Objects::new();
 
-        let object = Handle::<HalfEdge>::partial()
+        let object = HalfEdge::partial()
             .with_surface(Some(objects.surfaces.xy_plane()))
             .as_line_segment_from_points([[0., 0.], [1., 0.]])
             .build(&objects);
@@ -584,7 +583,7 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Handle::<Curve>::partial()
+        let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects);

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -203,7 +203,7 @@ impl VerticesInNormalizedOrder {
 mod tests {
     use pretty_assertions::assert_eq;
 
-    use crate::{objects::Objects, partial::HasPartial, storage::Handle};
+    use crate::{objects::Objects, partial::HasPartial};
 
     use super::HalfEdge;
 
@@ -216,11 +216,11 @@ mod tests {
         let a = [0., 0.];
         let b = [1., 0.];
 
-        let a_to_b = Handle::<HalfEdge>::partial()
+        let a_to_b = HalfEdge::partial()
             .with_surface(Some(surface.clone()))
             .as_line_segment_from_points([a, b])
             .build(&objects);
-        let b_to_a = Handle::<HalfEdge>::partial()
+        let b_to_a = HalfEdge::partial()
             .with_surface(Some(surface))
             .as_line_segment_from_points([b, a])
             .build(&objects);

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -19,7 +19,7 @@ use super::{HasPartial, Partial};
 ///
 /// The set of available convenience methods is far from complete. Please feel
 /// free to just add more, if you need them.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum MaybePartial<T: HasPartial> {
     /// A full object
     Full(T),

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -22,7 +22,7 @@ use super::{HasPartial, Partial};
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum MaybePartial<T: HasPartial> {
     /// A full object
-    Full(T),
+    Full(Handle<T>),
 
     /// A partial object
     Partial(T::Partial),
@@ -48,7 +48,7 @@ impl<T: HasPartial> MaybePartial<T> {
     ///
     /// If this already is a full object, it is returned. If this is a partial
     /// object, the full object is built from it, using [`Partial::build`].
-    pub fn into_full(self, objects: &Objects) -> T {
+    pub fn into_full(self, objects: &Objects) -> Handle<T> {
         match self {
             Self::Partial(partial) => partial.build(objects),
             Self::Full(full) => full,
@@ -68,11 +68,11 @@ impl<T: HasPartial> MaybePartial<T> {
     }
 }
 
-impl<T> From<T> for MaybePartial<T>
+impl<T> From<Handle<T>> for MaybePartial<T>
 where
     T: HasPartial,
 {
-    fn from(full: T) -> Self {
+    fn from(full: Handle<T>) -> Self {
         Self::Full(full)
     }
 }
@@ -80,7 +80,7 @@ where
 // Unfortunately, we can't add a blanket implementation from `T::Partial` for
 // `MaybePartial<T>`, as that would conflict.
 
-impl MaybePartial<Handle<Curve>> {
+impl MaybePartial<Curve> {
     /// Access the global form
     pub fn global_form(&self) -> Option<Handle<GlobalCurve>> {
         match self {
@@ -92,7 +92,7 @@ impl MaybePartial<Handle<Curve>> {
     }
 }
 
-impl MaybePartial<Handle<GlobalEdge>> {
+impl MaybePartial<GlobalEdge> {
     /// Access the curve
     pub fn curve(&self) -> Option<&Handle<GlobalCurve>> {
         match self {
@@ -114,9 +114,9 @@ impl MaybePartial<Handle<GlobalEdge>> {
     }
 }
 
-impl MaybePartial<Handle<HalfEdge>> {
+impl MaybePartial<HalfEdge> {
     /// Access the back vertex
-    pub fn back(&self) -> Option<MaybePartial<Handle<Vertex>>> {
+    pub fn back(&self) -> Option<MaybePartial<Vertex>> {
         match self {
             Self::Full(full) => Some(full.back().clone().into()),
             Self::Partial(partial) => {
@@ -127,7 +127,7 @@ impl MaybePartial<Handle<HalfEdge>> {
     }
 
     /// Access the front vertex
-    pub fn front(&self) -> Option<MaybePartial<Handle<Vertex>>> {
+    pub fn front(&self) -> Option<MaybePartial<Vertex>> {
         match self {
             Self::Full(full) => Some(full.front().clone().into()),
             Self::Partial(partial) => {
@@ -138,7 +138,7 @@ impl MaybePartial<Handle<HalfEdge>> {
     }
 
     /// Access the vertices
-    pub fn vertices(&self) -> [Option<MaybePartial<Handle<Vertex>>>; 2] {
+    pub fn vertices(&self) -> [Option<MaybePartial<Vertex>>; 2] {
         match self {
             Self::Full(full) => {
                 full.vertices().clone().map(|vertex| Some(vertex.into()))
@@ -148,7 +148,7 @@ impl MaybePartial<Handle<HalfEdge>> {
     }
 }
 
-impl MaybePartial<Handle<SurfaceVertex>> {
+impl MaybePartial<SurfaceVertex> {
     /// Access the position
     pub fn position(&self) -> Option<Point<2>> {
         match self {
@@ -166,9 +166,9 @@ impl MaybePartial<Handle<SurfaceVertex>> {
     }
 }
 
-impl MaybePartial<Handle<Vertex>> {
+impl MaybePartial<Vertex> {
     /// Access the surface form
-    pub fn surface_form(&self) -> Option<MaybePartial<Handle<SurfaceVertex>>> {
+    pub fn surface_form(&self) -> Option<MaybePartial<SurfaceVertex>> {
         match self {
             Self::Full(full) => Some(full.surface_form().clone().into()),
             Self::Partial(partial) => partial.surface_form.clone(),

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -96,8 +96,8 @@ impl PartialCurve {
     }
 }
 
-impl From<&Handle<Curve>> for PartialCurve {
-    fn from(curve: &Handle<Curve>) -> Self {
+impl From<&Curve> for PartialCurve {
+    fn from(curve: &Curve) -> Self {
         Self {
             path: Some(curve.path()),
             surface: Some(curve.surface().clone()),

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -17,7 +17,7 @@ pub struct PartialCycle {
     pub surface: Option<Handle<Surface>>,
 
     /// The half-edges that make up the [`Cycle`]
-    pub half_edges: Vec<MaybePartial<Handle<HalfEdge>>>,
+    pub half_edges: Vec<MaybePartial<HalfEdge>>,
 }
 
 impl PartialCycle {
@@ -32,9 +32,7 @@ impl PartialCycle {
     /// Update the partial cycle with the given half-edges
     pub fn with_half_edges(
         mut self,
-        half_edge: impl IntoIterator<
-            Item = impl Into<MaybePartial<Handle<HalfEdge>>>,
-        >,
+        half_edge: impl IntoIterator<Item = impl Into<MaybePartial<HalfEdge>>>,
     ) -> Self {
         self.half_edges
             .extend(half_edge.into_iter().map(Into::into));
@@ -44,7 +42,7 @@ impl PartialCycle {
     /// Update the partial cycle with a polygonal chain from the provided points
     pub fn with_poly_chain(
         mut self,
-        vertices: impl IntoIterator<Item = MaybePartial<Handle<SurfaceVertex>>>,
+        vertices: impl IntoIterator<Item = MaybePartial<SurfaceVertex>>,
     ) -> Self {
         let iter = self
             .half_edges
@@ -59,7 +57,7 @@ impl PartialCycle {
             .into_iter()
             .chain(vertices);
 
-        let mut previous: Option<MaybePartial<Handle<SurfaceVertex>>> = None;
+        let mut previous: Option<MaybePartial<SurfaceVertex>> = None;
 
         for vertex_next in iter {
             if let Some(vertex_prev) = previous {
@@ -84,20 +82,20 @@ impl PartialCycle {
 
                 previous = Some(to.clone());
 
-                let curve = Handle::<Curve>::partial()
+                let curve = Curve::partial()
                     .with_surface(Some(surface.clone()))
                     .as_line_from_points([position_prev, position_next]);
 
                 let [from, to] =
                     [(0., from), (1., to)].map(|(position, surface_form)| {
-                        Handle::<Vertex>::partial()
+                        Vertex::partial()
                             .with_curve(Some(curve.clone()))
                             .with_position(Some([position]))
                             .with_surface_form(Some(surface_form))
                     });
 
                 self.half_edges.push(
-                    Handle::<HalfEdge>::partial()
+                    HalfEdge::partial()
                         .with_curve(Some(curve))
                         .with_vertices(Some([from, to]))
                         .into(),
@@ -118,7 +116,7 @@ impl PartialCycle {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         self.with_poly_chain(points.into_iter().map(|position| {
-            Handle::<SurfaceVertex>::partial()
+            SurfaceVertex::partial()
                 .with_position(Some(position))
                 .into()
         }))
@@ -151,7 +149,7 @@ impl PartialCycle {
                 self.surface.clone().expect("Need surface to close cycle");
 
             self.half_edges.push(
-                Handle::<HalfEdge>::partial()
+                HalfEdge::partial()
                     .with_surface(Some(surface))
                     .as_line_segment_from_points(vertices)
                     .into(),
@@ -230,8 +228,8 @@ impl PartialCycle {
     }
 }
 
-impl From<&Handle<Cycle>> for PartialCycle {
-    fn from(cycle: &Handle<Cycle>) -> Self {
+impl From<&Cycle> for PartialCycle {
+    fn from(cycle: &Cycle) -> Self {
         Self {
             surface: Some(cycle.surface().clone()),
             half_edges: cycle.half_edges().cloned().map(Into::into).collect(),

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -27,7 +27,7 @@ macro_rules! impl_traits {
             impl Partial for $partial {
                 type Full = $full;
 
-                fn build(self, objects: &Objects) -> Self::Full {
+                fn build(self, objects: &Objects) -> Handle<Self::Full> {
                     self.build(objects)
                 }
             }
@@ -42,11 +42,11 @@ macro_rules! impl_traits {
 }
 
 impl_traits!(
-    Handle<Curve>, PartialCurve;
-    Handle<Cycle>, PartialCycle;
-    Handle<GlobalEdge>, PartialGlobalEdge;
-    Handle<GlobalVertex>, PartialGlobalVertex;
-    Handle<HalfEdge>, PartialHalfEdge;
-    Handle<SurfaceVertex>, PartialSurfaceVertex;
-    Handle<Vertex>, PartialVertex;
+    Curve, PartialCurve;
+    Cycle, PartialCycle;
+    GlobalEdge, PartialGlobalEdge;
+    GlobalVertex, PartialGlobalVertex;
+    HalfEdge, PartialHalfEdge;
+    SurfaceVertex, PartialSurfaceVertex;
+    Vertex, PartialVertex;
 );

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -19,19 +19,19 @@ pub struct PartialVertex {
     /// The curve that the [`Vertex`] is defined in
     ///
     /// Must be provided before [`PartialVertex::build`] is called.
-    pub curve: Option<MaybePartial<Handle<Curve>>>,
+    pub curve: Option<MaybePartial<Curve>>,
 
     /// The surface form of the [`Vertex`]
     ///
     /// Can be provided, if already available, or computed from the position on
     /// the [`Curve`].
-    pub surface_form: Option<MaybePartial<Handle<SurfaceVertex>>>,
+    pub surface_form: Option<MaybePartial<SurfaceVertex>>,
 
     /// The global form of the [`Vertex`]
     ///
     /// Can be provided, if already available, or acquired through the surface
     /// form.
-    pub global_form: Option<MaybePartial<Handle<GlobalVertex>>>,
+    pub global_form: Option<MaybePartial<GlobalVertex>>,
 }
 
 impl PartialVertex {
@@ -49,7 +49,7 @@ impl PartialVertex {
     /// Provide a curve for the partial vertex
     pub fn with_curve(
         mut self,
-        curve: Option<impl Into<MaybePartial<Handle<Curve>>>>,
+        curve: Option<impl Into<MaybePartial<Curve>>>,
     ) -> Self {
         if let Some(curve) = curve {
             self.curve = Some(curve.into());
@@ -60,7 +60,7 @@ impl PartialVertex {
     /// Provide a surface form for the partial vertex
     pub fn with_surface_form(
         mut self,
-        surface_form: Option<impl Into<MaybePartial<Handle<SurfaceVertex>>>>,
+        surface_form: Option<impl Into<MaybePartial<SurfaceVertex>>>,
     ) -> Self {
         if let Some(surface_form) = surface_form {
             self.surface_form = Some(surface_form.into());
@@ -71,7 +71,7 @@ impl PartialVertex {
     /// Provide a global form for the partial vertex
     pub fn with_global_form(
         mut self,
-        global_form: Option<impl Into<MaybePartial<Handle<GlobalVertex>>>>,
+        global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
     ) -> Self {
         if let Some(global_form) = global_form {
             self.global_form = Some(global_form.into());
@@ -97,7 +97,7 @@ impl PartialVertex {
 
         let surface_form = self
             .surface_form
-            .unwrap_or_else(|| Handle::<SurfaceVertex>::partial().into())
+            .unwrap_or_else(|| SurfaceVertex::partial().into())
             .update_partial(|partial| {
                 let position = partial.position.unwrap_or_else(|| {
                     curve.path().point_from_path_coords(position)
@@ -114,8 +114,8 @@ impl PartialVertex {
     }
 }
 
-impl From<&Handle<Vertex>> for PartialVertex {
-    fn from(vertex: &Handle<Vertex>) -> Self {
+impl From<&Vertex> for PartialVertex {
+    fn from(vertex: &Vertex) -> Self {
         Self {
             position: Some(vertex.position()),
             curve: Some(vertex.curve().clone().into()),
@@ -144,7 +144,7 @@ pub struct PartialSurfaceVertex {
     ///
     /// Can be provided, if already available, or computed from the position on
     /// the [`Surface`].
-    pub global_form: Option<MaybePartial<Handle<GlobalVertex>>>,
+    pub global_form: Option<MaybePartial<GlobalVertex>>,
 }
 
 impl PartialSurfaceVertex {
@@ -170,7 +170,7 @@ impl PartialSurfaceVertex {
     /// Provide a global form for the partial surface vertex
     pub fn with_global_form(
         mut self,
-        global_form: Option<impl Into<MaybePartial<Handle<GlobalVertex>>>>,
+        global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
     ) -> Self {
         if let Some(global_form) = global_form {
             self.global_form = Some(global_form.into());
@@ -196,7 +196,7 @@ impl PartialSurfaceVertex {
         let global_form = self
             .global_form
             .unwrap_or_else(|| {
-                Handle::<GlobalVertex>::partial()
+                GlobalVertex::partial()
                     .from_surface_and_position(&surface, position)
                     .into()
             })
@@ -206,8 +206,8 @@ impl PartialSurfaceVertex {
     }
 }
 
-impl From<&Handle<SurfaceVertex>> for PartialSurfaceVertex {
-    fn from(surface_vertex: &Handle<SurfaceVertex>) -> Self {
+impl From<&SurfaceVertex> for PartialSurfaceVertex {
+    fn from(surface_vertex: &SurfaceVertex) -> Self {
         Self {
             position: Some(surface_vertex.position()),
             surface: Some(surface_vertex.surface().clone()),
@@ -242,7 +242,7 @@ impl PartialGlobalVertex {
     /// Update partial global vertex from the given curve and position on it
     pub fn from_curve_and_position(
         self,
-        curve: impl Into<MaybePartial<Handle<Curve>>>,
+        curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
     ) -> Self {
         let curve = curve.into().into_partial();
@@ -278,8 +278,8 @@ impl PartialGlobalVertex {
     }
 }
 
-impl From<&Handle<GlobalVertex>> for PartialGlobalVertex {
-    fn from(global_vertex: &Handle<GlobalVertex>) -> Self {
+impl From<&GlobalVertex> for PartialGlobalVertex {
+    fn from(global_vertex: &GlobalVertex) -> Self {
         Self {
             position: Some(global_vertex.position()),
         }

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -1,4 +1,4 @@
-use crate::objects::Objects;
+use crate::{objects::Objects, storage::Handle};
 
 /// Implemented for objects that a partial object type exists for
 ///
@@ -77,5 +77,5 @@ pub trait Partial: Default + for<'a> From<&'a Self::Full> {
     /// Calling `build` on a partial object that can't infer its missing parts
     /// is considered a programmer error, hence why this method doesn't return a
     /// [`Result`].
-    fn build(self, objects: &Objects) -> Self::Full;
+    fn build(self, objects: &Objects) -> Handle<Self::Full>;
 }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,7 +5,6 @@ use fj_kernel::{
     },
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
     partial::HasPartial,
-    storage::Handle,
 };
 use fj_math::{Aabb, Point};
 
@@ -27,7 +26,7 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let half_edge = Handle::<HalfEdge>::partial()
+                let half_edge = HalfEdge::partial()
                     .with_surface(Some(surface.clone()))
                     .as_circle_from_radius(circle.radius(), objects)
                     .build(objects);


### PR DESCRIPTION
From a commit message:
> Now that all implementations of `HasPartial` have been integrated into the centralized object storage, the previous irregularity that required us to specify the `Handle` explicitly, is no longer there.