### PR TITLE
Soften shading

### DIFF
--- a/crates/fj-viewer/src/graphics/shader.wgsl
+++ b/crates/fj-viewer/src/graphics/shader.wgsl
@@ -40,7 +40,7 @@ fn frag_model(in: VertexOutput) -> FragmentOutput {
     let light = vec3<f32>(0.0, 0.0, -1.0);
 
     let angle = acos(dot(light, -in.normal));
-    let f_angle = angle / (pi / 2.0);
+    let f_angle = angle / (pi * 0.75);
 
     let f_normal = max(1.0 - f_angle, 0.0);
 


### PR DESCRIPTION
Don't show surface as completely black at a 90% angle between between light and surface normal.

Here's what it looked like before:
![Screenshot from 2022-11-17 15-59-21](https://user-images.githubusercontent.com/85732/202481706-db4005b0-49dd-4016-b3a5-ae15fc5e3962.png)

And this is what it looks like now:
![Screenshot from 2022-11-17 16-00-36](https://user-images.githubusercontent.com/85732/202481759-7a007d70-cbdf-49f4-ad01-09ff8ab191c2.png)

Shading is still pretty basic, overall, but at least this looks a bit less harsh.