### PR TITLE
Improve output of `--version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
 name = "fj"
 version = "0.24.0"
 dependencies = [
+ "anyhow",
  "fj-proc",
  "serde",
  "serde_json",

--- a/crates/fj/Cargo.toml
+++ b/crates/fj/Cargo.toml
@@ -10,6 +10,11 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+
+[build-dependencies]
+anyhow = "1.0.66"
+
+
 [dependencies]
 fj-proc.workspace = true
 

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -7,7 +7,7 @@ fn main() {
     let version = Version::determine();
 
     println!("cargo:rustc-env=FJ_VERSION_PKG={}", version.pkg_version);
-    println!("cargo:rustc-env=FJ_VERSION_FULL={}", version.full_string);
+    println!("cargo:rustc-env=FJ_VERSION_FULL={}", version.full);
 
     // Make sure the build script doesn't run too often.
     println!("cargo:rerun-if-changed=Cargo.toml");
@@ -15,7 +15,7 @@ fn main() {
 
 struct Version {
     pkg_version: String,
-    full_string: String,
+    full: String,
 }
 impl Version {
     fn determine() -> Self {
@@ -26,7 +26,7 @@ impl Version {
             std::env::var("RELEASE_DETECTED").as_deref() == Ok("true");
         println!("cargo:rerun-if-env-changed=RELEASE_DETECTED");
 
-        let full_string = match (commit, official_release) {
+        let full = match (commit, official_release) {
             (Some(commit), true) => format!("{pkg_version} ({commit})"),
             (Some(commit), false) => {
                 format!("{pkg_version} ({commit}, unreleased)")
@@ -35,10 +35,7 @@ impl Version {
             (None, false) => format!("{pkg_version} (unreleased)"),
         };
 
-        Self {
-            pkg_version,
-            full_string,
-        }
+        Self { pkg_version, full }
     }
 }
 

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -57,7 +57,7 @@ fn git_description() -> Option<String> {
     let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
     let mut cmd = Command::new("git");
-    cmd.args(["describe", "--always", "--tags", "--dirty=-modified"])
+    cmd.args(["describe", "--always", "--tags"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .current_dir(&crate_dir);

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -3,14 +3,16 @@ use std::{
     process::{Command, Output, Stdio},
 };
 
-fn main() {
-    let version = Version::determine();
+fn main() -> anyhow::Result<()> {
+    let version = Version::determine()?;
 
     println!("cargo:rustc-env=FJ_VERSION_PKG={}", version.pkg);
     println!("cargo:rustc-env=FJ_VERSION_FULL={}", version.full);
 
     // Make sure the build script doesn't run too often.
     println!("cargo:rerun-if-changed=Cargo.toml");
+
+    Ok(())
 }
 
 struct Version {
@@ -18,7 +20,7 @@ struct Version {
     full: String,
 }
 impl Version {
-    fn determine() -> Self {
+    fn determine() -> anyhow::Result<Self> {
         let pkg = std::env::var("CARGO_PKG_VERSION").unwrap();
         let commit = git_description();
 
@@ -35,7 +37,7 @@ impl Version {
             (None, false) => format!("{pkg} (unreleased)"),
         };
 
-        Self { pkg, full }
+        Ok(Self { pkg, full })
     }
 }
 

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Write,
     path::PathBuf,
     process::{Command, Output, Stdio},
 };
@@ -28,14 +29,19 @@ impl Version {
             std::env::var("RELEASE_DETECTED").as_deref() == Ok("true");
         println!("cargo:rerun-if-env-changed=RELEASE_DETECTED");
 
-        let full = match (commit, official_release) {
-            (Some(commit), true) => format!("{pkg} ({commit})"),
-            (Some(commit), false) => {
-                format!("{pkg} ({commit}, unreleased)")
-            }
-            (None, true) => pkg.clone(),
-            (None, false) => format!("{pkg} (unreleased)"),
-        };
+        let mut full = format!("{pkg} (");
+
+        if official_release {
+            write!(full, "official release binary")?;
+        } else {
+            write!(full, "development build")?;
+        }
+
+        if let Some(commit) = commit {
+            write!(full, "; {commit}")?;
+        }
+
+        writeln!(full, ")")?;
 
         Ok(Self { pkg, full })
     }

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -6,7 +6,7 @@ use std::{
 fn main() {
     let version = Version::determine();
 
-    println!("cargo:rustc-env=FJ_VERSION_PKG={}", version.pkg_version);
+    println!("cargo:rustc-env=FJ_VERSION_PKG={}", version.pkg);
     println!("cargo:rustc-env=FJ_VERSION_FULL={}", version.full);
 
     // Make sure the build script doesn't run too often.
@@ -14,12 +14,12 @@ fn main() {
 }
 
 struct Version {
-    pkg_version: String,
+    pkg: String,
     full: String,
 }
 impl Version {
     fn determine() -> Self {
-        let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap();
+        let pkg = std::env::var("CARGO_PKG_VERSION").unwrap();
         let commit = git_description();
 
         let official_release =
@@ -27,15 +27,15 @@ impl Version {
         println!("cargo:rerun-if-env-changed=RELEASE_DETECTED");
 
         let full = match (commit, official_release) {
-            (Some(commit), true) => format!("{pkg_version} ({commit})"),
+            (Some(commit), true) => format!("{pkg} ({commit})"),
             (Some(commit), false) => {
-                format!("{pkg_version} ({commit}, unreleased)")
+                format!("{pkg} ({commit}, unreleased)")
             }
-            (None, true) => pkg_version.clone(),
-            (None, false) => format!("{pkg_version} (unreleased)"),
+            (None, true) => pkg.clone(),
+            (None, false) => format!("{pkg} (unreleased)"),
         };
 
-        Self { pkg_version, full }
+        Self { pkg, full }
     }
 }
 

--- a/crates/fj/build.rs
+++ b/crates/fj/build.rs
@@ -52,7 +52,7 @@ fn git_description() -> Option<String> {
     let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
 
     let mut cmd = Command::new("git");
-    cmd.args(["describe", "--always", "--dirty=-modified"])
+    cmd.args(["describe", "--always", "--tags", "--dirty=-modified"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .current_dir(&crate_dir);


### PR DESCRIPTION
The old output:
```
fj-app 0.24.0 (6b839a708, unreleased)
```

And the new one:
```
fj-app 0.24.0 (development build; v0.24.0-77-g5b3882c05)
```

The new one carries more information about the Git commit (and its relation to the most recent tag), and I believe "development build" is a bit clearer than "unreleased".

Close #1357 