### PR TITLE
fix: wrap assignment with quotes

### DIFF
--- a/tools/release-operator/src/github.rs
+++ b/tools/release-operator/src/github.rs
@@ -71,6 +71,6 @@ impl Actions {
     // Set an "output" in GitHub Actions
     pub fn set_output(key: Outputs, value: &str) {
         log::debug!("setting output name={key} value={value}");
-        println!("{key}={value} >> $GITHUB_OUTPUT");
+        println!("\"{key}={value}\" >> $GITHUB_OUTPUT");
     }
 }


### PR DESCRIPTION
After merging [the PR that remove deprecated set-input](https://github.com/hannobraun/Fornjot/commit/6d7a48ec5115f35a025fe917227b82f36cfb911f), I saw that `RELEASE_DETECTED` [flag](https://github.com/hannobraun/Fornjot/actions/runs/3432020181/jobs/5720842261#step:5:9) is set to an empty string (it should be `"false"` or `"true"`). Thus, weekly official release might not work.

I think that problem might lie in quoting. If the flag on CD after merge still be an empty string, please @hannobraun revert this and the former PR to not disrupt your release pattern. Sorry for trouble 🙏🏻 