### PR TITLE
Make use of `Insert` trait pervasively

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -60,7 +60,7 @@ impl SurfaceSurfaceIntersection {
 
         let curves = surfaces_and_planes.try_map_ext(|(surface, plane)| {
             let path = SurfacePath::Line(plane.project_line(&line));
-            let global_form = objects.global_curves.insert(GlobalCurve)?;
+            let global_form = GlobalCurve.insert(objects)?;
 
             Curve::new(surface, path, global_form).insert(objects)
         })?;

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -3,6 +3,7 @@ use fj_math::{Line, Plane, Point, Scalar};
 
 use crate::{
     geometry::path::{GlobalPath, SurfacePath},
+    insert::Insert,
     objects::{Curve, GlobalCurve, Objects, Surface},
     storage::Handle,
     validate::ValidationError,
@@ -61,9 +62,7 @@ impl SurfaceSurfaceIntersection {
             let path = SurfacePath::Line(plane.project_line(&line));
             let global_form = objects.global_curves.insert(GlobalCurve)?;
 
-            objects
-                .curves
-                .insert(Curve::new(surface, path, global_form))
+            Curve::new(surface, path, global_form).insert(objects)
         })?;
 
         Ok(Some(Self {

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -1,4 +1,5 @@
 use crate::{
+    insert::Insert,
     objects::{Cycle, Objects},
     storage::Handle,
     validate::ValidationError,
@@ -16,6 +17,6 @@ impl Reverse for Handle<Cycle> {
 
         edges.reverse();
 
-        Ok(objects.cycles.insert(Cycle::new(edges))?)
+        Ok(Cycle::new(edges).insert(objects)?)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -1,4 +1,5 @@
 use crate::{
+    insert::Insert,
     objects::{HalfEdge, Objects},
     storage::Handle,
     validate::ValidationError,
@@ -13,8 +14,7 @@ impl Reverse for Handle<HalfEdge> {
             [b, a]
         };
 
-        Ok(objects
-            .half_edges
-            .insert(HalfEdge::new(vertices, self.global_form().clone()))?)
+        Ok(HalfEdge::new(vertices, self.global_form().clone())
+            .insert(objects)?)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -79,11 +79,11 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         )
                         .insert(objects)?;
 
-                        Ok(objects.vertices.insert(Vertex::new(
+                        Ok(Vertex::new(
                             vertex.position(),
                             curve.clone(),
                             surface_vertex,
-                        ))?)
+                        ).insert(objects)?)
                     },
                 )?
             };
@@ -142,11 +142,8 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 .zip(surface_vertices)
                 .collect::<[_; 2]>()
                 .try_map_ext(|(vertex, surface_form)| {
-                    objects.vertices.insert(Vertex::new(
-                        vertex.position(),
-                        curve.clone(),
-                        surface_form,
-                    ))
+                    Vertex::new(vertex.position(), curve.clone(), surface_form)
+                        .insert(objects)
                 })?;
 
             HalfEdge::new(vertices, global).insert(objects)?

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -53,11 +53,12 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         points_curve_and_surface,
                     ));
 
-                objects.curves.insert(Curve::new(
+                Curve::new(
                     surface.clone(),
                     path,
                     edge.curve().global_form().clone(),
-                ))?
+                )
+                .insert(objects)?
             };
 
             let vertices = {
@@ -126,7 +127,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         points_curve_and_surface,
                     ));
 
-                objects.curves.insert(Curve::new(surface, path, global))?
+                Curve::new(surface, path, global).insert(objects)?
             };
 
             let global = objects.global_edges.insert(GlobalEdge::new(

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -130,12 +130,13 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 Curve::new(surface, path, global).insert(objects)?
             };
 
-            let global = objects.global_edges.insert(GlobalEdge::new(
+            let global = GlobalEdge::new(
                 curve.global_form().clone(),
                 surface_vertices
                     .clone()
                     .map(|surface_vertex| surface_vertex.global_form().clone()),
-            ))?;
+            )
+            .insert(objects)?;
 
             let vertices = bottom_vertices
                 .each_ref_ext()

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -72,13 +72,12 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     .collect::<[_; 2]>()
                     .try_map_ext(
                     |(vertex, point_surface)| -> Result<_, ValidationError> {
-                        let surface_vertex = objects.surface_vertices.insert(
-                            SurfaceVertex::new(
-                                point_surface,
-                                surface.clone(),
-                                vertex.global_form().clone(),
-                            ),
-                        )?;
+                        let surface_vertex = SurfaceVertex::new(
+                            point_surface,
+                            surface.clone(),
+                            vertex.global_form().clone(),
+                        )
+                        .insert(objects)?;
 
                         Ok(objects.vertices.insert(Vertex::new(
                             vertex.position(),

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -180,7 +180,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 i += 1;
             }
 
-            objects.cycles.insert(Cycle::new(edges))?
+            Cycle::new(edges).insert(objects)?
         };
 
         Ok(Face::partial()
@@ -295,9 +295,8 @@ mod tests {
                     .reverse(&objects)?
             };
 
-            let cycle = objects
-                .cycles
-                .insert(Cycle::new([bottom, side_up, top, side_down]))?;
+            let cycle = Cycle::new([bottom, side_up, top, side_down])
+                .insert(&objects)?;
 
             Face::partial()
                 .with_exterior(cycle)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -89,9 +89,8 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 )?
             };
 
-            objects
-                .half_edges
-                .insert(HalfEdge::new(vertices, edge.global_form().clone()))?
+            HalfEdge::new(vertices, edge.global_form().clone())
+                .insert(objects)?
         };
 
         let side_edges =
@@ -151,7 +150,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     ))
                 })?;
 
