### PR TITLE
Fix some crashes, turn them into actionable errors

### DIFF
--- a/crates/fj-host/src/evaluator.rs
+++ b/crates/fj-host/src/evaluator.rs
@@ -23,16 +23,6 @@ impl Evaluator {
 
             let evaluation = match model.evaluate() {
                 Ok(evaluation) => evaluation,
-                Err(Error::Compile { output }) => {
-                    event_tx
-                        .send(ModelEvent::StatusUpdate(format!(
-                            "Failed to compile model:\n{}",
-                            output
-                        )))
-                        .expect("Expected channel to never disconnect");
-
-                    continue;
-                }
                 Err(err) => {
                     event_tx
                         .send(ModelEvent::Error(err))
@@ -65,9 +55,6 @@ impl Evaluator {
 
 /// An event emitted by [`Evaluator`]
 pub enum ModelEvent {
-    /// A status update about the model
-    StatusUpdate(String),
-
     /// The model has been evaluated
     Evaluation(Evaluation),
 

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -231,17 +231,6 @@ fn ambiguous_path_error(
 /// An error that can occur when loading or reloading a model
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Model failed to compile
-    #[error("Error compiling model")]
-    Compile {
-        /// The compiler output
-        output: String,
-    },
-
-    /// I/O error while loading the model
-    #[error("I/O error while loading model")]
-    Io(#[from] io::Error),
-
     /// Failed to load the model's dynamic library
     #[error("Error loading model from dynamic library")]
     LibLoading(#[from] libloading::Error),
@@ -255,6 +244,17 @@ pub enum Error {
         /// The model version
         model: String,
     },
+
+    /// Model failed to compile
+    #[error("Error compiling model")]
+    Compile {
+        /// The compiler output
+        output: String,
+    },
+
+    /// I/O error while loading the model
+    #[error("I/O error while loading model")]
+    Io(#[from] io::Error),
 
     /// Initializing a model failed.
     #[error("Unable to initialize the model")]

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -104,7 +104,7 @@ impl Model {
             let lib = libloading::Library::new(&self.lib_path)?;
 
             let version_pkg: libloading::Symbol<fn() -> RawVersion> =
-                lib.get(b"version_pkg")?;
+                lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
 
             let version_pkg = version_pkg();
             if fj::version::VERSION_PKG != version_pkg.as_str() {
@@ -231,6 +231,14 @@ fn ambiguous_path_error(
 /// An error that can occur when loading or reloading a model
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Error loading Fornjot version that the model uses
+    #[error(
+        "Failed to load the Fornjot version that the model uses\n\
+        - Is your model using the `fj` library? All models must!\n\
+        - Was your model created with a really old version of Fornjot?"
+    )]
+    LoadingVersion(#[source] libloading::Error),
+
     /// Failed to load the model's dynamic library
     #[error("Error loading model from dynamic library")]
     LibLoading(#[from] libloading::Error),

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -267,7 +267,7 @@ pub enum Error {
     },
 
     /// Model failed to compile
-    #[error("Error compiling model")]
+    #[error("Error compiling model\n{output}")]
     Compile {
         /// The compiler output
         output: String,

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -120,8 +120,9 @@ impl Model {
                 return Err(Error::VersionMismatch { host, model });
             }
 
-            let init: libloading::Symbol<abi::InitFunction> =
-                lib.get(abi::INIT_FUNCTION_NAME.as_bytes())?;
+            let init: libloading::Symbol<abi::InitFunction> = lib
+                .get(abi::INIT_FUNCTION_NAME.as_bytes())
+                .map_err(Error::LoadingInit)?;
 
             let mut host = Host::new(&self.parameters);
 
@@ -248,9 +249,12 @@ pub enum Error {
     )]
     LoadingVersion(#[source] libloading::Error),
 
-    /// Failed to load the model's dynamic library
-    #[error("Error loading model from dynamic library")]
-    LibLoading(#[from] libloading::Error),
+    /// Error loading the model's `init` function
+    #[error(
+        "Failed to load the model's `init` function\n\
+        - Did you define a model function using `#[fj::model]`?"
+    )]
+    LoadingInit(#[source] libloading::Error),
 
     /// Host version and model version do not match
     #[error("Host version ({host}) and model version ({model}) do not match")]

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -101,7 +101,8 @@ impl Model {
         // to switch to a better technique:
         // https://github.com/hannobraun/Fornjot/issues/71
         let shape = unsafe {
-            let lib = libloading::Library::new(&self.lib_path)?;
+            let lib = libloading::Library::new(&self.lib_path)
+                .map_err(Error::LoadingLibrary)?;
 
             let version_pkg: libloading::Symbol<fn() -> RawVersion> =
                 lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
@@ -231,6 +232,14 @@ fn ambiguous_path_error(
 /// An error that can occur when loading or reloading a model
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// Error loading model library
+    #[error(
+        "Failed to load model library\n\
+        This might be a bug in Fornjot, or, at the very least, this error \
+        message should be improved. Please report this!"
+    )]
+    LoadingLibrary(#[source] libloading::Error),
+
     /// Error loading Fornjot version that the model uses
     #[error(
         "Failed to load the Fornjot version that the model uses\n\

--- a/crates/fj-interop/src/status_report.rs
+++ b/crates/fj-interop/src/status_report.rs
@@ -20,11 +20,17 @@ impl StatusReport {
     pub fn update_status(&mut self, status: &str) {
         let date = {
             let date = Local::now();
-            format!("{} ", date.format("[%H:%M:%S]"))
+            format!("{}", date.format("[%H:%M:%S]"))
         };
+        let empty_space = " ".repeat(date.chars().count());
 
-        let status = format!("\n{} {}", date, status.to_owned());
-        self.status.push_back(status);
+        let mut rendered = String::new();
+        for (i, line) in status.lines().enumerate() {
+            let prefix = if i == 0 { &date } else { &empty_space };
+            rendered.push_str(&format!("\n{prefix} {line}"));
+        }
+
+        self.status.push_back(rendered);
         if self.status.len() > 5 {
             for _ in 0..(self.status.len() - 5) {
                 self.status.pop_front();

--- a/crates/fj-interop/src/status_report.rs
+++ b/crates/fj-interop/src/status_report.rs
@@ -18,9 +18,12 @@ impl StatusReport {
 
     /// Update the status
     pub fn update_status(&mut self, status: &str) {
-        let date = Local::now();
-        let status =
-            format!("\n{} {}", date.format("[%H:%M:%S]"), status.to_owned());
+        let date = {
+            let date = Local::now();
+            format!("{} ", date.format("[%H:%M:%S]"))
+        };
+
+        let status = format!("\n{} {}", date, status.to_owned());
         self.status.push_back(status);
         if self.status.len() > 5 {
             for _ in 0..(self.status.len() - 5) {

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -237,6 +237,7 @@ impl Gui {
             ui.group(|ui| {
                 ui.add(egui::Label::new(
                     egui::RichText::new(format!("Status:{}", status.status()))
+                        .monospace()
                         .color(egui::Color32::BLACK)
                         .background_color(egui::Color32::WHITE),
                 ))

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -113,9 +113,6 @@ pub fn run(
 
                         current_err = err;
                     }
-
-                    *control_flow = ControlFlow::Exit;
-                    return;
                 }
             }
         }

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -69,9 +69,6 @@ pub fn run(
             };
 
             match event {
-                ModelEvent::StatusUpdate(status_update) => {
-                    status.update_status(&status_update)
-                }
                 ModelEvent::Evaluation(evaluation) => {
                     status.update_status(&format!(
                         "Model compiled successfully in {}!",

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -100,19 +100,7 @@ pub fn run(
                     }
                 }
                 ModelEvent::Error(err) => {
-                    // Can be cleaned up, once `Report` is stable:
-                    // https://doc.rust-lang.org/std/error/struct.Report.html
-
-                    println!("Error receiving updated shape: {}", err);
-
-                    let mut current_err = &err as &dyn error::Error;
-                    while let Some(err) = current_err.source() {
-                        println!();
-                        println!("Caused by:");
-                        println!("    {}", err);
-
-                        current_err = err;
-                    }
+                    status.update_status(&err.to_string());
                 }
             }
         }


### PR DESCRIPTION
Previously, the app would crash when evaluating the model failed (except in the case of a compiler error), partially with error messages that weren't really actionable. This pull request improves this situation, first of all by not crashing the app, then by showing an actionable error message in some of those cases.

Like this:
![error-1](https://user-images.githubusercontent.com/85732/198009912-c79c421c-a0f2-4a61-ae65-984a83011f5d.png)

Or this:
![error-2](https://user-images.githubusercontent.com/85732/198009918-00dbc7e0-a728-4841-943c-53bff2248855.png)

Close #848 