### PR TITLE
Continue cleaning up partial object code

### DIFF
--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -32,10 +32,7 @@ impl TransformObject for PartialCurve {
             .surface
             .map(|surface| surface.transform(transform, objects))
             .transpose()?;
-        let global_form = self
-            .global_form
-            .map(|global_form| global_form.transform(transform, objects))
-            .transpose()?;
+        let global_form = self.global_form.transform(transform, objects)?;
 
         // Don't need to transform `self.path`, as that's defined in surface
         // coordinates, and thus transforming `surface` takes care of it.

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -28,11 +28,13 @@ impl TransformObject for PartialHalfEdge {
                 Ok(vertex)
             },
         )?;
-        let global_form = self
+        let mut global_form = self
             .global_form()
             .into_partial()
-            .transform(transform, objects)?
-            .with_curve(curve.global_form());
+            .transform(transform, objects)?;
+        if let Some(curve) = curve.global_form() {
+            global_form.curve = curve;
+        }
 
         Ok(Self::default()
             .with_curve(curve)
@@ -57,8 +59,10 @@ impl TransformObject for PartialGlobalEdge {
             })
             .transpose()?;
 
-        Ok(Self::default()
-            .with_curve(Some(curve))
-            .with_vertices(vertices))
+        Ok(Self {
+            curve,
+            ..Default::default()
+        }
+        .with_vertices(vertices))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -17,11 +17,10 @@ impl TransformObject for PartialHalfEdge {
     ) -> Result<Self, ValidationError> {
         let curve: MaybePartial<_> = self
             .curve
-            .clone()
             .into_partial()
             .transform(transform, objects)?
             .into();
-        let vertices = self.vertices.clone().try_map_ext(
+        let vertices = self.vertices.try_map_ext(
             |vertex| -> Result<_, ValidationError> {
                 let mut vertex =
                     vertex.into_partial().transform(transform, objects)?;
@@ -30,7 +29,7 @@ impl TransformObject for PartialHalfEdge {
             },
         )?;
         let mut global_form = self
-            .global_form()
+            .global_form
             .into_partial()
             .transform(transform, objects)?;
         if let Some(curve) = curve.global_form() {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -50,14 +50,11 @@ impl TransformObject for PartialGlobalEdge {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
-        let vertices = self
-            .vertices
-            .map(|vertices| {
-                vertices.try_map_ext(|vertex| -> Result<_, ValidationError> {
-                    vertex.transform(transform, objects)
-                })
-            })
-            .transpose()?;
+        let vertices = self.vertices.try_map_ext(
+            |vertex| -> Result<_, ValidationError> {
+                vertex.transform(transform, objects)
+            },
+        )?;
 
         Ok(Self { curve, vertices })
     }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -21,7 +21,7 @@ impl TransformObject for PartialHalfEdge {
             .into_partial()
             .transform(transform, objects)?
             .into();
-        let vertices = self.vertices().try_map_ext(
+        let vertices = self.vertices.clone().try_map_ext(
             |vertex| -> Result<_, ValidationError> {
                 let mut vertex =
                     vertex.into_partial().transform(transform, objects)?;

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -32,9 +32,7 @@ impl TransformObject for PartialHalfEdge {
             .global_form
             .into_partial()
             .transform(transform, objects)?;
-        if let Some(curve) = curve.global_form() {
-            global_form.curve = curve;
-        }
+        global_form.curve = curve.global_form();
 
         Ok(Self::default()
             .with_curve(curve)

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -59,10 +59,6 @@ impl TransformObject for PartialGlobalEdge {
             })
             .transpose()?;
 
-        Ok(Self {
-            curve,
-            ..Default::default()
-        }
-        .with_vertices(vertices))
+        Ok(Self { curve, vertices })
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -47,7 +47,7 @@ impl TransformObject for PartialGlobalEdge {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self.curve().transform(transform, objects)?;
+        let curve = self.curve.clone().transform(transform, objects)?;
         let vertices = self
             .vertices()
             .map(|vertices| {

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -47,9 +47,9 @@ impl TransformObject for PartialGlobalEdge {
         transform: &Transform,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let curve = self.curve.clone().transform(transform, objects)?;
+        let curve = self.curve.transform(transform, objects)?;
         let vertices = self
-            .vertices()
+            .vertices
             .map(|vertices| {
                 vertices.try_map_ext(|vertex| -> Result<_, ValidationError> {
                     vertex.transform(transform, objects)

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -16,7 +16,8 @@ impl TransformObject for PartialHalfEdge {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let curve: MaybePartial<_> = self
-            .curve()
+            .curve
+            .clone()
             .into_partial()
             .transform(transform, objects)?
             .into();

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -184,14 +184,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .collect::<[_; 2]>()
                 .map(|(vertex, global_form)| {
                     vertex.update_partial(|mut vertex| {
-                        let surface_form = PartialSurfaceVertex {
-                            global_form,
-                            ..Default::default()
-                        };
-
-                        vertex.surface_form =
-                            vertex.surface_form.merge_with(surface_form);
-
+                        vertex.surface_form = vertex.surface_form.merge_with(
+                            PartialSurfaceVertex {
+                                global_form,
+                                ..Default::default()
+                            },
+                        );
                         vertex
                     })
                 })

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -66,7 +66,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let mut curve = self.curve.clone().into_partial();
-        curve.global_form = self.extract_global_curve();
         curve.update_as_circle_from_radius(radius);
 
         let path = curve.path.expect("Expected path that was just created");
@@ -136,7 +135,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let mut curve = self.curve.clone().into_partial();
         curve.surface = Some(surface);
-        curve.global_form = self.extract_global_curve();
         curve.update_as_line_from_points(points);
 
         let [back, front] = {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -74,7 +74,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        let [global_vertex, _] = self.global_form().vertices();
+        let [global_vertex, _] = self.global_form.vertices();
 
         let surface_vertex = PartialSurfaceVertex {
             position: Some(path.point_from_path_coords(a_curve)),
@@ -170,7 +170,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                     must_switch_order
                 };
 
-                let [a, b] = self.global_form().vertices();
+                let [a, b] = self.global_form.vertices();
                 if must_switch_order {
                     [b, a]
                 } else {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -51,12 +51,12 @@ pub trait HalfEdgeBuilder: Sized {
 
 impl HalfEdgeBuilder for PartialHalfEdge {
     fn with_back_vertex(self, back: impl Into<MaybePartial<Vertex>>) -> Self {
-        let [_, front] = self.vertices();
+        let [_, front] = self.vertices.clone();
         self.with_vertices([back.into(), front])
     }
 
     fn with_front_vertex(self, front: impl Into<MaybePartial<Vertex>>) -> Self {
-        let [back, _] = self.vertices();
+        let [back, _] = self.vertices.clone();
         self.with_vertices([back, front.into()])
     }
 
@@ -118,7 +118,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     }
 
     fn update_as_line_segment(self) -> Self {
-        let [from, to] = self.vertices();
+        let [from, to] = self.vertices.clone();
         let [from_surface, to_surface] =
             [&from, &to].map(|vertex| vertex.surface_form());
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -65,7 +65,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         radius: impl Into<Scalar>,
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
-        let mut curve = self.curve().into_partial();
+        let mut curve = self.curve.clone().into_partial();
         curve.global_form = Some(self.extract_global_curve());
         curve.update_as_circle_from_radius(radius);
 
@@ -123,7 +123,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             [&from, &to].map(|vertex| vertex.surface_form());
 
         let surface = self
-            .curve()
+            .curve
             .surface()
             .merge_with(from_surface.surface())
             .merge_with(to_surface.surface())

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -235,13 +235,13 @@ pub trait GlobalEdgeBuilder {
 
 impl GlobalEdgeBuilder for PartialGlobalEdge {
     fn update_from_curve_and_vertices(
-        self,
+        mut self,
         curve: &Curve,
         vertices: &[Handle<Vertex>; 2],
     ) -> Self {
-        self.with_curve(Some(curve.global_form().clone()))
-            .with_vertices(Some(
-                vertices.clone().map(|vertex| vertex.global_form().clone()),
-            ))
+        self.curve = curve.global_form().clone().into();
+        self.with_vertices(Some(
+            vertices.clone().map(|vertex| vertex.global_form().clone()),
+        ))
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -171,8 +171,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 };
 
                 let [a, b] = self.global_form().vertices();
-                let [a, b] = if must_switch_order { [b, a] } else { [a, b] };
-                [Some(a), Some(b)]
+                if must_switch_order {
+                    [b, a]
+                } else {
+                    [a, b]
+                }
             };
 
             vertices
@@ -181,10 +184,10 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .collect::<[_; 2]>()
                 .map(|(vertex, global_form)| {
                     vertex.update_partial(|mut vertex| {
-                        let mut surface_form = PartialSurfaceVertex::default();
-                        if let Some(global_form) = global_form {
-                            surface_form.global_form = global_form;
-                        }
+                        let surface_form = PartialSurfaceVertex {
+                            global_form,
+                            ..Default::default()
+                        };
 
                         vertex.surface_form =
                             vertex.surface_form.merge_with(surface_form);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -5,8 +5,8 @@ use crate::{
     insert::Insert,
     objects::{Curve, Objects, Surface, Vertex, VerticesInNormalizedOrder},
     partial::{
-        MaybePartial, MergeWith, PartialCurve, PartialGlobalEdge,
-        PartialHalfEdge, PartialSurfaceVertex, PartialVertex,
+        MaybePartial, MergeWith, PartialGlobalEdge, PartialHalfEdge,
+        PartialSurfaceVertex, PartialVertex,
     },
     storage::Handle,
     validate::ValidationError,
@@ -134,11 +134,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .expect("Can't infer line segment without surface position")
         });
 
-        let mut curve = PartialCurve {
-            surface: Some(surface),
-            global_form: self.extract_global_curve(),
-            ..Default::default()
-        };
+        let mut curve = self.curve.clone().into_partial();
+        curve.surface = Some(surface);
+        curve.global_form = self.extract_global_curve();
         curve.update_as_line_from_points(points);
 
         let [back, front] = {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -202,14 +202,14 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .collect::<[_; 2]>()
                 .map(|(vertex, global_form)| {
                     vertex.update_partial(|mut vertex| {
-                        vertex.surface_form = vertex
-                            .surface_form
-                            .update_partial(|mut surface_vertex| {
-                                if let Some(global_form) = global_form {
-                                    surface_vertex.global_form = global_form;
-                                }
-                                surface_vertex
-                            });
+                        let mut surface_form = PartialSurfaceVertex::default();
+                        if let Some(global_form) = global_form {
+                            surface_form.global_form = global_form;
+                        }
+
+                        vertex.surface_form =
+                            vertex.surface_form.merge_with(surface_form);
+
                         vertex
                     })
                 })

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -6,14 +6,13 @@ use crate::{
     objects::{Curve, Objects, Surface, Vertex, VerticesInNormalizedOrder},
     partial::{
         MaybePartial, MergeWith, PartialCurve, PartialGlobalEdge,
-        PartialGlobalVertex, PartialHalfEdge, PartialSurfaceVertex,
-        PartialVertex,
+        PartialHalfEdge, PartialSurfaceVertex, PartialVertex,
     },
     storage::Handle,
     validate::ValidationError,
 };
 
-use super::{CurveBuilder, GlobalVertexBuilder};
+use super::CurveBuilder;
 
 /// Builder API for [`PartialHalfEdge`]
 pub trait HalfEdgeBuilder: Sized {
@@ -75,17 +74,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        let global_vertex = self
-            .global_form()
-            .vertices()
-            .map(|[global_form, _]| global_form)
-            .unwrap_or_else(|| {
-                PartialGlobalVertex::from_curve_and_position(
-                    curve.clone(),
-                    a_curve,
-                )
-                .into()
-            });
+        let [global_vertex, _] = self.global_form().vertices();
 
         let surface_vertex = PartialSurfaceVertex {
             position: Some(path.point_from_path_coords(a_curve)),
@@ -181,19 +170,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                     must_switch_order
                 };
 
-                self.global_form()
-                    .vertices()
-                    .map(
-                        |[a, b]| {
-                            if must_switch_order {
-                                [b, a]
-                            } else {
-                                [a, b]
-                            }
-                        },
-                    )
-                    .map(|[a, b]| [Some(a), Some(b)])
-                    .unwrap_or([None, None])
+                let [a, b] = self.global_form().vertices();
+                let [a, b] = if must_switch_order { [b, a] } else { [a, b] };
+                [Some(a), Some(b)]
             };
 
             vertices

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -240,11 +240,9 @@ impl GlobalEdgeBuilder for PartialGlobalEdge {
         vertices: &[Handle<Vertex>; 2],
     ) -> Self {
         self.curve = curve.global_form().clone().into();
-        self.vertices = Some(
-            vertices
-                .clone()
-                .map(|vertex| vertex.global_form().clone().into()),
-        );
+        self.vertices = vertices
+            .clone()
+            .map(|vertex| vertex.global_form().clone().into());
         self
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -240,8 +240,11 @@ impl GlobalEdgeBuilder for PartialGlobalEdge {
         vertices: &[Handle<Vertex>; 2],
     ) -> Self {
         self.curve = curve.global_form().clone().into();
-        self.with_vertices(Some(
-            vertices.clone().map(|vertex| vertex.global_form().clone()),
-        ))
+        self.vertices = Some(
+            vertices
+                .clone()
+                .map(|vertex| vertex.global_form().clone().into()),
+        );
+        self
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -66,7 +66,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         objects: &Objects,
     ) -> Result<Self, ValidationError> {
         let mut curve = self.curve.clone().into_partial();
-        curve.global_form = Some(self.extract_global_curve());
+        curve.global_form = self.extract_global_curve();
         curve.update_as_circle_from_radius(radius);
 
         let path = curve.path.expect("Expected path that was just created");
@@ -136,7 +136,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let mut curve = PartialCurve {
             surface: Some(surface),
-            global_form: Some(self.extract_global_curve()),
+            global_form: self.extract_global_curve(),
             ..Default::default()
         };
         curve.update_as_line_from_points(points);

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -161,13 +161,11 @@ impl<'a> ShellBuilder<'a> {
                         };
 
                         let curve = PartialCurve {
-                            global_form: Some(
-                                side_up_prev
-                                    .curve()
-                                    .global_form()
-                                    .clone()
-                                    .into(),
-                            ),
+                            global_form: side_up_prev
+                                .curve()
+                                .global_form()
+                                .clone()
+                                .into(),
                             ..Default::default()
                         };
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -155,10 +155,10 @@ impl MaybePartial<Curve> {
     }
 
     /// Access the global form
-    pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
+    pub fn global_form(&self) -> MaybePartial<GlobalCurve> {
         match self {
-            Self::Full(full) => Some(full.global_form().clone().into()),
-            Self::Partial(partial) => Some(partial.global_form.clone()),
+            Self::Full(full) => full.global_form().clone().into(),
+            Self::Partial(partial) => partial.global_form.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -173,12 +173,12 @@ impl MaybePartial<GlobalEdge> {
     }
 
     /// Access the vertices
-    pub fn vertices(&self) -> Option<[MaybePartial<GlobalVertex>; 2]> {
+    pub fn vertices(&self) -> [MaybePartial<GlobalVertex>; 2] {
         match self {
-            Self::Full(full) => Some(
-                full.vertices().access_in_normalized_order().map(Into::into),
-            ),
-            Self::Partial(partial) => Some(partial.vertices.clone()),
+            Self::Full(full) => {
+                full.vertices().access_in_normalized_order().map(Into::into)
+            }
+            Self::Partial(partial) => partial.vertices.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -178,7 +178,7 @@ impl MaybePartial<GlobalEdge> {
             Self::Full(full) => Some(
                 full.vertices().access_in_normalized_order().map(Into::into),
             ),
-            Self::Partial(partial) => partial.vertices(),
+            Self::Partial(partial) => partial.vertices.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -197,7 +197,7 @@ impl MaybePartial<HalfEdge> {
         match self {
             Self::Full(full) => full.front().clone().into(),
             Self::Partial(partial) => {
-                let [_, front] = &partial.vertices();
+                let [_, front] = &partial.vertices;
                 front.clone()
             }
         }
@@ -207,7 +207,7 @@ impl MaybePartial<HalfEdge> {
     pub fn vertices(&self) -> [MaybePartial<Vertex>; 2] {
         match self {
             Self::Full(full) => full.vertices().clone().map(Into::into),
-            Self::Partial(partial) => partial.vertices(),
+            Self::Partial(partial) => partial.vertices.clone(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -168,7 +168,7 @@ impl MaybePartial<GlobalEdge> {
     pub fn curve(&self) -> MaybePartial<GlobalCurve> {
         match self {
             Self::Full(full) => full.curve().clone().into(),
-            Self::Partial(partial) => partial.curve(),
+            Self::Partial(partial) => partial.curve.clone(),
         }
     }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -188,7 +188,7 @@ impl MaybePartial<HalfEdge> {
     pub fn curve(&self) -> MaybePartial<Curve> {
         match self {
             Self::Full(full) => full.curve().clone().into(),
-            Self::Partial(partial) => partial.curve(),
+            Self::Partial(partial) => partial.curve.clone(),
         }
     }
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -178,7 +178,7 @@ impl MaybePartial<GlobalEdge> {
             Self::Full(full) => Some(
                 full.vertices().access_in_normalized_order().map(Into::into),
             ),
-            Self::Partial(partial) => partial.vertices.clone(),
+            Self::Partial(partial) => Some(partial.vertices.clone()),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -158,7 +158,7 @@ impl MaybePartial<Curve> {
     pub fn global_form(&self) -> Option<MaybePartial<GlobalCurve>> {
         match self {
             Self::Full(full) => Some(full.global_form().clone().into()),
-            Self::Partial(partial) => partial.global_form.clone(),
+            Self::Partial(partial) => Some(partial.global_form.clone()),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -6,7 +6,7 @@ use crate::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, Vertex,
     },
-    partial::{MaybePartial, MergeWith, PartialCurve},
+    partial::{MaybePartial, MergeWith, PartialCurve, PartialVertex},
     storage::Handle,
     validate::ValidationError,
 };
@@ -97,9 +97,9 @@ impl PartialHalfEdge {
         };
         let vertices = self.vertices.try_map_ext(|vertex| {
             vertex
-                .update_partial(|mut vertex| {
-                    vertex.curve = curve.clone().into();
-                    vertex
+                .merge_with(PartialVertex {
+                    curve: curve.clone().into(),
+                    ..Default::default()
                 })
                 .into_full(objects)
         })?;

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -27,11 +27,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Access the vertices that bound this [`HalfEdge`] in the [`Curve`]
-    pub fn vertices(&self) -> [MaybePartial<Vertex>; 2] {
-        self.vertices.clone()
-    }
-
     /// Access the global form of the [`HalfEdge`]
     pub fn global_form(&self) -> MaybePartial<GlobalEdge> {
         self.global_form.clone()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -33,8 +33,7 @@ impl PartialHalfEdge {
     pub fn extract_global_curve(&self) -> MaybePartial<GlobalCurve> {
         self.curve
             .global_form()
-            .map(|global_form| global_form.merge_with(self.global_form.curve()))
-            .unwrap_or_else(|| self.global_form.curve())
+            .merge_with(self.global_form.curve())
     }
 
     /// Update the partial half-edge with the given surface

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -27,15 +27,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Extract the global curve from either the curve or global form
-    ///
-    /// If a global curve is available through both, the curve is preferred.
-    pub fn extract_global_curve(&self) -> MaybePartial<GlobalCurve> {
-        self.curve
-            .global_form()
-            .merge_with(self.global_form.curve())
-    }
-
     /// Update the partial half-edge with the given surface
     pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
         self.curve = self.curve.update_partial(|mut curve| {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -16,9 +16,14 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialHalfEdge {
-    curve: MaybePartial<Curve>,
-    vertices: [MaybePartial<Vertex>; 2],
-    global_form: MaybePartial<GlobalEdge>,
+    /// The curve that the [`HalfEdge`] is defined in
+    pub curve: MaybePartial<Curve>,
+
+    /// The vertices that bound the [`HalfEdge`] in the curve
+    pub vertices: [MaybePartial<Vertex>; 2],
+
+    /// The global form of the [`HalfEdge`]
+    pub global_form: MaybePartial<GlobalEdge>,
 }
 
 impl PartialHalfEdge {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -27,11 +27,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Access the global form of the [`HalfEdge`]
-    pub fn global_form(&self) -> MaybePartial<GlobalEdge> {
-        self.global_form.clone()
-    }
-
     /// Extract the global curve from either the curve or global form
     ///
     /// If a global curve is available through both, the curve is preferred.

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -157,11 +157,6 @@ pub struct PartialGlobalEdge {
 }
 
 impl PartialGlobalEdge {
-    /// Access the vertices that bound the [`GlobalEdge`] in the curve
-    pub fn vertices(&self) -> Option<[MaybePartial<GlobalVertex>; 2]> {
-        self.vertices.clone()
-    }
-
     /// Update the partial global edge with the given curve
     pub fn with_curve(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -157,11 +157,6 @@ pub struct PartialGlobalEdge {
 }
 
 impl PartialGlobalEdge {
-    /// Access the curve that the [`GlobalEdge`] is defined in
-    pub fn curve(&self) -> MaybePartial<GlobalCurve> {
-        self.curve.clone()
-    }
-
     /// Access the vertices that bound the [`GlobalEdge`] in the curve
     pub fn vertices(&self) -> Option<[MaybePartial<GlobalVertex>; 2]> {
         self.vertices.clone()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -33,6 +33,7 @@ impl PartialHalfEdge {
     pub fn extract_global_curve(&self) -> MaybePartial<GlobalCurve> {
         self.curve
             .global_form()
+            .map(|global_form| global_form.merge_with(self.global_form.curve()))
             .unwrap_or_else(|| self.global_form.curve())
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -27,11 +27,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Access the curve that the [`HalfEdge`] is defined in
-    pub fn curve(&self) -> MaybePartial<Curve> {
-        self.curve.clone()
-    }
-
     /// Access the vertices that bound this [`HalfEdge`] in the [`Curve`]
     pub fn vertices(&self) -> [MaybePartial<Vertex>; 2] {
         self.vertices.clone()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -157,17 +157,6 @@ pub struct PartialGlobalEdge {
 }
 
 impl PartialGlobalEdge {
-    /// Update the partial global edge with the given curve
-    pub fn with_curve(
-        mut self,
-        curve: Option<impl Into<MaybePartial<GlobalCurve>>>,
-    ) -> Self {
-        if let Some(curve) = curve {
-            self.curve = curve.into();
-        }
-        self
-    }
-
     /// Update the partial global edge with the given vertices
     pub fn with_vertices(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -149,8 +149,11 @@ impl From<&HalfEdge> for PartialHalfEdge {
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {
-    curve: MaybePartial<GlobalCurve>,
-    vertices: Option<[MaybePartial<GlobalVertex>; 2]>,
+    /// The curve that the [`GlobalEdge`] is defined in
+    pub curve: MaybePartial<GlobalCurve>,
+
+    /// The vertices that bound the [`GlobalEdge`] in the curve
+    pub vertices: Option<[MaybePartial<GlobalVertex>; 2]>,
 }
 
 impl PartialGlobalEdge {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -157,17 +157,6 @@ pub struct PartialGlobalEdge {
 }
 
 impl PartialGlobalEdge {
-    /// Update the partial global edge with the given vertices
-    pub fn with_vertices(
-        mut self,
-        vertices: Option<[impl Into<MaybePartial<GlobalVertex>>; 2]>,
-    ) -> Self {
-        if let Some(vertices) = vertices {
-            self.vertices = Some(vertices.map(Into::into));
-        }
-        self
-    }
-
     /// Build a full [`GlobalEdge`] from the partial global edge
     pub fn build(
         self,

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -91,7 +91,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             let first_half_edge = &mut half_edges[0];
-            let [first_vertex, _] = first_half_edge.vertices();
+            let [first_vertex, _] = first_half_edge.vertices.clone();
 
             // Sever connection between the last and first half-edge in the
             // cycle.

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -244,15 +244,11 @@ mod tests {
                 [[0., 0.], [1., 0.]],
             )
             .build(&objects)?;
-        let invalid = HalfEdge::new(
-            valid.vertices().clone(),
-            valid
-                .global_form()
-                .to_partial()
-                .with_curve(Some(objects.global_curves.insert(GlobalCurve)?))
-                .build(&objects)?
-                .insert(&objects)?,
-        );
+        let invalid = HalfEdge::new(valid.vertices().clone(), {
+            let mut tmp = valid.global_form().to_partial();
+            tmp.curve = objects.global_curves.insert(GlobalCurve)?.into();
+            tmp.build(&objects)?.insert(&objects)?
+        });
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -266,22 +266,18 @@ mod tests {
                 [[0., 0.], [1., 0.]],
             )
             .build(&objects)?;
-        let invalid = HalfEdge::new(
-            valid.vertices().clone(),
-            valid
-                .global_form()
-                .to_partial()
-                .with_vertices(Some(
-                    valid
-                        .global_form()
-                        .vertices()
-                        .access_in_normalized_order()
-                        // Creating equal but not identical vertices here.
-                        .map(|vertex| vertex.to_partial()),
-                ))
-                .build(&objects)?
-                .insert(&objects)?,
-        );
+        let invalid = HalfEdge::new(valid.vertices().clone(), {
+            let mut tmp = valid.global_form().to_partial();
+            tmp.vertices = Some(
+                valid
+                    .global_form()
+                    .vertices()
+                    .access_in_normalized_order()
+                    // Creating equal but not identical vertices here.
+                    .map(|vertex| vertex.to_partial().into()),
+            );
+            tmp.build(&objects)?.insert(&objects)?
+        });
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -268,14 +268,12 @@ mod tests {
             .build(&objects)?;
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
-            tmp.vertices = Some(
-                valid
-                    .global_form()
-                    .vertices()
-                    .access_in_normalized_order()
-                    // Creating equal but not identical vertices here.
-                    .map(|vertex| vertex.to_partial().into()),
-            );
+            tmp.vertices = valid
+                .global_form()
+                .vertices()
+                .access_in_normalized_order()
+                // Creating equal but not identical vertices here.
+                .map(|vertex| vertex.to_partial().into());
             tmp.build(&objects)?.insert(&objects)?
         });
 


### PR DESCRIPTION
Clean up `PartialGlobalEdge`, start cleaning up `PartialHalfEdge`, and make some smaller changes. All of this is based on the latest round of ideas in #1249, namely lowering the level of abstraction of the partial object API again, and leaning more heavily on the merge operation.

I'm starting to run into some of the more load-bearing code, which introduces some complications, but so far I haven't run into anything that would invalidate these ideas. We'll see how that goes, as I continue these cleanups.