### PR TITLE
Improve status messages around model loading

### DIFF
--- a/crates/fj-host/src/evaluator.rs
+++ b/crates/fj-host/src/evaluator.rs
@@ -18,6 +18,10 @@ impl Evaluator {
 
         thread::spawn(move || {
             while let Ok(TriggerEvaluation) = trigger_rx.recv() {
+                event_tx
+                    .send(ModelEvent::ChangeDetected)
+                    .expect("Expected channel to never disconnect");
+
                 let evaluation = match model.evaluate() {
                     Ok(evaluation) => evaluation,
                     Err(err) => {
@@ -60,6 +64,9 @@ pub struct TriggerEvaluation;
 
 /// An event emitted by [`Evaluator`]
 pub enum ModelEvent {
+    /// A change in the model has been detected
+    ChangeDetected,
+
     /// The model has been evaluated
     Evaluation(Evaluation),
 

--- a/crates/fj-viewer/src/status_report.rs
+++ b/crates/fj-viewer/src/status_report.rs
@@ -20,7 +20,7 @@ impl StatusReport {
     pub fn update_status(&mut self, status: &str) {
         let date = {
             let date = Local::now();
-            format!("{}", date.format("[%H:%M:%S]"))
+            format!("{}", date.format("[%H:%M:%S.%3f]"))
         };
         let empty_space = " ".repeat(date.chars().count());
 

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -75,10 +75,7 @@ pub fn run(
                         );
                     }
                     ModelEvent::Evaluation(evaluation) => {
-                        status.update_status(&format!(
-                            "Model compiled successfully in {}!",
-                            evaluation.compile_time
-                        ));
+                        status.update_status("Model compiled. Processing...");
 
                         match shape_processor.process(&evaluation.shape) {
                             Ok(shape) => {

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -97,6 +97,8 @@ pub fn run(
                                 }
                             }
                         }
+
+                        status.update_status("Model processed.");
                     }
 
                     ModelEvent::Error(err) => {

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -69,6 +69,11 @@ pub fn run(
                 };
 
                 match event {
+                    ModelEvent::ChangeDetected => {
+                        status.update_status(
+                            "Change in model detected. Compiling...",
+                        );
+                    }
                     ModelEvent::Evaluation(evaluation) => {
                         status.update_status(&format!(
                             "Model compiled successfully in {}!",


### PR DESCRIPTION
Print more status messages and increase the resolution of the timestamp shown. From one of the commit messages:

> This exposes that the model processing is blocking the event loop. The "processing..." and "processed." messages have different time stamps, but show up at the same time.

I plan to open an issue about that.