### PR TITLE
Separate object construction from store insertion

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -57,7 +57,7 @@ impl SurfaceSurfaceIntersection {
 
         let curves = surfaces_and_planes.map(|(surface, plane)| {
             let path = SurfacePath::Line(plane.project_line(&line));
-            let global_form = GlobalCurve::new(objects);
+            let global_form = objects.global_curves.insert(GlobalCurve);
 
             Curve::new(surface, path, global_form, objects)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -59,7 +59,9 @@ impl SurfaceSurfaceIntersection {
             let path = SurfacePath::Line(plane.project_line(&line));
             let global_form = objects.global_curves.insert(GlobalCurve);
 
-            Curve::new(surface, path, global_form, objects)
+            objects
+                .curves
+                .insert(Curve::new(surface, path, global_form))
         });
 
         Some(Self {

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -17,6 +17,6 @@ impl Reverse for Handle<Cycle> {
 
         edges.reverse();
 
-        Cycle::new(surface, edges, objects)
+        objects.cycles.insert(Cycle::new(surface, edges))
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -12,6 +12,8 @@ impl Reverse for Handle<HalfEdge> {
             [b, a]
         };
 
-        HalfEdge::new(vertices, self.global_form().clone(), objects)
+        objects
+            .half_edges
+            .insert(HalfEdge::new(vertices, self.global_form().clone()))
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -80,7 +80,9 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 )
             };
 
-            HalfEdge::new(vertices, edge.global_form().clone(), objects)
+            objects
+                .half_edges
+                .insert(HalfEdge::new(vertices, edge.global_form().clone()))
         };
 
         let side_edges =
@@ -139,7 +141,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     ))
                 });
 
-            HalfEdge::new(vertices, global, objects)
+            objects.half_edges.insert(HalfEdge::new(vertices, global))
         };
 
         let cycle = {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -121,13 +121,12 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     .insert(Curve::new(surface.clone(), path, global))
             };
 
-            let global = GlobalEdge::new(
+            let global = objects.global_edges.insert(GlobalEdge::new(
                 curve.global_form().clone(),
                 surface_vertices
                     .clone()
                     .map(|surface_vertex| surface_vertex.global_form().clone()),
-                objects,
-            );
+            ));
 
             let vertices = bottom_vertices
                 .each_ref_ext()

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -50,12 +50,11 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         points_curve_and_surface,
                     ));
 
-                Curve::new(
+                objects.curves.insert(Curve::new(
                     surface.clone(),
                     path,
                     edge.curve().global_form().clone(),
-                    objects,
-                )
+                ))
             };
 
             let vertices = {
@@ -117,7 +116,9 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         points_curve_and_surface,
                     ));
 
-                Curve::new(surface.clone(), path, global, objects)
+                objects
+                    .curves
+                    .insert(Curve::new(surface.clone(), path, global))
             };
 
             let global = GlobalEdge::new(

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -170,7 +170,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 i += 1;
             }
 
-            Cycle::new(surface, edges, objects)
+            objects.cycles.insert(Cycle::new(surface, edges))
         };
 
         Ok(Face::builder(objects)
@@ -247,11 +247,9 @@ mod tests {
                 .build(&objects)?
                 .reverse(&objects);
 
-            let cycle = Cycle::new(
-                surface,
-                [bottom, side_up, top, side_down],
-                &objects,
-            );
+            let cycle = objects
+                .cycles
+                .insert(Cycle::new(surface, [bottom, side_up, top, side_down]));
 
             Face::builder(&objects).with_exterior(cycle).build()
         };

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -71,12 +71,11 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                             ),
                         );
 
-                        Vertex::new(
+                        objects.vertices.insert(Vertex::new(
                             vertex.position(),
                             curve.clone(),
                             surface_vertex,
-                            objects,
-                        )
+                        ))
                     },
                 )
             };
