### PR TITLE
Move most validation code to new validation infrastructure

### DIFF
--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use pretty_assertions::{assert_eq, assert_ne};
+use pretty_assertions::assert_ne;
 
 use crate::storage::{Handle, HandleWrapper};
 
@@ -33,23 +33,6 @@ impl HalfEdge {
         [a, b]: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
     ) -> Self {
-        let (vertices_in_normalized_order, _) = VerticesInNormalizedOrder::new(
-            [&a, &b].map(|vertex| vertex.global_form().clone()),
-        );
-
-        // Make sure `curve` and `vertices` match `global_form`.
-        assert_eq!(
-            vertices_in_normalized_order
-                .access_in_normalized_order()
-                .map(|global_vertex| global_vertex.id()),
-            global_form
-                .vertices()
-                .access_in_normalized_order()
-                .map(|global_vertex| global_vertex.id()),
-            "The global forms of a half-edge's vertices must match the \
-            vertices of the half-edge's global form"
-        );
-
         // Make sure that the edge vertices are not coincident on the curve.
         assert_ne!(
             a.position(),

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -13,20 +13,6 @@ pub struct HalfEdge {
 
 impl HalfEdge {
     /// Create a new instance of `HalfEdge`
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the provided `vertices` are not defined on the same curve as
-    /// `curve`.
-    ///
-    /// Panics, if the provided [`GlobalEdge`] instance doesn't refer to the
-    /// same [`GlobalCurve`] and [`GlobalVertex`] instances that the other
-    /// objects that are passed refer to.
-    ///
-    /// Panics, if the provided vertices are coincident on the curve. If they
-    /// were, the edge would have no length, and thus not be valid. (It is
-    /// perfectly fine for global forms of the the vertices to be coincident.
-    /// That would just mean, that ends of the edge connect to each other.)
     pub fn new(
         vertices: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -33,13 +33,6 @@ impl HalfEdge {
         [a, b]: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
     ) -> Self {
-        // Make sure `curve` and `vertices` match.
-        assert_eq!(
-            a.curve().id(),
-            b.curve().id(),
-            "An edge's vertices must be defined in the same curve",
-        );
-
         let curve = a.curve();
 
         let (vertices_in_normalized_order, _) = VerticesInNormalizedOrder::new(

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -33,19 +33,11 @@ impl HalfEdge {
         [a, b]: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
     ) -> Self {
-        let curve = a.curve();
-
         let (vertices_in_normalized_order, _) = VerticesInNormalizedOrder::new(
             [&a, &b].map(|vertex| vertex.global_form().clone()),
         );
 
         // Make sure `curve` and `vertices` match `global_form`.
-        assert_eq!(
-            curve.global_form().id(),
-            global_form.curve().id(),
-            "The global form of a half-edge's curve must match the curve of \
-            the half-edge's global form"
-        );
         assert_eq!(
             vertices_in_normalized_order
                 .access_in_normalized_order()

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -28,11 +28,11 @@ impl HalfEdge {
     /// perfectly fine for global forms of the the vertices to be coincident.
     /// That would just mean, that ends of the edge connect to each other.)
     pub fn new(
-        [a, b]: [Handle<Vertex>; 2],
+        vertices: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
     ) -> Self {
         Self {
-            vertices: [a, b],
+            vertices,
             global_form,
         }
     }

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use pretty_assertions::assert_ne;
-
 use crate::storage::{Handle, HandleWrapper};
 
 use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
@@ -33,13 +31,6 @@ impl HalfEdge {
         [a, b]: [Handle<Vertex>; 2],
         global_form: Handle<GlobalEdge>,
     ) -> Self {
-        // Make sure that the edge vertices are not coincident on the curve.
-        assert_ne!(
-            a.position(),
-            b.position(),
-            "Vertices of an edge must not be coincident on curve"
-        );
-
         Self {
             vertices: [a, b],
             global_form,

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -95,12 +95,17 @@ pub use self::{
     vertex::{GlobalVertex, SurfaceVertex, Vertex},
 };
 
+use std::convert::Infallible;
+
 use fj_math::Vector;
 
 use crate::{
     path::GlobalPath,
     storage::{Handle, Store},
-    validate::Validate2,
+    validate::{
+        HalfEdgeValidationError, SurfaceVertexValidationError, Validate2,
+        VertexValidationError,
+    },
 };
 
 /// The available object stores
@@ -168,10 +173,7 @@ pub struct Curves {
 
 impl Curves {
     /// Insert a [`Curve`] into the store
-    pub fn insert(
-        &self,
-        curve: Curve,
-    ) -> Result<Handle<Curve>, <Curve as Validate2>::Error> {
+    pub fn insert(&self, curve: Curve) -> Result<Handle<Curve>, Infallible> {
         curve.validate()?;
         Ok(self.store.insert(curve))
     }
@@ -185,10 +187,7 @@ pub struct Cycles {
 
 impl Cycles {
     /// Insert a [`Cycle`] into the store
-    pub fn insert(
-        &self,
-        cycle: Cycle,
-    ) -> Result<Handle<Cycle>, <Cycle as Validate2>::Error> {
+    pub fn insert(&self, cycle: Cycle) -> Result<Handle<Cycle>, Infallible> {
         cycle.validate()?;
         Ok(self.store.insert(cycle))
     }
@@ -202,10 +201,7 @@ pub struct Faces {
 
 impl Faces {
     /// Insert a [`Face`] into the store
-    pub fn insert(
-        &self,
-        face: Face,
-    ) -> Result<Handle<Face>, <Face as Validate2>::Error> {
+    pub fn insert(&self, face: Face) -> Result<Handle<Face>, Infallible> {
         face.validate()?;
         Ok(self.store.insert(face))
     }
@@ -222,7 +218,7 @@ impl GlobalCurves {
     pub fn insert(
         &self,
         global_curve: GlobalCurve,
-    ) -> Result<Handle<GlobalCurve>, <GlobalCurve as Validate2>::Error> {
+    ) -> Result<Handle<GlobalCurve>, Infallible> {
         global_curve.validate()?;
         Ok(self.store.insert(global_curve))
     }
@@ -239,7 +235,7 @@ impl GlobalEdges {
     pub fn insert(
         &self,
         global_edge: GlobalEdge,
-    ) -> Result<Handle<GlobalEdge>, <GlobalEdge as Validate2>::Error> {
+    ) -> Result<Handle<GlobalEdge>, Infallible> {
         global_edge.validate()?;
         Ok(self.store.insert(global_edge))
     }
@@ -256,7 +252,7 @@ impl GlobalVertices {
     pub fn insert(
         &self,
         global_vertex: GlobalVertex,
-    ) -> Result<Handle<GlobalVertex>, <GlobalVertex as Validate2>::Error> {
+    ) -> Result<Handle<GlobalVertex>, Infallible> {
         global_vertex.validate()?;
         Ok(self.store.insert(global_vertex))
     }
@@ -273,7 +269,7 @@ impl HalfEdges {
     pub fn insert(
         &self,
         half_edge: HalfEdge,
-    ) -> Result<Handle<HalfEdge>, <HalfEdge as Validate2>::Error> {
+    ) -> Result<Handle<HalfEdge>, HalfEdgeValidationError> {
         half_edge.validate()?;
         Ok(self.store.insert(half_edge))
     }
@@ -287,10 +283,7 @@ pub struct Shells {
 
 impl Shells {
     /// Insert a [`Shell`] into the store
-    pub fn insert(
-        &self,
-        shell: Shell,
-    ) -> Result<Handle<Shell>, <Shell as Validate2>::Error> {
+    pub fn insert(&self, shell: Shell) -> Result<Handle<Shell>, Infallible> {
         shell.validate()?;
         Ok(self.store.insert(shell))
     }
@@ -304,10 +297,7 @@ pub struct Sketches {
 
 impl Sketches {
     /// Insert a [`Sketch`] into the store
-    pub fn insert(
-        &self,
-        sketch: Sketch,
-    ) -> Result<Handle<Sketch>, <Sketch as Validate2>::Error> {
+    pub fn insert(&self, sketch: Sketch) -> Result<Handle<Sketch>, Infallible> {
         sketch.validate()?;
         Ok(self.store.insert(sketch))
     }
@@ -321,10 +311,7 @@ pub struct Solids {
 
 impl Solids {
     /// Insert a [`Solid`] into the store
-    pub fn insert(
-        &self,
-        solid: Solid,
-    ) -> Result<Handle<Solid>, <Solid as Validate2>::Error> {
+    pub fn insert(&self, solid: Solid) -> Result<Handle<Solid>, Infallible> {
         solid.validate()?;
         Ok(self.store.insert(solid))
     }
@@ -341,8 +328,7 @@ impl SurfaceVertices {
     pub fn insert(
         &self,
         surface_vertex: SurfaceVertex,
-    ) -> Result<Handle<SurfaceVertex>, <SurfaceVertex as Validate2>::Error>
-    {
+    ) -> Result<Handle<SurfaceVertex>, SurfaceVertexValidationError> {
         surface_vertex.validate()?;
         Ok(self.store.insert(surface_vertex))
     }
@@ -363,7 +349,7 @@ impl Surfaces {
     pub fn insert(
         &self,
         surface: Surface,
-    ) -> Result<Handle<Surface>, <Surface as Validate2>::Error> {
+    ) -> Result<Handle<Surface>, Infallible> {
         surface.validate()?;
         Ok(self.store.insert(surface))
     }
@@ -415,7 +401,7 @@ impl Vertices {
     pub fn insert(
         &self,
         vertex: Vertex,
-    ) -> Result<Handle<Vertex>, <Vertex as Validate2>::Error> {
+    ) -> Result<Handle<Vertex>, VertexValidationError> {
         vertex.validate()?;
         Ok(self.store.insert(vertex))
     }

--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -39,6 +39,16 @@ impl<T> Handle<T> {
     {
         self.deref().clone()
     }
+
+    /// Return a `Debug` implementation with full debug info
+    pub fn full_debug(&self) -> impl fmt::Debug
+    where
+        T: fmt::Debug,
+    {
+        // It would be nicer to return a struct that implements `Debug`, as that
+        // would cut down on allocations, but this will work for now.
+        format!("{:?} -> {:?}", self.id(), self.deref())
+    }
 }
 
 impl<T> Deref for Handle<T> {

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -18,12 +18,12 @@ impl Validate2 for HalfEdge {
 
     fn validate_with_config(
         &self,
-        _: &ValidationConfig,
+        config: &ValidationConfig,
     ) -> Result<(), Self::Error> {
         HalfEdgeValidationError::check_curve_identity(self)?;
         HalfEdgeValidationError::check_global_curve_identity(self)?;
         HalfEdgeValidationError::check_global_vertex_identity(self)?;
-        HalfEdgeValidationError::check_vertex_positions(self)?;
+        HalfEdgeValidationError::check_vertex_positions(self, config)?;
         Ok(())
     }
 }
@@ -175,11 +175,16 @@ impl HalfEdgeValidationError {
         Ok(())
     }
 
-    fn check_vertex_positions(half_edge: &HalfEdge) -> Result<(), Self> {
+    fn check_vertex_positions(
+        half_edge: &HalfEdge,
+        config: &ValidationConfig,
+    ) -> Result<(), Self> {
         let back_position = half_edge.back().position();
         let front_position = half_edge.front().position();
 
-        if back_position == front_position {
+        let distance = (back_position - front_position).magnitude();
+
+        if distance < config.distinct_min_distance {
             return Err(Self::VerticesAreCoincident {
                 back_position,
                 front_position,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -1,16 +1,20 @@
 use std::convert::Infallible;
 
-use crate::objects::{GlobalEdge, HalfEdge};
+use crate::{
+    objects::{Curve, GlobalEdge, HalfEdge},
+    storage::Handle,
+};
 
 use super::{Validate2, ValidationConfig};
 
 impl Validate2 for HalfEdge {
-    type Error = Infallible;
+    type Error = HalfEdgeValidationError;
 
     fn validate_with_config(
         &self,
         _: &ValidationConfig,
     ) -> Result<(), Self::Error> {
+        HalfEdgeValidationError::check_curve_identity(self)?;
         Ok(())
     }
 }
@@ -22,6 +26,121 @@ impl Validate2 for GlobalEdge {
         &self,
         _: &ValidationConfig,
     ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// [`HalfEdge`] validation failed
+#[derive(Debug, thiserror::Error)]
+pub enum HalfEdgeValidationError {
+    /// [`HalfEdge`] vertices are not defined on the same `Curve`
+    #[error(
+        "`HalfEdge` vertices are not defined on the same `Curve`\n\
+        - `Curve` of back vertex: {:?}\n\
+        - `Curve` of front vertex: {:?}",
+        .back_curve.full_debug(),
+        .front_curve.full_debug(),
+    )]
+    CurveMismatch {
+        /// The curve of the [`HalfEdge`]'s back vertex
+        back_curve: Handle<Curve>,
+
+        /// The curve of the [`HalfEdge`]'s front vertex
+        front_curve: Handle<Curve>,
+    },
+}
+
+impl HalfEdgeValidationError {
+    fn check_curve_identity(half_edge: &HalfEdge) -> Result<(), Self> {
+        let back_curve = half_edge.back().curve();
+        let front_curve = half_edge.front().curve();
+
+        if back_curve.id() != front_curve.id() {
+            return Err(HalfEdgeValidationError::CurveMismatch {
+                back_curve: back_curve.clone(),
+                front_curve: front_curve.clone(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fj_interop::ext::ArrayExt;
+
+    use crate::{
+        objects::{Curve, GlobalEdge, HalfEdge, Objects, Vertex},
+        partial::HasPartial,
+        validate::Validate2,
+    };
+
+    #[test]
+    fn half_edge_curve_mismatch() -> anyhow::Result<()> {
+        let valid = {
+            let objects = Objects::new();
+
+            let curve = Curve::partial()
+                .with_surface(Some(objects.surfaces.xy_plane()))
+                .as_line_from_points([[0., 0.], [1., 0.]])
+                .build(&objects)?;
+
+            let vertices = {
+                [0., 1.].try_map_ext(|position| {
+                    Vertex::partial()
+                        .with_position(Some([position]))
+                        .with_curve(Some(curve.clone()))
+                        .build(&objects)
+                })?
+            };
+
+            let global_form = GlobalEdge::partial()
+                .with_curve(Some(curve.global_form().clone()))
+                .with_vertices(Some(
+                    vertices
+                        .each_ref_ext()
+                        .map(|vertex| vertex.global_form().clone()),
+                ))
+                .build(&objects)?;
+
+            HalfEdge::new(vertices, global_form)
+        };
+        let invalid = {
+            let objects = Objects::new();
+
+            let curve = Curve::partial()
+                .with_surface(Some(objects.surfaces.xy_plane()))
+                .as_line_from_points([[0., 0.], [1., 0.]])
+                .build(&objects)?;
+
+            let vertices = [
+                Vertex::partial()
+                    .with_position(Some([0.]))
+                    .with_curve(Some(curve.clone()))
+                    .build(&objects)?,
+                Vertex::partial()
+                    .with_position(Some([1.]))
+                    // Arranging for an equal but not identical curve here.
+                    .with_curve(Some(curve.to_partial()))
+                    .build(&objects)?,
+            ];
+
+            let global_form = GlobalEdge::partial()
+                .with_curve(Some(curve.global_form().clone()))
+                .with_vertices(Some(
+                    vertices
+                        .each_ref_ext()
+                        .map(|vertex| vertex.global_form().clone()),
+                ))
+                .build(&objects)?;
+
+            HalfEdge::new(vertices, global_form)
+        };
+
+        assert!(valid.validate().is_ok());
+        assert!(invalid.validate().is_err());
+
         Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use fj_interop::ext::ArrayExt;
-use fj_math::Point;
+use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{
@@ -108,6 +108,9 @@ pub enum HalfEdgeValidationError {
 
         /// The position of the front vertex
         front_position: Point<1>,
+
+        /// The distance between the two vertices
+        distance: Scalar,
     },
 }
 
@@ -188,6 +191,7 @@ impl HalfEdgeValidationError {
             return Err(Self::VerticesAreCoincident {
                 back_position,
                 front_position,
+                distance,
             });
         }
 

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -172,10 +172,6 @@ impl<T> Deref for Validated<T> {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum ValidationError {
-    /// Geometric validation failed
-    #[error("Geometric validation failed")]
-    Geometric,
-
     /// Uniqueness validation failed
     #[error("Uniqueness validation failed")]
     Uniqueness(#[from] UniquenessIssues),

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -26,6 +26,7 @@ mod uniqueness;
 mod vertex;
 
 pub use self::{
+    edge::HalfEdgeValidationError,
     uniqueness::UniquenessIssues,
     vertex::{SurfaceVertexPositionMismatch, VertexValidationError},
 };
@@ -175,6 +176,10 @@ pub enum ValidationError {
     /// Uniqueness validation failed
     #[error("Uniqueness validation failed")]
     Uniqueness(#[from] UniquenessIssues),
+
+    /// `HalfEdge` validation error
+    #[error(transparent)]
+    HalfEdge(#[from] HalfEdgeValidationError),
 
     /// `SurfaceVertex` position didn't match `GlobalVertex`
     #[error(transparent)]

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -28,7 +28,7 @@ mod vertex;
 pub use self::{
     edge::HalfEdgeValidationError,
     uniqueness::UniquenessIssues,
-    vertex::{SurfaceVertexPositionMismatch, VertexValidationError},
+    vertex::{SurfaceVertexValidationError, VertexValidationError},
 };
 
 use std::{collections::HashSet, convert::Infallible, ops::Deref};
@@ -183,7 +183,7 @@ pub enum ValidationError {
 
     /// `SurfaceVertex` position didn't match `GlobalVertex`
     #[error(transparent)]
-    SurfaceVertexPositionMismatch(#[from] SurfaceVertexPositionMismatch),
+    SurfaceVertex(#[from] SurfaceVertexValidationError),
 
     /// `Vertex` validation error
     #[error(transparent)]

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -180,7 +180,7 @@ pub enum ValidationError {
     #[error(transparent)]
     SurfaceVertexPositionMismatch(#[from] SurfaceVertexPositionMismatch),
 
-    /// `Vertex` position didn't match `SurfaceVertex`
+    /// `Vertex` validation error
     #[error(transparent)]
     Vertex(#[from] VertexValidationError),
 }

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -16,14 +16,7 @@ impl Validate2 for Vertex {
         &self,
         config: &ValidationConfig,
     ) -> Result<(), Self::Error> {
-        let curve_surface = self.curve().surface();
-        let surface_form_surface = self.surface_form().surface();
-        if curve_surface.id() != surface_form_surface.id() {
-            return Err(VertexValidationError::SurfaceMismatch {
-                curve_surface: curve_surface.clone(),
-                surface_form_surface: surface_form_surface.clone(),
-            });
-        }
+        VertexValidationError::check_surface_identity(self)?;
 
         let curve_position_as_surface =
             self.curve().path().point_from_path_coords(self.position());
@@ -84,6 +77,22 @@ pub enum VertexValidationError {
         /// The distance between the positions
         distance: Scalar,
     },
+}
+
+impl VertexValidationError {
+    fn check_surface_identity(vertex: &Vertex) -> Result<(), Self> {
+        let curve_surface = vertex.curve().surface();
+        let surface_form_surface = vertex.surface_form().surface();
+
+        if curve_surface.id() != surface_form_surface.id() {
+            return Err(VertexValidationError::SurfaceMismatch {
+                curve_surface: curve_surface.clone(),
+                surface_form_surface: surface_form_surface.clone(),
+            });
+        }
+
+        Ok(())
+    }
 }
 
 impl Validate2 for SurfaceVertex {

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, ops::Deref};
+use std::convert::Infallible;
 
 use fj_math::{Point, Scalar};
 
@@ -51,10 +51,10 @@ pub enum VertexValidationError {
     /// Mismatch between the surface's of the curve and surface form
     #[error(
         "Surface form of vertex must be defined on same surface as curve\n\
-        `Surface` of curve: {curve_surface:?} -> {:?}\n\
-        `Surface` of surface form: {surface_form_surface:?} -> {:?}",
-        .curve_surface.deref(),
-        .surface_form_surface.deref(),
+        `Surface` of curve: {:?}\n\
+        `Surface` of surface form: {:?}",
+        .curve_surface.full_debug(),
+        .surface_form_surface.full_debug(),
     )]
     SurfaceMismatch {
         /// The surface of the vertex' curve

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -22,6 +22,29 @@ impl Validate2 for Vertex {
     }
 }
 
+impl Validate2 for SurfaceVertex {
+    type Error = SurfaceVertexPositionMismatch;
+
+    fn validate_with_config(
+        &self,
+        config: &ValidationConfig,
+    ) -> Result<(), Self::Error> {
+        SurfaceVertexPositionMismatch::check_position(self, config)?;
+        Ok(())
+    }
+}
+
+impl Validate2 for GlobalVertex {
+    type Error = Infallible;
+
+    fn validate_with_config(
+        &self,
+        _: &ValidationConfig,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
 /// [`Vertex`] validation failed
 #[derive(Debug, thiserror::Error)]
 pub enum VertexValidationError {
@@ -104,18 +127,6 @@ impl VertexValidationError {
     }
 }
 
-impl Validate2 for SurfaceVertex {
-    type Error = SurfaceVertexPositionMismatch;
-
-    fn validate_with_config(
-        &self,
-        config: &ValidationConfig,
-    ) -> Result<(), Self::Error> {
-        SurfaceVertexPositionMismatch::check_position(self, config)?;
-        Ok(())
-    }
-}
-
 /// Mismatch between position of surface vertex and position of its global form
 #[derive(Debug, thiserror::Error)]
 #[error(
@@ -160,17 +171,6 @@ impl SurfaceVertexPositionMismatch {
             });
         }
 
-        Ok(())
-    }
-}
-
-impl Validate2 for GlobalVertex {
-    type Error = Infallible;
-
-    fn validate_with_config(
-        &self,
-        _: &ValidationConfig,
-    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -111,21 +111,7 @@ impl Validate2 for SurfaceVertex {
         &self,
         config: &ValidationConfig,
     ) -> Result<(), Self::Error> {
-        let surface_position_as_global =
-            self.surface().point_from_surface_coords(self.position());
-        let global_position = self.global_form().position();
-
-        let distance = surface_position_as_global.distance_to(&global_position);
-
-        if distance > config.identical_max_distance {
-            return Err(SurfaceVertexPositionMismatch {
-                surface_vertex: self.clone(),
-                global_vertex: self.global_form().clone_object(),
-                surface_position_as_global,
-                distance,
-            });
-        }
-
+        SurfaceVertexPositionMismatch::check_position(self, config)?;
         Ok(())
     }
 }
@@ -151,6 +137,31 @@ pub struct SurfaceVertexPositionMismatch {
 
     /// The distance between the positions
     pub distance: Scalar,
+}
+
+impl SurfaceVertexPositionMismatch {
+    fn check_position(
+        surface_vertex: &SurfaceVertex,
+        config: &ValidationConfig,
+    ) -> Result<(), Self> {
+        let surface_position_as_global = surface_vertex
+            .surface()
+            .point_from_surface_coords(surface_vertex.position());
+        let global_position = surface_vertex.global_form().position();
+
+        let distance = surface_position_as_global.distance_to(&global_position);
+
+        if distance > config.identical_max_distance {
+            return Err(SurfaceVertexPositionMismatch {
+                surface_vertex: surface_vertex.clone(),
+                global_vertex: surface_vertex.global_form().clone_object(),
+                surface_position_as_global,
+                distance,
+            });
+        }
+
+        Ok(())
+    }
 }
 
 impl Validate2 for GlobalVertex {

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -51,8 +51,8 @@ pub enum VertexValidationError {
     /// Mismatch between the surface's of the curve and surface form
     #[error(
         "Surface form of vertex must be defined on same surface as curve\n\
-        `Surface` of curve: {:?}\n\
-        `Surface` of surface form: {:?}",
+        `- Surface` of curve: {:?}\n\
+        `- Surface` of surface form: {:?}",
         .curve_surface.full_debug(),
         .surface_form_surface.full_debug(),
     )]
@@ -67,10 +67,10 @@ pub enum VertexValidationError {
     /// Mismatch between position of the vertex and position of its surface form
     #[error(
         "`Vertex` position doesn't match position of its surface form\n\
-        `Vertex`: {vertex:#?}\n\
-        `SurfaceVertex`: {surface_vertex:#?}\n\
-        `Vertex` position as surface: {curve_position_as_surface:?}\n\
-        Distance between the positions: {distance}"
+        - `Vertex`: {vertex:#?}\n\
+        - `SurfaceVertex`: {surface_vertex:#?}\n\
+        - `Vertex` position as surface: {curve_position_as_surface:?}\n\
+        - Distance between the positions: {distance}"
     )]
     PositionMismatch {
         /// The vertex
@@ -131,10 +131,10 @@ impl VertexValidationError {
 #[derive(Debug, thiserror::Error)]
 #[error(
     "`SurfaceVertex` position doesn't match position of its global form\n\
-    `SurfaceVertex`: {surface_vertex:#?}\n\
-    `GlobalVertex`: {global_vertex:#?}\n\
-    `SurfaceVertex` position as global: {surface_position_as_global:?}\n\
-    Distance between the positions: {distance}"
+    - `SurfaceVertex`: {surface_vertex:#?}\n\
+    - `GlobalVertex`: {global_vertex:#?}\n\
+    - `SurfaceVertex` position as global: {surface_position_as_global:?}\n\
+    - Distance between the positions: {distance}"
 )]
 pub struct SurfaceVertexPositionMismatch {
     /// The surface vertex

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -17,22 +17,7 @@ impl Validate2 for Vertex {
         config: &ValidationConfig,
     ) -> Result<(), Self::Error> {
         VertexValidationError::check_surface_identity(self)?;
-
-        let curve_position_as_surface =
-            self.curve().path().point_from_path_coords(self.position());
-        let surface_position = self.surface_form().position();
-
-        let distance = curve_position_as_surface.distance_to(&surface_position);
-
-        if distance > config.identical_max_distance {
-            return Err(VertexValidationError::PositionMismatch {
-                vertex: self.clone(),
-                surface_vertex: self.surface_form().clone_object(),
-                curve_position_as_surface,
-                distance,
-            });
-        }
-
+        VertexValidationError::check_position(self, config)?;
         Ok(())
     }
 }
@@ -88,6 +73,30 @@ impl VertexValidationError {
             return Err(VertexValidationError::SurfaceMismatch {
                 curve_surface: curve_surface.clone(),
                 surface_form_surface: surface_form_surface.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn check_position(
+        vertex: &Vertex,
+        config: &ValidationConfig,
+    ) -> Result<(), Self> {
+        let curve_position_as_surface = vertex
+            .curve()
+            .path()
+            .point_from_path_coords(vertex.position());
+        let surface_position = vertex.surface_form().position();
+
+        let distance = curve_position_as_surface.distance_to(&surface_position);
+
+        if distance > config.identical_max_distance {
+            return Err(VertexValidationError::PositionMismatch {
+                vertex: vertex.clone(),
+                surface_vertex: vertex.surface_form().clone_object(),
+                curve_position_as_surface,
+                distance,
             });
         }
 


### PR DESCRIPTION
Moves the bulk of the validation code over to the new validation infrastructure introduced in #1279 and #1283. Also cleans up the validation code already moved over in #1285. This extends the error messages and greatly increases the test coverage of the validation code.

The remaining validation code that is not on the new infrastructure will be moved over in future pull requests.