### PR TITLE
Implement `Replace` operation for partial object API

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -228,26 +228,34 @@ mod tests {
                 )
                 .build(&objects)?
                 .insert(&objects)?;
-            let side_up = HalfEdge::partial()
-                .with_surface(surface.clone())
-                .with_back_vertex(PartialVertex {
-                    surface_form: bottom.front().surface_form().clone().into(),
-                    ..Default::default()
-                })
-                .with_front_vertex(PartialVertex {
-                    surface_form: PartialSurfaceVertex {
-                        position: Some([1., 1.].into()),
+            let side_up = {
+                let mut side_up = HalfEdge::partial();
+                side_up.with_surface(surface.clone());
+                side_up
+                    .with_back_vertex(PartialVertex {
+                        surface_form: bottom
+                            .front()
+                            .surface_form()
+                            .clone()
+                            .into(),
                         ..Default::default()
-                    }
-                    .into(),
-                    ..Default::default()
-                })
-                .update_as_line_segment()
-                .build(&objects)?
-                .insert(&objects)?;
-            let top = HalfEdge::partial()
-                .with_surface(surface.clone())
-                .with_back_vertex(PartialVertex {
+                    })
+                    .with_front_vertex(PartialVertex {
+                        surface_form: PartialSurfaceVertex {
+                            position: Some([1., 1.].into()),
+                            ..Default::default()
+                        }
+                        .into(),
+                        ..Default::default()
+                    })
+                    .update_as_line_segment()
+                    .build(&objects)?
+                    .insert(&objects)?
+            };
+            let top = {
+                let mut top = HalfEdge::partial();
+                top.with_surface(surface.clone());
+                top.with_back_vertex(PartialVertex {
                     surface_form: PartialSurfaceVertex {
                         position: Some([0., 1.].into()),
                         ..Default::default()
@@ -262,21 +270,29 @@ mod tests {
                 .update_as_line_segment()
                 .build(&objects)?
                 .insert(&objects)?
-                .reverse(&objects)?;
-            let side_down = HalfEdge::partial()
-                .with_surface(surface)
-                .with_back_vertex(PartialVertex {
-                    surface_form: bottom.back().surface_form().clone().into(),
-                    ..Default::default()
-                })
-                .with_front_vertex(PartialVertex {
-                    surface_form: top.front().surface_form().clone().into(),
-                    ..Default::default()
-                })
-                .update_as_line_segment()
-                .build(&objects)?
-                .insert(&objects)?
-                .reverse(&objects)?;
+                .reverse(&objects)?
+            };
+            let side_down = {
+                let mut side_down = HalfEdge::partial();
+                side_down.with_surface(surface);
+                side_down
+                    .with_back_vertex(PartialVertex {
+                        surface_form: bottom
+                            .back()
+                            .surface_form()
+                            .clone()
+                            .into(),
+                        ..Default::default()
+                    })
+                    .with_front_vertex(PartialVertex {
+                        surface_form: top.front().surface_form().clone().into(),
+                        ..Default::default()
+                    })
+                    .update_as_line_segment()
+                    .build(&objects)?
+                    .insert(&objects)?
+                    .reverse(&objects)?
+            };
 
             let cycle = objects
                 .cycles

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -200,7 +200,7 @@ mod tests {
         builder::HalfEdgeBuilder,
         insert::Insert,
         objects::{Cycle, Face, HalfEdge, Objects},
-        partial::{HasPartial, PartialSurfaceVertex, PartialVertex},
+        partial::{HasPartial, PartialSurfaceVertex, PartialVertex, Replace},
     };
 
     #[test]
@@ -230,7 +230,7 @@ mod tests {
                 .insert(&objects)?;
             let side_up = {
                 let mut side_up = HalfEdge::partial();
-                side_up.with_surface(surface.clone());
+                side_up.replace(surface.clone());
                 side_up
                     .with_back_vertex(PartialVertex {
                         surface_form: bottom
@@ -254,7 +254,7 @@ mod tests {
             };
             let top = {
                 let mut top = HalfEdge::partial();
-                top.with_surface(surface.clone());
+                top.replace(surface.clone());
                 top.with_back_vertex(PartialVertex {
                     surface_form: PartialSurfaceVertex {
                         position: Some([0., 1.].into()),
@@ -274,7 +274,7 @@ mod tests {
             };
             let side_down = {
                 let mut side_down = HalfEdge::partial();
-                side_down.with_surface(surface);
+                side_down.replace(surface);
                 side_down
                     .with_back_vertex(PartialVertex {
                         surface_form: bottom

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -94,7 +94,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     }
 
     fn update_as_line_segment_from_points(
-        self,
+        mut self,
         surface: Handle<Surface>,
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
@@ -111,9 +111,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             }
         });
 
-        self.with_surface(surface)
-            .with_vertices(vertices)
-            .update_as_line_segment()
+        self.with_surface(surface);
+        self.with_vertices(vertices).update_as_line_segment()
     }
 
     fn update_as_line_segment(self) -> Self {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -6,7 +6,7 @@ use crate::{
     objects::{Curve, Objects, Surface, Vertex, VerticesInNormalizedOrder},
     partial::{
         MaybePartial, MergeWith, PartialGlobalEdge, PartialHalfEdge,
-        PartialSurfaceVertex, PartialVertex,
+        PartialSurfaceVertex, PartialVertex, Replace,
     },
     storage::Handle,
     validate::ValidationError,
@@ -111,7 +111,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             }
         });
 
-        self.with_surface(surface);
+        self.replace(surface);
         self.with_vertices(vertices).update_as_line_segment()
     }
 

--- a/crates/fj-kernel/src/partial/mod.rs
+++ b/crates/fj-kernel/src/partial/mod.rs
@@ -37,6 +37,7 @@
 mod maybe_partial;
 mod merge;
 mod objects;
+mod replace;
 mod traits;
 
 pub use self::{
@@ -50,5 +51,6 @@ pub use self::{
         surface::PartialSurface,
         vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     },
+    replace::Replace,
     traits::{HasPartial, Partial},
 };

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -1,7 +1,7 @@
 use crate::{
     geometry::path::SurfacePath,
     objects::{Curve, GlobalCurve, Objects, Surface},
-    partial::{MaybePartial, MergeWith},
+    partial::{MaybePartial, MergeWith, Replace},
     storage::Handle,
     validate::ValidationError,
 };
@@ -43,6 +43,13 @@ impl MergeWith for PartialCurve {
             surface: self.surface.merge_with(other.surface),
             global_form: self.global_form.merge_with(other.global_form),
         }
+    }
+}
+
+impl Replace<Surface> for PartialCurve {
+    fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
+        self.surface = Some(surface);
+        self
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -1,7 +1,9 @@
 use crate::{
     builder::HalfEdgeBuilder,
     objects::{Cycle, HalfEdge, Objects, Surface},
-    partial::{MaybePartial, MergeWith, PartialHalfEdge, PartialVertex},
+    partial::{
+        MaybePartial, MergeWith, PartialHalfEdge, PartialVertex, Replace,
+    },
     storage::Handle,
     validate::ValidationError,
 };
@@ -58,7 +60,7 @@ impl PartialCycle {
             for half_edge in &mut self.half_edges {
                 *half_edge =
                     half_edge.clone().update_partial(|mut half_edge| {
-                        half_edge.with_surface(surface.clone());
+                        half_edge.replace(surface.clone());
                         half_edge
                     });
             }

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -56,9 +56,11 @@ impl PartialCycle {
     pub fn with_surface(mut self, surface: Option<Handle<Surface>>) -> Self {
         if let Some(surface) = surface {
             for half_edge in &mut self.half_edges {
-                *half_edge = half_edge.clone().update_partial(|half_edge| {
-                    half_edge.with_surface(surface.clone())
-                });
+                *half_edge =
+                    half_edge.clone().update_partial(|mut half_edge| {
+                        half_edge.with_surface(surface.clone());
+                        half_edge
+                    });
             }
         }
         self

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -109,14 +109,7 @@ impl Replace<Surface> for PartialHalfEdge {
 
         self.vertices = self.vertices.clone().map(|vertex| {
             vertex.update_partial(|mut vertex| {
-                let surface_form = vertex.surface_form.clone().update_partial(
-                    |mut surface_vertex| {
-                        surface_vertex.replace(surface.clone());
-                        surface_vertex
-                    },
-                );
-
-                vertex.surface_form = surface_form;
+                vertex.surface_form.replace(surface.clone());
                 vertex
             })
         });

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -109,7 +109,7 @@ impl Replace<Surface> for PartialHalfEdge {
 
         self.vertices = self.vertices.clone().map(|vertex| {
             vertex.update_partial(|mut vertex| {
-                vertex.surface_form.replace(surface.clone());
+                vertex.replace(surface.clone());
                 vertex
             })
         });

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -107,11 +107,9 @@ impl Replace<Surface> for PartialHalfEdge {
     fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
         self.curve.replace(surface.clone());
 
-        self.vertices = self.vertices.clone().map(|vertex| {
-            vertex.update_partial(|mut vertex| {
-                vertex.replace(surface.clone());
-                vertex
-            })
+        self.vertices = self.vertices.clone().map(|mut vertex| {
+            vertex.replace(surface.clone());
+            vertex
         });
 
         self

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -6,7 +6,7 @@ use crate::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, Vertex,
     },
-    partial::{MaybePartial, MergeWith, PartialCurve, PartialVertex},
+    partial::{MaybePartial, MergeWith, PartialCurve, PartialVertex, Replace},
     storage::Handle,
     validate::ValidationError,
 };
@@ -29,8 +29,8 @@ pub struct PartialHalfEdge {
 impl PartialHalfEdge {
     /// Update the partial half-edge with the given surface
     pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
-        self.curve = self.curve.update_partial(|mut curve| {
-            curve.surface = Some(surface.clone());
+        self.curve = self.curve.clone().update_partial(|mut curve| {
+            curve.replace(surface.clone());
             curve
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -28,13 +28,13 @@ pub struct PartialHalfEdge {
 
 impl PartialHalfEdge {
     /// Update the partial half-edge with the given surface
-    pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
+    pub fn with_surface(&mut self, surface: Handle<Surface>) -> &mut Self {
         self.curve = self.curve.clone().update_partial(|mut curve| {
             curve.replace(surface.clone());
             curve
         });
 
-        self.vertices = self.vertices.map(|vertex| {
+        self.vertices = self.vertices.clone().map(|vertex| {
             vertex.update_partial(|mut vertex| {
                 let surface_form = vertex.surface_form.clone().update_partial(
                     |mut surface_vertex| {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -27,30 +27,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Update the partial half-edge with the given surface
-    pub fn with_surface(&mut self, surface: Handle<Surface>) -> &mut Self {
-        self.curve = self.curve.clone().update_partial(|mut curve| {
-            curve.replace(surface.clone());
-            curve
-        });
-
-        self.vertices = self.vertices.clone().map(|vertex| {
-            vertex.update_partial(|mut vertex| {
-                let surface_form = vertex.surface_form.clone().update_partial(
-                    |mut surface_vertex| {
-                        surface_vertex.replace(surface.clone());
-                        surface_vertex
-                    },
-                );
-
-                vertex.surface_form = surface_form;
-                vertex
-            })
-        });
-
-        self
-    }
-
     /// Update the partial half-edge with the given curve
     pub fn with_curve(mut self, curve: impl Into<MaybePartial<Curve>>) -> Self {
         self.curve = curve.into();
@@ -124,6 +100,31 @@ impl MergeWith for PartialHalfEdge {
             vertices: self.vertices.merge_with(other.vertices),
             global_form: self.global_form.merge_with(other.global_form),
         }
+    }
+}
+
+impl Replace<Surface> for PartialHalfEdge {
+    fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
+        self.curve = self.curve.clone().update_partial(|mut curve| {
+            curve.replace(surface.clone());
+            curve
+        });
+
+        self.vertices = self.vertices.clone().map(|vertex| {
+            vertex.update_partial(|mut vertex| {
+                let surface_form = vertex.surface_form.clone().update_partial(
+                    |mut surface_vertex| {
+                        surface_vertex.replace(surface.clone());
+                        surface_vertex
+                    },
+                );
+
+                vertex.surface_form = surface_form;
+                vertex
+            })
+        });
+
+        self
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -107,10 +107,9 @@ impl Replace<Surface> for PartialHalfEdge {
     fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
         self.curve.replace(surface.clone());
 
-        self.vertices = self.vertices.clone().map(|mut vertex| {
+        for vertex in &mut self.vertices {
             vertex.replace(surface.clone());
-            vertex
-        });
+        }
 
         self
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -38,7 +38,7 @@ impl PartialHalfEdge {
             vertex.update_partial(|mut vertex| {
                 let surface_form = vertex.surface_form.clone().update_partial(
                     |mut surface_vertex| {
-                        surface_vertex.surface = Some(surface.clone());
+                        surface_vertex.replace(surface.clone());
                         surface_vertex
                     },
                 );

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -105,10 +105,7 @@ impl MergeWith for PartialHalfEdge {
 
 impl Replace<Surface> for PartialHalfEdge {
     fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
-        self.curve = self.curve.clone().update_partial(|mut curve| {
-            curve.replace(surface.clone());
-            curve
-        });
+        self.curve.replace(surface.clone());
 
         self.vertices = self.vertices.clone().map(|vertex| {
             vertex.update_partial(|mut vertex| {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -3,7 +3,7 @@ use fj_math::Point;
 use crate::{
     builder::GlobalVertexBuilder,
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
-    partial::{MaybePartial, MergeWith},
+    partial::{MaybePartial, MergeWith, Replace},
     storage::Handle,
     validate::ValidationError,
 };
@@ -126,6 +126,13 @@ impl MergeWith for PartialSurfaceVertex {
             surface: self.surface.merge_with(other.surface),
             global_form: self.global_form.merge_with(other.global_form),
         }
+    }
+}
+
+impl Replace<Surface> for PartialSurfaceVertex {
+    fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
+        self.surface = Some(surface);
+        self
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -67,6 +67,13 @@ impl MergeWith for PartialVertex {
     }
 }
 
+impl Replace<Surface> for PartialVertex {
+    fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
+        self.surface_form.replace(surface);
+        self
+    }
+}
+
 impl From<&Vertex> for PartialVertex {
     fn from(vertex: &Vertex) -> Self {
         Self {

--- a/crates/fj-kernel/src/partial/replace.rs
+++ b/crates/fj-kernel/src/partial/replace.rs
@@ -1,0 +1,7 @@
+use crate::storage::Handle;
+
+/// Recursively replace a (partial) object referenced by another partial object
+pub trait Replace<T> {
+    /// Recursively replace the referenced object
+    fn replace(&mut self, object: Handle<T>) -> &mut Self;
+}

--- a/crates/fj-kernel/src/partial/replace.rs
+++ b/crates/fj-kernel/src/partial/replace.rs
@@ -5,3 +5,16 @@ pub trait Replace<T> {
     /// Recursively replace the referenced object
     fn replace(&mut self, object: Handle<T>) -> &mut Self;
 }
+
+impl<T, R, const N: usize> Replace<T> for [R; N]
+where
+    R: Replace<T>,
+{
+    fn replace(&mut self, object: Handle<T>) -> &mut Self {
+        for item in self.iter_mut() {
+            item.replace(object.clone());
+        }
+
+        self
+    }
+}

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,7 +5,7 @@ use fj_kernel::{
     builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
-    partial::HasPartial,
+    partial::{HasPartial, Replace},
     validate::ValidationError,
 };
 use fj_math::{Aabb, Point};
@@ -29,7 +29,7 @@ impl Shape for fj::Sketch {
 
                 let half_edge = {
                     let mut half_edge = HalfEdge::partial();
-                    half_edge.with_surface(surface);
+                    half_edge.replace(surface);
                     half_edge
                         .update_as_circle_from_radius(circle.radius(), objects)?
                         .build(objects)?

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -27,11 +27,14 @@ impl Shape for fj::Sketch {
                 // Circles have just a single round edge with no vertices. So
                 // none need to be added here.
 
-                let half_edge = HalfEdge::partial()
-                    .with_surface(surface)
-                    .update_as_circle_from_radius(circle.radius(), objects)?
-                    .build(objects)?
-                    .insert(objects)?;
+                let half_edge = {
+                    let mut half_edge = HalfEdge::partial();
+                    half_edge.with_surface(surface);
+                    half_edge
+                        .update_as_circle_from_radius(circle.radius(), objects)?
+                        .build(objects)?
+                        .insert(objects)?
+                };
                 let cycle = objects.cycles.insert(Cycle::new([half_edge]))?;
 
                 Face::partial()


### PR DESCRIPTION
Add the `Replace` trait and use it to simplify `PartialHalfEdge`. Builds on the `Get` infrastructure from #1359.

This is another step towards addressing #1249.