### PR TITLE
Upgrade from deprecated GH Actions `set-output` command

### DIFF
--- a/tools/release-operator/src/github.rs
+++ b/tools/release-operator/src/github.rs
@@ -71,6 +71,6 @@ impl Actions {
     // Set an "output" in GitHub Actions
     pub fn set_output(key: Outputs, value: &str) {
         log::debug!("setting output name={key} value={value}");
-        println!("::set-output name={key}::{value}");
+        println!("{key}={value} >> $GITHUB_OUTPUT");
     }
 }


### PR DESCRIPTION
Fixes deprecation warning on CD deployment. Change is very simple and coming directly form [an official guide](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Closes #1270 