### PR TITLE
Shuffle around some code in `fj::Sketch`

### DIFF
--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -45,7 +45,7 @@ impl Shape for fj::Sketch {
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let points = poly_chain
-                    .to_points()
+                    .to_segments()
                     .into_iter()
                     .map(|fj::SketchSegment::LineTo { point }| point)
                     .map(Point::from);
@@ -71,7 +71,7 @@ impl Shape for fj::Sketch {
             },
             fj::Chain::PolyChain(poly_chain) => Aabb::<3>::from_points(
                 poly_chain
-                    .to_points()
+                    .to_segments()
                     .into_iter()
                     .map(|fj::SketchSegment::LineTo { point }| point)
                     .map(Point::from)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -44,8 +44,11 @@ impl Shape for fj::Sketch {
                     .insert(objects)?
             }
             fj::Chain::PolyChain(poly_chain) => {
-                let points =
-                    poly_chain.to_points().into_iter().map(Point::from);
+                let points = poly_chain
+                    .to_points()
+                    .into_iter()
+                    .map(|fj::SketchSegment::LineTo { point }| point)
+                    .map(Point::from);
 
                 Face::partial()
                     .with_surface(surface)
@@ -70,6 +73,7 @@ impl Shape for fj::Sketch {
                 poly_chain
                     .to_points()
                     .into_iter()
+                    .map(|fj::SketchSegment::LineTo { point }| point)
                     .map(Point::from)
                     .map(Point::to_xyz),
             ),

--- a/crates/fj/src/abi/ffi_safe.rs
+++ b/crates/fj/src/abi/ffi_safe.rs
@@ -78,6 +78,12 @@ impl<T: Copy> From<Vec<T>> for Box<[T]> {
     }
 }
 
+impl<T> Default for Vec<T> {
+    fn default() -> Self {
+        std::vec::Vec::default().into()
+    }
+}
+
 impl<T> FromIterator<T> for Vec<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let vec: std::vec::Vec<T> = iter.into_iter().collect();

--- a/crates/fj/src/shape_2d.rs
+++ b/crates/fj/src/shape_2d.rs
@@ -184,18 +184,39 @@ impl Circle {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct PolyChain {
-    points: ffi_safe::Vec<[f64; 2]>,
+    points: ffi_safe::Vec<SketchSegment>,
 }
 
 impl PolyChain {
     /// Construct an instance from a list of points
     pub fn from_points(points: Vec<[f64; 2]>) -> Self {
-        let points = points.into();
+        let points = points
+            .into_iter()
+            .map(|point| SketchSegment::LineTo { point })
+            .collect();
         Self { points }
     }
 
     /// Return the points that define the polygonal chain
     pub fn to_points(&self) -> Vec<[f64; 2]> {
-        self.points.clone().into()
+        let segments: Vec<_> = self.points.clone().into();
+        segments
+            .into_iter()
+            .map(|SketchSegment::LineTo { point }| point)
+            .collect()
     }
+}
+
+/// A segment of a sketch
+///
+/// Each segment starts at the previous point of the sketch.
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(C)]
+pub enum SketchSegment {
+    /// A line to a point
+    LineTo {
+        /// The destination point of the line
+        point: [f64; 2],
+    },
 }

--- a/crates/fj/src/shape_2d.rs
+++ b/crates/fj/src/shape_2d.rs
@@ -184,7 +184,7 @@ impl Circle {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct PolyChain {
-    points: ffi_safe::Vec<SketchSegment>,
+    segments: ffi_safe::Vec<SketchSegment>,
 }
 
 impl PolyChain {
@@ -194,12 +194,12 @@ impl PolyChain {
             .into_iter()
             .map(|point| SketchSegment::LineTo { point })
             .collect();
-        Self { points }
+        Self { segments: points }
     }
 
     /// Return the points that define the polygonal chain
     pub fn to_points(&self) -> Vec<[f64; 2]> {
-        let segments: Vec<_> = self.points.clone().into();
+        let segments: Vec<_> = self.segments.clone().into();
         segments
             .into_iter()
             .map(|SketchSegment::LineTo { point }| point)

--- a/crates/fj/src/shape_2d.rs
+++ b/crates/fj/src/shape_2d.rs
@@ -198,7 +198,7 @@ impl PolyChain {
     }
 
     /// Return the points that define the polygonal chain
-    pub fn to_points(&self) -> Vec<SketchSegment> {
+    pub fn to_segments(&self) -> Vec<SketchSegment> {
         self.segments.clone().into()
     }
 }

--- a/crates/fj/src/shape_2d.rs
+++ b/crates/fj/src/shape_2d.rs
@@ -198,12 +198,8 @@ impl PolyChain {
     }
 
     /// Return the points that define the polygonal chain
-    pub fn to_points(&self) -> Vec<[f64; 2]> {
-        let segments: Vec<_> = self.segments.clone().into();
-        segments
-            .into_iter()
-            .map(|SketchSegment::LineTo { point }| point)
-            .collect()
+    pub fn to_points(&self) -> Vec<SketchSegment> {
+        self.segments.clone().into()
     }
 }
 


### PR DESCRIPTION
I've been working on #100 on the side, hoping I could implement it relatively quickly, but I ran out of juice. I'd have to modify `ffi_safe::Vec` in a non-trivial way now, and I'd rather not attempt that. I have enough non-trivial projects going on and don't want to take on another one.

I've decided to merge the commits I've made so far. They don't change a lot, but they bring `fj::Sketch` a few steps closer to being able to support a mix of lines and arcs. Maybe this will be helpful, once someone picks this back up.