### PR TITLE
Simplify `PartialCurve`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -213,13 +213,12 @@ mod tests {
         let surface = objects
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]))?;
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
-        }
-        .update_as_line_from_points([[1., 1.], [2., 1.]])
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
+        let curve = curve.build(&objects)?.insert(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -237,13 +236,12 @@ mod tests {
             GlobalPath::circle_from_radius(1.),
             [0., 0., 1.],
         ))?;
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
-        }
-        .update_as_line_from_points([[1., 1.], [1., 2.]])
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
+        let curve = curve.build(&objects)?.insert(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -259,13 +257,12 @@ mod tests {
         let path = GlobalPath::circle_from_radius(1.);
         let surface =
             objects.surfaces.insert(Surface::new(path, [0., 0., 1.]))?;
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_line_from_points([[0., 1.], [1., 1.]])
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
+        let curve = curve.build(&objects)?.insert(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -199,8 +199,8 @@ mod tests {
         algorithms::approx::{path::RangeOnPath, Approx, ApproxPoint},
         builder::CurveBuilder,
         insert::Insert,
-        objects::{Curve, Objects, Surface},
-        partial::HasPartial,
+        objects::{Objects, Surface},
+        partial::PartialCurve,
         path::GlobalPath,
     };
 
@@ -213,11 +213,13 @@ mod tests {
         let surface = objects
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]))?;
-        let curve = Curve::partial()
-            .with_surface(Some(surface))
-            .update_as_line_from_points([[1., 1.], [2., 1.]])
-            .build(&objects)?
-            .insert(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface),
+            ..Default::default()
+        }
+        .update_as_line_from_points([[1., 1.], [2., 1.]])
+        .build(&objects)?
+        .insert(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -235,11 +237,13 @@ mod tests {
             GlobalPath::circle_from_radius(1.),
             [0., 0., 1.],
         ))?;
-        let curve = Curve::partial()
-            .with_surface(Some(surface))
-            .update_as_line_from_points([[1., 1.], [1., 2.]])
-            .build(&objects)?
-            .insert(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface),
+            ..Default::default()
+        }
+        .update_as_line_from_points([[1., 1.], [1., 2.]])
+        .build(&objects)?
+        .insert(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -255,11 +259,13 @@ mod tests {
         let path = GlobalPath::circle_from_radius(1.);
         let surface =
             objects.surfaces.insert(Surface::new(path, [0., 0., 1.]))?;
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_line_from_points([[0., 1.], [1., 1.]])
-            .build(&objects)?
-            .insert(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_line_from_points([[0., 1.], [1., 1.]])
+        .build(&objects)?
+        .insert(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;
@@ -288,11 +294,13 @@ mod tests {
         let surface = objects
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]))?;
-        let curve = Curve::partial()
-            .with_surface(Some(surface))
-            .update_as_circle_from_radius(1.)
-            .build(&objects)?
-            .insert(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface),
+            ..Default::default()
+        }
+        .update_as_circle_from_radius(1.)
+        .build(&objects)?
+        .insert(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -291,13 +291,12 @@ mod tests {
         let surface = objects
             .surfaces
             .insert(Surface::new(GlobalPath::x_axis(), [0., 0., 1.]))?;
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
-        }
-        .update_as_circle_from_radius(1.)
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        curve.update_as_circle_from_radius(1.);
+        let curve = curve.build(&objects)?.insert(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -87,12 +87,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?;
+        };
+        curve.update_as_u_axis();
+        let curve = curve.build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[1., -1.], [1., 1.]])
             .build(&objects)?;
