### PR TITLE
Improve `Debug` implementation of `Handle`

### DIFF
--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -39,16 +39,6 @@ impl<T> Handle<T> {
     {
         self.deref().clone()
     }
-
-    /// Return a `Debug` implementation with full debug info
-    pub fn full_debug(&self) -> impl fmt::Debug
-    where
-        T: fmt::Debug,
-    {
-        // It would be nicer to return a struct that implements `Debug`, as that
-        // would cut down on allocations, but this will work for now.
-        format!("{:?} -> {:?}", self.id(), self.deref())
-    }
 }
 
 impl<T> Deref for Handle<T> {

--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -138,7 +138,10 @@ where
     }
 }
 
-impl<T> fmt::Debug for Handle<T> {
+impl<T> fmt::Debug for Handle<T>
+where
+    T: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = {
             let type_name = type_name::<T>();
@@ -272,7 +275,10 @@ impl<T> PartialOrd for HandleWrapper<T> {
     }
 }
 
-impl<T> fmt::Debug for HandleWrapper<T> {
+impl<T> fmt::Debug for HandleWrapper<T>
+where
+    T: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -151,8 +151,13 @@ where
             }
         };
         let id = self.id().0;
+        let object = self.deref();
 
-        write!(f, "{name} @ {id:#x}")?;
+        if f.alternate() {
+            write!(f, "{name} @ {id:#x} => {object:#?}")?;
+        } else {
+            write!(f, "{name} @ {id:#x}")?;
+        }
 
         Ok(())
     }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -45,10 +45,8 @@ pub enum HalfEdgeValidationError {
     /// [`HalfEdge`] vertices are not defined on the same `Curve`
     #[error(
         "`HalfEdge` vertices are not defined on the same `Curve`\n\
-        - `Curve` of back vertex: {:?}\n\
-        - `Curve` of front vertex: {:?}",
-        .back_curve.full_debug(),
-        .front_curve.full_debug(),
+        - `Curve` of back vertex: {back_curve:#?}\n\
+        - `Curve` of front vertex: {front_curve:#?}"
     )]
     CurveMismatch {
         /// The curve of the [`HalfEdge`]'s back vertex
@@ -62,10 +60,8 @@ pub enum HalfEdgeValidationError {
     #[error(
         "Global form of `HalfEdge`'s `Curve` does not match `GlobalCurve` of \n\
         the `HalfEdge`'s `GlobalEdge`\n\
-        - `GlobalCurve` from `Curve`: {:?}\n\
-        - `GlobalCurve` from `GlobalEdge`: {:?}",
-        .global_curve_from_curve.full_debug(),
-        .global_curve_from_global_form.full_debug(),
+        - `GlobalCurve` from `Curve`: {global_curve_from_curve:#?}\n\
+        - `GlobalCurve` from `GlobalEdge`: {global_curve_from_global_form:#?}",
     )]
     GlobalCurveMismatch {
         /// The [`GlobalCurve`] from the [`HalfEdge`]'s [`Curve`]
@@ -79,14 +75,10 @@ pub enum HalfEdgeValidationError {
     #[error(
         "Global forms of `HalfEdge` vertices do not match vertices of \n\
         `HalfEdge`'s global form\n\
-        - `GlobalVertex` objects from `Vertex` objects: {:?}\n\
-        - `GlobalVertex` objects from `GlobalEdge`: {:?}",
-        .global_vertices_from_vertices
-            .each_ref_ext()
-            .map(|vertex| vertex.full_debug()),
-        .global_vertices_from_global_form
-            .each_ref_ext()
-            .map(|vertex| vertex.full_debug()),
+        - `GlobalVertex` objects from `Vertex` objects: \
+            {global_vertices_from_vertices:#?}\n\
+        - `GlobalVertex` objects from `GlobalEdge`: \
+            {global_vertices_from_global_form:#?}"
     )]
     GlobalVertexMismatch {
         /// The [`GlobalVertex`] from the [`HalfEdge`]'s vertices

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -51,10 +51,8 @@ pub enum VertexValidationError {
     /// Mismatch between the surface's of the curve and surface form
     #[error(
         "Surface form of vertex must be defined on same surface as curve\n\
-        `- Surface` of curve: {:?}\n\
-        `- Surface` of surface form: {:?}",
-        .curve_surface.full_debug(),
-        .surface_form_surface.full_debug(),
+        `- Surface` of curve: {curve_surface:#?}\n\
+        `- Surface` of surface form: {surface_form_surface:#?}"
     )]
     SurfaceMismatch {
         /// The surface of the vertex' curve


### PR DESCRIPTION
By default, `Handle` has a very minimal `Debug` output:

``` rust
println!("{global_vertex:?");
// prints:
// GlobalVertex @ 0x7f3e24305d40
```

Its `Debug` implementation now respects `#`, and will print full output if it is present:

``` rust
println!("{global_vertex:#?");
// prints:
// GlobalVertex @ 0x7f3e24305d40 => GlobalVertex {
//     position: [
//         0.0,
//         0.0,
//         0.0,
//     ],
// }
```