### PR TITLE
Cross-compile to Android target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,11 +2768,7 @@ checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
 [[package]]
 name = "robust-predicates"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcbdd0b6bbb300dabed5c0faacb570e0dbafe71338d34a7caff70a5e98fed47"
-dependencies = [
- "cc",
-]
+source = "git+https://github.com/hannobraun/robust-predicates.git#99bcbb24886eda34f5a4f794cccb5f236c8bbbc7"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,7 @@ path = "crates/fj-viewer"
 [workspace.dependencies.fj-window]
 version = "0.21.0"
 path = "crates/fj-window"
+
+
+[patch.crates-io.robust-predicates]
+git = "https://github.com/hannobraun/robust-predicates.git"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.64.0"
 components = ["rustfmt", "clippy"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["aarch64-linux-android", "wasm32-unknown-unknown"]

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 use anyhow::anyhow;
 
 fn main() -> anyhow::Result<()> {
+    let targets = ["wasm32-unknown-unknown"];
     let crates = [
         "fj",
         "fj-export",
@@ -21,20 +22,22 @@ fn main() -> anyhow::Result<()> {
         "fj-viewer",
     ];
 
-    for crate_ in crates {
-        let mut command = Command::new("cargo");
-        command
-            .arg("build")
-            .arg("--all-features")
-            .args(["--target", "wasm32-unknown-unknown"])
-            .args(["-p", crate_])
-            .env("RUSTFLAGS", "-D warnings");
+    for target in targets {
+        for crate_ in crates {
+            let mut command = Command::new("cargo");
+            command
+                .arg("build")
+                .arg("--all-features")
+                .args(["--target", target])
+                .args(["-p", crate_])
+                .env("RUSTFLAGS", "-D warnings");
 
-        println!("Running {command:?}");
-        let status = command.status()?;
+            println!("Running {command:?}");
+            let status = command.status()?;
 
-        if !status.success() {
-            return Err(anyhow!("Cargo exited with error code: {status}"));
+            if !status.success() {
+                return Err(anyhow!("Cargo exited with error code: {status}"));
+            }
         }
     }
 

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use anyhow::anyhow;
 
 fn main() -> anyhow::Result<()> {
-    let targets = ["wasm32-unknown-unknown"];
+    let targets = ["aarch64-linux-android", "wasm32-unknown-unknown"];
     let crates = [
         "fj",
         "fj-export",


### PR DESCRIPTION
This isn't really Android support yet, in any real sense, but at least it should guarantee that we don't backslide and add any features that don't compile on Android.

Currently marked as draft, as it depends on my fork of `robust-predicates`.