-            objects.half_edges.insert(HalfEdge::new(vertices, global))?
+            HalfEdge::new(vertices, global).insert(objects)?
         };
 
         let cycle = {

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -112,11 +112,12 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
         // And now the vertices. Again, nothing wild here.
         let vertices = vertices_surface.try_map_ext(|surface_form| {
-            objects.vertices.insert(Vertex::new(
+            Vertex::new(
                 [surface_form.position().v],
                 curve.clone(),
                 surface_form,
-            ))
+            )
+            .insert(objects)
         })?;
 
         // And finally, creating the output `Edge` is just a matter of

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -124,9 +124,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.
-        Ok(objects
-            .half_edges
-            .insert(HalfEdge::new(vertices, edge_global))?)
+        Ok(HalfEdge::new(vertices, edge_global).insert(objects)?)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -105,11 +105,8 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
             [
                 vertex.surface_form().clone(),
-                objects.surface_vertices.insert(SurfaceVertex::new(
-                    position,
-                    surface,
-                    global_form,
-                ))?,
+                SurfaceVertex::new(position, surface, global_form)
+                    .insert(objects)?,
             ]
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -4,6 +4,7 @@ use try_insert_ext::EntryInsertExt;
 
 use crate::{
     geometry::path::SurfacePath,
+    insert::Insert,
     objects::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex,
@@ -90,11 +91,12 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         let curve = {
             let line = Line::from_points(points_surface);
 
-            objects.curves.insert(Curve::new(
+            Curve::new(
                 surface.clone(),
                 SurfacePath::Line(line),
                 edge_global.curve().clone(),
-            ))?
+            )
+            .insert(objects)?
         };
 
         let vertices_surface = {

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -139,7 +139,7 @@ impl Sweep for Handle<GlobalVertex> {
         cache: &mut SweepCache,
         objects: &Objects,
     ) -> Result<Self::Swept, ValidationError> {
-        let curve = objects.global_curves.insert(GlobalCurve)?;
+        let curve = GlobalCurve.insert(objects)?;
 
         let a = self.clone();
         let b = cache

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -153,9 +153,8 @@ impl Sweep for Handle<GlobalVertex> {
             .clone();
 
         let vertices = [a, b];
-        let global_edge = objects
-            .global_edges
-            .insert(GlobalEdge::new(curve, vertices.clone()))?;
+        let global_edge =
+            GlobalEdge::new(curve, vertices.clone()).insert(objects)?;
 
         // The vertices of the returned `GlobalEdge` are in normalized order,
         // which means the order can't be relied upon by the caller. Return the

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -146,9 +146,8 @@ impl Sweep for Handle<GlobalVertex> {
             .global_vertex
             .entry(self.id())
             .or_try_insert_with(|| {
-                objects.global_vertices.insert(GlobalVertex::from_position(
-                    self.position() + path.into(),
-                ))
+                GlobalVertex::from_position(self.position() + path.into())
+                    .insert(objects)
             })?
             .clone();
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -341,6 +341,6 @@ impl<'a> ShellBuilder<'a> {
 
     /// Build the [`Shell`]
     pub fn build(self) -> Handle<Shell> {
-        self.objects.shells.insert(Shell::new(self.faces)).unwrap()
+        Shell::new(self.faces).insert(self.objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -325,9 +325,7 @@ impl<'a> ShellBuilder<'a> {
             }
 
             Face::partial()
-                .with_exterior(
-                    self.objects.cycles.insert(Cycle::new(edges)).unwrap(),
-                )
+                .with_exterior(Cycle::new(edges).insert(self.objects).unwrap())
                 .build(self.objects)
                 .unwrap()
                 .insert(self.objects)

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -60,9 +60,6 @@ impl<'a> SketchBuilder<'a> {
 
     /// Build the [`Sketch`]
     pub fn build(self) -> Handle<Sketch> {
-        self.objects
-            .sketches
-            .insert(Sketch::new(self.faces))
-            .unwrap()
+        Sketch::new(self.faces).insert(self.objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use fj_math::Scalar;
 
 use crate::{
+    insert::Insert,
     objects::{Objects, Shell, Solid},
     storage::Handle,
 };
@@ -42,6 +43,6 @@ impl<'a> SolidBuilder<'a> {
 
     /// Build the [`Solid`]
     pub fn build(self) -> Handle<Solid> {
-        self.objects.solids.insert(Solid::new(self.shells)).unwrap()
+        Solid::new(self.shells).insert(self.objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -457,7 +457,7 @@ mod tests {
     fn global_curve() -> anyhow::Result<()> {
         let objects = Objects::new();
 
-        let object = objects.global_curves.insert(GlobalCurve)?;
+        let object = GlobalCurve.insert(&objects)?;
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -627,10 +627,7 @@ mod tests {
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex)
                 .insert(&objects)?;
-        let object =
-            objects
-                .vertices
-                .insert(Vertex::new([0.], curve, surface_vertex));
+        let object = Vertex::new([0.], curve, surface_vertex).insert(&objects);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -624,9 +624,9 @@ mod tests {
         let curve = curve.build(&objects)?.insert(&objects)?;
         let global_vertex =
             GlobalVertex::from_position([0., 0., 0.]).insert(&objects)?;
-        let surface_vertex = objects
-            .surface_vertices
-            .insert(SurfaceVertex::new([0., 0.], surface, global_vertex))?;
+        let surface_vertex =
+            SurfaceVertex::new([0., 0.], surface, global_vertex)
+                .insert(&objects)?;
         let object =
             objects
                 .vertices

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -478,9 +478,8 @@ mod tests {
     fn global_vertex() -> anyhow::Result<()> {
         let objects = Objects::new();
 
-        let object = objects
-            .global_vertices
-            .insert(GlobalVertex::from_position([0., 0., 0.]))?;
+        let object =
+            GlobalVertex::from_position([0., 0., 0.]).insert(&objects)?;
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -623,9 +622,8 @@ mod tests {
         };
         curve.update_as_u_axis();
         let curve = curve.build(&objects)?.insert(&objects)?;
-        let global_vertex = objects
-            .global_vertices
-            .insert(GlobalVertex::from_position([0., 0., 0.]))?;
+        let global_vertex =
+            GlobalVertex::from_position([0., 0., 0.]).insert(&objects)?;
         let surface_vertex = objects
             .surface_vertices
             .insert(SurfaceVertex::new([0., 0.], surface, global_vertex))?;

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -246,7 +246,7 @@ mod tests {
             .build(&objects)?;
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
-            tmp.curve = objects.global_curves.insert(GlobalCurve)?.into();
+            tmp.curve = GlobalCurve.insert(&objects)?.into();
             tmp.build(&objects)?.insert(&objects)?
         });
 

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -261,9 +261,7 @@ mod tests {
         let invalid = SurfaceVertex::new(
             valid.position(),
             valid.surface().clone(),
-            objects
-                .global_vertices
-                .insert(GlobalVertex::from_position([1., 0., 0.]))?,
+            GlobalVertex::from_position([1., 0., 0.]).insert(&objects)?,
         );
 
         assert!(valid.validate().is_ok());

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -35,7 +35,7 @@ impl Shape for fj::Sketch {
                         .build(objects)?
                         .insert(objects)?
                 };
-                let cycle = objects.cycles.insert(Cycle::new([half_edge]))?;
+                let cycle = Cycle::new([half_edge]).insert(objects)?;
 
                 Face::partial()
                     .with_exterior(cycle)

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::sweep::Sweep,
+    insert::Insert,
     objects::{Objects, Solid},
     validate::ValidationError,
 };
@@ -19,7 +20,7 @@ impl Shape for fj::Sweep {
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let sketch = self.shape().compute_brep(objects, debug_info)?;
-        let sketch = objects.sketches.insert(sketch)?;
+        let sketch = sketch.insert(objects)?;
 
         let path = Vector::from(self.path());
 


### PR DESCRIPTION
Change all code that inserts objects into a store to use the `Insert` trait. This is a bit more concise, on average, and it encapsulates object insertion a bit better, insulating most code from changes to the `Store` API. This came out of a local branch where I'm prototyping such changes.