### PR TITLE
Print timestamp with each status update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
 name = "fj-interop"
 version = "0.20.0"
 dependencies = [
+ "chrono",
  "fj-math",
 ]
 

--- a/crates/fj-interop/Cargo.toml
+++ b/crates/fj-interop/Cargo.toml
@@ -11,4 +11,5 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+chrono = "0.4.22"
 fj-math.workspace = true

--- a/crates/fj-interop/src/status_report.rs
+++ b/crates/fj-interop/src/status_report.rs
@@ -2,6 +2,8 @@
 
 use std::collections::VecDeque;
 
+use chrono::Local;
+
 /// Struct to store and update status messages
 #[derive(Default)]
 pub struct StatusReport {
@@ -16,7 +18,9 @@ impl StatusReport {
 
     /// Update the status
     pub fn update_status(&mut self, status: &str) {
-        let status = format!("\n{}", status.to_owned());
+        let date = Local::now();
+        let status =
+            format!("\n{} {}", date.format("[%H:%M:%S]"), status.to_owned());
         self.status.push_back(status);
         if self.status.len() > 5 {
             for _ in 0..(self.status.len() - 5) {


### PR DESCRIPTION
The timestamps are added with the format `[%H:%M:%S]` to the beginning of status updates.

Closes https://github.com/hannobraun/Fornjot/issues/971