### PR TITLE
Fix text of status messages looking jagged

### DIFF
--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -237,7 +237,8 @@ impl Gui {
             ui.group(|ui| {
                 ui.add(egui::Label::new(
                     egui::RichText::new(format!("Status:{}", status.status()))
-                        .color(egui::Color32::BLACK),
+                        .color(egui::Color32::BLACK)
+                        .background_color(egui::Color32::WHITE),
                 ))
             })
         });


### PR DESCRIPTION
Before:
![status-before](https://user-images.githubusercontent.com/85732/198006106-bf0fd69a-f871-4780-81de-7ed957af2cf6.png)

After:
![status-after](https://user-images.githubusercontent.com/85732/198006114-aa8fe7d1-4a27-4916-beae-126ea2d5e375.png)

This has the side effect of showing a white bar in front of non-white background:
![status-side-effect](https://user-images.githubusercontent.com/85732/198006119-185bf9dd-1ed5-4e5b-af5e-54e3414553c9.png)

I actually think this works pretty well.