### PR TITLE
Remove use of old validation infrastructure from `fj-host`

### DIFF
--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -5,7 +5,7 @@ use fj_kernel::{
     algorithms::reverse::Reverse,
     iter::ObjectIters,
     objects::{Face, Objects, Sketch},
-    validate::{Validate, Validated, ValidationConfig, ValidationError},
+    validate::{ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
 
@@ -19,7 +19,7 @@ impl Shape for fj::Difference2d {
         config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Self::Brep>, ValidationError> {
+    ) -> Result<Self::Brep, ValidationError> {
         // This method assumes that `b` is fully contained within `a`:
         // https://github.com/hannobraun/Fornjot/issues/92
 
@@ -87,7 +87,7 @@ impl Shape for fj::Difference2d {
         }
 
         let difference = Sketch::builder(objects).with_faces(faces).build();
-        difference.deref().clone().validate_with_config(config)
+        Ok(difference.deref().clone())
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -5,7 +5,7 @@ use fj_kernel::{
     algorithms::reverse::Reverse,
     iter::ObjectIters,
     objects::{Face, Objects, Sketch},
-    validate::{ValidationConfig, ValidationError},
+    validate::ValidationError,
 };
 use fj_math::Aabb;
 
@@ -16,7 +16,6 @@ impl Shape for fj::Difference2d {
 
     fn compute_brep(
         &self,
-        config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
@@ -28,9 +27,10 @@ impl Shape for fj::Difference2d {
         let mut exteriors = Vec::new();
         let mut interiors = Vec::new();
 
-        let [a, b] = self.shapes().each_ref_ext().try_map_ext(|shape| {
-            shape.compute_brep(config, objects, debug_info)
-        })?;
+        let [a, b] = self
+            .shapes()
+            .each_ref_ext()
+            .try_map_ext(|shape| shape.compute_brep(objects, debug_info))?;
 
         if let Some(face) = a.face_iter().next() {
             // If there's at least one face to subtract from, we can proceed.

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     objects::{FaceSet, Objects},
-    validate::{Validate, Validated, ValidationConfig, ValidationError},
+    validate::{ValidationConfig, ValidationError},
 };
 use fj_math::Aabb;
 
@@ -15,16 +15,16 @@ impl Shape for fj::Group {
         config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Self::Brep>, ValidationError> {
+    ) -> Result<Self::Brep, ValidationError> {
         let mut faces = FaceSet::new();
 
         let a = self.a.compute_brep(config, objects, debug_info)?;
         let b = self.b.compute_brep(config, objects, debug_info)?;
 
-        faces.extend(a.into_inner());
-        faces.extend(b.into_inner());
+        faces.extend(a);
+        faces.extend(b);
 
-        faces.validate_with_config(config)
+        Ok(faces)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -1,7 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     objects::{FaceSet, Objects},
-    validate::{ValidationConfig, ValidationError},
+    validate::ValidationError,
 };
 use fj_math::Aabb;
 
@@ -12,14 +12,13 @@ impl Shape for fj::Group {
 
     fn compute_brep(
         &self,
-        config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let mut faces = FaceSet::new();
 
-        let a = self.a.compute_brep(config, objects, debug_info)?;
-        let b = self.b.compute_brep(config, objects, debug_info)?;
+        let a = self.a.compute_brep(objects, debug_info)?;
+        let b = self.b.compute_brep(objects, debug_info)?;
 
         faces.extend(a);
         faces.extend(b);

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -46,7 +46,7 @@ impl ShapeProcessor {
         let objects = Objects::new();
         let mut debug_info = DebugInfo::new();
         let shape = shape.compute_brep(&config, &objects, &mut debug_info)?;
-        let mesh = (&shape.into_inner(), tolerance).triangulate();
+        let mesh = (&shape, tolerance).triangulate();
 
         Ok(ProcessedShape {
             aabb,

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -7,7 +7,7 @@ use fj_kernel::{
         triangulate::Triangulate,
     },
     objects::Objects,
-    validate::{ValidationConfig, ValidationError},
+    validate::ValidationError,
 };
 use fj_math::Scalar;
 
@@ -42,10 +42,9 @@ impl ShapeProcessor {
             Some(user_defined_tolerance) => user_defined_tolerance,
         };
 
-        let config = ValidationConfig::default();
         let objects = Objects::new();
         let mut debug_info = DebugInfo::new();
-        let shape = shape.compute_brep(&config, &objects, &mut debug_info)?;
+        let shape = shape.compute_brep(&objects, &mut debug_info)?;
         let mesh = (&shape, tolerance).triangulate();
 
         Ok(ProcessedShape {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,7 +5,7 @@ use fj_kernel::{
     builder::HalfEdgeBuilder,
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
     partial::HasPartial,
-    validate::{Validate, Validated, ValidationConfig, ValidationError},
+    validate::{ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Point};
 
@@ -16,10 +16,10 @@ impl Shape for fj::Sketch {
 
     fn compute_brep(
         &self,
-        config: &ValidationConfig,
+        _: &ValidationConfig,
         objects: &Objects,
         _: &mut DebugInfo,
-    ) -> Result<Validated<Self::Brep>, ValidationError> {
+    ) -> Result<Self::Brep, ValidationError> {
         let surface = objects.surfaces.xy_plane();
 
         let face = match self.chain() {
@@ -51,7 +51,7 @@ impl Shape for fj::Sketch {
         };
 
         let sketch = Sketch::builder(objects).with_faces([face]).build();
-        sketch.deref().clone().validate_with_config(config)
+        Ok(sketch.deref().clone())
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,7 +5,7 @@ use fj_kernel::{
     builder::HalfEdgeBuilder,
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
     partial::HasPartial,
-    validate::{ValidationConfig, ValidationError},
+    validate::ValidationError,
 };
 use fj_math::{Aabb, Point};
 
@@ -16,7 +16,6 @@ impl Shape for fj::Sketch {
 
     fn compute_brep(
         &self,
-        _: &ValidationConfig,
         objects: &Objects,
         _: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -4,7 +4,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::sweep::Sweep,
     objects::{Objects, Solid},
-    validate::{Validate, Validated, ValidationConfig, ValidationError},
+    validate::{ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Vector};
 
@@ -18,14 +18,14 @@ impl Shape for fj::Sweep {
         config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Self::Brep>, ValidationError> {
+    ) -> Result<Self::Brep, ValidationError> {
         let sketch = self.shape().compute_brep(config, objects, debug_info)?;
-        let sketch = objects.sketches.insert(sketch.into_inner())?;
+        let sketch = objects.sketches.insert(sketch)?;
 
         let path = Vector::from(self.path());
 
         let solid = sketch.sweep(path, objects)?;
-        solid.deref().clone().validate_with_config(config)
+        Ok(solid.deref().clone())
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -4,7 +4,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::sweep::Sweep,
     objects::{Objects, Solid},
-    validate::{ValidationConfig, ValidationError},
+    validate::ValidationError,
 };
 use fj_math::{Aabb, Vector};
 
@@ -15,11 +15,10 @@ impl Shape for fj::Sweep {
 
     fn compute_brep(
         &self,
-        config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
-        let sketch = self.shape().compute_brep(config, objects, debug_info)?;
+        let sketch = self.shape().compute_brep(objects, debug_info)?;
         let sketch = objects.sketches.insert(sketch)?;
 
         let path = Vector::from(self.path());

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -2,7 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::transform::TransformObject,
     objects::{FaceSet, Objects},
-    validate::{Validate, Validated, ValidationConfig, ValidationError},
+    validate::{ValidationConfig, ValidationError},
 };
 use fj_math::{Aabb, Transform, Vector};
 
@@ -16,14 +16,13 @@ impl Shape for fj::Transform {
         config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
-    ) -> Result<Validated<Self::Brep>, ValidationError> {
+    ) -> Result<Self::Brep, ValidationError> {
         let faces = self
             .shape
             .compute_brep(config, objects, debug_info)?
-            .into_inner()
             .transform(&make_transform(self), objects)?;
 
-        faces.validate_with_config(config)
+        Ok(faces)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -2,7 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::transform::TransformObject,
     objects::{FaceSet, Objects},
-    validate::{ValidationConfig, ValidationError},
+    validate::ValidationError,
 };
 use fj_math::{Aabb, Transform, Vector};
 
@@ -13,13 +13,12 @@ impl Shape for fj::Transform {
 
     fn compute_brep(
         &self,
-        config: &ValidationConfig,
         objects: &Objects,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let faces = self
             .shape
-            .compute_brep(config, objects, debug_info)?
+            .compute_brep(objects, debug_info)?
             .transform(&make_transform(self), objects)?;
 
         Ok(faces)


### PR DESCRIPTION
With the transition to the new validation infrastructure finished, the old one doesn't do anything useful anymore.