### PR TITLE
Consolidate builder API for `Face` in `FaceBuilder`

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -182,7 +182,8 @@ mod tests {
             [ 1., -1.],
         ];
 
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points(exterior)
             .with_interior_polygon_from_points(interior)
             .build();

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -79,7 +79,8 @@ mod tests {
         ];
         let [a, b] = [objects.surfaces.xy_plane(), objects.surfaces.xz_plane()]
             .map(|surface| {
-                Face::builder(&objects, surface)
+                Face::builder(&objects)
+                    .with_surface(surface)
                     .with_exterior_polygon_from_points(points)
                     .build()
             });
@@ -103,7 +104,8 @@ mod tests {
         let surfaces =
             [objects.surfaces.xy_plane(), objects.surfaces.xz_plane()];
         let [a, b] = surfaces.clone().map(|surface| {
-            Face::builder(&objects, surface)
+            Face::builder(&objects)
+                .with_surface(surface)
                 .with_exterior_polygon_from_points(points)
                 .build()
         });

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -145,7 +145,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
             .build();
         let point = Point::from([2., 1.]);
@@ -159,7 +160,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
             .build();
         let point = Point::from([1., 1.]);
@@ -176,7 +178,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
             .build();
         let point = Point::from([1., 2.]);
@@ -193,7 +196,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [0., 0.],
                 [2., 1.],
@@ -215,7 +219,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [0., 0.],
                 [2., 1.],
@@ -237,7 +242,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [0., 0.],
                 [2., 1.],
@@ -260,7 +266,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
             .build();
         let point = Point::from([1., 0.]);
@@ -286,7 +293,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build();
         let point = Point::from([1., 0.]);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -163,7 +163,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.yz_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],
@@ -183,7 +184,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.yz_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],
@@ -206,7 +208,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.yz_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],
@@ -226,7 +229,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.yz_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],
@@ -257,7 +261,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.yz_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],
@@ -286,7 +291,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],
@@ -308,7 +314,8 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([
                 [-1., -1.],
                 [1., -1.],

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -11,7 +11,7 @@ impl Reverse for Face {
         Face::builder(objects)
             .with_exterior(exterior)
             .with_interiors(interiors)
-            .build()
             .with_color(self.color())
+            .build()
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -8,7 +8,9 @@ impl Reverse for Face {
         let interiors =
             self.interiors().map(|cycle| cycle.clone().reverse(objects));
 
-        Face::new(exterior)
+        Face::builder(objects)
+            .with_exterior(exterior)
+            .build()
             .with_interiors(interiors)
             .with_color(self.color())
     }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -8,7 +8,7 @@ impl Reverse for Face {
         let interiors =
             self.interiors().map(|cycle| cycle.clone().reverse(objects));
 
-        Face::from_exterior(exterior)
+        Face::new(exterior)
             .with_interiors(interiors)
             .with_color(self.color())
     }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -10,8 +10,8 @@ impl Reverse for Face {
 
         Face::builder(objects)
             .with_exterior(exterior)
-            .build()
             .with_interiors(interiors)
+            .build()
             .with_color(self.color())
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -171,8 +171,8 @@ impl Sweep for (Handle<HalfEdge>, Color) {
 
         Face::builder(objects)
             .with_exterior(cycle)
-            .build()
             .with_color(color)
+            .build()
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -169,7 +169,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
             Cycle::new(surface, edges, objects)
         };
 
-        Face::from_exterior(cycle).with_color(color)
+        Face::new(cycle).with_color(color)
     }
 }
 
@@ -245,7 +245,7 @@ mod tests {
                 &objects,
             );
 
-            Face::from_exterior(cycle)
+            Face::new(cycle)
         };
 
         assert_eq!(face, expected_face);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -169,7 +169,10 @@ impl Sweep for (Handle<HalfEdge>, Color) {
             Cycle::new(surface, edges, objects)
         };
 
-        Face::new(cycle).with_color(color)
+        Face::builder(objects)
+            .with_exterior(cycle)
+            .build()
+            .with_color(color)
     }
 }
 
@@ -245,7 +248,7 @@ mod tests {
                 &objects,
             );
 
