### PR TITLE
Clean up CI build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,15 +35,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-
       - name: Cache
         uses: Swatinem/rust-cache@v1
         with:
@@ -83,15 +74,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Setup Toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
 
       - name: Operator | Cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,10 +41,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Binaries | Compile
-        uses: actions-rs/cargo@v1
-        with:
-          args: --release --target ${{ matrix.target }}
-          command: build
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Binaries | Prepare upload
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
 
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Operator | Cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
         with:
           key: release-operator-01
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,3 @@
----
-# Source: https://github.com/hendrikmaus/rust-workflows
-#
-# Continuous Integration Workflow For Rust
 name: CI
 
 # Define the triggers; usually merges to the repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,27 +33,15 @@ jobs:
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - name: Check formatting
-        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Run Clippy
-        uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
       - name: Build documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps --document-private-items --all-features --workspace
+        run: cargo doc --no-deps --document-private-items --all-features --workspace
         env:
           RUSTDOCFLAGS: -D warnings
       - name: Run `cross-compiler`
-        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: run
-          args: --package cross-compiler
+        run: cargo run --package cross-compiler
 
   test:
     name: Test
@@ -70,22 +58,13 @@ jobs:
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - name: Run `cargo build`
-        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: build
-          args: --all-features
+        run: cargo build --all-features
       - name: Reject uncommitted changes
         run: git diff --exit-code
       - name: Run `cargo test`
-        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
       - name: Run `export-validator`
-        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: run
-          args: --package export-validator
+        run: cargo run --package export-validator
         # Export Validator doesn't support Windows yet. Issue:
         # https://github.com/hannobraun/Fornjot/issues/920
         if: ${{ matrix.os != 'windows-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ defaults:
     shell: bash
 
 jobs:
-  fmt:
-    name: Format
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -38,59 +38,30 @@ jobs:
           override: true
           profile: minimal
           target: ${{ matrix.target }}
-      - name: Run `cargo fmt`
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
+      - name: Check formatting
         uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: fmt
           args: --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Set up toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-      - name: Install Clippy
-        run: rustup component add clippy
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
-      - name: Run `cargo clippy`
+      - name: Run Clippy
         uses: actions-rs/clippy-check@b5b5f21f4797c02da247df37026fcd0a5024aa4d
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features -- -D warnings
-
-  docs:
-    name: Docs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Set up toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@v1
-      - name: Run `cargo doc`
+      - name: Build documentation
         uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --no-deps --document-private-items --all-features --workspace
         env:
           RUSTDOCFLAGS: -D warnings
+      - name: Run `cross-compiler`
+        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
+        with:
+          command: run
+          args: --package cross-compiler
 
   test:
     name: Test
@@ -134,25 +105,3 @@ jobs:
         # Export Validator doesn't support Windows yet. Issue:
         # https://github.com/hannobraun/Fornjot/issues/920
         if: ${{ matrix.os != 'windows-latest' }}
-
-  wasm:
-    name: Cross-compile
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Set up toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
-      - name: Set up Rust cache
-        uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
-      - name: Run `cross-compiler`
-        uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
-        with:
-          command: run
-          args: --package cross-compiler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Run Clippy
         run: cargo clippy --all-features -- -D warnings
+      - name: Reject uncommitted changes
+        run: git diff --exit-code
       - name: Build documentation
         run: cargo doc --no-deps --document-private-items --all-features --workspace
         env:
@@ -59,8 +61,6 @@ jobs:
         uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - name: Run `cargo build`
         run: cargo build --all-features
-      - name: Reject uncommitted changes
-        run: git diff --exit-code
       - name: Run `cargo test`
         run: cargo test --all-features
       - name: Run `export-validator`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Set up toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - name: Check formatting
@@ -75,14 +67,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Set up toolchain
-        uses: oxidecomputer/actions-rs_toolchain@oxide/master
-        # see https://github.com/actions-rs/toolchain/pull/209
-        # uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          target: ${{ matrix.target }}
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
       - name: Run `cargo build`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up Rust cache
-        uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
+        uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: cargo fmt --all -- --check
       - name: Run Clippy
@@ -58,7 +58,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up Rust cache
-        uses: Swatinem/rust-cache@1232abb8968faf344409165de17cbf9e7f340fd8
+        uses: Swatinem/rust-cache@v2
       - name: Run `cargo build`
         run: cargo build --all-features
       - name: Run `cargo test`


### PR DESCRIPTION
Simplify the CI build configuration, removing lots of duplication and unnecessary actions. It even seems to be a performance win, judging from the first results while building this pull request.