@@ -113,12 +113,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?;
+        };
+        curve.update_as_u_axis();
+        let curve = curve.build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
@@ -142,12 +142,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?;
+        };
+        curve.update_as_u_axis();
+        let curve = curve.build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
@@ -166,12 +166,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?;
+        };
+        curve.update_as_u_axis();
+        let curve = curve.build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[-1., 0.], [1., 0.]])
             .build(&objects)?;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -76,8 +76,8 @@ mod tests {
 
     use crate::{
         builder::{CurveBuilder, HalfEdgeBuilder},
-        objects::{Curve, HalfEdge, Objects},
-        partial::HasPartial,
+        objects::{HalfEdge, Objects},
+        partial::{HasPartial, PartialCurve},
     };
 
     use super::CurveEdgeIntersection;
@@ -87,10 +87,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_u_axis()
-            .build(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[1., -1.], [1., 1.]])
             .build(&objects)?;
@@ -111,10 +113,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_u_axis()
-            .build(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
@@ -138,10 +142,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_u_axis()
-            .build(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
@@ -160,10 +166,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_u_axis()
-            .build(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[-1., 0.], [1., 0.]])
             .build(&objects)?;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -163,12 +163,12 @@ mod tests {
 
         let surface = objects.surfaces.xy_plane();
 
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_line_from_points([[-3., 0.], [-2., 0.]])
-        .build(&objects)?;
+        };
+        curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);
+        let curve = curve.build(&objects)?;
 
         #[rustfmt::skip]
         let exterior = [

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -151,8 +151,8 @@ where
 mod tests {
     use crate::{
         builder::{CurveBuilder, FaceBuilder},
-        objects::{Curve, Face, Objects},
-        partial::HasPartial,
+        objects::{Face, Objects},
+        partial::{HasPartial, PartialCurve},
     };
 
     use super::CurveFaceIntersection;
@@ -163,10 +163,12 @@ mod tests {
 
         let surface = objects.surfaces.xy_plane();
 
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_line_from_points([[-3., 0.], [-2., 0.]])
-            .build(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_line_from_points([[-3., 0.], [-2., 0.]])
+        .build(&objects)?;
 
         #[rustfmt::skip]
         let exterior = [

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -129,13 +129,12 @@ mod tests {
 
         let expected_curves =
             surfaces.try_map_ext(|surface| -> Result<_, ValidationError> {
-                Ok(PartialCurve {
+                let mut curve = PartialCurve {
                     surface: Some(surface),
                     ..Default::default()
-                }
-                .update_as_line_from_points([[0., 0.], [1., 0.]])
-                .build(&objects)?
-                .insert(&objects)?)
+                };
+                curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
+                Ok(curve.build(&objects)?.insert(&objects)?)
             })?;
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -72,8 +72,8 @@ mod tests {
         algorithms::intersect::CurveFaceIntersection,
         builder::{CurveBuilder, FaceBuilder},
         insert::Insert,
-        objects::{Curve, Face, Objects},
-        partial::HasPartial,
+        objects::{Face, Objects},
+        partial::{HasPartial, PartialCurve},
         validate::ValidationError,
     };
 
@@ -129,11 +129,13 @@ mod tests {
 
         let expected_curves =
             surfaces.try_map_ext(|surface| -> Result<_, ValidationError> {
-                Ok(Curve::partial()
-                    .with_surface(Some(surface))
-                    .update_as_line_from_points([[0., 0.], [1., 0.]])
-                    .build(&objects)?
-                    .insert(&objects)?)
+                Ok(PartialCurve {
+                    surface: Some(surface),
+                    ..Default::default()
+                }
+                .update_as_line_from_points([[0., 0.], [1., 0.]])
+                .build(&objects)?
+                .insert(&objects)?)
             })?;
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -91,11 +91,8 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::{
-        algorithms::transform::TransformObject,
-        builder::CurveBuilder,
-        insert::Insert,
-        objects::{Curve, Objects},
-        partial::HasPartial,
+        algorithms::transform::TransformObject, builder::CurveBuilder,
+        insert::Insert, objects::Objects, partial::PartialCurve,
     };
 
     use super::SurfaceSurfaceIntersection;
@@ -122,16 +119,20 @@ mod tests {
             None,
         );
 
-        let expected_xy = Curve::partial()
-            .with_surface(Some(xy.clone()))
-            .update_as_u_axis()
-            .build(&objects)?
-            .insert(&objects)?;
-        let expected_xz = Curve::partial()
-            .with_surface(Some(xz.clone()))
-            .update_as_u_axis()
-            .build(&objects)?
-            .insert(&objects)?;
+        let expected_xy = PartialCurve {
+            surface: Some(xy.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?
+        .insert(&objects)?;
+        let expected_xz = PartialCurve {
+            surface: Some(xz.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?
+        .insert(&objects)?;
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([xy, xz], &objects)?,

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -119,20 +119,18 @@ mod tests {
             None,
         );
 
-        let expected_xy = PartialCurve {
+        let mut expected_xy = PartialCurve {
             surface: Some(xy.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?
-        .insert(&objects)?;
-        let expected_xz = PartialCurve {
+        };
+        expected_xy.update_as_u_axis();
+        let expected_xy = expected_xy.build(&objects)?.insert(&objects)?;
+        let mut expected_xz = PartialCurve {
             surface: Some(xz.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        expected_xz.update_as_u_axis();
+        let expected_xz = expected_xz.build(&objects)?.insert(&objects)?;
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([xy, xz], &objects)?,

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -170,8 +170,8 @@ mod tests {
         algorithms::sweep::Sweep,
         builder::{CurveBuilder, HalfEdgeBuilder},
         insert::Insert,
-        objects::{Curve, HalfEdge, Objects, Vertex},
-        partial::HasPartial,
+        objects::{HalfEdge, Objects, Vertex},
+        partial::{HasPartial, PartialCurve},
     };
 
     #[test]
@@ -179,11 +179,13 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xz_plane();
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_u_axis()
-            .build(&objects)?
-            .insert(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?
+        .insert(&objects)?;
         let vertex = Vertex::partial()
             .with_position(Some([0.]))
             .with_curve(curve)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -179,13 +179,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xz_plane();
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        curve.update_as_u_axis();
+        let curve = curve.build(&objects)?.insert(&objects)?;
         let vertex = Vertex::partial()
             .with_position(Some([0.]))
             .with_curve(curve)

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -39,9 +39,11 @@ impl TransformObject for PartialCurve {
 
         // Don't need to transform `self.path`, as that's defined in surface
         // coordinates, and thus transforming `surface` takes care of it.
-        Ok(Self::default()
-            .with_surface(surface)
-            .with_path(self.path)
-            .with_global_form(global_form))
+        Ok(PartialCurve {
+            path: self.path,
+            ..Default::default()
+        }
+        .with_surface(surface)
+        .with_global_form(global_form))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -41,9 +41,9 @@ impl TransformObject for PartialCurve {
         // coordinates, and thus transforming `surface` takes care of it.
         Ok(PartialCurve {
             path: self.path,
+            surface,
             ..Default::default()
         }
-        .with_surface(surface)
         .with_global_form(global_form))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -42,8 +42,7 @@ impl TransformObject for PartialCurve {
         Ok(PartialCurve {
             path: self.path,
             surface,
-            ..Default::default()
-        }
-        .with_global_form(global_form))
+            global_form,
+        })
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -29,11 +29,11 @@ impl TransformObject for PartialCurve {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
-            .surface()
+            .surface
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
         let global_form = self
-            .global_form()
+            .global_form
             .map(|global_form| global_form.transform(transform, objects))
             .transpose()?;
 
@@ -41,7 +41,7 @@ impl TransformObject for PartialCurve {
         // coordinates, and thus transforming `surface` takes care of it.
         Ok(Self::default()
             .with_surface(surface)
-            .with_path(self.path())
+            .with_path(self.path)
             .with_global_form(global_form))
     }
 }

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -8,7 +8,7 @@ pub trait CurveBuilder {
     fn update_as_u_axis(self) -> Self;
 
     /// Update partial curve to represent the v-axis
-    fn update_as_v_axis(self) -> Self;
+    fn update_as_v_axis(&mut self) -> &mut Self;
 
     /// Update partial curve as a circle, from the provided radius
     fn update_as_circle_from_radius(
@@ -32,12 +32,11 @@ impl CurveBuilder for PartialCurve {
         self
     }
 
-    fn update_as_v_axis(mut self) -> Self {
+    fn update_as_v_axis(&mut self) -> &mut Self {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 
-        self.update_as_line_from_points([a, b]);
-        self
+        self.update_as_line_from_points([a, b])
     }
 
     fn update_as_circle_from_radius(

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -15,24 +15,26 @@ pub trait CurveBuilder {
 
     /// Update partial curve as a line, from the provided points
     fn update_as_line_from_points(
-        self,
+        &mut self,
         points: [impl Into<Point<2>>; 2],
-    ) -> Self;
+    ) -> &mut Self;
 }
 
 impl CurveBuilder for PartialCurve {
-    fn update_as_u_axis(self) -> Self {
+    fn update_as_u_axis(mut self) -> Self {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 
-        self.update_as_line_from_points([a, b])
+        self.update_as_line_from_points([a, b]);
+        self
     }
 
-    fn update_as_v_axis(self) -> Self {
+    fn update_as_v_axis(mut self) -> Self {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 
-        self.update_as_line_from_points([a, b])
+        self.update_as_line_from_points([a, b]);
+        self
     }
 
     fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
@@ -43,12 +45,10 @@ impl CurveBuilder for PartialCurve {
     }
 
     fn update_as_line_from_points(
-        self,
+        &mut self,
         points: [impl Into<Point<2>>; 2],
-    ) -> Self {
-        Self {
-            path: Some(SurfacePath::line_from_points(points)),
-            ..self
-        }
+    ) -> &mut Self {
+        self.path = Some(SurfacePath::line_from_points(points));
+        self
     }
 }

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -36,13 +36,19 @@ impl CurveBuilder for PartialCurve {
     }
 
     fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
-        self.with_path(Some(SurfacePath::circle_from_radius(radius)))
+        Self {
+            path: Some(SurfacePath::circle_from_radius(radius)),
+            ..self
+        }
     }
 
     fn update_as_line_from_points(
         self,
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
-        self.with_path(Some(SurfacePath::line_from_points(points)))
+        Self {
+            path: Some(SurfacePath::line_from_points(points)),
+            ..self
+        }
     }
 }

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -11,7 +11,10 @@ pub trait CurveBuilder {
     fn update_as_v_axis(self) -> Self;
 
     /// Update partial curve as a circle, from the provided radius
-    fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
+    fn update_as_circle_from_radius(
+        &mut self,
+        radius: impl Into<Scalar>,
+    ) -> &mut Self;
 
     /// Update partial curve as a line, from the provided points
     fn update_as_line_from_points(
@@ -37,11 +40,12 @@ impl CurveBuilder for PartialCurve {
         self
     }
 
-    fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self {
-        Self {
-            path: Some(SurfacePath::circle_from_radius(radius)),
-            ..self
-        }
+    fn update_as_circle_from_radius(
+        &mut self,
+        radius: impl Into<Scalar>,
+    ) -> &mut Self {
+        self.path = Some(SurfacePath::circle_from_radius(radius));
+        self
     }
 
     fn update_as_line_from_points(

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -5,7 +5,7 @@ use crate::{partial::PartialCurve, path::SurfacePath};
 /// Builder API for [`PartialCurve`]
 pub trait CurveBuilder {
     /// Update partial curve to represent the u-axis
-    fn update_as_u_axis(self) -> Self;
+    fn update_as_u_axis(&mut self) -> &mut Self;
 
     /// Update partial curve to represent the v-axis
     fn update_as_v_axis(&mut self) -> &mut Self;
@@ -24,12 +24,11 @@ pub trait CurveBuilder {
 }
 
 impl CurveBuilder for PartialCurve {
-    fn update_as_u_axis(mut self) -> Self {
+    fn update_as_u_axis(&mut self) -> &mut Self {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 
-        self.update_as_line_from_points([a, b]);
-        self
+        self.update_as_line_from_points([a, b])
     }
 
     fn update_as_v_axis(&mut self) -> &mut Self {

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -64,11 +64,12 @@ impl CycleBuilder for PartialCycle {
 
                 previous = Some(vertex_next.clone());
 
-                let curve = PartialCurve {
+                let mut curve = PartialCurve {
                     surface: Some(surface.clone()),
                     ..Default::default()
-                }
-                .update_as_line_from_points([position_prev, position_next]);
+                };
+                curve
+                    .update_as_line_from_points([position_prev, position_next]);
 
                 let vertices = [(0., vertex_prev), (1., vertex_next)].map(
                     |(position, surface_form)| {

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -1,8 +1,8 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Curve, HalfEdge, Surface, SurfaceVertex, Vertex},
-    partial::{HasPartial, MaybePartial, PartialCycle},
+    objects::{HalfEdge, Surface, SurfaceVertex, Vertex},
+    partial::{HasPartial, MaybePartial, PartialCurve, PartialCycle},
     storage::Handle,
 };
 
@@ -64,9 +64,11 @@ impl CycleBuilder for PartialCycle {
 
                 previous = Some(vertex_next.clone());
 
-                let curve = Curve::partial()
-                    .with_surface(Some(surface.clone()))
-                    .update_as_line_from_points([position_prev, position_next]);
+                let curve = PartialCurve {
+                    surface: Some(surface.clone()),
+                    ..Default::default()
+                }
+                .update_as_line_from_points([position_prev, position_next]);
 
                 let vertices = [(0., vertex_prev), (1., vertex_next)].map(
                     |(position, surface_form)| {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -68,11 +68,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         radius: impl Into<Scalar>,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self
-            .curve()
-            .into_partial()
-            .with_global_form(Some(self.extract_global_curve()))
-            .update_as_circle_from_radius(radius);
+        let mut curve = self.curve().into_partial();
+        curve.global_form = Some(self.extract_global_curve());
+        let curve = curve.update_as_circle_from_radius(radius);
 
         let path = curve.path.expect("Expected path that was just created");
 
@@ -143,9 +141,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let curve = PartialCurve {
             surface: Some(surface),
+            global_form: Some(self.extract_global_curve()),
             ..Default::default()
         }
-        .with_global_form(Some(self.extract_global_curve()))
         .update_as_line_from_points(points);
 
         let [back, front] = {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -71,7 +71,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             .with_global_form(Some(self.extract_global_curve()))
             .update_as_circle_from_radius(radius);
 
-        let path = curve.path().expect("Expected path that was just created");
+        let path = curve.path.expect("Expected path that was just created");
 
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
@@ -88,7 +88,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let surface_vertex = SurfaceVertex::partial()
             .with_position(Some(path.point_from_path_coords(a_curve)))
-            .with_surface(curve.surface())
+            .with_surface(curve.surface.clone())
             .with_global_form(Some(global_vertex))
             .build(objects)?
             .insert(objects)?;

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -139,12 +139,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .expect("Can't infer line segment without surface position")
         });
 
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface),
             global_form: Some(self.extract_global_curve()),
             ..Default::default()
-        }
-        .update_as_line_from_points(points);
+        };
+        curve.update_as_line_from_points(points);
 
         let [back, front] = {
             let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -7,7 +7,10 @@ use crate::{
         Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex,
         VerticesInNormalizedOrder,
     },
-    partial::{HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge},
+    partial::{
+        HasPartial, MaybePartial, PartialCurve, PartialGlobalEdge,
+        PartialHalfEdge,
+    },
     storage::Handle,
     validate::ValidationError,
 };
@@ -138,10 +141,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .expect("Can't infer line segment without surface position")
         });
 
-        let curve = Curve::partial()
-            .with_global_form(Some(self.extract_global_curve()))
-            .with_surface(Some(surface))
-            .update_as_line_from_points(points);
+        let curve = PartialCurve {
+            surface: Some(surface),
+            ..Default::default()
+        }
+        .with_global_form(Some(self.extract_global_curve()))
+        .update_as_line_from_points(points);
 
         let [back, front] = {
             let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -70,7 +70,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     ) -> Result<Self, ValidationError> {
         let mut curve = self.curve().into_partial();
         curve.global_form = Some(self.extract_global_curve());
-        let curve = curve.update_as_circle_from_radius(radius);
+        curve.update_as_circle_from_radius(radius);
 
         let path = curve.path.expect("Expected path that was just created");
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -9,10 +9,10 @@ use crate::{
     builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{
-        Curve, Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface,
-        SurfaceVertex, Vertex,
+        Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface, SurfaceVertex,
+        Vertex,
     },
-    partial::HasPartial,
+    partial::{HasPartial, PartialCurve},
     storage::Handle,
 };
 
@@ -152,9 +152,16 @@ impl<'a> ShellBuilder<'a> {
                             .with_surface(Some(surface.clone()))
                             .with_global_form(Some(from.global_form().clone()));
 
-                        let curve = Curve::partial().with_global_form(Some(
-                            side_up_prev.curve().global_form().clone(),
-                        ));
+                        let curve = PartialCurve {
+                            global_form: Some(
+                                side_up_prev
+                                    .curve()
+                                    .global_form()
+                                    .clone()
+                                    .into(),
+                            ),
+                            ..Default::default()
+                        };
 
                         HalfEdge::partial()
                             .with_curve(curve)

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -57,10 +57,10 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
     ) -> Self {
         let curve = curve.into().into_partial();
 
-        let path = curve.path().expect(
+        let path = curve.path.expect(
             "Need path to create `GlobalVertex` from curve and position",
         );
-        let surface = curve.surface().expect(
+        let surface = curve.surface.expect(
             "Need surface to create `GlobalVertex` from curve and position",
         );
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -376,13 +376,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let object = PartialCurve {
+        let mut object = PartialCurve {
             surface: Some(surface),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        object.update_as_u_axis();
+        let object = object.build(&objects)?.insert(&objects)?;
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -618,13 +617,12 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = PartialCurve {
+        let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
-        }
-        .update_as_u_axis()
-        .build(&objects)?
-        .insert(&objects)?;
+        };
+        curve.update_as_u_axis();
+        let curve = curve.build(&objects)?.insert(&objects)?;
         let global_vertex = objects
             .global_vertices
             .insert(GlobalVertex::from_position([0., 0., 0.]))?;

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -363,10 +363,10 @@ mod tests {
         builder::{CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder},
         insert::Insert,
         objects::{
-            Curve, Cycle, Face, GlobalCurve, GlobalVertex, HalfEdge, Objects,
-            Shell, Sketch, Solid, SurfaceVertex, Vertex,
+            Cycle, Face, GlobalCurve, GlobalVertex, HalfEdge, Objects, Shell,
+            Sketch, Solid, SurfaceVertex, Vertex,
         },
-        partial::HasPartial,
+        partial::{HasPartial, PartialCurve},
     };
 
     use super::ObjectIters as _;
@@ -376,11 +376,13 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let object = Curve::partial()
-            .with_surface(Some(surface))
-            .update_as_u_axis()
-            .build(&objects)?
-            .insert(&objects)?;
+        let object = PartialCurve {
+            surface: Some(surface),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?
+        .insert(&objects)?;
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -616,11 +618,13 @@ mod tests {
         let objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
-        let curve = Curve::partial()
-            .with_surface(Some(surface.clone()))
-            .update_as_u_axis()
-            .build(&objects)?
-            .insert(&objects)?;
+        let curve = PartialCurve {
+            surface: Some(surface.clone()),
+            ..Default::default()
+        }
+        .update_as_u_axis()
+        .build(&objects)?
+        .insert(&objects)?;
         let global_vertex = objects
             .global_vertices
             .insert(GlobalVertex::from_position([0., 0., 0.]))?;

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -142,7 +142,7 @@ impl MaybePartial<Curve> {
     pub fn path(&self) -> Option<SurfacePath> {
         match self {
             MaybePartial::Full(full) => Some(full.path()),
-            MaybePartial::Partial(partial) => partial.path(),
+            MaybePartial::Partial(partial) => partial.path,
         }
     }
 
@@ -150,7 +150,7 @@ impl MaybePartial<Curve> {
     pub fn surface(&self) -> Option<Handle<Surface>> {
         match self {
             MaybePartial::Full(full) => Some(full.surface().clone()),
-            MaybePartial::Partial(partial) => partial.surface(),
+            MaybePartial::Partial(partial) => partial.surface.clone(),
         }
     }
 
@@ -158,7 +158,7 @@ impl MaybePartial<Curve> {
     pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {
             Self::Full(full) => Some(full.global_form().clone().into()),
-            Self::Partial(partial) => partial.global_form(),
+            Self::Partial(partial) => partial.global_form.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -18,6 +18,12 @@ pub struct PartialCurve {
     pub surface: Option<Handle<Surface>>,
 
     /// The global form of the [`Curve`]
+    ///
+    /// # Implementation Note
+    ///
+    /// This can in principle be simplified to just `MaybePartial<GlobalForm`,
+    /// but as of this writing, there's still some code that relies on this
+    /// being an `Option`.
     pub global_form: Option<MaybePartial<GlobalCurve>>,
 }
 

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -22,21 +22,6 @@ pub struct PartialCurve {
 }
 
 impl PartialCurve {
-    /// Access the path that defines the [`Curve`]
-    pub fn path(&self) -> Option<SurfacePath> {
-        self.path
-    }
-
-    /// Access the surface that the [`Curve`] is defined in
-    pub fn surface(&self) -> Option<Handle<Surface>> {
-        self.surface.clone()
-    }
-
-    /// Access the global form of the [`Curve`]
-    pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
-        self.global_form.clone()
-    }
-
     /// Provide a path for the partial curve
     pub fn with_path(mut self, path: Option<SurfacePath>) -> Self {
         if let Some(path) = path {

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -22,14 +22,6 @@ pub struct PartialCurve {
 }
 
 impl PartialCurve {
-    /// Provide a path for the partial curve
-    pub fn with_path(mut self, path: Option<SurfacePath>) -> Self {
-        if let Some(path) = path {
-            self.path = Some(path);
-        }
-        self
-    }
-
     /// Provide a surface for the partial curve
     pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
         if let Some(surface) = surface {

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -11,9 +11,14 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialCurve {
-    path: Option<SurfacePath>,
-    surface: Option<Handle<Surface>>,
-    global_form: Option<MaybePartial<GlobalCurve>>,
+    /// The path that defines the [`Curve`]
+    pub path: Option<SurfacePath>,
+
+    /// The surface that the [`Curve`] is defined in
+    pub surface: Option<Handle<Surface>>,
+
+    /// The global form of the [`Curve`]
+    pub global_form: Option<MaybePartial<GlobalCurve>>,
 }
 
 impl PartialCurve {

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -22,14 +22,6 @@ pub struct PartialCurve {
 }
 
 impl PartialCurve {
-    /// Provide a surface for the partial curve
-    pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
-        if let Some(surface) = surface {
-            self.surface = Some(surface);
-        }
-        self
-    }
-
     /// Provide a global form for the partial curve
     pub fn with_global_form(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -22,17 +22,6 @@ pub struct PartialCurve {
 }
 
 impl PartialCurve {
-    /// Provide a global form for the partial curve
-    pub fn with_global_form(
-        mut self,
-        global_form: Option<impl Into<MaybePartial<GlobalCurve>>>,
-    ) -> Self {
-        if let Some(global_form) = global_form {
-            self.global_form = Some(global_form.into());
-        }
-        self
-    }
-
     /// Build a full [`Curve`] from the partial curve
     pub fn build(self, objects: &Objects) -> Result<Curve, ValidationError> {
         let path = self.path.expect("Can't build `Curve` without path");

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -48,9 +48,10 @@ impl PartialHalfEdge {
 
     /// Update the partial half-edge with the given surface
     pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
-        self.curve = self
-            .curve
-            .update_partial(|curve| curve.with_surface(Some(surface.clone())));
+        self.curve = self.curve.update_partial(|mut curve| {
+            curve.surface = Some(surface.clone());
+            curve
+        });
 
         self.vertices = self.vertices.map(|vertex| {
             vertex.update_partial(|vertex| {

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -190,15 +190,15 @@ mod tests {
     fn vertex_surface_mismatch() -> anyhow::Result<()> {
         let objects = Objects::new();
 
+        let mut curve = PartialCurve {
+            surface: Some(objects.surfaces.xy_plane()),
+            ..Default::default()
+        };
+        curve.update_as_u_axis();
+
         let valid = Vertex::partial()
             .with_position(Some([0.]))
-            .with_curve(
-                PartialCurve {
-                    surface: Some(objects.surfaces.xy_plane()),
-                    ..Default::default()
-                }
-                .update_as_u_axis(),
-            )
+            .with_curve(curve)
             .build(&objects)?;
         let invalid = Vertex::new(
             valid.position(),
@@ -221,16 +221,18 @@ mod tests {
     fn vertex_position_mismatch() -> anyhow::Result<()> {
         let objects = Objects::new();
 
-        let valid = Vertex::partial()
-            .with_position(Some([0.]))
-            .with_curve(
-                PartialCurve {
-                    surface: Some(objects.surfaces.xy_plane()),
-                    ..Default::default()
-                }
-                .update_as_u_axis(),
-            )
-            .build(&objects)?;
+        let valid = {
+            let mut curve = PartialCurve {
+                surface: Some(objects.surfaces.xy_plane()),
+                ..Default::default()
+            };
+            curve.update_as_u_axis();
+
+            Vertex::partial()
+                .with_position(Some([0.]))
+                .with_curve(curve)
+                .build(&objects)?
+        };
         let invalid = Vertex::new(
             valid.position(),
             valid.curve().clone(),

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -181,8 +181,8 @@ mod tests {
     use crate::{
         builder::{CurveBuilder, SurfaceVertexBuilder},
         insert::Insert,
-        objects::{Curve, GlobalVertex, Objects, SurfaceVertex, Vertex},
-        partial::HasPartial,
+        objects::{GlobalVertex, Objects, SurfaceVertex, Vertex},
+        partial::{HasPartial, PartialCurve},
         validate::Validate,
     };
 
@@ -193,9 +193,11 @@ mod tests {
         let valid = Vertex::partial()
             .with_position(Some([0.]))
             .with_curve(
-                Curve::partial()
-                    .with_surface(Some(objects.surfaces.xy_plane()))
-                    .update_as_u_axis(),
+                PartialCurve {
+                    surface: Some(objects.surfaces.xy_plane()),
+                    ..Default::default()
+                }
+                .update_as_u_axis(),
             )
             .build(&objects)?;
         let invalid = Vertex::new(
@@ -222,9 +224,11 @@ mod tests {
         let valid = Vertex::partial()
             .with_position(Some([0.]))
             .with_curve(
-                Curve::partial()
-                    .with_surface(Some(objects.surfaces.xy_plane()))
-                    .update_as_u_axis(),
+                PartialCurve {
+                    surface: Some(objects.surfaces.xy_plane()),
+                    ..Default::default()
+                }
+                .update_as_u_axis(),
             )
             .build(&objects)?;
         let invalid = Vertex::new(


### PR DESCRIPTION
Simplify `PartialCurve`, using some of the newer ideas from #1249. So far, so good, but `PartialCurve` is one of the less complicated partial object types. We'll see how this approach works out when applied to other partial objects.