### PR TITLE
Enable multisample anti-aliasing

### DIFF
--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -16,4 +16,4 @@ pub use self::{
 };
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
-const SAMPLE_COUNT: u32 = 1;
+const SAMPLE_COUNT: u32 = 4;

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -16,3 +16,4 @@ pub use self::{
 };
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+const SAMPLE_COUNT: u32 = 1;

--- a/crates/fj-viewer/src/graphics/pipelines.rs
+++ b/crates/fj-viewer/src/graphics/pipelines.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use super::{
     shaders::{Shader, Shaders},
     vertices::Vertex,
-    DEPTH_FORMAT,
+    DEPTH_FORMAT, SAMPLE_COUNT,
 };
 
 #[derive(Debug)]
@@ -108,7 +108,7 @@ impl Pipeline {
                     bias: wgpu::DepthBiasState::default(),
                 }),
                 multisample: wgpu::MultisampleState {
-                    count: 1,
+                    count: SAMPLE_COUNT,
                     mask: !0,
                     alpha_to_coverage_enabled: false,
                 },

--- a/crates/fj-viewer/src/graphics/pipelines.rs
+++ b/crates/fj-viewer/src/graphics/pipelines.rs
@@ -110,7 +110,7 @@ impl Pipeline {
                 multisample: wgpu::MultisampleState {
                     count: SAMPLE_COUNT,
                     mask: !0,
-                    alpha_to_coverage_enabled: false,
+                    alpha_to_coverage_enabled: true,
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: shader.module,

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -187,9 +187,8 @@ impl Renderer {
 
         self.surface.configure(&self.device, &self.surface_config);
 
-        let depth_view =
+        self.depth_view =
             Self::create_depth_buffer(&self.device, &self.surface_config);
-        self.depth_view = depth_view;
     }
 
     /// Draws the renderer, camera, and config state to the window.

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -14,7 +14,7 @@ use crate::{
 use super::{
     draw_config::DrawConfig, drawables::Drawables, geometries::Geometries,
     pipelines::Pipelines, transform::Transform, uniforms::Uniforms,
-    vertices::Vertices, DEPTH_FORMAT,
+    vertices::Vertices, DEPTH_FORMAT, SAMPLE_COUNT,
 };
 
 /// Graphics rendering state and target abstraction
@@ -315,7 +315,7 @@ impl Renderer {
                 depth_or_array_layers: 1,
             },
             mip_level_count: 1,
-            sample_count: 1,
+            sample_count: SAMPLE_COUNT,
             dimension: wgpu::TextureDimension::D2,
             format: DEPTH_FORMAT,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,


### PR DESCRIPTION
Before:
![msaa-no](https://user-images.githubusercontent.com/85732/198002534-0e2e1fa0-80c4-444d-9db0-0d9fc0f927a6.png)

After:
![msaa-yes](https://user-images.githubusercontent.com/85732/198002540-450ba381-8028-4678-a952-c043830921a4.png)

Looks better! (Especially when not magnified quite as much as in the images here.)