### PR TITLE
Clean up partial vertex types

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -199,8 +199,8 @@ mod tests {
         algorithms::{reverse::Reverse, sweep::Sweep},
         builder::HalfEdgeBuilder,
         insert::Insert,
-        objects::{Cycle, Face, HalfEdge, Objects, Vertex},
-        partial::{HasPartial, PartialSurfaceVertex},
+        objects::{Cycle, Face, HalfEdge, Objects},
+        partial::{HasPartial, PartialSurfaceVertex, PartialVertex},
     };
 
     #[test]
@@ -218,69 +218,75 @@ mod tests {
         let face =
             (half_edge, Color::default()).sweep([0., 0., 1.], &objects)?;
 
-        let expected_face =
-            {
-                let surface = objects.surfaces.xz_plane();
+        let expected_face = {
+            let surface = objects.surfaces.xz_plane();
 
-                let bottom = HalfEdge::partial()
-                    .update_as_line_segment_from_points(
-                        surface.clone(),
-                        [[0., 0.], [1., 0.]],
-                    )
-                    .build(&objects)?
-                    .insert(&objects)?;
-                let side_up = HalfEdge::partial()
-                    .with_surface(surface.clone())
-                    .with_back_vertex(Vertex::partial().with_surface_form(
-                        bottom.front().surface_form().clone(),
-                    ))
-                    .with_front_vertex(Vertex::partial().with_surface_form(
-                        PartialSurfaceVertex {
-                            position: Some([1., 1.].into()),
-                            ..Default::default()
-                        },
-                    ))
-                    .update_as_line_segment()
-                    .build(&objects)?
-                    .insert(&objects)?;
-                let top = HalfEdge::partial()
-                    .with_surface(surface.clone())
-                    .with_back_vertex(Vertex::partial().with_surface_form(
-                        PartialSurfaceVertex {
-                            position: Some([0., 1.].into()),
-                            ..Default::default()
-                        },
-                    ))
-                    .with_front_vertex(Vertex::partial().with_surface_form(
-                        side_up.front().surface_form().clone(),
-                    ))
-                    .update_as_line_segment()
-                    .build(&objects)?
-                    .insert(&objects)?
-                    .reverse(&objects)?;
-                let side_down =
-                    HalfEdge::partial()
-                        .with_surface(surface)
-                        .with_back_vertex(Vertex::partial().with_surface_form(
-                            bottom.back().surface_form().clone(),
-                        ))
-                        .with_front_vertex(Vertex::partial().with_surface_form(
-                            top.front().surface_form().clone(),
-                        ))
-                        .update_as_line_segment()
-                        .build(&objects)?
-                        .insert(&objects)?
-                        .reverse(&objects)?;
+            let bottom = HalfEdge::partial()
+                .update_as_line_segment_from_points(
+                    surface.clone(),
+                    [[0., 0.], [1., 0.]],
+                )
+                .build(&objects)?
+                .insert(&objects)?;
+            let side_up = HalfEdge::partial()
+                .with_surface(surface.clone())
+                .with_back_vertex(PartialVertex {
+                    surface_form: bottom.front().surface_form().clone().into(),
+                    ..Default::default()
+                })
+                .with_front_vertex(PartialVertex {
+                    surface_form: PartialSurfaceVertex {
+                        position: Some([1., 1.].into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    ..Default::default()
+                })
+                .update_as_line_segment()
+                .build(&objects)?
+                .insert(&objects)?;
+            let top = HalfEdge::partial()
+                .with_surface(surface.clone())
+                .with_back_vertex(PartialVertex {
+                    surface_form: PartialSurfaceVertex {
+                        position: Some([0., 1.].into()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    ..Default::default()
+                })
+                .with_front_vertex(PartialVertex {
+                    surface_form: side_up.front().surface_form().clone().into(),
+                    ..Default::default()
+                })
+                .update_as_line_segment()
+                .build(&objects)?
+                .insert(&objects)?
+                .reverse(&objects)?;
+            let side_down = HalfEdge::partial()
+                .with_surface(surface)
+                .with_back_vertex(PartialVertex {
+                    surface_form: bottom.back().surface_form().clone().into(),
+                    ..Default::default()
+                })
+                .with_front_vertex(PartialVertex {
+                    surface_form: top.front().surface_form().clone().into(),
+                    ..Default::default()
+                })
+                .update_as_line_segment()
+                .build(&objects)?
+                .insert(&objects)?
+                .reverse(&objects)?;
 
-                let cycle = objects
-                    .cycles
-                    .insert(Cycle::new([bottom, side_up, top, side_down]))?;
+            let cycle = objects
+                .cycles
+                .insert(Cycle::new([bottom, side_up, top, side_down]))?;
 
-                Face::partial()
-                    .with_exterior(cycle)
-                    .build(&objects)?
-                    .insert(&objects)?
-            };
+            Face::partial()
+                .with_exterior(cycle)
+                .build(&objects)?
+                .insert(&objects)?
+        };
 
         assert_eq!(face, expected_face);
         Ok(())

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -199,8 +199,8 @@ mod tests {
         algorithms::{reverse::Reverse, sweep::Sweep},
         builder::HalfEdgeBuilder,
         insert::Insert,
-        objects::{Cycle, Face, HalfEdge, Objects, SurfaceVertex, Vertex},
-        partial::HasPartial,
+        objects::{Cycle, Face, HalfEdge, Objects, Vertex},
+        partial::{HasPartial, PartialSurfaceVertex},
     };
 
     #[test]
@@ -235,7 +235,10 @@ mod tests {
                         bottom.front().surface_form().clone(),
                     ))
                     .with_front_vertex(Vertex::partial().with_surface_form(
-                        SurfaceVertex::partial().with_position(Some([1., 1.])),
+                        PartialSurfaceVertex {
+                            position: Some([1., 1.].into()),
+                            ..Default::default()
+                        },
                     ))
                     .update_as_line_segment()
                     .build(&objects)?
@@ -243,7 +246,10 @@ mod tests {
                 let top = HalfEdge::partial()
                     .with_surface(surface.clone())
                     .with_back_vertex(Vertex::partial().with_surface_form(
-                        SurfaceVertex::partial().with_position(Some([0., 1.])),
+                        PartialSurfaceVertex {
+                            position: Some([0., 1.].into()),
+                            ..Default::default()
+                        },
                     ))
                     .with_front_vertex(Vertex::partial().with_surface_form(
                         side_up.front().surface_form().clone(),

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -170,8 +170,8 @@ mod tests {
         algorithms::sweep::Sweep,
         builder::{CurveBuilder, HalfEdgeBuilder},
         insert::Insert,
-        objects::{HalfEdge, Objects, Vertex},
-        partial::{HasPartial, PartialCurve},
+        objects::{HalfEdge, Objects},
+        partial::{HasPartial, PartialCurve, PartialVertex},
     };
 
     #[test]
@@ -185,11 +185,13 @@ mod tests {
         };
         curve.update_as_u_axis();
         let curve = curve.build(&objects)?.insert(&objects)?;
-        let vertex = Vertex::partial()
-            .with_position(Some([0.]))
-            .with_curve(curve)
-            .build(&objects)?
-            .insert(&objects)?;
+        let vertex = PartialVertex {
+            position: Some([0.].into()),
+            ..Default::default()
+        }
+        .with_curve(curve)
+        .build(&objects)?
+        .insert(&objects)?;
 
         let half_edge =
             (vertex, surface.clone()).sweep([0., 0., 1.], &objects)?;

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -187,9 +187,9 @@ mod tests {
         let curve = curve.build(&objects)?.insert(&objects)?;
         let vertex = PartialVertex {
             position: Some([0.].into()),
+            curve: curve.into(),
             ..Default::default()
         }
-        .with_curve(curve)
         .build(&objects)?
         .insert(&objects)?;
 

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -22,10 +22,10 @@ impl TransformObject for PartialHalfEdge {
             .into();
         let vertices = self.vertices().try_map_ext(
             |vertex| -> Result<_, ValidationError> {
-                Ok(vertex
-                    .into_partial()
-                    .transform(transform, objects)?
-                    .with_curve(curve.clone()))
+                let mut vertex =
+                    vertex.into_partial().transform(transform, objects)?;
+                vertex.curve = curve.clone();
+                Ok(vertex)
             },
         )?;
         let global_form = self

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -44,7 +44,7 @@ impl TransformObject for PartialSurfaceVertex {
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.
         Ok(Self::default()
-            .with_position(self.position())
+            .with_position(self.position)
             .with_surface(surface)
             .with_global_form(Some(global_form)))
     }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -14,7 +14,7 @@ impl TransformObject for PartialVertex {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self.curve().transform(transform, objects)?;
+        let curve = self.curve.clone().transform(transform, objects)?;
         let surface_form = self
             .surface_form()
             .into_partial()

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -57,7 +57,7 @@ impl TransformObject for PartialGlobalVertex {
         _: &Objects,
     ) -> Result<Self, ValidationError> {
         let position = self
-            .position()
+            .position
             .map(|position| transform.transform_point(&position));
 
         Ok(Self::default().with_position(position))

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -36,7 +36,8 @@ impl TransformObject for PartialSurfaceVertex {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
-            .surface()
+            .surface
+            .clone()
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
         let global_form = self.global_form().transform(transform, objects)?;

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -23,7 +23,7 @@ impl TransformObject for PartialVertex {
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
         Ok(Self::default()
-            .with_position(self.position())
+            .with_position(self.position)
             .with_curve(curve)
             .with_surface_form(surface_form))
     }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -22,10 +22,12 @@ impl TransformObject for PartialVertex {
 
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
-        Ok(Self::default()
-            .with_position(self.position)
-            .with_curve(curve)
-            .with_surface_form(surface_form))
+        Ok(Self {
+            position: self.position,
+            ..Default::default()
+        }
+        .with_curve(curve)
+        .with_surface_form(surface_form))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -44,10 +44,12 @@ impl TransformObject for PartialSurfaceVertex {
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.
-        Ok(Self::default()
-            .with_position(self.position)
-            .with_surface(surface)
-            .with_global_form(Some(global_form)))
+        Ok(Self {
+            position: self.position,
+            ..Default::default()
+        }
+        .with_surface(surface)
+        .with_global_form(Some(global_form)))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -47,9 +47,8 @@ impl TransformObject for PartialSurfaceVertex {
         Ok(Self {
             position: self.position,
             surface,
-            ..Default::default()
-        }
-        .with_global_form(Some(global_form)))
+            global_form,
+        })
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -60,6 +60,6 @@ impl TransformObject for PartialGlobalVertex {
             .position
             .map(|position| transform.transform_point(&position));
 
-        Ok(Self::default().with_position(position))
+        Ok(Self { position })
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -24,9 +24,9 @@ impl TransformObject for PartialVertex {
         // coordinates and thus transforming the curve takes care of it.
         Ok(Self {
             position: self.position,
+            curve,
             ..Default::default()
         }
-        .with_curve(curve)
         .with_surface_form(surface_form))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -25,9 +25,8 @@ impl TransformObject for PartialVertex {
         Ok(Self {
             position: self.position,
             curve,
-            ..Default::default()
-        }
-        .with_surface_form(surface_form))
+            surface_form: surface_form.into(),
+        })
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -14,9 +14,9 @@ impl TransformObject for PartialVertex {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self.curve.clone().transform(transform, objects)?;
+        let curve = self.curve.transform(transform, objects)?;
         let surface_form = self
-            .surface_form()
+            .surface_form
             .into_partial()
             .transform(transform, objects)?;
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -40,7 +40,7 @@ impl TransformObject for PartialSurfaceVertex {
             .clone()
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
-        let global_form = self.global_form().transform(transform, objects)?;
+        let global_form = self.global_form.transform(transform, objects)?;
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -46,9 +46,9 @@ impl TransformObject for PartialSurfaceVertex {
         // coordinates and thus transforming the surface takes care of it.
         Ok(Self {
             position: self.position,
+            surface,
             ..Default::default()
         }
-        .with_surface(surface)
         .with_global_form(Some(global_form)))
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -1,10 +1,10 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{HalfEdge, Surface, SurfaceVertex, Vertex},
+    objects::{HalfEdge, Surface, SurfaceVertex},
     partial::{
         HasPartial, MaybePartial, PartialCurve, PartialCycle,
-        PartialSurfaceVertex,
+        PartialSurfaceVertex, PartialVertex,
     },
     storage::Handle,
 };
@@ -76,10 +76,12 @@ impl CycleBuilder for PartialCycle {
 
                 let vertices = [(0., vertex_prev), (1., vertex_next)].map(
                     |(position, surface_form)| {
-                        Vertex::partial()
-                            .with_curve(curve.clone())
-                            .with_position(Some([position]))
-                            .with_surface_form(surface_form)
+                        PartialVertex {
+                            position: Some([position].into()),
+                            ..Default::default()
+                        }
+                        .with_curve(curve.clone())
+                        .with_surface_form(surface_form)
                     },
                 );
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -106,9 +106,9 @@ impl CycleBuilder for PartialCycle {
         self.with_poly_chain(points.into_iter().map(|position| {
             PartialSurfaceVertex {
                 position: Some(position.into()),
+                surface: Some(surface.clone()),
                 ..Default::default()
             }
-            .with_surface(Some(surface.clone()))
         }))
     }
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -75,13 +75,10 @@ impl CycleBuilder for PartialCycle {
                     .update_as_line_from_points([position_prev, position_next]);
 
                 let vertices = [(0., vertex_prev), (1., vertex_next)].map(
-                    |(position, surface_form)| {
-                        PartialVertex {
-                            position: Some([position].into()),
-                            curve: curve.clone().into(),
-                            ..Default::default()
-                        }
-                        .with_surface_form(surface_form)
+                    |(position, surface_form)| PartialVertex {
+                        position: Some([position].into()),
+                        curve: curve.clone().into(),
+                        surface_form,
                     },
                 );
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -78,9 +78,9 @@ impl CycleBuilder for PartialCycle {
                     |(position, surface_form)| {
                         PartialVertex {
                             position: Some([position].into()),
+                            curve: curve.clone().into(),
                             ..Default::default()
                         }
-                        .with_curve(curve.clone())
                         .with_surface_form(surface_form)
                     },
                 );

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -2,7 +2,10 @@ use fj_math::Point;
 
 use crate::{
     objects::{HalfEdge, Surface, SurfaceVertex, Vertex},
-    partial::{HasPartial, MaybePartial, PartialCurve, PartialCycle},
+    partial::{
+        HasPartial, MaybePartial, PartialCurve, PartialCycle,
+        PartialSurfaceVertex,
+    },
     storage::Handle,
 };
 
@@ -101,9 +104,11 @@ impl CycleBuilder for PartialCycle {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         self.with_poly_chain(points.into_iter().map(|position| {
-            SurfaceVertex::partial()
-                .with_surface(Some(surface.clone()))
-                .with_position(Some(position))
+            PartialSurfaceVertex {
+                position: Some(position.into()),
+                ..Default::default()
+            }
+            .with_surface(Some(surface.clone()))
         }))
     }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -90,9 +90,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let surface_vertex = PartialSurfaceVertex {
             position: Some(path.point_from_path_coords(a_curve)),
+            surface: curve.surface.clone(),
             ..Default::default()
         }
-        .with_surface(curve.surface.clone())
         .with_global_form(Some(global_vertex))
         .build(objects)?
         .insert(objects)?;
@@ -115,9 +115,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let vertices = points.map(|point| {
             let surface_form = PartialSurfaceVertex {
                 position: Some(point.into()),
+                surface: Some(surface.clone()),
                 ..Default::default()
-            }
-            .with_surface(Some(surface.clone()));
+            };
 
             Vertex::partial().with_surface_form(surface_form)
         });

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     partial::{
         HasPartial, MaybePartial, PartialCurve, PartialGlobalEdge,
-        PartialHalfEdge, PartialSurfaceVertex,
+        PartialHalfEdge, PartialSurfaceVertex, PartialVertex,
     },
     storage::Handle,
     validate::ValidationError,
@@ -97,10 +97,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         .insert(objects)?;
 
         let [back, front] = [a_curve, b_curve].map(|point_curve| {
-            Vertex::partial()
-                .with_position(Some(point_curve))
-                .with_curve(curve.clone())
-                .with_surface_form(surface_vertex.clone())
+            PartialVertex {
+                position: Some(point_curve),
+                ..Default::default()
+            }
+            .with_curve(curve.clone())
+            .with_surface_form(surface_vertex.clone())
         });
 
         Ok(self.with_curve(curve).with_vertices([back, front]))
@@ -152,10 +154,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let [back, front] = {
             let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {
-                vertex.update_partial(|vertex| {
-                    vertex
-                        .with_position(Some([position]))
-                        .with_curve(curve.clone())
+                vertex.update_partial(|mut vertex| {
+                    vertex.position = Some([position].into());
+                    vertex.with_curve(curve.clone())
                 })
             });
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -82,9 +82,10 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             .vertices()
             .map(|[global_form, _]| global_form)
             .unwrap_or_else(|| {
-                GlobalVertex::partial()
-                    .update_from_curve_and_position(curve.clone(), a_curve)
-                    .into()
+                let mut global_vertex = GlobalVertex::partial();
+                global_vertex
+                    .update_from_curve_and_position(curve.clone(), a_curve);
+                global_vertex.into()
             });
 
         let surface_vertex = SurfaceVertex::partial()

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -4,12 +4,12 @@ use iter_fixed::IntoIteratorFixed;
 use crate::{
     insert::Insert,
     objects::{
-        Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex,
+        Curve, GlobalVertex, Objects, Surface, Vertex,
         VerticesInNormalizedOrder,
     },
     partial::{
         HasPartial, MaybePartial, PartialCurve, PartialGlobalEdge,
-        PartialHalfEdge,
+        PartialHalfEdge, PartialSurfaceVertex,
     },
     storage::Handle,
     validate::ValidationError,
@@ -88,12 +88,14 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 global_vertex.into()
             });
 
-        let surface_vertex = SurfaceVertex::partial()
-            .with_position(Some(path.point_from_path_coords(a_curve)))
-            .with_surface(curve.surface.clone())
-            .with_global_form(Some(global_vertex))
-            .build(objects)?
-            .insert(objects)?;
+        let surface_vertex = PartialSurfaceVertex {
+            position: Some(path.point_from_path_coords(a_curve)),
+            ..Default::default()
+        }
+        .with_surface(curve.surface.clone())
+        .with_global_form(Some(global_vertex))
+        .build(objects)?
+        .insert(objects)?;
 
         let [back, front] = [a_curve, b_curve].map(|point_curve| {
             Vertex::partial()
@@ -111,9 +113,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
         let vertices = points.map(|point| {
-            let surface_form = SurfaceVertex::partial()
-                .with_surface(Some(surface.clone()))
-                .with_position(Some(point));
+            let surface_form = PartialSurfaceVertex {
+                position: Some(point.into()),
+                ..Default::default()
+            }
+            .with_surface(Some(surface.clone()));
 
             Vertex::partial().with_surface_form(surface_form)
         });

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -201,7 +201,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .map(|(vertex, global_form)| {
                     vertex.update_partial(|vertex| {
                         vertex.clone().with_surface_form(
-                            vertex.surface_form().update_partial(
+                            vertex.surface_form.update_partial(
                                 |mut surface_vertex| {
                                     if let Some(global_form) = global_form {
                                         surface_vertex.global_form =

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -99,9 +99,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let [back, front] = [a_curve, b_curve].map(|point_curve| {
             PartialVertex {
                 position: Some(point_curve),
+                curve: curve.clone().into(),
                 ..Default::default()
             }
-            .with_curve(curve.clone())
             .with_surface_form(surface_vertex.clone())
         });
 
@@ -156,7 +156,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             let vertices = [(from, 0.), (to, 1.)].map(|(vertex, position)| {
                 vertex.update_partial(|mut vertex| {
                     vertex.position = Some([position].into());
-                    vertex.with_curve(curve.clone())
+                    vertex.curve = curve.clone().into();
+                    vertex
                 })
             });
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -91,9 +91,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let surface_vertex = PartialSurfaceVertex {
             position: Some(path.point_from_path_coords(a_curve)),
             surface: curve.surface.clone(),
-            ..Default::default()
+            global_form: global_vertex,
         }
-        .with_global_form(Some(global_vertex))
         .build(objects)?
         .insert(objects)?;
 
@@ -203,8 +202,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                     vertex.update_partial(|vertex| {
                         vertex.clone().with_surface_form(
                             vertex.surface_form().update_partial(
-                                |surface_vertex| {
-                                    surface_vertex.with_global_form(global_form)
+                                |mut surface_vertex| {
+                                    if let Some(global_form) = global_form {
+                                        surface_vertex.global_form =
+                                            global_form;
+                                    }
+                                    surface_vertex
                                 },
                             ),
                         )

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -3,12 +3,9 @@ use iter_fixed::IntoIteratorFixed;
 
 use crate::{
     insert::Insert,
-    objects::{
-        Curve, GlobalVertex, Objects, Surface, Vertex,
-        VerticesInNormalizedOrder,
-    },
+    objects::{Curve, Objects, Surface, Vertex, VerticesInNormalizedOrder},
     partial::{
-        HasPartial, MaybePartial, PartialCurve, PartialGlobalEdge,
+        MaybePartial, PartialCurve, PartialGlobalEdge, PartialGlobalVertex,
         PartialHalfEdge, PartialSurfaceVertex, PartialVertex,
     },
     storage::Handle,
@@ -82,10 +79,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             .vertices()
             .map(|[global_form, _]| global_form)
             .unwrap_or_else(|| {
-                let mut global_vertex = GlobalVertex::partial();
-                global_vertex
-                    .update_from_curve_and_position(curve.clone(), a_curve);
-                global_vertex.into()
+                PartialGlobalVertex::from_curve_and_position(
+                    curve.clone(),
+                    a_curve,
+                )
+                .into()
             });
 
         let surface_vertex = PartialSurfaceVertex {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -115,9 +115,9 @@ impl<'a> ShellBuilder<'a> {
                     let from = from.surface_form().clone();
                     let to = PartialSurfaceVertex {
                         position: Some(from.position() + [Z, edge_length]),
+                        surface: Some(surface.clone()),
                         ..Default::default()
-                    }
-                    .with_surface(Some(surface.clone()));
+                    };
 
                     HalfEdge::partial()
                         .with_vertices([
@@ -148,9 +148,9 @@ impl<'a> ShellBuilder<'a> {
                         let to = to.surface_form().clone();
                         let from = PartialSurfaceVertex {
                             position: Some(to.position() + [Z, edge_length]),
+                            surface: Some(surface.clone()),
                             ..Default::default()
                         }
-                        .with_surface(Some(surface.clone()))
                         .with_global_form(Some(from.global_form().clone()));
 
                         let curve = PartialCurve {
@@ -253,9 +253,9 @@ impl<'a> ShellBuilder<'a> {
 
                         PartialSurfaceVertex {
                             position: Some(point.into()),
+                            surface: Some(surface.clone()),
                             ..Default::default()
                         }
-                        .with_surface(Some(surface.clone()))
                         .with_global_form(Some(vertex.global_form().clone()))
                         .build(self.objects)
                         .unwrap()

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -149,9 +149,8 @@ impl<'a> ShellBuilder<'a> {
                         let from = PartialSurfaceVertex {
                             position: Some(to.position() + [Z, edge_length]),
                             surface: Some(surface.clone()),
-                            ..Default::default()
-                        }
-                        .with_global_form(Some(from.global_form().clone()));
+                            global_form: from.global_form().clone().into(),
+                        };
 
                         let curve = PartialCurve {
                             global_form: Some(
@@ -254,9 +253,8 @@ impl<'a> ShellBuilder<'a> {
                         PartialSurfaceVertex {
                             position: Some(point.into()),
                             surface: Some(surface.clone()),
-                            ..Default::default()
+                            global_form: vertex.global_form().clone().into(),
                         }
-                        .with_global_form(Some(vertex.global_form().clone()))
                         .build(self.objects)
                         .unwrap()
                         .insert(self.objects)

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -8,9 +8,7 @@ use crate::{
     algorithms::transform::TransformObject,
     builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{
-        Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface, Vertex,
-    },
+    objects::{Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface},
     partial::{HasPartial, PartialCurve, PartialSurfaceVertex, PartialVertex},
     storage::Handle,
 };
@@ -121,8 +119,14 @@ impl<'a> ShellBuilder<'a> {
 
                     HalfEdge::partial()
                         .with_vertices([
-                            Vertex::partial().with_surface_form(from),
-                            Vertex::partial().with_surface_form(to),
+                            PartialVertex {
+                                surface_form: from.into(),
+                                ..Default::default()
+                            },
+                            PartialVertex {
+                                surface_form: to.into(),
+                                ..Default::default()
+                            },
                         ])
                         .update_as_line_segment()
                         .build(self.objects)
@@ -166,8 +170,14 @@ impl<'a> ShellBuilder<'a> {
                         HalfEdge::partial()
                             .with_curve(curve)
                             .with_vertices([
-                                Vertex::partial().with_surface_form(from),
-                                Vertex::partial().with_surface_form(to),
+                                PartialVertex {
+                                    surface_form: from.into(),
+                                    ..Default::default()
+                                },
+                                PartialVertex {
+                                    surface_form: to.into(),
+                                    ..Default::default()
+                                },
                             ])
                             .update_as_line_segment()
                             .build(self.objects)
@@ -189,8 +199,14 @@ impl<'a> ShellBuilder<'a> {
                     let from = from.surface_form().clone();
                     let to = to.surface_form().clone();
 
-                    let from = Vertex::partial().with_surface_form(from);
-                    let to = Vertex::partial().with_surface_form(to);
+                    let from = PartialVertex {
+                        surface_form: from.into(),
+                        ..Default::default()
+                    };
+                    let to = PartialVertex {
+                        surface_form: to.into(),
+                        ..Default::default()
+                    };
 
                     HalfEdge::partial()
                         .with_vertices([from, to])
@@ -276,12 +292,10 @@ impl<'a> ShellBuilder<'a> {
                     .into_iter_fixed()
                     .zip(surface_vertices.clone())
                     .collect::<[_; 2]>()
-                    .map(|(vertex, surface_form)| {
-                        PartialVertex {
-                            position: Some(vertex.position()),
-                            ..Default::default()
-                        }
-                        .with_surface_form(surface_form)
+                    .map(|(vertex, surface_form)| PartialVertex {
+                        position: Some(vertex.position()),
+                        surface_form: surface_form.into(),
+                        ..Default::default()
                     });
 
                 edges.push(

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -9,10 +9,9 @@ use crate::{
     builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{
-        Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface, SurfaceVertex,
-        Vertex,
+        Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface, Vertex,
     },
-    partial::{HasPartial, PartialCurve},
+    partial::{HasPartial, PartialCurve, PartialSurfaceVertex},
     storage::Handle,
 };
 
@@ -114,9 +113,11 @@ impl<'a> ShellBuilder<'a> {
                     let [_, from] = bottom.vertices();
 
                     let from = from.surface_form().clone();
-                    let to = SurfaceVertex::partial()
-                        .with_position(Some(from.position() + [Z, edge_length]))
-                        .with_surface(Some(surface.clone()));
+                    let to = PartialSurfaceVertex {
+                        position: Some(from.position() + [Z, edge_length]),
+                        ..Default::default()
+                    }
+                    .with_surface(Some(surface.clone()));
 
                     HalfEdge::partial()
                         .with_vertices([
@@ -145,12 +146,12 @@ impl<'a> ShellBuilder<'a> {
                         let [to, _] = bottom.vertices();
 
                         let to = to.surface_form().clone();
-                        let from = SurfaceVertex::partial()
-                            .with_position(Some(
-                                to.position() + [Z, edge_length],
-                            ))
-                            .with_surface(Some(surface.clone()))
-                            .with_global_form(Some(from.global_form().clone()));
+                        let from = PartialSurfaceVertex {
+                            position: Some(to.position() + [Z, edge_length]),
+                            ..Default::default()
+                        }
+                        .with_surface(Some(surface.clone()))
+                        .with_global_form(Some(from.global_form().clone()));
 
                         let curve = PartialCurve {
                             global_form: Some(
@@ -250,16 +251,16 @@ impl<'a> ShellBuilder<'a> {
                     .map(|(point, edge)| {
                         let vertex = edge.back();
 
-                        SurfaceVertex::partial()
-                            .with_position(Some(point))
-                            .with_surface(Some(surface.clone()))
-                            .with_global_form(Some(
-                                vertex.global_form().clone(),
-                            ))
-                            .build(self.objects)
-                            .unwrap()
-                            .insert(self.objects)
-                            .unwrap()
+                        PartialSurfaceVertex {
+                            position: Some(point.into()),
+                            ..Default::default()
+                        }
+                        .with_surface(Some(surface.clone()))
+                        .with_global_form(Some(vertex.global_form().clone()))
+                        .build(self.objects)
+                        .unwrap()
+                        .insert(self.objects)
+                        .unwrap()
                     });
 
                 [a.clone(), b, c, d, a]

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -11,7 +11,7 @@ use crate::{
     objects::{
         Cycle, Face, FaceSet, HalfEdge, Objects, Shell, Surface, Vertex,
     },
-    partial::{HasPartial, PartialCurve, PartialSurfaceVertex},
+    partial::{HasPartial, PartialCurve, PartialSurfaceVertex, PartialVertex},
     storage::Handle,
 };
 
@@ -277,9 +277,11 @@ impl<'a> ShellBuilder<'a> {
                     .zip(surface_vertices.clone())
                     .collect::<[_; 2]>()
                     .map(|(vertex, surface_form)| {
-                        Vertex::partial()
-                            .with_position(Some(vertex.position()))
-                            .with_surface_form(surface_form)
+                        PartialVertex {
+                            position: Some(vertex.position()),
+                            ..Default::default()
+                        }
+                        .with_surface_form(surface_form)
                     });
 
                 edges.push(

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -43,11 +43,10 @@ pub trait GlobalVertexBuilder {
     ) -> Self;
 
     /// Update partial global vertex from the given surface and position on it
-    fn update_from_surface_and_position(
-        &mut self,
+    fn from_surface_and_position(
         surface: &Surface,
         position: impl Into<Point<2>>,
-    ) -> &mut Self;
+    ) -> Self;
 }
 
 impl GlobalVertexBuilder for PartialGlobalVertex {
@@ -66,18 +65,15 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
 
         let position_surface = path.point_from_path_coords(position);
 
-        let mut global_vertex = PartialGlobalVertex::default();
-        global_vertex
-            .update_from_surface_and_position(&surface, position_surface);
-        global_vertex
+        Self::from_surface_and_position(&surface, position_surface)
     }
 
-    fn update_from_surface_and_position(
-        &mut self,
+    fn from_surface_and_position(
         surface: &Surface,
         position: impl Into<Point<2>>,
-    ) -> &mut Self {
-        self.position = Some(surface.point_from_surface_coords(position));
-        self
+    ) -> Self {
+        PartialGlobalVertex {
+            position: Some(surface.point_from_surface_coords(position)),
+        }
     }
 }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -36,10 +36,10 @@ impl SurfaceVertexBuilder for PartialSurfaceVertex {
 pub trait GlobalVertexBuilder {
     /// Update partial global vertex from the given curve and position on it
     fn update_from_curve_and_position(
-        self,
+        &mut self,
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
-    ) -> Self;
+    ) -> &mut Self;
 
     /// Update partial global vertex from the given surface and position on it
     fn update_from_surface_and_position(
@@ -51,10 +51,10 @@ pub trait GlobalVertexBuilder {
 
 impl GlobalVertexBuilder for PartialGlobalVertex {
     fn update_from_curve_and_position(
-        mut self,
+        &mut self,
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
-    ) -> Self {
+    ) -> &mut Self {
         let curve = curve.into().into_partial();
 
         let path = curve.path.expect(
@@ -65,8 +65,7 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
         );
 
         let position_surface = path.point_from_path_coords(position);
-        self.update_from_surface_and_position(&surface, position_surface);
-        self
+        self.update_from_surface_and_position(&surface, position_surface)
     }
 
     fn update_from_surface_and_position(

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -23,11 +23,11 @@ impl VertexBuilder for PartialVertex {
 /// Builder API for [`PartialSurfaceVertex`]
 pub trait SurfaceVertexBuilder {
     /// Infer the global form of the partial vertex
-    fn infer_global_form(self) -> Self;
+    fn infer_global_form(&mut self) -> &mut Self;
 }
 
 impl SurfaceVertexBuilder for PartialSurfaceVertex {
-    fn infer_global_form(mut self) -> Self {
+    fn infer_global_form(&mut self) -> &mut Self {
         self.global_form = GlobalVertex::partial().into();
         self
     }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -27,8 +27,9 @@ pub trait SurfaceVertexBuilder {
 }
 
 impl SurfaceVertexBuilder for PartialSurfaceVertex {
-    fn infer_global_form(self) -> Self {
-        self.with_global_form(Some(GlobalVertex::partial()))
+    fn infer_global_form(mut self) -> Self {
+        self.global_form = GlobalVertex::partial().into();
+        self
     }
 }
 

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -11,11 +11,11 @@ use crate::{
 /// Builder API for [`PartialVertex`]
 pub trait VertexBuilder {
     /// Remove the surface form of the partial vertex, inferring it on build
-    fn infer_surface_form(self) -> Self;
+    fn infer_surface_form(&mut self) -> &mut Self;
 }
 
 impl VertexBuilder for PartialVertex {
-    fn infer_surface_form(mut self) -> Self {
+    fn infer_surface_form(&mut self) -> &mut Self {
         self.surface_form = PartialSurfaceVertex::default().into();
         self
     }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -69,10 +69,11 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
     }
 
     fn update_from_surface_and_position(
-        self,
+        mut self,
         surface: &Surface,
         position: impl Into<Point<2>>,
     ) -> Self {
-        self.with_position(Some(surface.point_from_surface_coords(position)))
+        self.position = Some(surface.point_from_surface_coords(position));
+        self
     }
 }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -43,15 +43,15 @@ pub trait GlobalVertexBuilder {
 
     /// Update partial global vertex from the given surface and position on it
     fn update_from_surface_and_position(
-        self,
+        &mut self,
         surface: &Surface,
         position: impl Into<Point<2>>,
-    ) -> Self;
+    ) -> &mut Self;
 }
 
 impl GlobalVertexBuilder for PartialGlobalVertex {
     fn update_from_curve_and_position(
-        self,
+        mut self,
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
     ) -> Self {
@@ -65,14 +65,15 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
         );
 
         let position_surface = path.point_from_path_coords(position);
-        self.update_from_surface_and_position(&surface, position_surface)
+        self.update_from_surface_and_position(&surface, position_surface);
+        self
     }
 
     fn update_from_surface_and_position(
-        mut self,
+        &mut self,
         surface: &Surface,
         position: impl Into<Point<2>>,
-    ) -> Self {
+    ) -> &mut Self {
         self.position = Some(surface.point_from_surface_coords(position));
         self
     }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -37,11 +37,10 @@ impl SurfaceVertexBuilder for PartialSurfaceVertex {
 /// Builder API for [`PartialGlobalVertex`]
 pub trait GlobalVertexBuilder {
     /// Update partial global vertex from the given curve and position on it
-    fn update_from_curve_and_position(
-        &mut self,
+    fn from_curve_and_position(
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
-    ) -> &mut Self;
+    ) -> Self;
 
     /// Update partial global vertex from the given surface and position on it
     fn update_from_surface_and_position(
@@ -52,11 +51,10 @@ pub trait GlobalVertexBuilder {
 }
 
 impl GlobalVertexBuilder for PartialGlobalVertex {
-    fn update_from_curve_and_position(
-        &mut self,
+    fn from_curve_and_position(
         curve: impl Into<MaybePartial<Curve>>,
         position: impl Into<Point<1>>,
-    ) -> &mut Self {
+    ) -> Self {
         let curve = curve.into().into_partial();
 
         let path = curve.path.expect(
@@ -67,7 +65,11 @@ impl GlobalVertexBuilder for PartialGlobalVertex {
         );
 
         let position_surface = path.point_from_path_coords(position);
-        self.update_from_surface_and_position(&surface, position_surface)
+
+        let mut global_vertex = PartialGlobalVertex::default();
+        global_vertex
+            .update_from_surface_and_position(&surface, position_surface);
+        global_vertex
     }
 
     fn update_from_surface_and_position(

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -15,8 +15,9 @@ pub trait VertexBuilder {
 }
 
 impl VertexBuilder for PartialVertex {
-    fn infer_surface_form(self) -> Self {
-        self.with_surface_form(PartialSurfaceVertex::default())
+    fn infer_surface_form(mut self) -> Self {
+        self.surface_form = PartialSurfaceVertex::default().into();
+        self
     }
 }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -217,7 +217,7 @@ impl MaybePartial<SurfaceVertex> {
     pub fn position(&self) -> Option<Point<2>> {
         match self {
             Self::Full(full) => Some(full.position()),
-            Self::Partial(partial) => partial.position(),
+            Self::Partial(partial) => partial.position,
         }
     }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -225,7 +225,7 @@ impl MaybePartial<SurfaceVertex> {
     pub fn surface(&self) -> Option<Handle<Surface>> {
         match self {
             Self::Full(full) => Some(full.surface().clone()),
-            Self::Partial(partial) => partial.surface(),
+            Self::Partial(partial) => partial.surface.clone(),
         }
     }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -243,7 +243,7 @@ impl MaybePartial<Vertex> {
     pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
         match self {
             Self::Full(full) => full.surface_form().clone().into(),
-            Self::Partial(partial) => partial.surface_form(),
+            Self::Partial(partial) => partial.surface_form.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -233,7 +233,7 @@ impl MaybePartial<SurfaceVertex> {
     pub fn global_form(&self) -> MaybePartial<GlobalVertex> {
         match self {
             Self::Full(full) => full.global_form().clone().into(),
-            Self::Partial(partial) => partial.global_form(),
+            Self::Partial(partial) => partial.global_form.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -96,9 +96,14 @@ impl PartialCycle {
 
             *half_edge = half_edge.clone().merge_with(
                 PartialHalfEdge::default().with_vertices([
-                    PartialVertex::default().with_surface_form(back_vertex),
-                    PartialVertex::default()
-                        .with_surface_form(front_vertex.clone()),
+                    PartialVertex {
+                        surface_form: back_vertex,
+                        ..Default::default()
+                    },
+                    PartialVertex {
+                        surface_form: front_vertex.clone().into(),
+                        ..Default::default()
+                    },
                 ]),
             );
 
@@ -111,9 +116,10 @@ impl PartialCycle {
             let back_vertex = previous_vertex.unwrap_or_default();
 
             *half_edge = half_edge.clone().merge_with(
-                PartialHalfEdge::default().with_back_vertex(
-                    PartialVertex::default().with_surface_form(back_vertex),
-                ),
+                PartialHalfEdge::default().with_back_vertex(PartialVertex {
+                    surface_form: back_vertex,
+                    ..Default::default()
+                }),
             );
         }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -55,10 +55,12 @@ impl PartialHalfEdge {
 
         self.vertices = self.vertices.map(|vertex| {
             vertex.update_partial(|vertex| {
-                let surface_form =
-                    vertex.surface_form().update_partial(|surface_vertex| {
-                        surface_vertex.with_surface(Some(surface.clone()))
-                    });
+                let surface_form = vertex.surface_form().update_partial(
+                    |mut surface_vertex| {
+                        surface_vertex.surface = Some(surface.clone());
+                        surface_vertex
+                    },
+                );
 
                 vertex.with_surface_form(surface_form)
             })

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -55,7 +55,7 @@ impl PartialHalfEdge {
 
         self.vertices = self.vertices.map(|vertex| {
             vertex.update_partial(|vertex| {
-                let surface_form = vertex.surface_form().update_partial(
+                let surface_form = vertex.surface_form.clone().update_partial(
                     |mut surface_vertex| {
                         surface_vertex.surface = Some(surface.clone());
                         surface_vertex

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -54,7 +54,7 @@ impl PartialHalfEdge {
         });
 
         self.vertices = self.vertices.map(|vertex| {
-            vertex.update_partial(|vertex| {
+            vertex.update_partial(|mut vertex| {
                 let surface_form = vertex.surface_form.clone().update_partial(
                     |mut surface_vertex| {
                         surface_vertex.surface = Some(surface.clone());
@@ -62,7 +62,8 @@ impl PartialHalfEdge {
                     },
                 );
 
-                vertex.with_surface_form(surface_form)
+                vertex.surface_form = surface_form;
+                vertex
             })
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -100,7 +100,10 @@ impl PartialHalfEdge {
         let curve = self.curve.into_full(objects)?;
         let vertices = self.vertices.try_map_ext(|vertex| {
             vertex
-                .update_partial(|vertex| vertex.with_curve(curve.clone()))
+                .update_partial(|mut vertex| {
+                    vertex.curve = curve.clone().into();
+                    vertex
+                })
                 .into_full(objects)
         })?;
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -75,14 +75,13 @@ impl PartialVertex {
 
         let surface_form = self
             .surface_form
-            .update_partial(|partial| {
+            .update_partial(|mut partial| {
                 let position = partial.position.unwrap_or_else(|| {
                     curve.path().point_from_path_coords(position)
                 });
 
-                partial
-                    .with_position(Some(position))
-                    .with_surface(Some(curve.surface().clone()))
+                partial.position = Some(position);
+                partial.with_surface(Some(curve.surface().clone()))
             })
             .into_full(objects)?;
 
@@ -128,17 +127,6 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
-    /// Provide a position for the partial surface vertex
-    pub fn with_position(
-        mut self,
-        position: Option<impl Into<Point<2>>>,
-    ) -> Self {
-        if let Some(position) = position {
-            self.position = Some(position.into());
-        }
-        self
-    }
-
     /// Provide a surface for the partial surface vertex
     pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
         if let Some(surface) = surface {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -182,8 +182,10 @@ impl PartialSurfaceVertex {
 
         let global_form = self
             .global_form
-            .update_partial(|global_form| {
-                global_form.update_from_surface_and_position(&surface, position)
+            .update_partial(|mut global_form| {
+                global_form
+                    .update_from_surface_and_position(&surface, position);
+                global_form
             })
             .into_full(objects)?;
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -107,10 +107,10 @@ impl PartialSurfaceVertex {
 
         let global_form = self
             .global_form
-            .update_partial(|mut global_form| {
-                global_form
-                    .update_from_surface_and_position(&surface, position);
-                global_form
+            .update_partial(|_| {
+                PartialGlobalVertex::from_surface_and_position(
+                    &surface, position,
+                )
             })
             .into_full(objects)?;
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -128,11 +128,6 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
-    /// Access the position of the [`SurfaceVertex`]
-    pub fn position(&self) -> Option<Point<2>> {
-        self.position
-    }
-
     /// Access the surface that the [`SurfaceVertex`] is defined in
     pub fn surface(&self) -> Option<Handle<Surface>> {
         self.surface.clone()

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -24,15 +24,6 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
-    /// Provide a surface form for the partial vertex
-    pub fn with_surface_form(
-        mut self,
-        surface_form: impl Into<MaybePartial<SurfaceVertex>>,
-    ) -> Self {
-        self.surface_form = surface_form.into();
-        self
-    }
-
     /// Build a full [`Vertex`] from the partial vertex
     ///
     /// # Panics

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -81,7 +81,9 @@ impl PartialVertex {
                 });
 
                 partial.position = Some(position);
-                partial.with_surface(Some(curve.surface().clone()))
+                partial.surface = Some(curve.surface().clone());
+
+                partial
             })
             .into_full(objects)?;
 
@@ -127,14 +129,6 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
-    /// Provide a surface for the partial surface vertex
-    pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
-        if let Some(surface) = surface {
-            self.surface = Some(surface);
-        }
-        self
-    }
-
     /// Provide a global form for the partial surface vertex
     pub fn with_global_form(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -24,11 +24,6 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
-    /// Access the curve that the [`Vertex`] is defined in
-    pub fn curve(&self) -> MaybePartial<Curve> {
-        self.curve.clone()
-    }
-
     /// Access the surface form of the [`Vertex`]
     pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
         self.surface_form.clone()

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -128,11 +128,6 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
-    /// Access the global form of the [`SurfaceVertex`]
-    pub fn global_form(&self) -> MaybePartial<GlobalVertex> {
-        self.global_form.clone()
-    }
-
     /// Provide a position for the partial surface vertex
     pub fn with_position(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -24,11 +24,6 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
-    /// Access the position of the [`Vertex`] on the curve
-    pub fn position(&self) -> Option<Point<1>> {
-        self.position
-    }
-
     /// Access the curve that the [`Vertex`] is defined in
     pub fn curve(&self) -> MaybePartial<Curve> {
         self.curve.clone()

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -128,11 +128,6 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
-    /// Access the surface that the [`SurfaceVertex`] is defined in
-    pub fn surface(&self) -> Option<Handle<Surface>> {
-        self.surface.clone()
-    }
-
     /// Access the global form of the [`SurfaceVertex`]
     pub fn global_form(&self) -> MaybePartial<GlobalVertex> {
         self.global_form.clone()

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -218,7 +218,8 @@ impl From<&SurfaceVertex> for PartialSurfaceVertex {
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialGlobalVertex {
-    position: Option<Point<3>>,
+    /// The position of the [`GlobalVertex`]
+    pub position: Option<Point<3>>,
 }
 
 impl PartialGlobalVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -24,17 +24,6 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
-    /// Provide a position for the partial vertex
-    pub fn with_position(
-        mut self,
-        position: Option<impl Into<Point<1>>>,
-    ) -> Self {
-        if let Some(position) = position {
-            self.position = Some(position.into());
-        }
-        self
-    }
-
     /// Provide a curve for the partial vertex
     pub fn with_curve(mut self, curve: impl Into<MaybePartial<Curve>>) -> Self {
         self.curve = curve.into();

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -24,12 +24,6 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
-    /// Provide a curve for the partial vertex
-    pub fn with_curve(mut self, curve: impl Into<MaybePartial<Curve>>) -> Self {
-        self.curve = curve.into();
-        self
-    }
-
     /// Provide a surface form for the partial vertex
     pub fn with_surface_form(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -129,17 +129,6 @@ pub struct PartialSurfaceVertex {
 }
 
 impl PartialSurfaceVertex {
-    /// Provide a global form for the partial surface vertex
-    pub fn with_global_form(
-        mut self,
-        global_form: Option<impl Into<MaybePartial<GlobalVertex>>>,
-    ) -> Self {
-        if let Some(global_form) = global_form {
-            self.global_form = global_form.into();
-        }
-        self
-    }
-
     /// Build a full [`SurfaceVertex`] from the partial surface vertex
     pub fn build(
         self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -107,11 +107,9 @@ impl PartialSurfaceVertex {
 
         let global_form = self
             .global_form
-            .update_partial(|_| {
-                PartialGlobalVertex::from_surface_and_position(
-                    &surface, position,
-                )
-            })
+            .merge_with(PartialGlobalVertex::from_surface_and_position(
+                &surface, position,
+            ))
             .into_full(objects)?;
 
         Ok(SurfaceVertex::new(position, surface, global_form))

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -24,11 +24,6 @@ pub struct PartialVertex {
 }
 
 impl PartialVertex {
-    /// Access the surface form of the [`Vertex`]
-    pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
-        self.surface_form.clone()
-    }
-
     /// Provide a position for the partial vertex
     pub fn with_position(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -117,9 +117,14 @@ impl From<&Vertex> for PartialVertex {
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PartialSurfaceVertex {
-    position: Option<Point<2>>,
-    surface: Option<Handle<Surface>>,
-    global_form: MaybePartial<GlobalVertex>,
+    /// The position of the [`SurfaceVertex`]
+    pub position: Option<Point<2>>,
+
+    /// The surface that the [`SurfaceVertex`] is defined in
+    pub surface: Option<Handle<Surface>>,
+
+    /// The global form of the [`SurfaceVertex`]
+    pub global_form: MaybePartial<GlobalVertex>,
 }
 
 impl PartialSurfaceVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -223,17 +223,6 @@ pub struct PartialGlobalVertex {
 }
 
 impl PartialGlobalVertex {
-    /// Provide a position for the partial global vertex
-    pub fn with_position(
-        mut self,
-        position: Option<impl Into<Point<3>>>,
-    ) -> Self {
-        if let Some(position) = position {
-            self.position = Some(position.into());
-        }
-        self
-    }
-
     /// Build a full [`GlobalVertex`] from the partial global vertex
     pub fn build(self, _: &Objects) -> Result<GlobalVertex, ValidationError> {
         let position = self

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -13,9 +13,14 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialVertex {
-    position: Option<Point<1>>,
-    curve: MaybePartial<Curve>,
-    surface_form: MaybePartial<SurfaceVertex>,
+    /// The position of the [`Vertex`]
+    pub position: Option<Point<1>>,
+
+    /// The curve that the [`Vertex`] is defined in
+    pub curve: MaybePartial<Curve>,
+
+    /// The surface form of the [`Vertex`]
+    pub surface_form: MaybePartial<SurfaceVertex>,
 }
 
 impl PartialVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -223,11 +223,6 @@ pub struct PartialGlobalVertex {
 }
 
 impl PartialGlobalVertex {
-    /// Access the position of the [`GlobalVertex`]
-    pub fn position(&self) -> Option<Point<3>> {
-        self.position
-    }
-
     /// Provide a position for the partial global vertex
     pub fn with_position(
         mut self,

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -95,7 +95,8 @@ mod tests {
 
             // Sever connection between the last and first half-edge in the
             // cycle.
-            let first_vertex = first_vertex.into_partial().infer_surface_form();
+            let mut first_vertex = first_vertex.into_partial();
+            first_vertex.infer_surface_form();
             *first_half_edge = first_half_edge
                 .clone()
                 .with_back_vertex(first_vertex)

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -220,12 +220,10 @@ mod tests {
             .build(&objects)?;
         let invalid = {
             let mut vertices = valid.vertices().clone();
-            vertices[1] = vertices[1]
-                .to_partial()
-                // Arranging for an equal but not identical curve here.
-                .with_curve(valid.curve().to_partial())
-                .build(&objects)?
-                .insert(&objects)?;
+            let mut vertex = vertices[1].to_partial();
+            // Arranging for an equal but not identical curve here.
+            vertex.curve = valid.curve().to_partial().into();
+            vertices[1] = vertex.build(&objects)?.insert(&objects)?;
 
             HalfEdge::new(vertices, valid.global_form().clone())
         };

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -308,9 +308,9 @@ mod tests {
         let invalid = HalfEdge::new(
             valid.vertices().clone().try_map_ext(
                 |vertex| -> anyhow::Result<_, ValidationError> {
+                    let mut vertex = vertex.to_partial();
+                    vertex.position = Some([0.].into());
                     Ok(vertex
-                        .to_partial()
-                        .with_position(Some([0.]))
                         .infer_surface_form()
                         .build(&objects)?
                         .insert(&objects)?)

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -308,10 +308,8 @@ mod tests {
                 |vertex| -> anyhow::Result<_, ValidationError> {
                     let mut vertex = vertex.to_partial();
                     vertex.position = Some([0.].into());
-                    Ok(vertex
-                        .infer_surface_form()
-                        .build(&objects)?
-                        .insert(&objects)?)
+                    vertex.infer_surface_form();
+                    Ok(vertex.build(&objects)?.insert(&objects)?)
                 },
             )?,
             valid.global_form().clone(),

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -182,7 +182,9 @@ mod tests {
         builder::{CurveBuilder, SurfaceVertexBuilder},
         insert::Insert,
         objects::{GlobalVertex, Objects, SurfaceVertex, Vertex},
-        partial::{HasPartial, PartialCurve, PartialSurfaceVertex},
+        partial::{
+            HasPartial, PartialCurve, PartialSurfaceVertex, PartialVertex,
+        },
         validate::Validate,
     };
 
@@ -196,10 +198,12 @@ mod tests {
         };
         curve.update_as_u_axis();
 
-        let valid = Vertex::partial()
-            .with_position(Some([0.]))
-            .with_curve(curve)
-            .build(&objects)?;
+        let valid = PartialVertex {
+            position: Some([0.].into()),
+            ..Default::default()
+        }
+        .with_curve(curve)
+        .build(&objects)?;
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.surface = Some(objects.surfaces.xz_plane());
@@ -223,10 +227,12 @@ mod tests {
             };
             curve.update_as_u_axis();
 
-            Vertex::partial()
-                .with_position(Some([0.]))
-                .with_curve(curve)
-                .build(&objects)?
+            PartialVertex {
+                position: Some([0.].into()),
+                ..Default::default()
+            }
+            .with_curve(curve)
+            .build(&objects)?
         };
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -200,16 +200,11 @@ mod tests {
             .with_position(Some([0.]))
             .with_curve(curve)
             .build(&objects)?;
-        let invalid = Vertex::new(
-            valid.position(),
-            valid.curve().clone(),
-            valid
-                .surface_form()
-                .to_partial()
-                .with_surface(Some(objects.surfaces.xz_plane()))
-                .build(&objects)?
-                .insert(&objects)?,
-        );
+        let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
+            let mut tmp = valid.surface_form().to_partial();
+            tmp.surface = Some(objects.surfaces.xz_plane());
+            tmp.build(&objects)?.insert(&objects)?
+        });
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
@@ -251,9 +246,9 @@ mod tests {
 
         let valid = PartialSurfaceVertex {
             position: Some([0., 0.].into()),
+            surface: Some(objects.surfaces.xy_plane()),
             ..Default::default()
         }
-        .with_surface(Some(objects.surfaces.xy_plane()))
         .build(&objects)?;
         let invalid = SurfaceVertex::new(
             valid.position(),

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -231,7 +231,8 @@ mod tests {
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.position = Some([1., 0.].into());
-            tmp.infer_global_form().build(&objects)?.insert(&objects)?
+            tmp.infer_global_form();
+            tmp.build(&objects)?.insert(&objects)?
         });
 
         assert!(valid.validate().is_ok());

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -200,9 +200,9 @@ mod tests {
 
         let valid = PartialVertex {
             position: Some([0.].into()),
+            curve: curve.into(),
             ..Default::default()
         }
-        .with_curve(curve)
         .build(&objects)?;
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
@@ -229,9 +229,9 @@ mod tests {
 
             PartialVertex {
                 position: Some([0.].into()),
+                curve: curve.into(),
                 ..Default::default()
             }
-            .with_curve(curve)
             .build(&objects)?
         };
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {


### PR DESCRIPTION
Cleans up the partial object types for vertices according to ideas from #1249.

This makes quite a bit of code that benefited from the builder-style API. I think that's okay for now, as it doesn't make the code more *complicated*, and I think simplifying the APIs is worth more right now than the added convenience. Once the partial object API has settled down somewhat, it'll be worth looking into which convenience APIs to add back.