### PR TITLE
Unify release flags and correctly mark dev build releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,6 +40,7 @@ jobs:
 
   binaries:
     name: Binaries
+    needs: calculate-release-flags
     strategy:
       matrix:
         include:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
     name: Calculate release flags
     runs-on: ubuntu-latest
     outputs:
-      release-detected: ${{ steps.step1.outputs.release-detected }}
+      release-detected: ${{ steps.release.outputs.release-detected }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,9 @@ jobs:
   calculate-release-flags:
     name: Calculate release flags
     runs-on: ubuntu-latest
+    outputs:
+      release-detected: ${{ steps.step1.outputs.release-detected }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
           - { target: aarch64-apple-darwin, os: macOS-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
 
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
 
   release:
     name: Release
-    if: ${{ steps.calculate-release-flags.outputs.release-detected == 'true' }}
+    if: ${{ needs.calculate-release-flags.outputs.release-detected == 'true' }}
     needs: binaries
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Binaries | Compile
         run: cargo build --release --target ${{ matrix.target }}
         env:
+          # This lets our app know it's an "official" release. Otherwise we would get
+          # a version number like "fj-app 0.8.0 (8cb928bb, unreleased)"
           RELEASE_DETECTED: ${{ needs.calculate-release-flags.outputs.release-detected }}
 
       - name: Binaries | Prepare upload

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,28 @@ defaults:
     shell: bash
 
 jobs:
+  calculate-release-flags:
+    name: Calculate release flags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Operator | Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-operator-01
+
+      - name: Operator | Deduce
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_LABEL: release
+          RUST_LOG: info
+        run: |
+          # Run release operator
+          cargo run -p release-operator -- detect
+
   binaries:
     name: Binaries
     strategy:
@@ -79,16 +101,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: release-operator-01
-
-      - name: Operator | Deduce
-        id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_LABEL: release
-          RUST_LOG: info
-        run: |
-          # Run release operator
-          cargo run -p release-operator -- detect
 
       - name: Binaries | Download
         if: ${{ steps.release.outputs.release-detected == 'true' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -92,7 +92,9 @@ jobs:
   release:
     name: Release
     if: ${{ needs.calculate-release-flags.outputs.release-detected == 'true' }}
-    needs: binaries
+    needs:
+      - calculate-release-flags
+      - binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Binaries | Compile
         run: cargo build --release --target ${{ matrix.target }}
+        env:
+          RELEASE_DETECTED: ${{ needs.calculate-release-flags.outputs.release-detected }}
 
       - name: Binaries | Prepare upload
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,6 +91,7 @@ jobs:
 
   release:
     name: Release
+    if: ${{ steps.calculate-release-flags.outputs.release-detected == 'true' }}
     needs: binaries
     runs-on: ubuntu-latest
     steps:
@@ -103,11 +104,9 @@ jobs:
           key: release-operator-01
 
       - name: Binaries | Download
-        if: ${{ steps.release.outputs.release-detected == 'true' }}
         uses: actions/download-artifact@v3
 
       - name: Binaries | Checksums
-        if: ${{ steps.release.outputs.release-detected == 'true' }}
         run: |
           # Build binary checksums
           for file in "${PROJ_NAME}"-*/"${PROJ_NAME}"-*; do
@@ -117,7 +116,6 @@ jobs:
           done
 
       - name: Release | GitHub
-        if: ${{ steps.release.outputs.release-detected == 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.release.outputs.tag-name }}
@@ -125,7 +123,6 @@ jobs:
           files: ${{ env.PROJ_NAME }}-*/${{ env.PROJ_NAME }}-*
 
       - name: Release | Crates.io
-        if: ${{ steps.release.outputs.release-detected == 'true' }}
         env:
           RUST_LOG: info
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,10 +11,6 @@ env:
   # used to rename and upload the binaries
   PROJ_NAME: fj-app
 
-  # This lets our app know it's an "official" release. Otherwise we would get
-  # a version number like "fj-app 0.8.0 (8cb928bb, unreleased)"
-  FJ_OFFICIAL_RELEASE: 1
-
 defaults:
   run:
     shell: bash

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -23,8 +23,8 @@ impl Version {
         let commit = git_description();
 
         let official_release =
-            std::env::var("release-detected").as_deref() == Ok("true");
-        println!("cargo:rerun-if-env-changed=release-detected");
+            std::env::var("RELEASE_DETECTED").as_deref() == Ok("true");
+        println!("cargo:rerun-if-env-changed=RELEASE_DETECTED");
 
         let full_string = match (commit, official_release) {
             (Some(commit), true) => format!("{pkg_version} ({commit})"),

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -23,8 +23,8 @@ impl Version {
         let commit = git_description();
 
         let official_release =
-            std::env::var("FJ_OFFICIAL_RELEASE").as_deref() == Ok("1");
-        println!("cargo:rerun-if-env-changed=FJ_OFFICIAL_RELEASE");
+            std::env::var("release-detected").as_deref() == Ok("true");
+        println!("cargo:rerun-if-env-changed=release-detected");
 
         let full_string = match (commit, official_release) {
             (Some(commit), true) => format!("{pkg_version} ({commit})"),


### PR DESCRIPTION
❗NOT TESTED❗

This PR unifies the `FJ_OFFICIAL_RELEASE` and `release-detected` flags that carry the same meaning.

To properly read the `release-detected` as env, work in https://github.com/hannobraun/Fornjot/issues/1270 is required I think.

Closes https://github.com/hannobraun/Fornjot/issues/883