### PR TITLE
Add infrastructure for abstracting over access to referenced objects

### DIFF
--- a/crates/fj-kernel/src/get.rs
+++ b/crates/fj-kernel/src/get.rs
@@ -1,0 +1,15 @@
+//! Infrastructure for abstracting over accessing referenced objects
+
+use crate::storage::Handle;
+
+/// Access a single referenced object
+///
+/// Object types implement this trait for the objects they reference. It can be
+/// used by other generic infrastructure to abstract over object access.
+///
+/// This trait is specifically intended to access single objects, like *the*
+/// curve that a vertex references, not *a* half-edge that a cycle references.
+pub trait Get<T> {
+    /// Access the referenced object
+    fn get(&self) -> Handle<T>;
+}

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -90,6 +90,7 @@
 pub mod algorithms;
 pub mod builder;
 pub mod geometry;
+pub mod get;
 pub mod insert;
 pub mod iter;
 pub mod objects;

--- a/crates/fj-kernel/src/objects/curve.rs
+++ b/crates/fj-kernel/src/objects/curve.rs
@@ -1,5 +1,6 @@
 use crate::{
     geometry::path::SurfacePath,
+    get::Get,
     storage::{Handle, HandleWrapper},
 };
 
@@ -40,6 +41,18 @@ impl Curve {
     /// Access the global form of this curve
     pub fn global_form(&self) -> &Handle<GlobalCurve> {
         &self.global_form
+    }
+}
+
+impl Get<Surface> for Curve {
+    fn get(&self) -> Handle<Surface> {
+        self.surface().clone()
+    }
+}
+
+impl Get<GlobalCurve> for Curve {
+    fn get(&self) -> Handle<GlobalCurve> {
+        self.global_form().clone()
     }
 }
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
-use crate::storage::{Handle, HandleWrapper};
+use crate::{
+    get::Get,
+    storage::{Handle, HandleWrapper},
+};
 
 use super::{Curve, GlobalCurve, GlobalVertex, Surface, Vertex};
 
@@ -54,6 +57,12 @@ impl HalfEdge {
     /// Access the global form of this half-edge
     pub fn global_form(&self) -> &Handle<GlobalEdge> {
         &self.global_form
+    }
+}
+
+impl Get<GlobalEdge> for HalfEdge {
+    fn get(&self) -> Handle<GlobalEdge> {
+        self.global_form().clone()
     }
 }
 
@@ -112,6 +121,12 @@ impl GlobalEdge {
     /// specific order.
     pub fn vertices(&self) -> &VerticesInNormalizedOrder {
         &self.vertices
+    }
+}
+
+impl Get<GlobalCurve> for GlobalEdge {
+    fn get(&self) -> Handle<GlobalCurve> {
+        self.curve().clone()
     }
 }
 

--- a/crates/fj-kernel/src/objects/edge.rs
+++ b/crates/fj-kernel/src/objects/edge.rs
@@ -66,6 +66,12 @@ impl Get<GlobalEdge> for HalfEdge {
     }
 }
 
+impl Get<GlobalCurve> for HalfEdge {
+    fn get(&self) -> Handle<GlobalCurve> {
+        self.global_form().curve().clone()
+    }
+}
+
 impl fmt::Display for HalfEdge {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let [a, b] = self.vertices().clone().map(|vertex| vertex.position());

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{get::Get, storage::Handle};
 
-use super::{Curve, Surface};
+use super::{Curve, GlobalCurve, Surface};
 
 /// A vertex
 ///
@@ -65,6 +65,24 @@ impl Get<Curve> for Vertex {
 impl Get<SurfaceVertex> for Vertex {
     fn get(&self) -> Handle<SurfaceVertex> {
         self.surface_form().clone()
+    }
+}
+
+impl Get<Surface> for Vertex {
+    fn get(&self) -> Handle<Surface> {
+        self.curve().surface().clone()
+    }
+}
+
+impl Get<GlobalCurve> for Vertex {
+    fn get(&self) -> Handle<GlobalCurve> {
+        self.curve().global_form().clone()
+    }
+}
+
+impl Get<GlobalVertex> for Vertex {
+    fn get(&self) -> Handle<GlobalVertex> {
+        self.surface_form().global_form().clone()
     }
 }
 

--- a/crates/fj-kernel/src/objects/vertex.rs
+++ b/crates/fj-kernel/src/objects/vertex.rs
@@ -1,6 +1,6 @@
 use fj_math::Point;
 
-use crate::storage::Handle;
+use crate::{get::Get, storage::Handle};
 
 use super::{Curve, Surface};
 
@@ -56,6 +56,18 @@ impl Vertex {
     }
 }
 
+impl Get<Curve> for Vertex {
+    fn get(&self) -> Handle<Curve> {
+        self.curve().clone()
+    }
+}
+
+impl Get<SurfaceVertex> for Vertex {
+    fn get(&self) -> Handle<SurfaceVertex> {
+        self.surface_form().clone()
+    }
+}
+
 /// A vertex, defined in surface (2D) coordinates
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfaceVertex {
@@ -92,6 +104,18 @@ impl SurfaceVertex {
     /// Access the global form of this vertex
     pub fn global_form(&self) -> &Handle<GlobalVertex> {
         &self.global_form
+    }
+}
+
+impl Get<Surface> for SurfaceVertex {
+    fn get(&self) -> Handle<Surface> {
+        self.surface().clone()
+    }
+}
+
+impl Get<GlobalVertex> for SurfaceVertex {
+    fn get(&self) -> Handle<GlobalVertex> {
+        self.global_form().clone()
     }
 }
 


### PR DESCRIPTION
Add a `Get` trait that can be used to abstract over access to referenced objects, and implement it for a bunch of these references.

This is more progress towards #1249. I'm using this infrastructure in a local branch, where it is a building block for a new *replace* operator, which has already led to some nice improvements.