### PR TITLE
Turn the "--models" CLI option into an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Models are Rust libraries that depend on the [`fj`](https://crates.io/crates/fj)
 To view a model, run:
 
 ``` sh
-fj-app --model my-model
+fj-app my-model
 ```
 
 This will usually compile and load the model in the `my-model/` directory. If there is a configuration file (`fj.toml`) available, it might define a default path to load models from that is different from the current working directory. This is the case [in the Fornjot repository](fj.toml).
@@ -122,7 +122,7 @@ Toggle model rendering by pressing `1`. Toggle mesh rendering by pressing `2`. T
 To export a model to a file, run:
 
 ``` sh
-fj-app --model my-model --export my-model.3mf
+fj-app my-model --export my-model.3mf
 ```
 
 The file type is chosen based on the file extension. Both 3MF and STL are supported.
@@ -132,7 +132,7 @@ The file type is chosen based on the file extension. Both 3MF and STL are suppor
 Models can define parameters that can be overridden. This can be done using the `--parameters` argument:
 
 ``` sh
-fj-app --model my-model --parameters "width=3.0,height=5.0"
+fj-app my-model --parameters "width=3.0,height=5.0"
 ```
 
 

--- a/crates/fj-app/src/args.rs
+++ b/crates/fj-app/src/args.rs
@@ -10,7 +10,6 @@ use fj_math::Scalar;
 #[command(version = fj::version::VERSION_FULL)]
 pub struct Args {
     /// The model to open
-    #[arg(short, long)]
     pub model: Option<PathBuf>,
 
     /// Export model to this path

--- a/fj.toml
+++ b/fj.toml
@@ -1,9 +1,9 @@
-# The default path that models are loaded from. If the `--model` argument is a
+# The default path that models are loaded from. If the `model` argument is a
 # relative path, it is assumed to be relative to `default_path`.
 default_path = "models"
 
-# The default models that is loaded, if none is specified. If this is a relative
-# path, it should be relative to `default_path`.
+# The default models that is loaded, if none is specified in a CLI.
+# If this is a relative path, it should be relative to `default_path`.
 default_model = "test"
 
 # Indicate whether to invert the zoom direction. Can be used to override the

--- a/models/cuboid/README.md
+++ b/models/cuboid/README.md
@@ -4,7 +4,7 @@ A model of a simple cuboid that demonstrates sweeping a 3D shape from a primitiv
 
 To display this model, run the following from the repository root (model parameters are optional):
 ``` sh
-cargo run -- --model cuboid --parameters x=3.0,y=2.0,z=1.0
+cargo run -- cuboid --parameters x=3.0,y=2.0,z=1.0
 ```
 
 ![Screenshot of the cuboid model](cuboid.png)

--- a/models/spacer/README.md
+++ b/models/spacer/README.md
@@ -4,7 +4,7 @@ A simple spacer model that demonstrates the circle primitive, the difference ope
 
 To display this model, run the following from the repository root (model parameters are optional):
 ``` sh
-cargo run -- --model spacer --parameters outer=1.0,inner=0.5,height=1.0
+cargo run -- spacer --parameters outer=1.0,inner=0.5,height=1.0
 ```
 
 ![Screenshot of the spacer model](spacer.png)

--- a/models/star/README.md
+++ b/models/star/README.md
@@ -4,7 +4,7 @@ A model of a star that demonstrates sweeping a sketch to create a 3D shape, conc
 
 To display this model, run the following from the repository root (model parameters are optional):
 ``` sh
-cargo run -- --model star --parameters num_points=5,r1=1.0,r2=2.0,h=1.0
+cargo run -- star --parameters num_points=5,r1=1.0,r2=2.0,h=1.0
 ```
 
 ![Screenshot of the star model](star.png)

--- a/models/test/README.md
+++ b/models/test/README.md
@@ -4,7 +4,7 @@ A model that tries to use all of Fornjot's features, to serve as a testing groun
 
 To display this model, run the following from the repository root:
 ``` sh
-cargo run -- --model test
+cargo run -- test
 ```
 
 ![Screenshot of the test model](test.png)

--- a/tools/export-validator/src/main.rs
+++ b/tools/export-validator/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
         let exit_status = Command::new("cargo")
             .arg("run")
             .arg("--")
-            .args(["--model", &model])
+            .arg(&model)
             .args(["--export", export_file_path_str])
             .status()?;
 


### PR DESCRIPTION
This PR removes the `--model` flag in the CLI in favour of an optional `model` argument.
Tested locally on custom inputs & examples from the documentation - no regression found.

Closes #1272