### PR TITLE
Start extracting new builder API from partial object API

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -197,6 +197,7 @@ mod tests {
 
     use crate::{
         algorithms::approx::{path::RangeOnPath, Approx, ApproxPoint},
+        builder::CurveBuilder,
         objects::{Curve, Objects, Surface},
         partial::HasPartial,
         path::GlobalPath,

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -286,7 +286,7 @@ mod tests {
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]))?;
         let curve = Curve::partial()
             .with_surface(Some(surface))
-            .as_circle_from_radius(1.)
+            .update_as_circle_from_radius(1.)
             .build(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -214,7 +214,7 @@ mod tests {
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]))?;
         let curve = Curve::partial()
             .with_surface(Some(surface))
-            .as_line_from_points([[1., 1.], [2., 1.]])
+            .update_as_line_from_points([[1., 1.], [2., 1.]])
             .build(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
@@ -235,7 +235,7 @@ mod tests {
         ))?;
         let curve = Curve::partial()
             .with_surface(Some(surface))
-            .as_line_from_points([[1., 1.], [1., 2.]])
+            .update_as_line_from_points([[1., 1.], [1., 2.]])
             .build(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
@@ -254,7 +254,7 @@ mod tests {
             objects.surfaces.insert(Surface::new(path, [0., 0., 1.]))?;
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_line_from_points([[0., 1.], [1., 1.]])
+            .update_as_line_from_points([[0., 1.], [1., 1.]])
             .build(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -75,6 +75,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
+        builder::CurveBuilder,
         objects::{Curve, HalfEdge, Objects},
         partial::HasPartial,
     };

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -89,7 +89,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
@@ -114,7 +114,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
@@ -139,7 +139,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))
@@ -159,7 +159,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .with_surface(Some(surface))

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -165,7 +165,7 @@ mod tests {
 
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_line_from_points([[-3., 0.], [-2., 0.]])
+            .update_as_line_from_points([[-3., 0.], [-2., 0.]])
             .build(&objects)?;
 
         #[rustfmt::skip]

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -150,6 +150,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
+        builder::CurveBuilder,
         objects::{Curve, Face, Objects},
         partial::HasPartial,
     };

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -125,7 +125,7 @@ mod tests {
         let expected_curves = surfaces.try_map_ext(|surface| {
             Curve::partial()
                 .with_surface(Some(surface))
-                .as_line_from_points([[0., 0.], [1., 0.]])
+                .update_as_line_from_points([[0., 0.], [1., 0.]])
                 .build(&objects)
         })?;
         let expected_intervals =

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -67,6 +67,7 @@ mod tests {
 
     use crate::{
         algorithms::intersect::CurveFaceIntersection,
+        builder::CurveBuilder,
         objects::{Curve, Face, Objects},
         partial::HasPartial,
     };

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -123,11 +123,11 @@ mod tests {
 
         let expected_xy = Curve::partial()
             .with_surface(Some(xy.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let expected_xz = Curve::partial()
             .with_surface(Some(xz.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
 
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -92,6 +92,7 @@ mod tests {
 
     use crate::{
         algorithms::transform::TransformObject,
+        builder::CurveBuilder,
         objects::{Curve, Objects},
         partial::HasPartial,
     };

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -180,7 +180,7 @@ mod tests {
         let surface = objects.surfaces.xz_plane();
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let vertex = Vertex::partial()
             .with_position(Some([0.]))

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -168,6 +168,7 @@ mod tests {
 
     use crate::{
         algorithms::sweep::Sweep,
+        builder::CurveBuilder,
         objects::{Curve, HalfEdge, Objects, Vertex},
         partial::HasPartial,
     };

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -44,10 +44,9 @@ impl TransformObject for PartialCurve {
 
         // Don't need to transform `self.path`, as that's defined in surface
         // coordinates, and thus transforming `surface` takes care of it.
-        Ok(Self {
-            surface,
-            path: self.path,
-            global_form: global_form.map(Into::into),
-        })
+        Ok(Self::default()
+            .with_surface(surface)
+            .with_path(self.path())
+            .with_global_form(global_form))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -34,12 +34,12 @@ impl TransformObject for PartialCurve {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
-            .surface
+            .surface()
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
         let global_form = self
-            .global_form
-            .map(|global_form| global_form.0.transform(transform, objects))
+            .global_form()
+            .map(|global_form| global_form.transform(transform, objects))
             .transpose()?;
 
         // Don't need to transform `self.path`, as that's defined in surface

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -1,29 +1,24 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{GlobalCurve, Objects},
-    partial::PartialCurve,
-    storage::Handle,
+    objects::Objects,
+    partial::{PartialCurve, PartialGlobalCurve},
     validate::ValidationError,
 };
 
 use super::TransformObject;
 
-impl TransformObject for Handle<GlobalCurve> {
+impl TransformObject for PartialGlobalCurve {
     fn transform(
         self,
         _: &Transform,
-        objects: &Objects,
+        _: &Objects,
     ) -> Result<Self, ValidationError> {
         // `GlobalCurve` doesn't contain any internal geometry. If it did, that
         // would just be redundant with the geometry of other objects, and this
         // other geometry is already being transformed by other implementations
         // of this trait.
-        //
-        // All we need to do here is create a new `GlobalCurve` instance, to
-        // make sure the transformed `GlobalCurve` has a different identity than
-        // the original one.
-        Ok(objects.global_curves.insert(GlobalCurve)?)
+        Ok(self)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -57,10 +57,7 @@ impl TransformObject for PartialGlobalEdge {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self
-            .curve
-            .map(|curve| curve.transform(transform, objects))
-            .transpose()?;
+        let curve = self.curve.transform(transform, objects)?;
         let vertices = self
             .vertices
             .map(|vertices| {
@@ -70,9 +67,6 @@ impl TransformObject for PartialGlobalEdge {
             })
             .transpose()?;
 
-        Ok(Self {
-            curve: curve.map(Into::into),
-            vertices,
-        })
+        Ok(Self { curve, vertices })
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -59,7 +59,7 @@ impl TransformObject for PartialGlobalEdge {
     ) -> Result<Self, ValidationError> {
         let curve = self
             .curve
-            .map(|curve| curve.0.transform(transform, objects))
+            .map(|curve| curve.transform(transform, objects))
             .transpose()?;
         let vertices = self
             .vertices

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -23,11 +23,10 @@ impl TransformObject for PartialVertex {
 
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
-        Ok(Self {
-            position: self.position(),
-            curve,
-            surface_form,
-        })
+        Ok(Self::default()
+            .with_position(self.position())
+            .with_curve(Some(curve))
+            .with_surface_form(surface_form))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -60,7 +60,7 @@ impl TransformObject for PartialGlobalVertex {
         _: &Objects,
     ) -> Result<Self, ValidationError> {
         let position = self
-            .position
+            .position()
             .map(|position| transform.transform_point(&position));
 
         Ok(Self { position })

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -45,11 +45,10 @@ impl TransformObject for PartialSurfaceVertex {
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.
-        Ok(Self {
-            position: self.position(),
-            surface,
-            global_form,
-        })
+        Ok(Self::default()
+            .with_position(self.position())
+            .with_surface(surface)
+            .with_global_form(Some(global_form)))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -38,15 +38,15 @@ impl TransformObject for PartialSurfaceVertex {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
-            .surface
+            .surface()
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
-        let global_form = self.global_form.transform(transform, objects)?;
+        let global_form = self.global_form().transform(transform, objects)?;
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.
         Ok(Self {
-            position: self.position,
+            position: self.position(),
             surface,
             global_form,
         })

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -63,6 +63,6 @@ impl TransformObject for PartialGlobalVertex {
             .position()
             .map(|position| transform.transform_point(&position));
 
-        Ok(Self { position })
+        Ok(Self::default().with_position(position))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -14,9 +14,9 @@ impl TransformObject for PartialVertex {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self.curve.transform(transform, objects)?;
+        let curve = self.curve().transform(transform, objects)?;
         let surface_form = self
-            .surface_form
+            .surface_form()
             .into_partial()
             .transform(transform, objects)?
             .into();
@@ -24,7 +24,7 @@ impl TransformObject for PartialVertex {
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
         Ok(Self {
-            position: self.position,
+            position: self.position(),
             curve,
             surface_form,
         })

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -12,7 +12,7 @@ pub trait CurveBuilder {
     fn update_as_v_axis(self) -> Self;
 
     /// Update partial curve as a circle, from the provided radius
-    fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
+    fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
 
     /// Update partial curve as a line, from the provided points
     fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self;
@@ -33,7 +33,7 @@ impl CurveBuilder for PartialCurve {
         self.as_line_from_points([a, b])
     }
 
-    fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
+    fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
         self.with_path(Some(SurfacePath::circle_from_radius(radius)))
     }
 

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -6,7 +6,7 @@ use crate::{partial::PartialCurve, path::SurfacePath};
 #[allow(clippy::wrong_self_convention)]
 pub trait CurveBuilder {
     /// Update partial curve to represent the u-axis
-    fn as_u_axis(self) -> Self;
+    fn update_as_u_axis(self) -> Self;
 
     /// Update partial curve to represent the v-axis
     fn as_v_axis(self) -> Self;
@@ -19,7 +19,7 @@ pub trait CurveBuilder {
 }
 
 impl CurveBuilder for PartialCurve {
-    fn as_u_axis(self) -> Self {
+    fn update_as_u_axis(self) -> Self {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -9,7 +9,7 @@ pub trait CurveBuilder {
     fn update_as_u_axis(self) -> Self;
 
     /// Update partial curve to represent the v-axis
-    fn as_v_axis(self) -> Self;
+    fn update_as_v_axis(self) -> Self;
 
     /// Update partial curve as a circle, from the provided radius
     fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
@@ -26,7 +26,7 @@ impl CurveBuilder for PartialCurve {
         self.as_line_from_points([a, b])
     }
 
-    fn as_v_axis(self) -> Self {
+    fn update_as_v_axis(self) -> Self {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -15,7 +15,10 @@ pub trait CurveBuilder {
     fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
 
     /// Update partial curve as a line, from the provided points
-    fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self;
+    fn update_as_line_from_points(
+        self,
+        points: [impl Into<Point<2>>; 2],
+    ) -> Self;
 }
 
 impl CurveBuilder for PartialCurve {
@@ -23,21 +26,24 @@ impl CurveBuilder for PartialCurve {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 
-        self.as_line_from_points([a, b])
+        self.update_as_line_from_points([a, b])
     }
 
     fn update_as_v_axis(self) -> Self {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 
-        self.as_line_from_points([a, b])
+        self.update_as_line_from_points([a, b])
     }
 
     fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
         self.with_path(Some(SurfacePath::circle_from_radius(radius)))
     }
 
-    fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self {
+    fn update_as_line_from_points(
+        self,
+        points: [impl Into<Point<2>>; 2],
+    ) -> Self {
         self.with_path(Some(SurfacePath::line_from_points(points)))
     }
 }

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -1,0 +1,43 @@
+use fj_math::{Point, Scalar, Vector};
+
+use crate::{partial::PartialCurve, path::SurfacePath};
+
+/// Builder API for [`PartialCurve`]
+#[allow(clippy::wrong_self_convention)]
+pub trait CurveBuilder {
+    /// Update partial curve to represent the u-axis
+    fn as_u_axis(self) -> Self;
+
+    /// Update partial curve to represent the v-axis
+    fn as_v_axis(self) -> Self;
+
+    /// Update partial curve as a circle, from the provided radius
+    fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
+
+    /// Update partial curve as a line, from the provided points
+    fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self;
+}
+
+impl CurveBuilder for PartialCurve {
+    fn as_u_axis(self) -> Self {
+        let a = Point::origin();
+        let b = a + Vector::unit_u();
+
+        self.as_line_from_points([a, b])
+    }
+
+    fn as_v_axis(self) -> Self {
+        let a = Point::origin();
+        let b = a + Vector::unit_v();
+
+        self.as_line_from_points([a, b])
+    }
+
+    fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
+        self.with_path(Some(SurfacePath::circle_from_radius(radius)))
+    }
+
+    fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self {
+        self.with_path(Some(SurfacePath::line_from_points(points)))
+    }
+}

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -3,7 +3,6 @@ use fj_math::{Point, Scalar, Vector};
 use crate::{partial::PartialCurve, path::SurfacePath};
 
 /// Builder API for [`PartialCurve`]
-#[allow(clippy::wrong_self_convention)]
 pub trait CurveBuilder {
     /// Update partial curve to represent the u-axis
     fn update_as_u_axis(self) -> Self;

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -13,6 +13,10 @@ mod curve;
 mod vertex;
 
 pub use self::{
-    curve::CurveBuilder, face::FaceBuilder, shell::ShellBuilder,
-    sketch::SketchBuilder, solid::SolidBuilder, vertex::GlobalVertexBuilder,
+    curve::CurveBuilder,
+    face::FaceBuilder,
+    shell::ShellBuilder,
+    sketch::SketchBuilder,
+    solid::SolidBuilder,
+    vertex::{GlobalVertexBuilder, SurfaceVertexBuilder},
 };

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -18,5 +18,5 @@ pub use self::{
     shell::ShellBuilder,
     sketch::SketchBuilder,
     solid::SolidBuilder,
-    vertex::{GlobalVertexBuilder, SurfaceVertexBuilder},
+    vertex::{GlobalVertexBuilder, SurfaceVertexBuilder, VertexBuilder},
 };

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -10,8 +10,9 @@ mod solid;
 
 // These are new-style builders that build on top of the partial object API.
 mod curve;
+mod vertex;
 
 pub use self::{
     curve::CurveBuilder, face::FaceBuilder, shell::ShellBuilder,
-    sketch::SketchBuilder, solid::SolidBuilder,
+    sketch::SketchBuilder, solid::SolidBuilder, vertex::GlobalVertexBuilder,
 };

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -1,11 +1,17 @@
 //! API for building objects
 
+// These are the old-style builders that need to be transferred to the partial
+// object API. Issue:
+// https://github.com/hannobraun/Fornjot/issues/1147
 mod face;
 mod shell;
 mod sketch;
 mod solid;
 
+// These are new-style builders that build on top of the partial object API.
+mod curve;
+
 pub use self::{
-    face::FaceBuilder, shell::ShellBuilder, sketch::SketchBuilder,
-    solid::SolidBuilder,
+    curve::CurveBuilder, face::FaceBuilder, shell::ShellBuilder,
+    sketch::SketchBuilder, solid::SolidBuilder,
 };

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -4,8 +4,21 @@ use crate::{
     objects::{Curve, GlobalVertex, Surface},
     partial::{
         HasPartial, MaybePartial, PartialGlobalVertex, PartialSurfaceVertex,
+        PartialVertex,
     },
 };
+
+/// Builder API for [`PartialVertex`]
+pub trait VertexBuilder {
+    /// Remove the surface form of the partial vertex, inferring it on build
+    fn infer_surface_form(self) -> Self;
+}
+
+impl VertexBuilder for PartialVertex {
+    fn infer_surface_form(self) -> Self {
+        self.with_surface_form(Some(PartialSurfaceVertex::default()))
+    }
+}
 
 /// Builder API for [`PartialSurfaceVertex`]
 pub trait SurfaceVertexBuilder {

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -9,7 +9,7 @@ use crate::{
 #[allow(clippy::wrong_self_convention)]
 pub trait GlobalVertexBuilder {
     /// Update partial global vertex from the given curve and position on it
-    fn from_curve_and_position(
+    fn update_from_curve_and_position(
         self,
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
@@ -24,7 +24,7 @@ pub trait GlobalVertexBuilder {
 }
 
 impl GlobalVertexBuilder for PartialGlobalVertex {
-    fn from_curve_and_position(
+    fn update_from_curve_and_position(
         self,
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -16,7 +16,7 @@ pub trait GlobalVertexBuilder {
     ) -> Self;
 
     /// Update partial global vertex from the given surface and position on it
-    fn from_surface_and_position(
+    fn update_from_surface_and_position(
         self,
         surface: &Surface,
         position: impl Into<Point<2>>,
@@ -39,10 +39,10 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
         );
 
         let position_surface = path.point_from_path_coords(position);
-        self.from_surface_and_position(&surface, position_surface)
+        self.update_from_surface_and_position(&surface, position_surface)
     }
 
-    fn from_surface_and_position(
+    fn update_from_surface_and_position(
         self,
         surface: &Surface,
         position: impl Into<Point<2>>,

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,9 +1,23 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Curve, Surface},
-    partial::{MaybePartial, PartialGlobalVertex},
+    objects::{Curve, GlobalVertex, Surface},
+    partial::{
+        HasPartial, MaybePartial, PartialGlobalVertex, PartialSurfaceVertex,
+    },
 };
+
+/// Builder API for [`PartialSurfaceVertex`]
+pub trait SurfaceVertexBuilder {
+    /// Remove the global form of the partial vertex, inferring it in `build`
+    fn infer_global_form(self) -> Self;
+}
+
+impl SurfaceVertexBuilder for PartialSurfaceVertex {
+    fn infer_global_form(self) -> Self {
+        self.with_global_form(Some(GlobalVertex::partial()))
+    }
+}
 
 /// Builder API for [`PartialGlobalVertex`]
 pub trait GlobalVertexBuilder {

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 /// Builder API for [`PartialGlobalVertex`]
-#[allow(clippy::wrong_self_convention)]
 pub trait GlobalVertexBuilder {
     /// Update partial global vertex from the given curve and position on it
     fn update_from_curve_and_position(

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,0 +1,52 @@
+use fj_math::Point;
+
+use crate::{
+    objects::{Curve, Surface},
+    partial::{MaybePartial, PartialGlobalVertex},
+};
+
+/// Builder API for [`PartialGlobalVertex`]
+#[allow(clippy::wrong_self_convention)]
+pub trait GlobalVertexBuilder {
+    /// Update partial global vertex from the given curve and position on it
+    fn from_curve_and_position(
+        self,
+        curve: impl Into<MaybePartial<Curve>>,
+        position: impl Into<Point<1>>,
+    ) -> Self;
+
+    /// Update partial global vertex from the given surface and position on it
+    fn from_surface_and_position(
+        self,
+        surface: &Surface,
+        position: impl Into<Point<2>>,
+    ) -> Self;
+}
+
+impl GlobalVertexBuilder for PartialGlobalVertex {
+    fn from_curve_and_position(
+        self,
+        curve: impl Into<MaybePartial<Curve>>,
+        position: impl Into<Point<1>>,
+    ) -> Self {
+        let curve = curve.into().into_partial();
+
+        let path = curve.path().expect(
+            "Need path to create `GlobalVertex` from curve and position",
+        );
+        let surface = curve.surface().expect(
+            "Need surface to create `GlobalVertex` from curve and position",
+        );
+
+        let position_surface = path.point_from_path_coords(position);
+        self.from_surface_and_position(&surface, position_surface)
+    }
+
+    fn from_surface_and_position(
+        self,
+        surface: &Surface,
+        position: impl Into<Point<2>>,
+    ) -> Self {
+        self.with_position(Some(surface.point_from_surface_coords(position)))
+    }
+}

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Builder API for [`PartialSurfaceVertex`]
 pub trait SurfaceVertexBuilder {
-    /// Remove the global form of the partial vertex, inferring it in `build`
+    /// Infer the global form of the partial vertex
     fn infer_global_form(self) -> Self;
 }
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -377,7 +377,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let object = Curve::partial()
             .with_surface(Some(surface))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects);
 
         assert_eq!(1, object.curve_iter().count());
@@ -594,7 +594,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let curve = Curve::partial()
             .with_surface(Some(surface.clone()))
-            .as_u_axis()
+            .update_as_u_axis()
             .build(&objects)?;
         let global_vertex = objects
             .global_vertices

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -360,6 +360,7 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        builder::CurveBuilder,
         objects::{
             Curve, Cycle, Face, GlobalCurve, GlobalVertex, HalfEdge, Objects,
             Shell, Sketch, Solid, SurfaceVertex, Vertex,

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -157,10 +157,10 @@ impl MaybePartial<SurfaceVertex> {
     }
 
     /// Access the surface
-    pub fn surface(&self) -> Option<&Handle<Surface>> {
+    pub fn surface(&self) -> Option<Handle<Surface>> {
         match self {
-            Self::Full(full) => Some(full.surface()),
-            Self::Partial(partial) => partial.surface.as_ref(),
+            Self::Full(full) => Some(full.surface().clone()),
+            Self::Partial(partial) => partial.surface.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -122,6 +122,14 @@ impl MaybePartial<Curve> {
         }
     }
 
+    /// Access the surface
+    pub fn surface(&self) -> Option<Handle<Surface>> {
+        match self {
+            MaybePartial::Full(full) => Some(full.surface().clone()),
+            MaybePartial::Partial(partial) => partial.surface(),
+        }
+    }
+
     /// Access the global form
     pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -5,6 +5,7 @@ use crate::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex,
     },
+    path::SurfacePath,
     storage::Handle,
     validate::ValidationError,
 };
@@ -113,6 +114,14 @@ where
 // `MaybePartial<T>`, as that would conflict.
 
 impl MaybePartial<Curve> {
+    /// Access the path
+    pub fn path(&self) -> Option<SurfacePath> {
+        match self {
+            MaybePartial::Full(full) => Some(full.path()),
+            MaybePartial::Partial(partial) => partial.path(),
+        }
+    }
+
     /// Access the global form
     pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -30,6 +30,24 @@ pub enum MaybePartial<T: HasPartial> {
 }
 
 impl<T: HasPartial> MaybePartial<T> {
+    /// Indicate whether this is a full object
+    pub fn is_full(&self) -> bool {
+        if let Self::Full(_) = self {
+            return true;
+        }
+
+        false
+    }
+
+    /// Indicate whether this is a partial object
+    pub fn is_partial(&self) -> bool {
+        if let Self::Partial(_) = self {
+            return true;
+        }
+
+        false
+    }
+
     /// If this is a partial object, update it
     ///
     /// This is useful whenever a partial object can infer something about its

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -186,7 +186,7 @@ impl MaybePartial<Vertex> {
     pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
         match self {
             Self::Full(full) => full.surface_form().clone().into(),
-            Self::Partial(partial) => partial.surface_form.clone(),
+            Self::Partial(partial) => partial.surface_form(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -99,9 +99,7 @@ impl MaybePartial<Curve> {
     pub fn global_form(&self) -> Option<Handle<GlobalCurve>> {
         match self {
             Self::Full(full) => Some(full.global_form().clone()),
-            Self::Partial(partial) => {
-                partial.global_form.clone().map(Into::into)
-            }
+            Self::Partial(partial) => partial.global_form(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -152,7 +152,7 @@ impl MaybePartial<SurfaceVertex> {
     pub fn position(&self) -> Option<Point<2>> {
         match self {
             Self::Full(full) => Some(full.position()),
-            Self::Partial(partial) => partial.position,
+            Self::Partial(partial) => partial.position(),
         }
     }
 
@@ -160,7 +160,7 @@ impl MaybePartial<SurfaceVertex> {
     pub fn surface(&self) -> Option<Handle<Surface>> {
         match self {
             Self::Full(full) => Some(full.surface().clone()),
-            Self::Partial(partial) => partial.surface.clone(),
+            Self::Partial(partial) => partial.surface(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -124,11 +124,11 @@ impl MaybePartial<Curve> {
 
 impl MaybePartial<GlobalEdge> {
     /// Access the curve
-    pub fn curve(&self) -> Option<&Handle<GlobalCurve>> {
+    pub fn curve(&self) -> Option<Handle<GlobalCurve>> {
         match self {
-            Self::Full(full) => Some(full.curve()),
+            Self::Full(full) => Some(full.curve().clone()),
             Self::Partial(partial) => {
-                partial.curve.as_ref().map(|wrapper| &wrapper.0)
+                partial.curve.clone().map(|wrapper| wrapper.0)
             }
         }
     }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -124,10 +124,10 @@ impl MaybePartial<Curve> {
 
 impl MaybePartial<GlobalEdge> {
     /// Access the curve
-    pub fn curve(&self) -> Option<MaybePartial<GlobalCurve>> {
+    pub fn curve(&self) -> MaybePartial<GlobalCurve> {
         match self {
-            Self::Full(full) => Some(full.curve().clone().into()),
-            Self::Partial(partial) => Some(partial.curve.clone()),
+            Self::Full(full) => full.curve().clone().into(),
+            Self::Partial(partial) => partial.curve.clone(),
         }
     }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -114,9 +114,9 @@ where
 
 impl MaybePartial<Curve> {
     /// Access the global form
-    pub fn global_form(&self) -> Option<Handle<GlobalCurve>> {
+    pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {
-            Self::Full(full) => Some(full.global_form().clone()),
+            Self::Full(full) => Some(full.global_form().clone().into()),
             Self::Partial(partial) => partial.global_form(),
         }
     }
@@ -124,12 +124,10 @@ impl MaybePartial<Curve> {
 
 impl MaybePartial<GlobalEdge> {
     /// Access the curve
-    pub fn curve(&self) -> Option<Handle<GlobalCurve>> {
+    pub fn curve(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {
-            Self::Full(full) => Some(full.curve().clone()),
-            Self::Partial(partial) => {
-                partial.curve.clone().map(|wrapper| wrapper.0)
-            }
+            Self::Full(full) => Some(full.curve().clone().into()),
+            Self::Partial(partial) => partial.curve.clone(),
         }
     }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -127,7 +127,7 @@ impl MaybePartial<GlobalEdge> {
     pub fn curve(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {
             Self::Full(full) => Some(full.curve().clone().into()),
-            Self::Partial(partial) => partial.curve.clone(),
+            Self::Partial(partial) => Some(partial.curve.clone()),
         }
     }
 

--- a/crates/fj-kernel/src/partial/mod.rs
+++ b/crates/fj-kernel/src/partial/mod.rs
@@ -41,7 +41,7 @@ mod traits;
 pub use self::{
     maybe_partial::MaybePartial,
     objects::{
-        curve::PartialCurve,
+        curve::{PartialCurve, PartialGlobalCurve},
         cycle::PartialCycle,
         edge::{PartialGlobalEdge, PartialHalfEdge},
         vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -1,5 +1,3 @@
-use fj_math::{Point, Scalar, Vector};
-
 use crate::{
     objects::{Curve, GlobalCurve, Objects, Surface},
     path::SurfacePath,
@@ -60,32 +58,6 @@ impl PartialCurve {
             self.global_form = Some(global_form.into());
         }
         self
-    }
-
-    /// Update partial curve to represent the u-axis
-    pub fn as_u_axis(self) -> Self {
-        let a = Point::origin();
-        let b = a + Vector::unit_u();
-
-        self.as_line_from_points([a, b])
-    }
-
-    /// Update partial curve to represent the v-axis
-    pub fn as_v_axis(self) -> Self {
-        let a = Point::origin();
-        let b = a + Vector::unit_v();
-
-        self.as_line_from_points([a, b])
-    }
-
-    /// Update partial curve as a circle, from the provided radius
-    pub fn as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
-        self.with_path(Some(SurfacePath::circle_from_radius(radius)))
-    }
-
-    /// Update partial curve as a line, from the provided points
-    pub fn as_line_from_points(self, points: [impl Into<Point<2>>; 2]) -> Self {
-        self.with_path(Some(SurfacePath::line_from_points(points)))
     }
 
     /// Build a full [`Curve`] from the partial curve

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -89,3 +89,31 @@ impl From<&Curve> for PartialCurve {
         }
     }
 }
+
+/// A partial [`GlobalCurve`]
+///
+/// This struct might seem unnecessary. [`GlobalCurve`] literally has nothing in
+/// it. Why would we need to represent a part of nothing? However, having this
+/// provides some regularity that helps simplify some things within the partial
+/// object and builder APIs.
+///
+/// See [`crate::partial`] for more information.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct PartialGlobalCurve;
+
+impl PartialGlobalCurve {
+    /// Build a full [`GlobalCurve`] from the partial global curve
+    pub fn build(
+        self,
+        objects: &Objects,
+    ) -> Result<Handle<GlobalCurve>, ValidationError> {
+        let global_curve = objects.global_curves.insert(GlobalCurve)?;
+        Ok(global_curve)
+    }
+}
+
+impl From<&GlobalCurve> for PartialGlobalCurve {
+    fn from(_: &GlobalCurve) -> Self {
+        Self
+    }
+}

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -30,6 +30,23 @@ pub struct PartialCurve {
 }
 
 impl PartialCurve {
+    /// Access the path that defines the [`Curve`]
+    pub fn path(&self) -> Option<SurfacePath> {
+        self.path
+    }
+
+    /// Access the surface that the [`Curve`] is defined in
+    pub fn surface(&self) -> Option<Handle<Surface>> {
+        self.surface.clone()
+    }
+
+    /// Access the global form of the [`Curve`]
+    pub fn global_form(&self) -> Option<Handle<GlobalCurve>> {
+        self.global_form
+            .clone()
+            .map(|handle_wrapper| handle_wrapper.0)
+    }
+
     /// Provide a path for the partial curve
     pub fn with_path(mut self, path: Option<SurfacePath>) -> Self {
         if let Some(path) = path {

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -12,21 +12,9 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialCurve {
-    /// The path that defines the [`Curve`]
-    ///
-    /// Must be provided before calling [`PartialCurve::build`].
-    pub path: Option<SurfacePath>,
-
-    /// The surface that the [`Curve`] is defined in
-    ///
-    /// Must be provided before calling [`PartialCurve::build`].
-    pub surface: Option<Handle<Surface>>,
-
-    /// The global form of the [`Curve`]
-    ///
-    /// Will be computed from `path` and `surface` in [`PartialCurve::build`],
-    /// if not provided.
-    pub global_form: Option<HandleWrapper<GlobalCurve>>,
+    path: Option<SurfacePath>,
+    surface: Option<Handle<Surface>>,
+    global_form: Option<HandleWrapper<GlobalCurve>>,
 }
 
 impl PartialCurve {

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -8,7 +8,7 @@ use crate::{
 /// A partial [`Curve`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialCurve {
     path: Option<SurfacePath>,
     surface: Option<Handle<Surface>>,

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -1,7 +1,8 @@
 use crate::{
     objects::{Curve, GlobalCurve, Objects, Surface},
+    partial::MaybePartial,
     path::SurfacePath,
-    storage::{Handle, HandleWrapper},
+    storage::Handle,
     validate::ValidationError,
 };
 
@@ -12,7 +13,7 @@ use crate::{
 pub struct PartialCurve {
     path: Option<SurfacePath>,
     surface: Option<Handle<Surface>>,
-    global_form: Option<HandleWrapper<GlobalCurve>>,
+    global_form: Option<MaybePartial<GlobalCurve>>,
 }
 
 impl PartialCurve {
@@ -27,10 +28,8 @@ impl PartialCurve {
     }
 
     /// Access the global form of the [`Curve`]
-    pub fn global_form(&self) -> Option<Handle<GlobalCurve>> {
-        self.global_form
-            .clone()
-            .map(|handle_wrapper| handle_wrapper.0)
+    pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
+        self.global_form.clone()
     }
 
     /// Provide a path for the partial curve
@@ -52,7 +51,7 @@ impl PartialCurve {
     /// Provide a global form for the partial curve
     pub fn with_global_form(
         mut self,
-        global_form: Option<impl Into<HandleWrapper<GlobalCurve>>>,
+        global_form: Option<impl Into<MaybePartial<GlobalCurve>>>,
     ) -> Self {
         if let Some(global_form) = global_form {
             self.global_form = Some(global_form.into());
@@ -72,7 +71,8 @@ impl PartialCurve {
         let global_form = match self.global_form {
             Some(global_form) => global_form,
             None => objects.global_curves.insert(GlobalCurve)?.into(),
-        };
+        }
+        .into_full(objects)?;
 
         Ok(objects
             .curves

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -1,6 +1,7 @@
 use fj_math::Point;
 
 use crate::{
+    builder::CurveBuilder,
     objects::{
         Curve, Cycle, HalfEdge, Objects, Surface, SurfaceVertex, Vertex,
     },

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -13,7 +13,7 @@ use crate::{
 /// A partial [`Cycle`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialCycle {
     /// The surface that the [`Cycle`] is defined in
     pub surface: Option<Handle<Surface>>,

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -83,7 +83,7 @@ impl PartialCycle {
 
                 let curve = Curve::partial()
                     .with_surface(Some(surface.clone()))
-                    .as_line_from_points([position_prev, position_next]);
+                    .update_as_line_from_points([position_prev, position_next]);
 
                 let [from, to] =
                     [(0., from), (1., to)].map(|(position, surface_form)| {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -252,9 +252,11 @@ impl PartialHalfEdge {
             vertices.zip_ext(global_forms).map(|(vertex, global_form)| {
                 vertex.update_partial(|vertex| {
                     vertex.clone().with_surface_form(Some(
-                        vertex.surface_form.update_partial(|surface_vertex| {
-                            surface_vertex.with_global_form(global_form)
-                        }),
+                        vertex.surface_form().update_partial(
+                            |surface_vertex| {
+                                surface_vertex.with_global_form(global_form)
+                            },
+                        ),
                     ))
                 })
             })

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -39,7 +39,7 @@ impl PartialHalfEdge {
     pub fn extract_global_curve(&self) -> Option<MaybePartial<GlobalCurve>> {
         self.curve
             .global_form()
-            .or_else(|| self.global_form.curve())
+            .or_else(|| Some(self.global_form.curve()))
     }
 
     /// Access the vertices of the global form, if available

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -317,7 +317,7 @@ pub struct PartialGlobalEdge {
     /// The curve that the [`GlobalEdge`] is defined in
     ///
     /// Must be provided before [`PartialGlobalEdge::build`] is called.
-    pub curve: Option<MaybePartial<GlobalCurve>>,
+    pub curve: MaybePartial<GlobalCurve>,
 
     /// The vertices that bound the [`GlobalEdge`] in the curve
     ///
@@ -332,7 +332,7 @@ impl PartialGlobalEdge {
         curve: Option<impl Into<MaybePartial<GlobalCurve>>>,
     ) -> Self {
         if let Some(curve) = curve {
-            self.curve = Some(curve.into());
+            self.curve = curve.into();
         }
         self
     }
@@ -365,10 +365,7 @@ impl PartialGlobalEdge {
         self,
         objects: &Objects,
     ) -> Result<Handle<GlobalEdge>, ValidationError> {
-        let curve = self
-            .curve
-            .expect("Can't build `GlobalEdge` without `GlobalCurve`")
-            .into_full(objects)?;
+        let curve = self.curve.into_full(objects)?;
         let vertices = self
             .vertices
             .expect("Can't build `GlobalEdge` without vertices")
@@ -383,7 +380,7 @@ impl PartialGlobalEdge {
 impl From<&GlobalEdge> for PartialGlobalEdge {
     fn from(global_edge: &GlobalEdge) -> Self {
         Self {
-            curve: Some(global_edge.curve().clone().into()),
+            curve: global_edge.curve().clone().into(),
             vertices: Some(
                 global_edge
                     .vertices()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -15,7 +15,7 @@ use crate::{
 /// A partial [`HalfEdge`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialHalfEdge {
     /// The surface that the [`HalfEdge`]'s [`Curve`] is defined in
     pub surface: Option<Handle<Surface>>,
@@ -312,7 +312,7 @@ impl From<&HalfEdge> for PartialHalfEdge {
 /// A partial [`GlobalEdge`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {
     /// The curve that the [`GlobalEdge`] is defined in
     ///

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -2,6 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::{Point, Scalar};
 
 use crate::{
+    builder::CurveBuilder,
     objects::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex, VerticesInNormalizedOrder,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -36,10 +36,10 @@ impl PartialHalfEdge {
     /// Extract the global curve from either the curve or global form
     ///
     /// If a global curve is available through both, the curve is preferred.
-    pub fn extract_global_curve(&self) -> Option<MaybePartial<GlobalCurve>> {
+    pub fn extract_global_curve(&self) -> MaybePartial<GlobalCurve> {
         self.curve
             .global_form()
-            .or_else(|| Some(self.global_form.curve()))
+            .unwrap_or_else(|| self.global_form.curve())
     }
 
     /// Access the vertices of the global form, if available
@@ -128,7 +128,7 @@ impl PartialHalfEdge {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let curve = Curve::partial()
-            .with_global_form(self.extract_global_curve())
+            .with_global_form(Some(self.extract_global_curve()))
             .with_surface(self.surface.clone())
             .update_as_circle_from_radius(radius);
 
@@ -202,7 +202,7 @@ impl PartialHalfEdge {
         });
 
         let curve = Curve::partial()
-            .with_global_form(self.extract_global_curve())
+            .with_global_form(Some(self.extract_global_curve()))
             .with_surface(Some(surface))
             .update_as_line_from_points(points);
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -130,7 +130,7 @@ impl PartialHalfEdge {
         let curve = Curve::partial()
             .with_global_form(self.extract_global_curve())
             .with_surface(self.surface.clone())
-            .as_circle_from_radius(radius);
+            .update_as_circle_from_radius(radius);
 
         let path = curve.path().expect("Expected path that was just created");
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -329,10 +329,10 @@ impl PartialGlobalEdge {
     /// Update the partial global edge with the given curve
     pub fn with_curve(
         mut self,
-        curve: Option<MaybePartial<GlobalCurve>>,
+        curve: Option<impl Into<MaybePartial<GlobalCurve>>>,
     ) -> Self {
         if let Some(curve) = curve {
-            self.curve = Some(curve);
+            self.curve = Some(curve.into());
         }
         self
     }
@@ -354,7 +354,7 @@ impl PartialGlobalEdge {
         curve: &Curve,
         vertices: &[Handle<Vertex>; 2],
     ) -> Self {
-        self.with_curve(Some(curve.global_form().clone().into()))
+        self.with_curve(Some(curve.global_form().clone()))
             .with_vertices(Some(
                 vertices.clone().map(|vertex| vertex.global_form().clone()),
             ))

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -142,7 +142,7 @@ impl PartialHalfEdge {
             .map(|[global_form, _]| global_form)
             .unwrap_or_else(|| {
                 GlobalVertex::partial()
-                    .from_curve_and_position(curve.clone(), a_curve)
+                    .update_from_curve_and_position(curve.clone(), a_curve)
                     .into()
             });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -2,7 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::{Point, Scalar};
 
 use crate::{
-    builder::CurveBuilder,
+    builder::{CurveBuilder, GlobalVertexBuilder},
     objects::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex, VerticesInNormalizedOrder,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -191,11 +191,10 @@ impl PartialHalfEdge {
 
         let surface = self
             .surface
-            .as_ref()
+            .clone()
             .or_else(|| from_surface.surface())
             .or_else(|| to_surface.surface())
-            .expect("Can't infer line segment without a surface")
-            .clone();
+            .expect("Can't infer line segment without a surface");
         let points = [&from_surface, &to_surface].map(|vertex| {
             vertex
                 .position()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -39,7 +39,7 @@ impl PartialHalfEdge {
     pub fn extract_global_curve(&self) -> Option<Handle<GlobalCurve>> {
         self.curve
             .global_form()
-            .or_else(|| self.global_form.curve().cloned())
+            .or_else(|| self.global_form.curve())
     }
 
     /// Access the vertices of the global form, if available

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -131,7 +131,7 @@ impl PartialHalfEdge {
             .with_surface(self.surface.clone())
             .as_circle_from_radius(radius);
 
-        let path = curve.path.expect("Expected path that was just created");
+        let path = curve.path().expect("Expected path that was just created");
 
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -205,7 +205,7 @@ impl PartialHalfEdge {
         let curve = Curve::partial()
             .with_global_form(self.extract_global_curve())
             .with_surface(Some(surface))
-            .as_line_from_points(points);
+            .update_as_line_from_points(points);
 
         let [back, front] = {
             let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -5,7 +5,7 @@ pub mod vertex;
 
 use crate::{
     objects::{
-        Curve, Cycle, GlobalEdge, GlobalVertex, HalfEdge, Objects,
+        Curve, Cycle, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         SurfaceVertex, Vertex,
     },
     storage::Handle,
@@ -13,8 +13,8 @@ use crate::{
 
 use super::{
     HasPartial, MaybePartial, Partial, PartialCurve, PartialCycle,
-    PartialGlobalEdge, PartialGlobalVertex, PartialHalfEdge,
-    PartialSurfaceVertex, PartialVertex,
+    PartialGlobalCurve, PartialGlobalEdge, PartialGlobalVertex,
+    PartialHalfEdge, PartialSurfaceVertex, PartialVertex,
 };
 
 macro_rules! impl_traits {
@@ -49,6 +49,7 @@ macro_rules! impl_traits {
 impl_traits!(
     Curve, PartialCurve;
     Cycle, PartialCycle;
+    GlobalCurve, PartialGlobalCurve;
     GlobalEdge, PartialGlobalEdge;
     GlobalVertex, PartialGlobalVertex;
     HalfEdge, PartialHalfEdge;

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -1,6 +1,7 @@
 use fj_math::Point;
 
 use crate::{
+    builder::GlobalVertexBuilder,
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
     partial::{HasPartial, MaybePartial},
     storage::Handle,
@@ -241,34 +242,6 @@ impl PartialGlobalVertex {
             self.position = Some(position.into());
         }
         self
-    }
-
-    /// Update partial global vertex from the given curve and position on it
-    pub fn from_curve_and_position(
-        self,
-        curve: impl Into<MaybePartial<Curve>>,
-        position: impl Into<Point<1>>,
-    ) -> Self {
-        let curve = curve.into().into_partial();
-
-        let path = curve.path().expect(
-            "Need path to create `GlobalVertex` from curve and position",
-        );
-        let surface = curve.surface().expect(
-            "Need surface to create `GlobalVertex` from curve and position",
-        );
-
-        let position_surface = path.point_from_path_coords(position);
-        self.from_surface_and_position(&surface, position_surface)
-    }
-
-    /// Update partial global vertex from the given surface and position on it
-    pub fn from_surface_and_position(
-        self,
-        surface: &Surface,
-        position: impl Into<Point<2>>,
-    ) -> Self {
-        self.with_position(Some(surface.point_from_surface_coords(position)))
     }
 
     /// Build a full [`GlobalVertex`] from the partial global vertex

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -11,7 +11,7 @@ use crate::{
 /// A partial [`Vertex`]
 ///
 /// See [`crate::partial`] for more information.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialVertex {
     /// The position of the [`Vertex`] on the [`Curve`]
     ///

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -122,21 +122,9 @@ impl From<&Vertex> for PartialVertex {
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialSurfaceVertex {
-    /// The position of the [`SurfaceVertex`] in the [`Surface`]
-    ///
-    /// Must be provided before [`PartialSurfaceVertex::build`] is called.
-    pub position: Option<Point<2>>,
-
-    /// The surface that the [`SurfaceVertex`] is defined in
-    ///
-    /// Must be provided before [`PartialSurfaceVertex::build`] is called.
-    pub surface: Option<Handle<Surface>>,
-
-    /// The global form of the [`SurfaceVertex`]
-    ///
-    /// Can be provided, if already available, or computed from the position on
-    /// the [`Surface`].
-    pub global_form: MaybePartial<GlobalVertex>,
+    position: Option<Point<2>>,
+    surface: Option<Handle<Surface>>,
+    global_form: MaybePartial<GlobalVertex>,
 }
 
 impl PartialSurfaceVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -173,11 +173,6 @@ impl PartialSurfaceVertex {
         self
     }
 
-    /// Remove the global form of the partial vertex, inferring it on build
-    pub fn infer_global_form(self) -> Self {
-        self.with_global_form(Some(GlobalVertex::partial()))
-    }
-
     /// Build a full [`SurfaceVertex`] from the partial surface vertex
     ///
     /// # Panics

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -65,9 +65,8 @@ impl PartialVertex {
     }
 
     /// Remove the surface form of the partial vertex, inferring it on build
-    pub fn infer_surface_form(mut self) -> Self {
-        self.surface_form = SurfaceVertex::partial().into();
-        self
+    pub fn infer_surface_form(self) -> Self {
+        self.with_surface_form(Some(SurfaceVertex::partial()))
     }
 
     /// Build a full [`Vertex`] from the partial vertex

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -140,6 +140,21 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
+    /// Access the position of the [`SurfaceVertex`]
+    pub fn position(&self) -> Option<Point<2>> {
+        self.position
+    }
+
+    /// Access the surface that the [`SurfaceVertex`] is defined in
+    pub fn surface(&self) -> Option<Handle<Surface>> {
+        self.surface.clone()
+    }
+
+    /// Access the global form of the [`SurfaceVertex`]
+    pub fn global_form(&self) -> MaybePartial<GlobalVertex> {
+        self.global_form.clone()
+    }
+
     /// Provide a position for the partial surface vertex
     pub fn with_position(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -31,6 +31,21 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
+    /// Access the position of the [`Vertex`] on the curve
+    pub fn position(&self) -> Option<Point<1>> {
+        self.position
+    }
+
+    /// Access the curve that the [`Vertex`] is defined in
+    pub fn curve(&self) -> MaybePartial<Curve> {
+        self.curve.clone()
+    }
+
+    /// Access the surface form of the [`Vertex`]
+    pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
+        self.surface_form.clone()
+    }
+
     /// Provide a position for the partial vertex
     pub fn with_position(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -3,7 +3,7 @@ use fj_math::Point;
 use crate::{
     builder::GlobalVertexBuilder,
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
-    partial::{HasPartial, MaybePartial},
+    partial::MaybePartial,
     storage::Handle,
     validate::ValidationError,
 };
@@ -66,7 +66,7 @@ impl PartialVertex {
 
     /// Remove the surface form of the partial vertex, inferring it on build
     pub fn infer_surface_form(self) -> Self {
-        self.with_surface_form(Some(SurfaceVertex::partial()))
+        self.with_surface_form(Some(PartialSurfaceVertex::default()))
     }
 
     /// Build a full [`Vertex`] from the partial vertex

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -249,10 +249,10 @@ impl PartialGlobalVertex {
     ) -> Self {
         let curve = curve.into().into_partial();
 
-        let path = curve.path.expect(
+        let path = curve.path().expect(
             "Need path to create `GlobalVertex` from curve and position",
         );
-        let surface = curve.surface.expect(
+        let surface = curve.surface().expect(
             "Need surface to create `GlobalVertex` from curve and position",
         );
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -197,7 +197,7 @@ impl PartialSurfaceVertex {
         let global_form = self
             .global_form
             .update_partial(|global_form| {
-                global_form.from_surface_and_position(&surface, position)
+                global_form.update_from_surface_and_position(&surface, position)
             })
             .into_full(objects)?;
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -64,11 +64,6 @@ impl PartialVertex {
         self
     }
 
-    /// Remove the surface form of the partial vertex, inferring it on build
-    pub fn infer_surface_form(self) -> Self {
-        self.with_surface_form(Some(PartialSurfaceVertex::default()))
-    }
-
     /// Build a full [`Vertex`] from the partial vertex
     ///
     /// # Panics

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -13,21 +13,9 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialVertex {
-    /// The position of the [`Vertex`] on the [`Curve`]
-    ///
-    /// Must be provided before calling [`PartialVertex::build`].
-    pub position: Option<Point<1>>,
-
-    /// The curve that the [`Vertex`] is defined in
-    ///
-    /// Must be provided before calling [`PartialVertex::build`].
-    pub curve: MaybePartial<Curve>,
-
-    /// The surface form of the [`Vertex`]
-    ///
-    /// Will be computed from `position` and `curve` in
-    /// [`PartialVertex::build`], if not provided.
-    pub surface_form: MaybePartial<SurfaceVertex>,
+    position: Option<Point<1>>,
+    curve: MaybePartial<Curve>,
+    surface_form: MaybePartial<SurfaceVertex>,
 }
 
 impl PartialVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -15,18 +15,18 @@ use crate::{
 pub struct PartialVertex {
     /// The position of the [`Vertex`] on the [`Curve`]
     ///
-    /// Must be provided before [`PartialVertex::build`] is called.
+    /// Must be provided before calling [`PartialVertex::build`].
     pub position: Option<Point<1>>,
 
     /// The curve that the [`Vertex`] is defined in
     ///
-    /// Must be provided before [`PartialVertex::build`] is called.
+    /// Must be provided before calling [`PartialVertex::build`].
     pub curve: MaybePartial<Curve>,
 
     /// The surface form of the [`Vertex`]
     ///
-    /// Can be provided, if already available, or computed from the position on
-    /// the [`Curve`].
+    /// Will be computed from `position` and `curve` in
+    /// [`PartialVertex::build`], if not provided.
     pub surface_form: MaybePartial<SurfaceVertex>,
 }
 
@@ -74,9 +74,9 @@ impl PartialVertex {
     ///
     /// # Panics
     ///
-    /// Panics, if no position has been provided.
+    /// Panics, if position has not been provided.
     ///
-    /// Panics, if no curve has been provided.
+    /// Panics, if curve has not been provided.
     pub fn build(
         self,
         objects: &Objects,
@@ -174,12 +174,6 @@ impl PartialSurfaceVertex {
     }
 
     /// Build a full [`SurfaceVertex`] from the partial surface vertex
-    ///
-    /// # Panics
-    ///
-    /// Panics, if no position has been provided.
-    ///
-    /// Panics, if no surface has been provided.
     pub fn build(
         self,
         objects: &Objects,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -223,10 +223,7 @@ impl From<&SurfaceVertex> for PartialSurfaceVertex {
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialGlobalVertex {
-    /// The position of the [`GlobalVertex`]
-    ///
-    /// Must be provided before [`PartialGlobalVertex::build`] is called.
-    pub position: Option<Point<3>>,
+    position: Option<Point<3>>,
 }
 
 impl PartialGlobalVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -174,9 +174,8 @@ impl PartialSurfaceVertex {
     }
 
     /// Remove the global form of the partial vertex, inferring it on build
-    pub fn infer_global_form(mut self) -> Self {
-        self.global_form = GlobalVertex::partial().into();
-        self
+    pub fn infer_global_form(self) -> Self {
+        self.with_global_form(Some(GlobalVertex::partial()))
     }
 
     /// Build a full [`SurfaceVertex`] from the partial surface vertex

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -264,12 +264,11 @@ impl PartialGlobalVertex {
 
     /// Update partial global vertex from the given surface and position on it
     pub fn from_surface_and_position(
-        mut self,
+        self,
         surface: &Surface,
         position: impl Into<Point<2>>,
     ) -> Self {
-        self.position = Some(surface.point_from_surface_coords(position));
-        self
+        self.with_position(Some(surface.point_from_surface_coords(position)))
     }
 
     /// Build a full [`GlobalVertex`] from the partial global vertex

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -230,6 +230,11 @@ pub struct PartialGlobalVertex {
 }
 
 impl PartialGlobalVertex {
+    /// Access the position of the [`GlobalVertex`]
+    pub fn position(&self) -> Option<Point<3>> {
+        self.position
+    }
+
     /// Provide a position for the partial global vertex
     pub fn with_position(
         mut self,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -239,7 +239,9 @@ mod tests {
             valid
                 .global_form()
                 .to_partial()
-                .with_curve(Some(objects.global_curves.insert(GlobalCurve)?))
+                .with_curve(Some(
+                    objects.global_curves.insert(GlobalCurve)?.into(),
+                ))
                 .build(&objects)?,
         );
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -196,6 +196,7 @@ mod tests {
     use fj_interop::ext::ArrayExt;
 
     use crate::{
+        builder::VertexBuilder,
         objects::{GlobalCurve, HalfEdge, Objects},
         partial::HasPartial,
         validate::Validate2,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -239,9 +239,7 @@ mod tests {
             valid
                 .global_form()
                 .to_partial()
-                .with_curve(Some(
-                    objects.global_curves.insert(GlobalCurve)?.into(),
-                ))
+                .with_curve(Some(objects.global_curves.insert(GlobalCurve)?))
                 .build(&objects)?,
         );
 

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -179,6 +179,7 @@ impl SurfaceVertexValidationError {
 #[cfg(test)]
 mod tests {
     use crate::{
+        builder::CurveBuilder,
         objects::{Curve, GlobalVertex, Objects, SurfaceVertex, Vertex},
         partial::HasPartial,
         validate::Validate2,

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -179,7 +179,7 @@ impl SurfaceVertexValidationError {
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::CurveBuilder,
+        builder::{CurveBuilder, SurfaceVertexBuilder},
         objects::{Curve, GlobalVertex, Objects, SurfaceVertex, Vertex},
         partial::HasPartial,
         validate::Validate2,

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -194,7 +194,7 @@ mod tests {
             .with_curve(Some(
                 Curve::partial()
                     .with_surface(Some(objects.surfaces.xy_plane()))
-                    .as_u_axis(),
+                    .update_as_u_axis(),
             ))
             .build(&objects)?;
         let invalid = Vertex::new(
@@ -222,7 +222,7 @@ mod tests {
             .with_curve(Some(
                 Curve::partial()
                     .with_surface(Some(objects.surfaces.xy_plane()))
-                    .as_u_axis(),
+                    .update_as_u_axis(),
             ))
             .build(&objects)?;
         let invalid = Vertex::new(


### PR DESCRIPTION
I've been running into some minor trouble with the builder API while working on the validation infrastructure for #1162, so I figured I'd try to solve some of its problems before trying to layer on some more hacks. This pull request starts the process of locking down the partial object API, reducing it to a minimal core, and moving any convenience functionality out of it into a new builder API.

This is the execution of an idea from #1249. I like it so far, as it relieves some pressure on the partial object API, making it simpler, and creating a clearer boundary between essential and non-essential code. I haven't attacked any of the really nasty code yet, so it's hard to say right now how much of a help this will be in solving the larger problem.