### PR TITLE
Fix blurry egui

### DIFF
--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -156,8 +156,8 @@ impl Renderer {
         })
     }
 
-    pub(crate) fn init_gui(&self) -> Gui {
-        Gui::new(&self.device, self.surface_config.format)
+    pub(crate) fn init_gui(&self, pixels_per_point: f32) -> Gui {
+        Gui::new(&self.device, self.surface_config.format, pixels_per_point)
     }
 
     /// Updates the geometry of the model being rendered.

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -156,8 +156,8 @@ impl Renderer {
         })
     }
 
-    pub(crate) fn init_gui(&self, pixels_per_point: f32) -> Gui {
-        Gui::new(&self.device, self.surface_config.format, pixels_per_point)
+    pub(crate) fn init_gui(&self) -> Gui {
+        Gui::new(&self.device, self.surface_config.format)
     }
 
     /// Updates the geometry of the model being rendered.

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -30,7 +30,7 @@ impl Gui {
     pub(crate) fn new(
         device: &wgpu::Device,
         texture_format: wgpu::TextureFormat,
-        pixels_per_point: f32,
+        _: f32,
     ) -> Self {
         // The implementation of the integration with `egui` is likely to need
         // to change "significantly" depending on what architecture approach is
@@ -51,7 +51,6 @@ impl Gui {
         // - https://github.com/emilk/egui/blob/eeae485629fca24a81a7251739460b671e1420f7/README.md#how-do-i-render-3d-stuff-in-an-egui-area
 
         let context = egui::Context::default();
-        context.set_pixels_per_point(pixels_per_point);
 
         // We need to hold on to this, otherwise it might cause the egui font
         // texture to get dropped after drawing one frame.
@@ -81,12 +80,14 @@ impl Gui {
 
     pub(crate) fn update(
         &mut self,
+        pixels_per_point: f32,
         egui_input: egui::RawInput,
         config: &mut DrawConfig,
         aabb: &Aabb<3>,
         status: &StatusReport,
         line_drawing_available: bool,
     ) {
+        self.context.set_pixels_per_point(pixels_per_point);
         self.context.begin_frame(egui_input);
 
         let bounding_box_size = {

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -30,6 +30,7 @@ impl Gui {
     pub(crate) fn new(
         device: &wgpu::Device,
         texture_format: wgpu::TextureFormat,
+        pixels_per_point: f32,
     ) -> Self {
         // The implementation of the integration with `egui` is likely to need
         // to change "significantly" depending on what architecture approach is
@@ -50,6 +51,7 @@ impl Gui {
         // - https://github.com/emilk/egui/blob/eeae485629fca24a81a7251739460b671e1420f7/README.md#how-do-i-render-3d-stuff-in-an-egui-area
 
         let context = egui::Context::default();
+        context.set_pixels_per_point(pixels_per_point);
 
         // We need to hold on to this, otherwise it might cause the egui font
         // texture to get dropped after drawing one frame.

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -30,7 +30,6 @@ impl Gui {
     pub(crate) fn new(
         device: &wgpu::Device,
         texture_format: wgpu::TextureFormat,
-        _: f32,
     ) -> Self {
         // The implementation of the integration with `egui` is likely to need
         // to change "significantly" depending on what architecture approach is

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -135,6 +135,7 @@ impl Viewer {
         self.camera.update_planes(&aabb);
 
         self.gui.update(
+            pixels_per_point,
             egui_input,
             &mut self.draw_config,
             &aabb,

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -122,7 +122,7 @@ impl Viewer {
     /// Draw the graphics
     pub fn draw(
         &mut self,
-        scale_factor: f32,
+        pixels_per_point: f32,
         status: &mut StatusReport,
         egui_input: egui::RawInput,
     ) {
@@ -145,7 +145,7 @@ impl Viewer {
         if let Err(err) = self.renderer.draw(
             &self.camera,
             &self.draw_config,
-            scale_factor,
+            pixels_per_point,
             &mut self.gui,
         ) {
             warn!("Draw error: {}", err);

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -38,12 +38,9 @@ pub struct Viewer {
 
 impl Viewer {
     /// Construct a new instance of `Viewer`
-    pub async fn new(
-        screen: &impl Screen,
-        pixels_per_point: f32,
-    ) -> Result<Self, RendererInitError> {
+    pub async fn new(screen: &impl Screen) -> Result<Self, RendererInitError> {
         let renderer = Renderer::new(screen).await?;
-        let gui = renderer.init_gui(pixels_per_point);
+        let gui = renderer.init_gui();
 
         Ok(Self {
             camera: Camera::default(),

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -38,9 +38,12 @@ pub struct Viewer {
 
 impl Viewer {
     /// Construct a new instance of `Viewer`
-    pub async fn new(screen: &impl Screen) -> Result<Self, RendererInitError> {
+    pub async fn new(
+        screen: &impl Screen,
+        pixels_per_point: f32,
+    ) -> Result<Self, RendererInitError> {
         let renderer = Renderer::new(screen).await?;
-        let gui = renderer.init_gui();
+        let gui = renderer.init_gui(pixels_per_point);
 
         Ok(Self {
             camera: Camera::default(),

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -36,8 +36,7 @@ pub fn run(
 
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop)?;
-    let mut viewer =
-        block_on(Viewer::new(&window, window.window().scale_factor() as f32))?;
+    let mut viewer = block_on(Viewer::new(&window))?;
 
     let events = watcher.events();
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -36,7 +36,8 @@ pub fn run(
 
     let event_loop = EventLoop::new();
     let window = Window::new(&event_loop)?;
-    let mut viewer = block_on(Viewer::new(&window))?;
+    let mut viewer =
+        block_on(Viewer::new(&window, window.window().scale_factor() as f32))?;
 
     let events = watcher.events();
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -204,6 +204,7 @@ pub fn run(
 
                 let pixels_per_point = window.window().scale_factor() as f32;
 
+                egui_winit_state.set_pixels_per_point(pixels_per_point);
                 let egui_input =
                     egui_winit_state.take_egui_input(window.window());
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -202,14 +202,12 @@ pub fn run(
                     viewer.handle_screen_resize(size);
                 }
 
+                let pixels_per_point = window.window().scale_factor() as f32;
+
                 let egui_input =
                     egui_winit_state.take_egui_input(window.window());
 
-                viewer.draw(
-                    window.window().scale_factor() as f32,
-                    &mut status,
-                    egui_input,
-                );
+                viewer.draw(pixels_per_point, &mut status, egui_input);
             }
             _ => {}
         }


### PR DESCRIPTION
The egui context created here: https://github.com/hannobraun/Fornjot/blob/8c423093840ac7bb99b56533cb8b5804d43a3836/crates/fj-viewer/src/gui.rs#L52 for some reason didn't have the right pixels_per_point ratio so I explicitly set this ratio with the value I got from winit. This solved the blurriness but unfortunately the mouse input is still offseted.