### PR TITLE
Fix panic when quitting application

### DIFF
--- a/crates/fj-host/src/evaluator.rs
+++ b/crates/fj-host/src/evaluator.rs
@@ -6,7 +6,7 @@ use crate::{Error, Evaluation, Model};
 
 /// Evaluates a model in a background thread
 pub struct Evaluator {
-    trigger_tx: Sender<()>,
+    trigger_tx: Sender<TriggerEvaluation>,
     event_rx: Receiver<ModelEvent>,
 }
 
@@ -17,7 +17,7 @@ impl Evaluator {
         let (trigger_tx, trigger_rx) = crossbeam_channel::bounded(0);
 
         thread::spawn(move || loop {
-            let () = trigger_rx
+            let TriggerEvaluation = trigger_rx
                 .recv()
                 .expect("Expected channel to never disconnect");
 
@@ -43,7 +43,7 @@ impl Evaluator {
     }
 
     /// Access a channel for triggering evaluations
-    pub fn trigger(&self) -> Sender<()> {
+    pub fn trigger(&self) -> Sender<TriggerEvaluation> {
         self.trigger_tx.clone()
     }
 
@@ -52,6 +52,9 @@ impl Evaluator {
         self.event_rx.clone()
     }
 }
+
+/// Command received by [`Evaluator`] through its channel
+pub struct TriggerEvaluation;
 
 /// An event emitted by [`Evaluator`]
 pub enum ModelEvent {

--- a/crates/fj-host/src/watcher.rs
+++ b/crates/fj-host/src/watcher.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, ffi::OsStr, path::Path, thread};
 
 use notify::Watcher as _;
 
-use crate::{Error, Evaluator};
+use crate::{evaluator::TriggerEvaluation, Error, Evaluator};
 
 /// Watches a model for changes, reloading it continually
 pub struct Watcher {
@@ -65,7 +65,9 @@ impl Watcher {
                     // application is being shut down.
                     //
                     // Either way, not much we can do about it here.
-                    watch_tx.send(()).expect("Channel is disconnected");
+                    watch_tx
+                        .send(TriggerEvaluation)
+                        .expect("Channel is disconnected");
                 }
             },
         )?;
@@ -82,7 +84,9 @@ impl Watcher {
         // Will panic, if the receiving end has panicked. Not much we can do
         // about that, if it happened.
         thread::spawn(move || {
-            watch_tx_2.send(()).expect("Channel is disconnected")
+            watch_tx_2
+                .send(TriggerEvaluation)
+                .expect("Channel is disconnected")
         });
 
         Ok(Self {


### PR DESCRIPTION
This fixes the following panic, discovered in #1286:
```
thread '<unnamed>' panicked at 'Expected channel to never disconnect: RecvError', crates/fj-host/src/evaluator.rs:22:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```