### PR TITLE
Fix potential soundness hole in version comparison

### DIFF
--- a/crates/fj-app/Cargo.toml
+++ b/crates/fj-app/Cargo.toml
@@ -32,7 +32,7 @@ fj-window.workspace = true
 
 [dependencies.clap]
 version = "4.0.23"
-features = ["derive"]
+features = ["derive", "string"]
 
 [dependencies.figment]
 version = "0.10.8"

--- a/crates/fj-app/src/args.rs
+++ b/crates/fj-app/src/args.rs
@@ -7,7 +7,7 @@ use fj_math::Scalar;
 
 /// Fornjot - Experimental CAD System
 #[derive(clap::Parser)]
-#[command(version = fj::version::VERSION_FULL)]
+#[command(version = fj::version::VERSION_FULL.to_string())]
 pub struct Args {
     /// The model to open
     pub model: Option<PathBuf>,

--- a/crates/fj-app/src/model_crate.rs
+++ b/crates/fj-app/src/model_crate.rs
@@ -27,7 +27,8 @@ fn postprocess_model_files(
             ),
             (
                 r#"path = "../../crates/fj""#.to_owned(),
-                ["version = \"", fj::version::VERSION_PKG, "\""].concat(),
+                ["version = \"", &fj::version::VERSION_PKG.to_string(), "\""]
+                    .concat(),
             ),
         ],
     )?;

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -113,9 +113,9 @@ impl Model {
             } else {
                 let version_pkg_host = fj::version::VERSION_PKG.to_string();
 
-                let version_pkg_model: libloading::Symbol<fn() -> Version> =
-                    lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
-                let version_pkg_mode = version_pkg_model().to_string();
+                let version_pkg_model: libloading::Symbol<*const Version> =
+                    lib.get(b"VERSION_PKG").map_err(Error::LoadingVersion)?;
+                let version_pkg_mode = (**version_pkg_model).to_string();
 
                 debug!(
                     "Comparing package versions (host: {}, model: {})",
@@ -132,9 +132,9 @@ impl Model {
 
                 let version_full_host = fj::version::VERSION_FULL.to_string();
 
-                let version_full_model: libloading::Symbol<fn() -> Version> =
-                    lib.get(b"version_full").map_err(Error::LoadingVersion)?;
-                let version_full_model = version_full_model().to_string();
+                let version_full_model: libloading::Symbol<*const Version> =
+                    lib.get(b"VERSION_FULL").map_err(Error::LoadingVersion)?;
+                let version_full_model = (**version_full_model).to_string();
 
                 debug!(
                     "Comparing full versions (host: {}, model: {})",

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use fj::{abi, version::RawVersion};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{platform::HostPlatform, Parameters};
 
@@ -113,8 +113,13 @@ impl Model {
             } else {
                 let version_pkg: libloading::Symbol<fn() -> RawVersion> =
                     lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
-
                 let version_pkg = version_pkg().to_string();
+
+                debug!(
+                    "Comparing package versions (host: {}, model: {})",
+                    fj::version::VERSION_PKG,
+                    version_pkg
+                );
                 if fj::version::VERSION_PKG != version_pkg {
                     let host = String::from_utf8_lossy(
                         fj::version::VERSION_PKG.as_bytes(),
@@ -127,8 +132,13 @@ impl Model {
 
                 let version_full: libloading::Symbol<fn() -> RawVersion> =
                     lib.get(b"version_full").map_err(Error::LoadingVersion)?;
-
                 let version_full = version_full().to_string();
+
+                debug!(
+                    "Comparing full versions (host: {}, model: {})",
+                    fj::version::VERSION_FULL,
+                    version_full
+                );
                 if fj::version::VERSION_FULL != version_full {
                     let host = String::from_utf8_lossy(
                         fj::version::VERSION_FULL.as_bytes(),

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -5,7 +5,7 @@ use std::{
     str,
 };
 
-use fj::{abi, version::RawVersion};
+use fj::{abi, version::Version};
 use tracing::{debug, warn};
 
 use crate::{platform::HostPlatform, Parameters};
@@ -111,7 +111,7 @@ impl Model {
                     https://github.com/hannobraun/Fornjot/issues/1307)"
                 );
             } else {
-                let version_pkg: libloading::Symbol<fn() -> RawVersion> =
+                let version_pkg: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
                 let version_pkg = version_pkg().to_string();
 
@@ -130,7 +130,7 @@ impl Model {
                     return Err(Error::VersionMismatch { host, model });
                 }
 
-                let version_full: libloading::Symbol<fn() -> RawVersion> =
+                let version_full: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_full").map_err(Error::LoadingVersion)?;
                 let version_full = version_full().to_string();
 

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -111,7 +111,7 @@ impl Model {
                     https://github.com/hannobraun/Fornjot/issues/1307)"
                 );
             } else {
-                let version_pkg_host = fj::version::VERSION_PKG;
+                let version_pkg_host = fj::version::VERSION_PKG.to_string();
 
                 let version_pkg_model: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
@@ -130,7 +130,7 @@ impl Model {
                     return Err(Error::VersionMismatch { host, model });
                 }
 
-                let version_full_host = fj::version::VERSION_FULL;
+                let version_full_host = fj::version::VERSION_FULL.to_string();
 
                 let version_full_model: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_full").map_err(Error::LoadingVersion)?;

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -113,38 +113,38 @@ impl Model {
             } else {
                 let version_pkg_host = fj::version::VERSION_PKG;
 
-                let version_pkg: libloading::Symbol<fn() -> Version> =
+                let version_pkg_model: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
-                let version_pkg = version_pkg().to_string();
+                let version_pkg_mode = version_pkg_model().to_string();
 
                 debug!(
                     "Comparing package versions (host: {}, model: {})",
-                    version_pkg_host, version_pkg
+                    version_pkg_host, version_pkg_mode
                 );
-                if version_pkg_host != version_pkg {
+                if version_pkg_host != version_pkg_mode {
                     let host =
                         String::from_utf8_lossy(version_pkg_host.as_bytes())
                             .into_owned();
-                    let model = version_pkg;
+                    let model = version_pkg_mode;
 
                     return Err(Error::VersionMismatch { host, model });
                 }
 
                 let version_full_host = fj::version::VERSION_FULL;
 
-                let version_full: libloading::Symbol<fn() -> Version> =
+                let version_full_model: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_full").map_err(Error::LoadingVersion)?;
-                let version_full = version_full().to_string();
+                let version_full_model = version_full_model().to_string();
 
                 debug!(
                     "Comparing full versions (host: {}, model: {})",
-                    version_full_host, version_full
+                    version_full_host, version_full_model
                 );
-                if version_full_host != version_full {
+                if version_full_host != version_full_model {
                     let host =
                         String::from_utf8_lossy(version_full_host.as_bytes())
                             .into_owned();
-                    let model = version_full;
+                    let model = version_full_model;
 
                     warn!("{}", Error::VersionMismatch { host, model });
                 }

--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -111,24 +111,26 @@ impl Model {
                     https://github.com/hannobraun/Fornjot/issues/1307)"
                 );
             } else {
+                let version_pkg_host = fj::version::VERSION_PKG;
+
                 let version_pkg: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_pkg").map_err(Error::LoadingVersion)?;
                 let version_pkg = version_pkg().to_string();
 
                 debug!(
                     "Comparing package versions (host: {}, model: {})",
-                    fj::version::VERSION_PKG,
-                    version_pkg
+                    version_pkg_host, version_pkg
                 );
-                if fj::version::VERSION_PKG != version_pkg {
-                    let host = String::from_utf8_lossy(
-                        fj::version::VERSION_PKG.as_bytes(),
-                    )
-                    .into_owned();
+                if version_pkg_host != version_pkg {
+                    let host =
+                        String::from_utf8_lossy(version_pkg_host.as_bytes())
+                            .into_owned();
                     let model = version_pkg;
 
                     return Err(Error::VersionMismatch { host, model });
                 }
+
+                let version_full_host = fj::version::VERSION_FULL;
 
                 let version_full: libloading::Symbol<fn() -> Version> =
                     lib.get(b"version_full").map_err(Error::LoadingVersion)?;
@@ -136,14 +138,12 @@ impl Model {
 
                 debug!(
                     "Comparing full versions (host: {}, model: {})",
-                    fj::version::VERSION_FULL,
-                    version_full
+                    version_full_host, version_full
                 );
-                if fj::version::VERSION_FULL != version_full {
-                    let host = String::from_utf8_lossy(
-                        fj::version::VERSION_FULL.as_bytes(),
-                    )
-                    .into_owned();
+                if version_full_host != version_full {
+                    let host =
+                        String::from_utf8_lossy(version_full_host.as_bytes())
+                            .into_owned();
                     let model = version_full;
 
                     warn!("{}", Error::VersionMismatch { host, model });

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -66,13 +66,3 @@ unsafe impl Send for Version {}
 // There is no reason why a `&Version` wouldn't be `Send`, so per definition,
 // `Version` can be `Sync`.
 unsafe impl Sync for Version {}
-
-#[no_mangle]
-extern "C" fn version_pkg() -> Version {
-    VERSION_PKG
-}
-
-#[no_mangle]
-extern "C" fn version_full() -> Version {
-    VERSION_FULL
-}

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -25,11 +25,8 @@ pub static VERSION_FULL: &str = env!("FJ_VERSION_FULL");
 /// and the app.
 #[repr(C)]
 pub struct RawVersion {
-    /// The pointer to the `str`
-    pub ptr: *const u8,
-
-    /// The length of the `str`
-    pub len: usize,
+    ptr: *const u8,
+    len: usize,
 }
 
 impl RawVersion {

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -24,12 +24,12 @@ pub static VERSION_FULL: &str = env!("FJ_VERSION_FULL");
 /// Used by the Fornjot application to check for compatibility between a model
 /// and the app.
 #[repr(C)]
-pub struct RawVersion {
+pub struct Version {
     ptr: *const u8,
     len: usize,
 }
 
-impl RawVersion {
+impl Version {
     const fn from_static_str(s: &'static str) -> Self {
         Self {
             ptr: s.as_ptr(),
@@ -51,11 +51,11 @@ impl RawVersion {
 }
 
 #[no_mangle]
-extern "C" fn version_pkg() -> RawVersion {
-    RawVersion::from_static_str(VERSION_PKG)
+extern "C" fn version_pkg() -> Version {
+    Version::from_static_str(VERSION_PKG)
 }
 
 #[no_mangle]
-extern "C" fn version_full() -> RawVersion {
-    RawVersion::from_static_str(VERSION_FULL)
+extern "C" fn version_full() -> Version {
+    Version::from_static_str(VERSION_FULL)
 }

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -11,13 +11,15 @@ use std::{fmt, slice};
 /// constant between releases, even though changes are made throughout. A match
 /// of this version does not conclusively determine that the app and a model are
 /// compatible.
-pub static VERSION_PKG: &str = env!("FJ_VERSION_PKG");
+pub static VERSION_PKG: Version =
+    Version::from_static_str(env!("FJ_VERSION_PKG"));
 
 /// The full Fornjot version
 ///
 /// Can be used to check for compatibility between a model and the Fornjot app
 /// that runs it.
-pub static VERSION_FULL: &str = env!("FJ_VERSION_FULL");
+pub static VERSION_FULL: Version =
+    Version::from_static_str(env!("FJ_VERSION_FULL"));
 
 /// C-ABI-compatible representation of a version
 ///
@@ -65,10 +67,10 @@ unsafe impl Sync for Version {}
 
 #[no_mangle]
 extern "C" fn version_pkg() -> Version {
-    Version::from_static_str(VERSION_PKG)
+    VERSION_PKG
 }
 
 #[no_mangle]
 extern "C" fn version_full() -> Version {
-    Version::from_static_str(VERSION_FULL)
+    VERSION_FULL
 }

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -44,8 +44,10 @@ impl Version {
     /// Must be a `RawVersion` returned from one of the hidden version functions
     /// in this module.
     #[allow(clippy::inherent_to_string)]
-    pub unsafe fn to_string(&self) -> String {
-        let slice = slice::from_raw_parts(self.ptr, self.len);
+    pub fn to_string(&self) -> String {
+        // This is sound. We only ever create `ptr` and `len` from static
+        // strings.
+        let slice = unsafe { slice::from_raw_parts(self.ptr, self.len) };
         String::from_utf8_lossy(slice).into_owned()
     }
 }

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -1,6 +1,6 @@
 //! API for checking compatibility between the Fornjot app and a model
 
-use core::slice;
+use std::slice;
 
 /// The Fornjot package version
 ///

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -50,6 +50,16 @@ impl Version {
     }
 }
 
+// The only reason this is not derived automatically, is that `Version` contains
+// a `*const u8`. `Version` can still safely be `Send`, for the following
+// reasons:
+// - The field is private, and no code in this module uses it for any write
+//   access, un-synchronized or not.
+// - `Version` can only be constructed from strings with a static lifetime, so
+//   it's guaranteed that the pointer is valid over the whole lifetime of the
+//   program.
+unsafe impl Send for Version {}
+
 #[no_mangle]
 extern "C" fn version_pkg() -> Version {
     Version::from_static_str(VERSION_PKG)

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -33,6 +33,13 @@ pub struct RawVersion {
 }
 
 impl RawVersion {
+    const fn from_static_str(s: &'static str) -> Self {
+        Self {
+            ptr: s.as_ptr(),
+            len: s.len(),
+        }
+    }
+
     /// Convert the `RawVersion` into a string
     ///
     /// # Safety
@@ -48,16 +55,10 @@ impl RawVersion {
 
 #[no_mangle]
 extern "C" fn version_pkg() -> RawVersion {
-    RawVersion {
-        ptr: VERSION_PKG.as_ptr(),
-        len: VERSION_PKG.len(),
-    }
+    RawVersion::from_static_str(VERSION_PKG)
 }
 
 #[no_mangle]
 extern "C" fn version_full() -> RawVersion {
-    RawVersion {
-        ptr: VERSION_FULL.as_ptr(),
-        len: VERSION_FULL.len(),
-    }
+    RawVersion::from_static_str(VERSION_FULL)
 }

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -1,6 +1,6 @@
 //! API for checking compatibility between the Fornjot app and a model
 
-use std::slice;
+use std::{fmt, slice};
 
 /// The Fornjot package version
 ///
@@ -36,19 +36,15 @@ impl Version {
             len: s.len(),
         }
     }
+}
 
-    /// Convert the `RawVersion` into a string
-    ///
-    /// # Safety
-    ///
-    /// Must be a `RawVersion` returned from one of the hidden version functions
-    /// in this module.
-    #[allow(clippy::inherent_to_string)]
-    pub fn to_string(&self) -> String {
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // This is sound. We only ever create `ptr` and `len` from static
         // strings.
         let slice = unsafe { slice::from_raw_parts(self.ptr, self.len) };
-        String::from_utf8_lossy(slice).into_owned()
+
+        write!(f, "{}", String::from_utf8_lossy(slice).into_owned())
     }
 }
 

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -23,6 +23,7 @@ pub static VERSION_FULL: &str = env!("FJ_VERSION_FULL");
 ///
 /// Used by the Fornjot application to check for compatibility between a model
 /// and the app.
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct Version {
     ptr: *const u8,

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -60,6 +60,10 @@ impl Version {
 //   program.
 unsafe impl Send for Version {}
 
+// There is no reason why a `&Version` wouldn't be `Send`, so per definition,
+// `Version` can be `Sync`.
+unsafe impl Sync for Version {}
+
 #[no_mangle]
 extern "C" fn version_pkg() -> Version {
     Version::from_static_str(VERSION_PKG)

--- a/crates/fj/src/version.rs
+++ b/crates/fj/src/version.rs
@@ -11,6 +11,7 @@ use std::{fmt, slice};
 /// constant between releases, even though changes are made throughout. A match
 /// of this version does not conclusively determine that the app and a model are
 /// compatible.
+#[no_mangle]
 pub static VERSION_PKG: Version =
     Version::from_static_str(env!("FJ_VERSION_PKG"));
 
@@ -18,6 +19,7 @@ pub static VERSION_PKG: Version =
 ///
 /// Can be used to check for compatibility between a model and the Fornjot app
 /// that runs it.
+#[no_mangle]
 pub static VERSION_FULL: Version =
     Version::from_static_str(env!("FJ_VERSION_FULL"));
 


### PR DESCRIPTION
From one of the commit messages:

> Going over the relevant parts of the standard library documentation with a fine comb, I realized that a pointer casted from a reference is only valid, if only raw pointers are used to access that memory.[[1]]
>
> I don't know if this carries over to the pointer returned by `str::as_ptr`, but if it does, this could have indeed been a soundness hole, as the original `str` is still used, in `fj-app`'s `args` module.
>
> [1]: https://doc.rust-lang.org/std/ptr/index.html#safety

This could be the fix required for #1307, but having no access to Windows, I cannot be sure.