-            Face::new(cycle)
+            Face::builder(&objects).with_exterior(cycle).build()
         };
 
         assert_eq!(face, expected_face);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -102,11 +102,13 @@ mod tests {
             .build_polygon_from_points(TRIANGLE)
             .sweep(UP, &objects);
 
-        let bottom = Face::builder(&objects, surface.clone())
+        let bottom = Face::builder(&objects)
+            .with_surface(surface.clone())
             .with_exterior_polygon_from_points(TRIANGLE)
             .build()
             .reverse(&objects);
-        let top = Face::builder(&objects, surface.translate(UP, &objects))
+        let top = Face::builder(&objects)
+            .with_surface(surface.translate(UP, &objects))
             .with_exterior_polygon_from_points(TRIANGLE)
             .build();
 
@@ -134,12 +136,13 @@ mod tests {
             .build_polygon_from_points(TRIANGLE)
             .sweep(DOWN, &objects);
 
-        let bottom =
-            Face::builder(&objects, surface.clone().translate(DOWN, &objects))
-                .with_exterior_polygon_from_points(TRIANGLE)
-                .build()
-                .reverse(&objects);
-        let top = Face::builder(&objects, surface)
+        let bottom = Face::builder(&objects)
+            .with_surface(surface.clone().translate(DOWN, &objects))
+            .with_exterior_polygon_from_points(TRIANGLE)
+            .build()
+            .reverse(&objects);
+        let top = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build();
 

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -26,7 +26,9 @@ impl TransformObject for Face {
 
         let color = self.color();
 
-        Face::new(exterior)
+        Face::builder(objects)
+            .with_exterior(exterior)
+            .build()
             .with_interiors(interiors)
             .with_color(color)
     }

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -26,7 +26,7 @@ impl TransformObject for Face {
 
         let color = self.color();
 
-        Face::from_exterior(exterior)
+        Face::new(exterior)
             .with_interiors(interiors)
             .with_color(color)
     }

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -29,8 +29,8 @@ impl TransformObject for Face {
         Face::builder(objects)
             .with_exterior(exterior)
             .with_interiors(interiors)
-            .build()
             .with_color(color)
+            .build()
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -28,8 +28,8 @@ impl TransformObject for Face {
 
         Face::builder(objects)
             .with_exterior(exterior)
-            .build()
             .with_interiors(interiors)
+            .build()
             .with_color(color)
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -99,7 +99,8 @@ mod tests {
         let d = [0., 1.];
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([a, b, c, d])
             .build();
 
@@ -133,7 +134,8 @@ mod tests {
         let h = [3., 1.];
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface.clone())
+        let face = Face::builder(&objects)
+            .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
             .build();
@@ -193,7 +195,8 @@ mod tests {
         let e = [0., 0.8];
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface.clone())
+        let face = Face::builder(&objects)
+            .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d, e])
             .build();
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -33,6 +33,12 @@ impl<'a> FaceBuilder<'a> {
         self
     }
 
+    /// Build the [`Face`] with the provided exterior
+    pub fn with_exterior(mut self, exterior: Handle<Cycle>) -> Self {
+        self.exterior = Some(exterior);
+        self
+    }
+
     /// Build the [`Face`] with an exterior polygon from the provided points
     pub fn with_exterior_polygon_from_points(
         mut self,

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -54,6 +54,15 @@ impl<'a> FaceBuilder<'a> {
         self
     }
 
+    /// Build the [`Face`] with the provided interior polygons
+    pub fn with_interiors(
+        mut self,
+        interiors: impl IntoIterator<Item = Handle<Cycle>>,
+    ) -> Self {
+        self.interiors.extend(interiors);
+        self
+    }
+
     /// Build the [`Face`] with an interior polygon from the provided points
     pub fn with_interior_polygon_from_points(
         mut self,

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -83,6 +83,6 @@ impl<'a> FaceBuilder<'a> {
         let exterior = self
             .exterior
             .expect("Can't build `Face` without exterior cycle");
-        Face::new(exterior).with_interiors(self.interiors)
+        Face::new(exterior, self.interiors)
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -14,7 +14,7 @@ pub struct FaceBuilder<'a> {
     pub objects: &'a Objects,
 
     /// The surface that the [`Face`] is defined in
-    pub surface: Handle<Surface>,
+    pub surface: Option<Handle<Surface>>,
 
     /// The exterior cycle that bounds the [`Face`] on the outside
     ///
@@ -34,7 +34,7 @@ impl<'a> FaceBuilder<'a> {
     ) -> Self {
         self.exterior = Some(
             Cycle::partial()
-                .with_surface(Some(self.surface.clone()))
+                .with_surface(self.surface.clone())
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()
                 .build(self.objects),
@@ -49,7 +49,7 @@ impl<'a> FaceBuilder<'a> {
     ) -> Self {
         self.interiors.push(
             Cycle::partial()
-                .with_surface(Some(self.surface.clone()))
+                .with_surface(self.surface.clone())
                 .with_poly_chain_from_points(points)
                 .close_with_line_segment()
                 .build(self.objects),

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,3 +1,4 @@
+use fj_interop::mesh::Color;
 use fj_math::Point;
 
 use crate::{
@@ -24,6 +25,9 @@ pub struct FaceBuilder<'a> {
 
     /// The interior cycles that form holes in the [`Face`]
     pub interiors: Vec<Handle<Cycle>>,
+
+    /// The color of the [`Face`]
+    pub color: Option<Color>,
 }
 
 impl<'a> FaceBuilder<'a> {
@@ -78,11 +82,19 @@ impl<'a> FaceBuilder<'a> {
         self
     }
 
+    /// Build the [`Face`] with the provided color
+    pub fn with_color(mut self, color: Color) -> Self {
+        self.color = Some(color);
+        self
+    }
+
     /// Construct a polygon from a list of points
     pub fn build(self) -> Face {
         let exterior = self
             .exterior
             .expect("Can't build `Face` without exterior cycle");
-        Face::new(exterior, self.interiors)
+        let color = self.color.unwrap_or_default();
+
+        Face::new(exterior, self.interiors).with_color(color)
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -95,6 +95,6 @@ impl<'a> FaceBuilder<'a> {
             .expect("Can't build `Face` without exterior cycle");
         let color = self.color.unwrap_or_default();
 
-        Face::new(exterior, self.interiors).with_color(color)
+        Face::new(exterior, self.interiors, color)
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -62,6 +62,6 @@ impl<'a> FaceBuilder<'a> {
         let exterior = self
             .exterior
             .expect("Can't build `Face` without exterior cycle");
-        Face::from_exterior(exterior).with_interiors(self.interiors)
+        Face::new(exterior).with_interiors(self.interiors)
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -27,6 +27,12 @@ pub struct FaceBuilder<'a> {
 }
 
 impl<'a> FaceBuilder<'a> {
+    /// Build the [`Face`] with the provided surface
+    pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
+        self.surface = Some(surface);
+        self
+    }
+
     /// Build the [`Face`] with an exterior polygon from the provided points
     pub fn with_exterior_polygon_from_points(
         mut self,

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -39,7 +39,8 @@ impl<'a> ShellBuilder<'a> {
                 .xy_plane()
                 .translate([Z, Z, -h], self.objects);
 
-            Face::builder(self.objects, surface)
+            Face::builder(self.objects)
+                .with_surface(surface)
                 .with_exterior_polygon_from_points([
                     [-h, -h],
                     [h, -h],

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -171,7 +171,7 @@ impl<'a> ShellBuilder<'a> {
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(self.objects);
 
-                    Face::from_exterior(cycle)
+                    Face::new(cycle)
                 });
 
             (sides, tops)
@@ -234,7 +234,7 @@ impl<'a> ShellBuilder<'a> {
                 );
             }
 
-            Face::from_exterior(Cycle::new(surface, edges, self.objects))
+            Face::new(Cycle::new(surface, edges, self.objects))
         };
 
         let mut faces = Vec::new();

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -172,7 +172,7 @@ impl<'a> ShellBuilder<'a> {
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(self.objects);
 
-                    Face::new(cycle)
+                    Face::builder(self.objects).with_exterior(cycle).build()
                 });
 
             (sides, tops)
@@ -235,7 +235,9 @@ impl<'a> ShellBuilder<'a> {
                 );
             }
 
-            Face::new(Cycle::new(surface, edges, self.objects))
+            Face::builder(self.objects)
+                .with_exterior(Cycle::new(surface, edges, self.objects))
+                .build()
         };
 
         let mut faces = Vec::new();

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -22,7 +22,8 @@ impl<'a> SketchBuilder<'a> {
         self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Sketch {
-        let face = Face::builder(self.objects, self.surface)
+        let face = Face::builder(self.objects)
+            .with_surface(self.surface)
             .with_exterior_polygon_from_points(points)
             .build();
         Sketch::new().with_faces([face])

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -421,7 +421,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let object = Face::builder(&objects, surface)
+        let object = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build();
 
@@ -522,7 +523,8 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let face = Face::builder(&objects, surface)
+        let face = Face::builder(&objects)
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build();
         let object = Sketch::new().with_faces([face]);

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -55,11 +55,15 @@ impl Face {
     /// Creates the face with no interiors and the default color. This can be
     /// overridden using the `with_` methods.
     pub fn new(exterior: Handle<Cycle>) -> Self {
+        let surface = exterior.surface().clone();
+        let interiors = Vec::new();
+        let color = Color::default();
+
         Self {
-            surface: exterior.surface().clone(),
+            surface,
             exterior,
-            interiors: Vec::new(),
-            color: Color::default(),
+            interiors,
+            color,
         }
     }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -47,6 +47,7 @@ impl Face {
             surface: None,
             exterior: None,
             interiors: Vec::new(),
+            color: None,
         }
     }
 

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -54,7 +54,7 @@ impl Face {
     ///
     /// Creates the face with no interiors and the default color. This can be
     /// overridden using the `with_` methods.
-    pub fn from_exterior(exterior: Handle<Cycle>) -> Self {
+    pub fn new(exterior: Handle<Cycle>) -> Self {
         Self {
             surface: exterior.surface().clone(),
             exterior,

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -41,10 +41,10 @@ pub struct Face {
 
 impl Face {
     /// Build a `Face` using [`FaceBuilder`]
-    pub fn builder(objects: &Objects, surface: Handle<Surface>) -> FaceBuilder {
+    pub fn builder(objects: &Objects) -> FaceBuilder {
         FaceBuilder {
             objects,
-            surface: Some(surface),
+            surface: None,
             exterior: None,
             interiors: Vec::new(),
         }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -44,7 +44,7 @@ impl Face {
     pub fn builder(objects: &Objects, surface: Handle<Surface>) -> FaceBuilder {
         FaceBuilder {
             objects,
-            surface,
+            surface: Some(surface),
             exterior: None,
             interiors: Vec::new(),
         }

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -62,10 +62,10 @@ impl Face {
     pub fn new(
         exterior: Handle<Cycle>,
         the_interiors: impl IntoIterator<Item = Handle<Cycle>>,
+        color: Color,
     ) -> Self {
         let surface = exterior.surface().clone();
         let mut interiors = Vec::new();
-        let color = Color::default();
 
         for interior in the_interiors.into_iter() {
             assert_eq!(
@@ -88,14 +88,6 @@ impl Face {
             interiors,
             color,
         }
-    }
-
-    /// Update the color of the face
-    ///
-    /// Consumes the face and returns the updated instance.
-    pub fn with_color(mut self, color: Color) -> Self {
-        self.color = color;
-        self
     }
 
     /// Access this face's surface

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -78,7 +78,9 @@ impl Shape for fj::Difference2d {
             );
 
             faces.push(
-                Face::new(exterior)
+                Face::builder(objects)
+                    .with_exterior(exterior)
+                    .build()
                     .with_interiors(interiors)
                     .with_color(Color(self.color())),
             );

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -80,8 +80,8 @@ impl Shape for fj::Difference2d {
             faces.push(
                 Face::builder(objects)
                     .with_exterior(exterior)
-                    .build()
                     .with_interiors(interiors)
+                    .build()
                     .with_color(Color(self.color())),
             );
         }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -81,8 +81,8 @@ impl Shape for fj::Difference2d {
                 Face::builder(objects)
                     .with_exterior(exterior)
                     .with_interiors(interiors)
-                    .build()
-                    .with_color(Color(self.color())),
+                    .with_color(Color(self.color()))
+                    .build(),
             );
         }
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -78,7 +78,7 @@ impl Shape for fj::Difference2d {
             );
 
             faces.push(
-                Face::from_exterior(exterior)
+                Face::new(exterior)
                     .with_interiors(interiors)
                     .with_color(Color(self.color())),
             );

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -32,7 +32,10 @@ impl Shape for fj::Sketch {
                     .build(objects);
                 let cycle = Cycle::new(surface, [half_edge], objects);
 
-                Face::new(cycle).with_color(Color(self.color()))
+                Face::builder(objects)
+                    .with_exterior(cycle)
+                    .build()
+                    .with_color(Color(self.color()))
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let points =

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -38,7 +38,8 @@ impl Shape for fj::Sketch {
                 let points =
                     poly_chain.to_points().into_iter().map(Point::from);
 
-                Face::builder(objects, surface)
+                Face::builder(objects)
+                    .with_surface(surface)
                     .with_exterior_polygon_from_points(points)
                     .build()
                     .with_color(Color(self.color()))

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -34,8 +34,8 @@ impl Shape for fj::Sketch {
 
                 Face::builder(objects)
                     .with_exterior(cycle)
-                    .build()
                     .with_color(Color(self.color()))
+                    .build()
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let points =
@@ -44,8 +44,8 @@ impl Shape for fj::Sketch {
                 Face::builder(objects)
                     .with_surface(surface)
                     .with_exterior_polygon_from_points(points)
-                    .build()
                     .with_color(Color(self.color()))
+                    .build()
             }
         };
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -32,7 +32,7 @@ impl Shape for fj::Sketch {
                     .build(objects);
                 let cycle = Cycle::new(surface, [half_edge], objects);
 
-                Face::from_exterior(cycle).with_color(Color(self.color()))
+                Face::new(cycle).with_color(Color(self.color()))
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let points =


### PR DESCRIPTION
This makes `Face` completely immutable, preparing it for integration into the centralized object storage (#1021). This should be a very small step from here, but unfortunately I've run out of time.