### PR TITLE
Simplify `Cycle` and `Face`

### DIFF
--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -8,8 +8,6 @@ use super::Reverse;
 
 impl Reverse for Handle<Cycle> {
     fn reverse(self, objects: &Objects) -> Result<Self, ValidationError> {
-        let surface = self.surface().clone();
-
         let mut edges = self
             .half_edges()
             .cloned()
@@ -18,6 +16,6 @@ impl Reverse for Handle<Cycle> {
 
         edges.reverse();
 
-        Ok(objects.cycles.insert(Cycle::new(surface, edges))?)
+        Ok(objects.cycles.insert(Cycle::new(edges))?)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -121,11 +121,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         points_curve_and_surface,
                     ));
 
-                objects.curves.insert(Curve::new(
-                    surface.clone(),
-                    path,
-                    global,
-                ))?
+                objects.curves.insert(Curve::new(surface, path, global))?
             };
 
             let global = objects.global_edges.insert(GlobalEdge::new(
@@ -176,7 +172,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 i += 1;
             }
 
-            objects.cycles.insert(Cycle::new(surface, edges))?
+            objects.cycles.insert(Cycle::new(edges))?
         };
 
         Ok(Face::builder(objects)
@@ -242,7 +238,7 @@ mod tests {
                 .build(&objects)?
                 .reverse(&objects)?;
             let side_down = HalfEdge::partial()
-                .with_surface(Some(surface.clone()))
+                .with_surface(Some(surface))
                 .with_back_vertex(Some(Vertex::partial().with_surface_form(
                     Some(bottom.back().surface_form().clone()),
                 )))
@@ -253,10 +249,9 @@ mod tests {
                 .build(&objects)?
                 .reverse(&objects)?;
 
-            let cycle = objects.cycles.insert(Cycle::new(
-                surface,
-                [bottom, side_up, top, side_down],
-            ))?;
+            let cycle = objects
+                .cycles
+                .insert(Cycle::new([bottom, side_up, top, side_down]))?;
 
             Face::builder(&objects).with_exterior(cycle).build()
         };

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -260,10 +260,7 @@ impl<'a> ShellBuilder<'a> {
 
             Face::builder(self.objects)
                 .with_exterior(
-                    self.objects
-                        .cycles
-                        .insert(Cycle::new(surface, edges))
-                        .unwrap(),
+                    self.objects.cycles.insert(Cycle::new(edges)).unwrap(),
                 )
                 .build()
         };

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -18,6 +18,8 @@ impl Cycle {
     ///
     /// # Panics
     ///
+    /// Panics, if `half_edges` does not yield at least one half-edge.
+    ///
     /// Panic, if the end of each half-edge does not connect to the beginning of
     /// the next one.
     pub fn new(half_edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -20,11 +20,13 @@ impl Cycle {
     ///
     /// Panic, if the end of each half-edge does not connect to the beginning of
     /// the next one.
-    pub fn new(
-        surface: Handle<Surface>,
-        half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
-    ) -> Self {
+    pub fn new(half_edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
+
+        let surface = match half_edges.first() {
+            Some(half_edge) => half_edge.surface().clone(),
+            None => panic!("Cycle must contain at least one half-edge"),
+        };
 
         // Verify, that the curves of all edges are defined in the correct
         // surface.

--- a/crates/fj-kernel/src/objects/cycle.rs
+++ b/crates/fj-kernel/src/objects/cycle.rs
@@ -9,7 +9,6 @@ use super::{HalfEdge, Surface};
 /// A cycle of connected half-edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
-    surface: Handle<Surface>,
     half_edges: Vec<Handle<HalfEdge>>,
 }
 
@@ -68,15 +67,18 @@ impl Cycle {
             }
         }
 
-        Self {
-            surface,
-            half_edges,
-        }
+        Self { half_edges }
     }
 
     /// Access the surface that this cycle is in
     pub fn surface(&self) -> &Handle<Surface> {
-        &self.surface
+        if let Some(half_edge) = self.half_edges.first() {
+            return half_edge.surface();
+        }
+
+        unreachable!(
+            "Cycle has no half-edges, which the constructor should prevent."
+        )
     }
 
     /// Access the half-edges that make up the cycle

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::storage::{Handle, HandleWrapper};
 
-use super::{Curve, GlobalCurve, GlobalVertex, Vertex};
+use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -44,6 +44,11 @@ impl HalfEdge {
     pub fn front(&self) -> &Handle<Vertex> {
         let [_, front] = self.vertices();
         front
+    }
+
+    /// Access the surface that the half-edge's curve is defined in
+    pub fn surface(&self) -> &Handle<Surface> {
+        self.curve().surface()
     }
 
     /// Access the global form of this half-edge

--- a/crates/fj-kernel/src/objects/face.rs
+++ b/crates/fj-kernel/src/objects/face.rs
@@ -33,7 +33,6 @@ use super::{Cycle, Objects, Surface};
 /// [`Shell`]: super::Shell
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Face {
-    surface: Handle<Surface>,
     exterior: Handle<Cycle>,
     interiors: Vec<Handle<Cycle>>,
     color: Color,
@@ -64,7 +63,7 @@ impl Face {
         the_interiors: impl IntoIterator<Item = Handle<Cycle>>,
         color: Color,
     ) -> Self {
-        let surface = exterior.surface().clone();
+        let surface = exterior.surface();
         let mut interiors = Vec::new();
 
         for interior in the_interiors.into_iter() {
@@ -83,7 +82,6 @@ impl Face {
         }
 
         Self {
-            surface,
             exterior,
             interiors,
             color,
@@ -92,7 +90,7 @@ impl Face {
 
     /// Access this face's surface
     pub fn surface(&self) -> &Handle<Surface> {
-        &self.surface
+        self.exterior().surface()
     }
 
     /// Access the cycle that bounds the face on the outside

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -222,7 +222,7 @@ impl PartialCycle {
             half_edges
         };
 
-        Ok(objects.cycles.insert(Cycle::new(surface, half_edges))?)
+        Ok(objects.cycles.insert(Cycle::new(half_edges))?)
     }
 }
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -27,11 +27,10 @@ impl Shape for fj::Sketch {
                 // none need to be added here.
 
                 let half_edge = HalfEdge::partial()
-                    .with_surface(Some(surface.clone()))
+                    .with_surface(Some(surface))
                     .as_circle_from_radius(circle.radius(), objects)?
                     .build(objects)?;
-                let cycle =
-                    objects.cycles.insert(Cycle::new(surface, [half_edge]))?;
+                let cycle = objects.cycles.insert(Cycle::new([half_edge]))?;
 
                 Face::builder(objects)
                     .with_exterior(cycle)


### PR DESCRIPTION
Remove the redundant `surface` argument from `Cycle::new` and remove the redundant `surface` fields from `Cycle` and `Face`.