@@ -134,12 +133,11 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 .each_ref_ext()
                 .zip_ext(surface_vertices)
                 .map(|(vertex, surface_form)| {
-                    Vertex::new(
+                    objects.vertices.insert(Vertex::new(
                         vertex.position(),
                         curve.clone(),
                         surface_form,
-                        objects,
-                    )
+                    ))
                 });
 
             HalfEdge::new(vertices, global, objects)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -63,11 +63,12 @@ impl Sweep for (Handle<HalfEdge>, Color) {
 
                 vertices.each_ref_ext().zip_ext(points_surface).map(
                     |(vertex, point_surface)| {
-                        let surface_vertex = SurfaceVertex::new(
-                            point_surface,
-                            surface.clone(),
-                            vertex.global_form().clone(),
-                            objects,
+                        let surface_vertex = objects.surface_vertices.insert(
+                            SurfaceVertex::new(
+                                point_surface,
+                                surface.clone(),
+                                vertex.global_form().clone(),
+                            ),
                         );
 
                         Vertex::new(

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -137,10 +137,9 @@ impl Sweep for Handle<GlobalVertex> {
             .global_vertex
             .entry(self.id())
             .or_insert_with(|| {
-                GlobalVertex::from_position(
+                objects.global_vertices.insert(GlobalVertex::from_position(
                     self.position() + path.into(),
-                    objects,
-                )
+                ))
             })
             .clone();
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -111,12 +111,11 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
         // And now the vertices. Again, nothing wild here.
         let vertices = vertices_surface.map(|surface_form| {
-            Vertex::new(
+            objects.vertices.insert(Vertex::new(
                 [surface_form.position().v],
                 curve.clone(),
                 surface_form,
-                objects,
-            )
+            ))
         });
 
         // And finally, creating the output `Edge` is just a matter of

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -101,7 +101,11 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
             [
                 vertex.surface_form().clone(),
-                SurfaceVertex::new(position, surface, global_form, objects),
+                objects.surface_vertices.insert(SurfaceVertex::new(
+                    position,
+                    surface,
+                    global_form,
+                )),
             ]
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -88,12 +88,11 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         let curve = {
             let line = Line::from_points(points_surface);
 
-            Curve::new(
+            objects.curves.insert(Curve::new(
                 surface.clone(),
                 SurfacePath::Line(line),
                 edge_global.curve().clone(),
-                objects,
-            )
+            ))
         };
 
         let vertices_surface = {

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -147,7 +147,9 @@ impl Sweep for Handle<GlobalVertex> {
             .clone();
 
         let vertices = [a, b];
-        let global_edge = GlobalEdge::new(curve, vertices.clone(), objects);
+        let global_edge = objects
+            .global_edges
+            .insert(GlobalEdge::new(curve, vertices.clone()));
 
         // The vertices of the returned `GlobalEdge` are in normalized order,
         // which means the order can't be relied upon by the caller. Return the

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -120,7 +120,9 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.
-        Ok(HalfEdge::new(vertices, edge_global, objects))
+        Ok(objects
+            .half_edges
+            .insert(HalfEdge::new(vertices, edge_global)))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -131,7 +131,7 @@ impl Sweep for Handle<GlobalVertex> {
         cache: &mut SweepCache,
         objects: &Objects,
     ) -> Result<Self::Swept, ValidationError> {
-        let curve = GlobalCurve::new(objects);
+        let curve = objects.global_curves.insert(GlobalCurve);
 
         let a = self.clone();
         let b = cache

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -23,7 +23,7 @@ impl TransformObject for Handle<GlobalCurve> {
         // All we need to do here is create a new `GlobalCurve` instance, to
         // make sure the transformed `GlobalCurve` has a different identity than
         // the original one.
-        Ok(GlobalCurve::new(objects))
+        Ok(objects.global_curves.insert(GlobalCurve))
     }
 }
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -97,6 +97,8 @@ impl<'a> FaceBuilder<'a> {
             .expect("Can't build `Face` without exterior cycle");
         let color = self.color.unwrap_or_default();
 
-        Face::new(exterior, self.interiors, color, self.objects)
+        self.objects
+            .faces
+            .insert(Face::new(exterior, self.interiors, color))
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -258,7 +258,9 @@ impl<'a> ShellBuilder<'a> {
             }
 
             Face::builder(self.objects)
-                .with_exterior(Cycle::new(surface, edges, self.objects))
+                .with_exterior(
+                    self.objects.cycles.insert(Cycle::new(surface, edges)),
+                )
                 .build()
         };
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -273,6 +273,6 @@ impl<'a> ShellBuilder<'a> {
 
     /// Build the [`Shell`]
     pub fn build(self) -> Handle<Shell> {
-        Shell::new(self.faces, self.objects)
+        self.objects.shells.insert(Shell::new(self.faces))
     }
 }

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -53,6 +53,6 @@ impl<'a> SketchBuilder<'a> {
 
     /// Build the [`Sketch`]
     pub fn build(self) -> Handle<Sketch> {
-        Sketch::new(self.faces, self.objects)
+        self.objects.sketches.insert(Sketch::new(self.faces))
     }
 }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -42,6 +42,6 @@ impl<'a> SolidBuilder<'a> {
 
     /// Build the [`Solid`]
     pub fn build(self) -> Handle<Solid> {
-        Solid::new(self.shells, self.objects)
+        self.objects.solids.insert(Solid::new(self.shells))
     }
 }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -598,8 +598,9 @@ mod tests {
         let global_vertex = objects
             .global_vertices
             .insert(GlobalVertex::from_position([0., 0., 0.]));
-        let surface_vertex =
-            SurfaceVertex::new([0., 0.], surface, global_vertex, &objects);
+        let surface_vertex = objects
+            .surface_vertices
+            .insert(SurfaceVertex::new([0., 0.], surface, global_vertex));
         let object = Vertex::new([0.], curve, surface_vertex, &objects);
 
         assert_eq!(1, object.curve_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -601,7 +601,10 @@ mod tests {
         let surface_vertex = objects
             .surface_vertices
             .insert(SurfaceVertex::new([0., 0.], surface, global_vertex));
-        let object = Vertex::new([0.], curve, surface_vertex, &objects);
+        let object =
+            objects
+                .vertices
+                .insert(Vertex::new([0.], curve, surface_vertex));
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -462,7 +462,9 @@ mod tests {
     fn global_vertex() {
         let objects = Objects::new();
 
-        let object = GlobalVertex::from_position([0., 0., 0.], &objects);
+        let object = objects
+            .global_vertices
+            .insert(GlobalVertex::from_position([0., 0., 0.]));
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -593,7 +595,9 @@ mod tests {
             .with_surface(Some(surface.clone()))
             .as_u_axis()
             .build(&objects)?;
-        let global_vertex = GlobalVertex::from_position([0., 0., 0.], &objects);
+        let global_vertex = objects
+            .global_vertices
+            .insert(GlobalVertex::from_position([0., 0., 0.]));
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex, &objects);
         let object = Vertex::new([0.], curve, surface_vertex, &objects);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -443,7 +443,7 @@ mod tests {
     fn global_curve() {
         let objects = Objects::new();
 
-        let object = GlobalCurve::new(&objects);
+        let object = objects.global_curves.insert(GlobalCurve);
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -47,10 +47,3 @@ impl Curve {
 /// A curve, defined in global (3D) coordinates
 #[derive(Clone, Copy, Debug)]
 pub struct GlobalCurve;
-
-impl GlobalCurve {
-    /// Construct a new instance of `Handle` and add it to the store
-    pub fn new(objects: &Objects) -> Handle<Self> {
-        objects.global_curves.insert(GlobalCurve)
-    }
-}

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -3,7 +3,7 @@ use crate::{
     storage::{Handle, HandleWrapper},
 };
 
-use super::{Objects, Surface};
+use super::Surface;
 
 /// A curve, defined in local surface coordinates
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -19,13 +19,12 @@ impl Curve {
         surface: Handle<Surface>,
         path: SurfacePath,
         global_form: impl Into<HandleWrapper<GlobalCurve>>,
-        objects: &Objects,
-    ) -> Handle<Self> {
-        objects.curves.insert(Self {
+    ) -> Self {
+        Self {
             surface,
             path,
             global_form: global_form.into(),
-        })
+        }
     }
 
     /// Access the path that defines this curve

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -4,7 +4,7 @@ use pretty_assertions::assert_eq;
 
 use crate::{path::SurfacePath, storage::Handle};
 
-use super::{HalfEdge, Objects, Surface};
+use super::{HalfEdge, Surface};
 
 /// A cycle of connected half-edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -23,8 +23,7 @@ impl Cycle {
     pub fn new(
         surface: Handle<Surface>,
         half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
-        objects: &Objects,
-    ) -> Handle<Self> {
+    ) -> Self {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
 
         // Verify, that the curves of all edges are defined in the correct
@@ -65,10 +64,10 @@ impl Cycle {
             }
         }
 
-        objects.cycles.insert(Self {
+        Self {
             surface,
             half_edges,
-        })
+        }
     }
 
     /// Access the surface that this cycle is in

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -4,7 +4,7 @@ use pretty_assertions::{assert_eq, assert_ne};
 
 use crate::storage::{Handle, HandleWrapper};
 
-use super::{Curve, GlobalCurve, GlobalVertex, Objects, Vertex};
+use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
 
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -32,8 +32,7 @@ impl HalfEdge {
     pub fn new(
         [a, b]: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
-        objects: &Objects,
-    ) -> Handle<Self> {
+    ) -> Self {
         // Make sure `curve` and `vertices` match.
         assert_eq!(
             a.curve().id(),
@@ -75,10 +74,10 @@ impl HalfEdge {
             "Vertices of an edge must not be coincident on curve"
         );
 
-        objects.half_edges.insert(Self {
+        Self {
             vertices: [a, b],
             global_form,
-        })
+        }
     }
 
     /// Access the curve that defines the half-edge's geometry

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -141,12 +141,11 @@ impl GlobalEdge {
     pub fn new(
         curve: impl Into<HandleWrapper<GlobalCurve>>,
         vertices: [Handle<GlobalVertex>; 2],
-        objects: &Objects,
-    ) -> Handle<Self> {
+    ) -> Self {
         let curve = curve.into();
         let (vertices, _) = VerticesInNormalizedOrder::new(vertices);
 
-        objects.global_edges.insert(Self { curve, vertices })
+        Self { curve, vertices }
     }
 
     /// Access the curve that defines the edge's geometry

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -63,8 +63,7 @@ impl Face {
         exterior: Handle<Cycle>,
         the_interiors: impl IntoIterator<Item = Handle<Cycle>>,
         color: Color,
-        objects: &Objects,
-    ) -> Handle<Self> {
+    ) -> Self {
         let surface = exterior.surface().clone();
         let mut interiors = Vec::new();
 
@@ -83,12 +82,12 @@ impl Face {
             interiors.push(interior);
         }
 
-        objects.faces.insert(Self {
+        Self {
             surface,
             exterior,
             interiors,
             color,
-        })
+        }
     }
 
     /// Access this face's surface

--- a/crates/fj-kernel/src/objects/shell.rs
+++ b/crates/fj-kernel/src/objects/shell.rs
@@ -23,13 +23,10 @@ impl Shell {
     }
 
     /// Construct an empty instance of `Shell`
-    pub fn new(
-        faces: impl IntoIterator<Item = Handle<Face>>,
-        objects: &Objects,
-    ) -> Handle<Self> {
-        objects.shells.insert(Self {
+    pub fn new(faces: impl IntoIterator<Item = Handle<Face>>) -> Self {
+        Self {
             faces: faces.into_iter().collect(),
-        })
+        }
     }
 
     /// Access the shell's faces

--- a/crates/fj-kernel/src/objects/sketch.rs
+++ b/crates/fj-kernel/src/objects/sketch.rs
@@ -24,13 +24,10 @@ impl Sketch {
     }
 
     /// Construct an empty instance of `Sketch`
-    pub fn new(
-        faces: impl IntoIterator<Item = Handle<Face>>,
-        objects: &Objects,
-    ) -> Handle<Self> {
-        objects.sketches.insert(Self {
+    pub fn new(faces: impl IntoIterator<Item = Handle<Face>>) -> Self {
+        Self {
             faces: faces.into_iter().collect(),
-        })
+        }
     }
 
     /// Access the sketch's faces

--- a/crates/fj-kernel/src/objects/solid.rs
+++ b/crates/fj-kernel/src/objects/solid.rs
@@ -25,13 +25,10 @@ impl Solid {
     }
 
     /// Construct an empty instance of `Solid`
-    pub fn new(
-        shells: impl IntoIterator<Item = Handle<Shell>>,
-        objects: &Objects,
-    ) -> Handle<Self> {
-        objects.solids.insert(Self {
+    pub fn new(shells: impl IntoIterator<Item = Handle<Shell>>) -> Self {
+        Self {
             shells: shells.into_iter().collect(),
-        })
+        }
     }
 
     /// Access the solid's shells

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 
 use crate::storage::Handle;
 
-use super::{Curve, Objects, Surface};
+use super::{Curve, Surface};
 
 /// A vertex
 ///
@@ -26,8 +26,7 @@ impl Vertex {
         position: impl Into<Point<1>>,
         curve: Handle<Curve>,
         surface_form: Handle<SurfaceVertex>,
-        objects: &Objects,
-    ) -> Handle<Self> {
+    ) -> Self {
         let position = position.into();
 
         assert_eq!(
@@ -36,11 +35,11 @@ impl Vertex {
             "Surface form of vertex must be defined on same surface as curve",
         );
 
-        objects.vertices.insert(Self {
+        Self {
             position,
             curve,
             surface_form,
-        })
+        }
     }
 
     /// Access the position of the vertex on the curve

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -78,14 +78,13 @@ impl SurfaceVertex {
         position: impl Into<Point<2>>,
         surface: Handle<Surface>,
         global_form: Handle<GlobalVertex>,
-        objects: &Objects,
-    ) -> Handle<Self> {
+    ) -> Self {
         let position = position.into();
-        objects.surface_vertices.insert(Self {
+        Self {
             position,
             surface,
             global_form,
-        })
+        }
     }
 
     /// Access the position of the vertex on the surface

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -129,12 +129,9 @@ pub struct GlobalVertex {
 
 impl GlobalVertex {
     /// Construct a `GlobalVertex` from a position
-    pub fn from_position(
-        position: impl Into<Point<3>>,
-        objects: &Objects,
-    ) -> Handle<Self> {
+    pub fn from_position(position: impl Into<Point<3>>) -> Self {
         let position = position.into();
-        objects.global_vertices.insert(Self { position })
+        Self { position }
     }
 
     /// Access the position of the vertex

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -92,9 +92,9 @@ impl PartialCurve {
         let surface =
             self.surface.expect("Can't build `Curve` without surface");
 
-        let global_form = self
-            .global_form
-            .unwrap_or_else(|| GlobalCurve::new(objects).into());
+        let global_form = self.global_form.unwrap_or_else(|| {
+            objects.global_curves.insert(GlobalCurve).into()
+        });
 
         Ok(Curve::new(surface, path, global_form, objects))
     }

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -96,7 +96,9 @@ impl PartialCurve {
             objects.global_curves.insert(GlobalCurve).into()
         });
 
-        Ok(Curve::new(surface, path, global_form, objects))
+        Ok(objects
+            .curves
+            .insert(Curve::new(surface, path, global_form)))
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -233,7 +233,7 @@ impl PartialCycle {
             half_edges
         };
 
-        Ok(Cycle::new(surface, half_edges, objects))
+        Ok(objects.cycles.insert(Cycle::new(surface, half_edges)))
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -293,7 +293,9 @@ impl PartialHalfEdge {
             })
             .into_full(objects)?;
 
-        Ok(HalfEdge::new(vertices, global_form, objects))
+        Ok(objects
+            .half_edges
+            .insert(HalfEdge::new(vertices, global_form)))
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -371,7 +371,9 @@ impl PartialGlobalEdge {
             .vertices
             .expect("Can't build `GlobalEdge` without vertices");
 
-        Ok(GlobalEdge::new(curve, vertices, objects))
+        Ok(objects
+            .global_edges
+            .insert(GlobalEdge::new(curve, vertices)))
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -209,7 +209,11 @@ impl PartialSurfaceVertex {
             })
             .into_full(objects)?;
 
-        Ok(SurfaceVertex::new(position, surface, global_form, objects))
+        Ok(objects.surface_vertices.insert(SurfaceVertex::new(
+            position,
+            surface,
+            global_form,
+        )))
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -114,7 +114,9 @@ impl PartialVertex {
             })
             .into_full(objects)?;
 
-        Ok(Vertex::new(position, curve, surface_form, objects))
+        Ok(objects
+            .vertices
+            .insert(Vertex::new(position, curve, surface_form)))
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -284,7 +284,9 @@ impl PartialGlobalVertex {
             .position
             .expect("Can't build a `GlobalVertex` without a position");
 
-        Ok(GlobalVertex::from_position(position, objects))
+        Ok(objects
+            .global_vertices
+            .insert(GlobalVertex::from_position(position)))
     }
 }
 

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -240,18 +240,16 @@ mod tests {
 
         let deviation = Scalar::from_f64(0.25);
 
-        let a = Vertex::new(
+        let a = objects.vertices.insert(Vertex::new(
             Point::from([Scalar::ZERO + deviation]),
             curve.clone(),
             a_surface,
-            &objects,
-        );
-        let b = Vertex::new(
+        ));
+        let b = objects.vertices.insert(Vertex::new(
             Point::from([Scalar::ONE]),
             curve.clone(),
             b_surface,
-            &objects,
-        );
+        ));
         let vertices = [a, b];
 
         let global_edge = GlobalEdge::partial()

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -48,7 +48,9 @@ pub trait Validate: Sized {
     /// #     validate::{Validate, ValidationConfig},
     /// # };
     /// # let objects = Objects::new();
-    /// # let object = GlobalVertex::from_position([0., 0., 0.], &objects);
+    /// # let object = objects.global_vertices.insert(
+    /// #     GlobalVertex::from_position([0., 0., 0.])
+    /// # );
     /// object.validate();
     /// ```
     /// ``` rust
@@ -57,7 +59,9 @@ pub trait Validate: Sized {
     /// #     validate::{Validate, ValidationConfig},
     /// # };
     /// # let objects = Objects::new();
-    /// # let object = GlobalVertex::from_position([0., 0., 0.], &objects);
+    /// # let object = objects.global_vertices.insert(
+    /// #     GlobalVertex::from_position([0., 0., 0.])
+    /// # );
     /// object.validate_with_config(&ValidationConfig::default());
     /// ```
     fn validate(self) -> Result<Validated<Self>, ValidationError> {
@@ -218,8 +222,11 @@ mod tests {
             ))
         };
 
-        let vertices_global = points_global
-            .map(|point| GlobalVertex::from_position(point, &objects));
+        let vertices_global = points_global.map(|point| {
+            objects
+                .global_vertices
+                .insert(GlobalVertex::from_position(point))
+        });
 
         let [a_surface, b_surface] = points_surface
             .zip_ext(vertices_global)
@@ -286,11 +293,19 @@ mod tests {
         };
 
         // Adding a vertex should work.
-        shape.push(GlobalVertex::from_position(a, &objects));
+        shape.push(
+            objects
+                .global_vertices
+                .insert(GlobalVertex::from_position(a)),
+        );
         shape.clone().validate_with_config(&config)?;
 
         // Adding a second vertex that is considered identical should fail.
-        shape.push(GlobalVertex::from_position(b, &objects));
+        shape.push(
+            objects
+                .global_vertices
+                .insert(GlobalVertex::from_position(b)),
+        );
         let result = shape.validate_with_config(&config);
         assert!(matches!(result, Err(ValidationError::Uniqueness(_))));
 

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -255,7 +255,9 @@ mod tests {
         let global_edge = GlobalEdge::partial()
             .from_curve_and_vertices(&curve, &vertices)
             .build(&objects)?;
-        let half_edge = HalfEdge::new(vertices, global_edge, &objects);
+        let half_edge = objects
+            .half_edges
+            .insert(HalfEdge::new(vertices, global_edge));
 
         let result =
             half_edge.clone().validate_with_config(&ValidationConfig {

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -211,7 +211,11 @@ mod tests {
             let path = SurfacePath::line_from_points(points_surface);
             let global_form = objects.global_curves.insert(GlobalCurve);
 
-            Curve::new(surface.clone(), path, global_form, &objects)
+            objects.curves.insert(Curve::new(
+                surface.clone(),
+                path,
+                global_form,
+            ))
         };
 
         let vertices_global = points_global

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -209,7 +209,7 @@ mod tests {
 
         let curve = {
             let path = SurfacePath::line_from_points(points_surface);
-            let global_form = GlobalCurve::new(&objects);
+            let global_form = objects.global_curves.insert(GlobalCurve);
 
             Curve::new(surface.clone(), path, global_form, &objects)
         };

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -231,12 +231,11 @@ mod tests {
         let [a_surface, b_surface] = points_surface
             .zip_ext(vertices_global)
             .map(|(point_surface, vertex_global)| {
-                SurfaceVertex::new(
+                objects.surface_vertices.insert(SurfaceVertex::new(
                     point_surface,
                     surface.clone(),
                     vertex_global,
-                    &objects,
-                )
+                ))
             });
 
         let deviation = Scalar::from_f64(0.25);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -30,7 +30,8 @@ impl Shape for fj::Sketch {
                     .with_surface(Some(surface.clone()))
                     .as_circle_from_radius(circle.radius(), objects)?
                     .build(objects)?;
-                let cycle = Cycle::new(surface, [half_edge], objects);
+                let cycle =
+                    objects.cycles.insert(Cycle::new(surface, [half_edge]));
 
                 Face::builder(objects)
                     .with_exterior(cycle)


### PR DESCRIPTION
That both concepts were muddled up in the object constructors didn't sit quite right with me, but I did it anyway, for the sake of convenience. Now this came back to bite me, as some code I'm working on becomes harder to write because of that.

This pull request moves store insertion out of the object constructors. This makes the code using these constructors a bit more verbose, but that's fine for now. Maybe better solutions will present themselves.