### PR TITLE
Simplify handling of `MaybePartial`

### DIFF
--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -30,8 +30,8 @@ impl TransformObject for PartialHalfEdge {
                     .into())
             })
             .transpose()?;
-        let vertices = self.vertices.clone().try_map_ext(|vertices| {
-            vertices
+        let vertices = self.vertices.clone().try_map_ext(|vertex| {
+            vertex
                 .map(|vertex| -> Result<_, ValidationError> {
                     Ok(vertex
                         .into_partial()

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -41,18 +41,14 @@ impl TransformObject for PartialHalfEdge {
                 })
                 .transpose()
         })?;
-        let global_form = self
-            .global_form
-            .map(|global_form| -> Result<_, ValidationError> {
-                Ok(global_form
-                    .into_partial()
-                    .transform(transform, objects)?
-                    .with_curve(curve.as_ref().and_then(
-                        |curve: &MaybePartial<Curve>| curve.global_form(),
-                    ))
-                    .into())
-            })
-            .transpose()?;
+        let global_form =
+            self.global_form
+                .into_partial()
+                .transform(transform, objects)?
+                .with_curve(curve.as_ref().and_then(
+                    |curve: &MaybePartial<Curve>| curve.global_form(),
+                ))
+                .into();
 
         Ok(Self {
             surface,

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -30,17 +30,15 @@ impl TransformObject for PartialHalfEdge {
                     .into())
             })
             .transpose()?;
-        let vertices = self.vertices.clone().try_map_ext(|vertex| {
-            vertex
-                .map(|vertex| -> Result<_, ValidationError> {
-                    Ok(vertex
-                        .into_partial()
-                        .transform(transform, objects)?
-                        .with_curve(curve.clone())
-                        .into())
-                })
-                .transpose()
-        })?;
+        let vertices = self.vertices.clone().try_map_ext(
+            |vertex| -> Result<_, ValidationError> {
+                Ok(vertex
+                    .into_partial()
+                    .transform(transform, objects)?
+                    .with_curve(curve.clone())
+                    .into())
+            },
+        )?;
         let global_form =
             self.global_form
                 .into_partial()

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -20,13 +20,9 @@ impl TransformObject for PartialVertex {
             .transpose()?;
         let surface_form = self
             .surface_form
-            .map(|surface_form| -> Result<_, ValidationError> {
-                Ok(surface_form
-                    .into_partial()
-                    .transform(transform, objects)?
-                    .into())
-            })
-            .transpose()?;
+            .into_partial()
+            .transform(transform, objects)?
+            .into();
         let global_form = self
             .global_form
             .map(|global_form| global_form.transform(transform, objects))

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -14,10 +14,7 @@ impl TransformObject for PartialVertex {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self
-            .curve
-            .map(|curve| curve.transform(transform, objects))
-            .transpose()?;
+        let curve = self.curve.transform(transform, objects)?;
         let surface_form = self
             .surface_form
             .into_partial()

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -23,10 +23,6 @@ impl TransformObject for PartialVertex {
             .into_partial()
             .transform(transform, objects)?
             .into();
-        let global_form = self
-            .global_form
-            .map(|global_form| global_form.transform(transform, objects))
-            .transpose()?;
 
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
@@ -34,7 +30,6 @@ impl TransformObject for PartialVertex {
             position: self.position,
             curve,
             surface_form,
-            global_form,
         })
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -53,10 +53,7 @@ impl TransformObject for PartialSurfaceVertex {
             .surface
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
-        let global_form = self
-            .global_form
-            .map(|global_form| global_form.transform(transform, objects))
-            .transpose()?;
+        let global_form = self.global_form.transform(transform, objects)?;
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -135,7 +135,7 @@ impl MaybePartial<HalfEdge> {
             Self::Full(full) => Some(full.back().clone().into()),
             Self::Partial(partial) => {
                 let [back, _] = &partial.vertices;
-                back.clone()
+                Some(back.clone())
             }
         }
     }
@@ -146,7 +146,7 @@ impl MaybePartial<HalfEdge> {
             Self::Full(full) => Some(full.front().clone().into()),
             Self::Partial(partial) => {
                 let [_, front] = &partial.vertices;
-                front.clone()
+                Some(front.clone())
             }
         }
     }
@@ -157,7 +157,7 @@ impl MaybePartial<HalfEdge> {
             Self::Full(full) => {
                 full.vertices().clone().map(|vertex| Some(vertex.into()))
             }
-            Self::Partial(partial) => partial.vertices.clone(),
+            Self::Partial(partial) => partial.vertices.clone().map(Some),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -185,7 +185,7 @@ impl MaybePartial<Vertex> {
     pub fn surface_form(&self) -> Option<MaybePartial<SurfaceVertex>> {
         match self {
             Self::Full(full) => Some(full.surface_form().clone().into()),
-            Self::Partial(partial) => partial.surface_form.clone(),
+            Self::Partial(partial) => Some(partial.surface_form.clone()),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -182,10 +182,10 @@ impl MaybePartial<SurfaceVertex> {
 
 impl MaybePartial<Vertex> {
     /// Access the surface form
-    pub fn surface_form(&self) -> Option<MaybePartial<SurfaceVertex>> {
+    pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
         match self {
-            Self::Full(full) => Some(full.surface_form().clone().into()),
-            Self::Partial(partial) => Some(partial.surface_form.clone()),
+            Self::Full(full) => full.surface_form().clone().into(),
+            Self::Partial(partial) => partial.surface_form.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -143,9 +143,7 @@ impl MaybePartial<HalfEdge> {
     /// Access the vertices
     pub fn vertices(&self) -> [MaybePartial<Vertex>; 2] {
         match self {
-            Self::Full(full) => {
-                full.vertices().clone().map(|vertex| vertex.into())
-            }
+            Self::Full(full) => full.vertices().clone().map(Into::into),
             Self::Partial(partial) => partial.vertices.clone(),
         }
     }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -72,6 +72,16 @@ impl<T: HasPartial> MaybePartial<T> {
     }
 }
 
+impl<T> Default for MaybePartial<T>
+where
+    T: HasPartial,
+    T::Partial: Default,
+{
+    fn default() -> Self {
+        Self::Partial(T::Partial::default())
+    }
+}
+
 impl<T> From<Handle<T>> for MaybePartial<T>
 where
     T: HasPartial,

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -130,12 +130,12 @@ impl MaybePartial<GlobalEdge> {
 
 impl MaybePartial<HalfEdge> {
     /// Access the front vertex
-    pub fn front(&self) -> Option<MaybePartial<Vertex>> {
+    pub fn front(&self) -> MaybePartial<Vertex> {
         match self {
-            Self::Full(full) => Some(full.front().clone().into()),
+            Self::Full(full) => full.front().clone().into(),
             Self::Partial(partial) => {
                 let [_, front] = &partial.vertices;
-                Some(front.clone())
+                front.clone()
             }
         }
     }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -141,12 +141,12 @@ impl MaybePartial<HalfEdge> {
     }
 
     /// Access the vertices
-    pub fn vertices(&self) -> [Option<MaybePartial<Vertex>>; 2] {
+    pub fn vertices(&self) -> [MaybePartial<Vertex>; 2] {
         match self {
             Self::Full(full) => {
-                full.vertices().clone().map(|vertex| Some(vertex.into()))
+                full.vertices().clone().map(|vertex| vertex.into())
             }
-            Self::Partial(partial) => partial.vertices.clone().map(Some),
+            Self::Partial(partial) => partial.vertices.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -129,17 +129,6 @@ impl MaybePartial<GlobalEdge> {
 }
 
 impl MaybePartial<HalfEdge> {
-    /// Access the back vertex
-    pub fn back(&self) -> Option<MaybePartial<Vertex>> {
-        match self {
-            Self::Full(full) => Some(full.back().clone().into()),
-            Self::Partial(partial) => {
-                let [back, _] = &partial.vertices;
-                Some(back.clone())
-            }
-        }
-    }
-
     /// Access the front vertex
     pub fn front(&self) -> Option<MaybePartial<Vertex>> {
         match self {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -169,8 +169,9 @@ impl PartialCycle {
             let last_vertex = self
                 .half_edges
                 .last_mut()
-                .and_then(|half_edge| {
-                    half_edge.front().map(|vertex| (half_edge, vertex))
+                .map(|half_edge| {
+                    let vertex = half_edge.front();
+                    (half_edge, vertex)
                 })
                 .map(|(half_edge, vertex)| {
                     let surface_vertex = vertex.surface_form();

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -208,15 +208,13 @@ impl PartialCycle {
                     let half_edge = half_edge
                         .update_partial(|half_edge| {
                             let [back, _] = half_edge.vertices.clone();
-                            let back = back.map(|vertex| {
-                                vertex.update_partial(|partial| {
-                                    partial.with_surface_form(previous_vertex)
-                                })
+                            let back = back.update_partial(|partial| {
+                                partial.with_surface_form(previous_vertex)
                             });
 
                             half_edge
                                 .with_surface(Some(surface_for_edges.clone()))
-                                .with_back_vertex(back)
+                                .with_back_vertex(Some(back))
                         })
                         .into_full(objects)?;
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -49,9 +49,7 @@ impl PartialCycle {
             .half_edges
             .last()
             .map(|half_edge| {
-                let [_, last] = half_edge.vertices().map(|vertex| {
-                    vertex.expect("Need half-edge vertices to extend cycle")
-                });
+                let [_, last] = half_edge.vertices();
                 last.surface_form()
             })
             .into_iter()
@@ -129,13 +127,8 @@ impl PartialCycle {
         let first = self.half_edges.first();
         let last = self.half_edges.last();
 
-        let vertices = [first, last].map(|option| {
-            option.map(|half_edge| {
-                half_edge
-                    .vertices()
-                    .map(|vertex| vertex.expect("Need vertices to close cycle"))
-            })
-        });
+        let vertices = [first, last]
+            .map(|option| option.map(|half_edge| half_edge.vertices()));
 
         if let [Some([first, _]), Some([_, last])] = vertices {
             let vertices = [last, first].map(|vertex| {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -53,7 +53,6 @@ impl PartialCycle {
                     vertex.expect("Need half-edge vertices to extend cycle")
                 });
                 last.surface_form()
-                    .expect("Need surface vertex to extend cycle")
             })
             .into_iter()
             .chain(vertices);
@@ -142,7 +141,6 @@ impl PartialCycle {
             let vertices = [last, first].map(|vertex| {
                 vertex
                     .surface_form()
-                    .expect("Need surface vertex to close cycle")
                     .position()
                     .expect("Need surface position to close cycle")
             });
@@ -174,10 +172,9 @@ impl PartialCycle {
                 .and_then(|half_edge| {
                     half_edge.front().map(|vertex| (half_edge, vertex))
                 })
-                .and_then(|(half_edge, vertex)| {
-                    vertex.surface_form().map(|surface_vertex| {
-                        (half_edge, vertex, surface_vertex)
-                    })
+                .map(|(half_edge, vertex)| {
+                    let surface_vertex = vertex.surface_form();
+                    (half_edge, vertex, surface_vertex)
                 })
                 .map(|(half_edge, vertex, surface_vertex)|
                     -> Result<_, ValidationError>

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -252,8 +252,8 @@ impl PartialHalfEdge {
             };
 
             vertices.zip_ext(global_forms).map(|(vertex, global_form)| {
-                vertex.update_partial(|partial| {
-                    partial.with_global_form(global_form)
+                vertex.update_partial(|vertex| {
+                    vertex.with_global_form(global_form)
                 })
             })
         };

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -23,7 +23,7 @@ pub struct PartialHalfEdge {
     pub curve: Option<MaybePartial<Curve>>,
 
     /// The vertices that bound this [`HalfEdge`] in the [`Curve`]
-    pub vertices: [Option<MaybePartial<Vertex>>; 2],
+    pub vertices: [MaybePartial<Vertex>; 2],
 
     /// The global form of the [`HalfEdge`]
     ///
@@ -74,7 +74,7 @@ impl PartialHalfEdge {
     ) -> Self {
         if let Some(vertex) = vertex {
             let [from, _] = &mut self.vertices;
-            *from = Some(vertex.into());
+            *from = vertex.into();
         }
         self
     }
@@ -86,7 +86,7 @@ impl PartialHalfEdge {
     ) -> Self {
         if let Some(vertex) = vertex {
             let [_, to] = &mut self.vertices;
-            *to = Some(vertex.into());
+            *to = vertex.into();
         }
         self
     }
@@ -98,7 +98,7 @@ impl PartialHalfEdge {
     ) -> Self {
         let vertices = vertices.map(|vertices| vertices.map(Into::into));
         if let Some([back, front]) = vertices {
-            self.vertices = [Some(back), Some(front)];
+            self.vertices = [back, front];
         }
         self
     }
@@ -160,7 +160,7 @@ impl PartialHalfEdge {
         });
 
         self.curve = Some(curve.into());
-        self.vertices = [Some(back), Some(front)];
+        self.vertices = [back, front];
 
         Ok(self)
     }
@@ -184,9 +184,7 @@ impl PartialHalfEdge {
 
     /// Update partial half-edge as a line segment, reusing existing vertices
     pub fn as_line_segment(mut self) -> Self {
-        let [from, to] = self.vertices.clone().map(|vertex| {
-            vertex.expect("Can't infer line segment without vertices")
-        });
+        let [from, to] = self.vertices.clone();
         let [from_surface, to_surface] =
             [&from, &to].map(|vertex| vertex.surface_form());
 
@@ -263,7 +261,7 @@ impl PartialHalfEdge {
         };
 
         self.curve = Some(curve.into());
-        self.vertices = [Some(back), Some(front)];
+        self.vertices = [back, front];
 
         self
     }
@@ -281,7 +279,6 @@ impl PartialHalfEdge {
             .into_full(objects)?;
         let vertices = self.vertices.try_map_ext(|vertex| {
             vertex
-                .expect("Can't build `HalfEdge` without vertices")
                 .update_partial(|vertex| vertex.with_curve(Some(curve.clone())))
                 .into_full(objects)
         })?;
@@ -307,7 +304,7 @@ impl From<&HalfEdge> for PartialHalfEdge {
         Self {
             surface: Some(half_edge.curve().surface().clone()),
             curve: Some(half_edge.curve().clone().into()),
-            vertices: [Some(back_vertex), Some(front_vertex)],
+            vertices: [back_vertex, front_vertex],
             global_form: half_edge.global_form().clone().into(),
         }
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -20,7 +20,7 @@ pub struct PartialHalfEdge {
     pub surface: Option<Handle<Surface>>,
 
     /// The curve that the [`HalfEdge`] is defined in
-    pub curve: Option<MaybePartial<Curve>>,
+    pub curve: MaybePartial<Curve>,
 
     /// The vertices that bound this [`HalfEdge`] in the [`Curve`]
     pub vertices: [MaybePartial<Vertex>; 2],
@@ -36,7 +36,7 @@ impl PartialHalfEdge {
     ///
     /// If a global curve is available through both, the curve is preferred.
     pub fn extract_global_curve(&self) -> Option<Handle<GlobalCurve>> {
-        let global_curve_from_curve = || self.curve.as_ref()?.global_form();
+        let global_curve_from_curve = || self.curve.global_form();
         let global_curve_from_global_form =
             || self.global_form.curve().cloned();
 
@@ -62,7 +62,7 @@ impl PartialHalfEdge {
         curve: Option<impl Into<MaybePartial<Curve>>>,
     ) -> Self {
         if let Some(curve) = curve {
-            self.curve = Some(curve.into());
+            self.curve = curve.into();
         }
         self
     }
@@ -159,7 +159,7 @@ impl PartialHalfEdge {
                 .into()
         });
 
-        self.curve = Some(curve.into());
+        self.curve = curve.into();
         self.vertices = [back, front];
 
         Ok(self)
@@ -260,7 +260,7 @@ impl PartialHalfEdge {
             })
         };
 
-        self.curve = Some(curve.into());
+        self.curve = curve.into();
         self.vertices = [back, front];
 
         self
@@ -274,7 +274,6 @@ impl PartialHalfEdge {
         let surface = self.surface;
         let curve = self
             .curve
-            .expect("Can't build `HalfEdge` without curve")
             .update_partial(|curve| curve.with_surface(surface))
             .into_full(objects)?;
         let vertices = self.vertices.try_map_ext(|vertex| {
@@ -303,7 +302,7 @@ impl From<&HalfEdge> for PartialHalfEdge {
 
         Self {
             surface: Some(half_edge.curve().surface().clone()),
-            curve: Some(half_edge.curve().clone().into()),
+            curve: half_edge.curve().clone().into(),
             vertices: [back_vertex, front_vertex],
             global_form: half_edge.global_form().clone().into(),
         }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -28,7 +28,7 @@ pub struct PartialHalfEdge {
     /// The global form of the [`HalfEdge`]
     ///
     /// Can be computed by [`PartialHalfEdge::build`], if not available.
-    pub global_form: Option<MaybePartial<GlobalEdge>>,
+    pub global_form: MaybePartial<GlobalEdge>,
 }
 
 impl PartialHalfEdge {
@@ -38,14 +38,14 @@ impl PartialHalfEdge {
     pub fn extract_global_curve(&self) -> Option<Handle<GlobalCurve>> {
         let global_curve_from_curve = || self.curve.as_ref()?.global_form();
         let global_curve_from_global_form =
-            || self.global_form.as_ref()?.curve().cloned();
+            || self.global_form.curve().cloned();
 
         global_curve_from_curve().or_else(global_curve_from_global_form)
     }
 
     /// Access the vertices of the global form, if available
     pub fn extract_global_vertices(&self) -> Option<[Handle<GlobalVertex>; 2]> {
-        self.global_form.as_ref()?.vertices().cloned()
+        self.global_form.vertices().cloned()
     }
 
     /// Update the partial half-edge with the given surface
@@ -109,7 +109,7 @@ impl PartialHalfEdge {
         global_form: Option<impl Into<MaybePartial<GlobalEdge>>>,
     ) -> Self {
         if let Some(global_form) = global_form {
-            self.global_form = Some(global_form.into());
+            self.global_form = global_form.into();
         }
         self
     }
@@ -288,7 +288,6 @@ impl PartialHalfEdge {
 
         let global_form = self
             .global_form
-            .unwrap_or_else(|| GlobalEdge::partial().into())
             .update_partial(|partial| {
                 partial.from_curve_and_vertices(&curve, &vertices)
             })
@@ -309,7 +308,7 @@ impl From<&HalfEdge> for PartialHalfEdge {
             surface: Some(half_edge.curve().surface().clone()),
             curve: Some(half_edge.curve().clone().into()),
             vertices: [Some(back_vertex), Some(front_vertex)],
-            global_form: Some(half_edge.global_form().clone().into()),
+            global_form: half_edge.global_form().clone().into(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -36,11 +36,9 @@ impl PartialHalfEdge {
     ///
     /// If a global curve is available through both, the curve is preferred.
     pub fn extract_global_curve(&self) -> Option<Handle<GlobalCurve>> {
-        let global_curve_from_curve = || self.curve.global_form();
-        let global_curve_from_global_form =
-            || self.global_form.curve().cloned();
-
-        global_curve_from_curve().or_else(global_curve_from_global_form)
+        self.curve
+            .global_form()
+            .or_else(|| self.global_form.curve().cloned())
     }
 
     /// Access the vertices of the global form, if available

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -253,7 +253,11 @@ impl PartialHalfEdge {
 
             vertices.zip_ext(global_forms).map(|(vertex, global_form)| {
                 vertex.update_partial(|vertex| {
-                    vertex.with_global_form(global_form)
+                    vertex.clone().with_surface_form(Some(
+                        vertex.surface_form.update_partial(|surface_vertex| {
+                            surface_vertex.with_global_form(global_form)
+                        }),
+                    ))
                 })
             })
         };

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -187,11 +187,8 @@ impl PartialHalfEdge {
         let [from, to] = self.vertices.clone().map(|vertex| {
             vertex.expect("Can't infer line segment without vertices")
         });
-        let [from_surface, to_surface] = [&from, &to].map(|vertex| {
-            vertex
-                .surface_form()
-                .expect("Can't infer line segment without two surface vertices")
-        });
+        let [from_surface, to_surface] =
+            [&from, &to].map(|vertex| vertex.surface_form());
 
         let surface = self
             .surface

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -27,12 +27,6 @@ pub struct PartialVertex {
     /// Can be provided, if already available, or computed from the position on
     /// the [`Curve`].
     pub surface_form: MaybePartial<SurfaceVertex>,
-
-    /// The global form of the [`Vertex`]
-    ///
-    /// Can be provided, if already available, or acquired through the surface
-    /// form.
-    pub global_form: Option<MaybePartial<GlobalVertex>>,
 }
 
 impl PartialVertex {
@@ -69,17 +63,6 @@ impl PartialVertex {
         self
     }
 
-    /// Provide a global form for the partial vertex
-    pub fn with_global_form(
-        mut self,
-        global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
-    ) -> Self {
-        if let Some(global_form) = global_form {
-            self.global_form = Some(global_form.into());
-        }
-        self
-    }
-
     /// Build a full [`Vertex`] from the partial vertex
     ///
     /// # Panics
@@ -109,7 +92,6 @@ impl PartialVertex {
                 partial
                     .with_position(Some(position))
                     .with_surface(Some(curve.surface().clone()))
-                    .with_global_form(self.global_form)
             })
             .into_full(objects)?;
 
@@ -127,7 +109,6 @@ impl From<&Vertex> for PartialVertex {
             position: Some(vertex.position()),
             curve: Some(vertex.curve().clone().into()),
             surface_form: vertex.surface_form().clone().into(),
-            global_form: Some((vertex.global_form().clone()).into()),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -152,7 +152,7 @@ pub struct PartialSurfaceVertex {
     ///
     /// Can be provided, if already available, or computed from the position on
     /// the [`Surface`].
-    pub global_form: Option<MaybePartial<GlobalVertex>>,
+    pub global_form: MaybePartial<GlobalVertex>,
 }
 
 impl PartialSurfaceVertex {
@@ -181,7 +181,7 @@ impl PartialSurfaceVertex {
         global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
     ) -> Self {
         if let Some(global_form) = global_form {
-            self.global_form = Some(global_form.into());
+            self.global_form = global_form.into();
         }
         self
     }
@@ -206,10 +206,8 @@ impl PartialSurfaceVertex {
 
         let global_form = self
             .global_form
-            .unwrap_or_else(|| {
-                GlobalVertex::partial()
-                    .from_surface_and_position(&surface, position)
-                    .into()
+            .update_partial(|global_form| {
+                global_form.from_surface_and_position(&surface, position)
             })
             .into_full(objects)?;
 
@@ -226,7 +224,7 @@ impl From<&SurfaceVertex> for PartialSurfaceVertex {
         Self {
             position: Some(surface_vertex.position()),
             surface: Some(surface_vertex.surface().clone()),
-            global_form: Some((surface_vertex.global_form().clone()).into()),
+            global_form: (surface_vertex.global_form().clone()).into(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
-    partial::{HasPartial, MaybePartial},
+    partial::MaybePartial,
     storage::Handle,
     validate::ValidationError,
 };
@@ -26,7 +26,7 @@ pub struct PartialVertex {
     ///
     /// Can be provided, if already available, or computed from the position on
     /// the [`Curve`].
-    pub surface_form: Option<MaybePartial<SurfaceVertex>>,
+    pub surface_form: MaybePartial<SurfaceVertex>,
 
     /// The global form of the [`Vertex`]
     ///
@@ -64,7 +64,7 @@ impl PartialVertex {
         surface_form: Option<impl Into<MaybePartial<SurfaceVertex>>>,
     ) -> Self {
         if let Some(surface_form) = surface_form {
-            self.surface_form = Some(surface_form.into());
+            self.surface_form = surface_form.into();
         }
         self
     }
@@ -101,7 +101,6 @@ impl PartialVertex {
 
         let surface_form = self
             .surface_form
-            .unwrap_or_else(|| SurfaceVertex::partial().into())
             .update_partial(|partial| {
                 let position = partial.position.unwrap_or_else(|| {
                     curve.path().point_from_path_coords(position)
@@ -127,7 +126,7 @@ impl From<&Vertex> for PartialVertex {
         Self {
             position: Some(vertex.position()),
             curve: Some(vertex.curve().clone().into()),
-            surface_form: Some(vertex.surface_form().clone().into()),
+            surface_form: vertex.surface_form().clone().into(),
             global_form: Some((vertex.global_form().clone()).into()),
         }
     }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -20,7 +20,7 @@ pub struct PartialVertex {
     /// The curve that the [`Vertex`] is defined in
     ///
     /// Must be provided before [`PartialVertex::build`] is called.
-    pub curve: Option<MaybePartial<Curve>>,
+    pub curve: MaybePartial<Curve>,
 
     /// The surface form of the [`Vertex`]
     ///
@@ -47,7 +47,7 @@ impl PartialVertex {
         curve: Option<impl Into<MaybePartial<Curve>>>,
     ) -> Self {
         if let Some(curve) = curve {
-            self.curve = Some(curve.into());
+            self.curve = curve.into();
         }
         self
     }
@@ -77,10 +77,7 @@ impl PartialVertex {
         let position = self
             .position
             .expect("Cant' build `Vertex` without position");
-        let curve = self
-            .curve
-            .expect("Can't build `Vertex` without `Curve`")
-            .into_full(objects)?;
+        let curve = self.curve.into_full(objects)?;
 
         let surface_form = self
             .surface_form
@@ -107,7 +104,7 @@ impl From<&Vertex> for PartialVertex {
     fn from(vertex: &Vertex) -> Self {
         Self {
             position: Some(vertex.position()),
-            curve: Some(vertex.curve().clone().into()),
+            curve: vertex.curve().clone().into(),
             surface_form: vertex.surface_form().clone().into(),
         }
     }


### PR DESCRIPTION
Replace all `Option<MaybePartial<_>>` fields with just `MaybePartial<_>` (see https://github.com/hannobraun/Fornjot/issues/1249#issuecomment-1291659683). This is a nice (if modest) simplification of the partial object code.