### PR TITLE
Fix `Store` iteration bug

### DIFF
--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -135,6 +135,15 @@ pub struct Index {
     pub object_index: ObjectIndex,
 }
 
+impl Index {
+    pub fn zero() -> Self {
+        Self {
+            block_index: BlockIndex(0),
+            object_index: ObjectIndex(0),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct BlockIndex(pub usize);
 

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -142,6 +142,13 @@ impl Index {
             object_index: ObjectIndex(0),
         }
     }
+
+    pub fn inc<T>(&mut self, block: &Block<T>) {
+        self.object_index.0 += 1;
+        if self.object_index.0 >= block.len() {
+            self.block_index.0 += 1;
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -105,8 +105,8 @@ impl<T> Block<T> {
         &self.objects[index.0]
     }
 
-    pub fn get(&self, index: usize) -> &Option<T> {
-        &self.objects[index]
+    pub fn get(&self, index: ObjectIndex) -> &Option<T> {
+        &self.objects[index.0]
     }
 
     pub fn len(&self) -> usize {
@@ -121,7 +121,7 @@ impl<T> Block<T> {
                 return None;
             }
 
-            let object = self.get(i).as_ref()?;
+            let object = self.get(ObjectIndex(i)).as_ref()?;
             i += 1;
 
             Some(object)

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -136,8 +136,8 @@ impl<T> Block<T> {
 
 #[derive(Clone, Copy, Debug)]
 pub struct Index {
-    pub block_index: BlockIndex,
-    pub object_index: ObjectIndex,
+    block_index: BlockIndex,
+    object_index: ObjectIndex,
 }
 
 impl Index {
@@ -157,10 +157,10 @@ impl Index {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct BlockIndex(pub usize);
+pub struct BlockIndex(usize);
 
 #[derive(Clone, Copy, Debug)]
-pub struct ObjectIndex(pub usize);
+pub struct ObjectIndex(usize);
 
 #[cfg(test)]
 mod tests {

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -131,15 +131,15 @@ impl<T> Block<T> {
 
 #[derive(Clone, Copy, Debug)]
 pub struct Index {
-    block_index: BlockIndex,
-    object_index: ObjectIndex,
+    pub block_index: BlockIndex,
+    pub object_index: ObjectIndex,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct BlockIndex(usize);
+pub struct BlockIndex(pub usize);
 
 #[derive(Clone, Copy, Debug)]
-pub struct ObjectIndex(usize);
+pub struct ObjectIndex(pub usize);
 
 #[cfg(test)]
 mod tests {

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -55,8 +55,13 @@ impl<T> Blocks<T> {
         block.insert(index.object_index, object)
     }
 
-    pub fn get(&self, index: usize) -> Option<&Block<T>> {
-        self.inner.get(index)
+    pub fn get_and_inc(&self, index: &mut Index) -> Option<&Option<T>> {
+        let block = self.inner.get(index.block_index.0)?;
+        let object = block.get(index.object_index);
+
+        index.inc(block);
+
+        Some(object)
     }
 
     #[cfg(test)]

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -152,6 +152,7 @@ impl Index {
         self.object_index.0 += 1;
         if self.object_index.0 >= block.len() {
             self.block_index.0 += 1;
+            self.object_index.0 = 0;
         }
     }
 }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -26,7 +26,7 @@ use std::{marker::PhantomData, sync::Arc};
 use parking_lot::RwLock;
 
 use super::{
-    blocks::{BlockIndex, Blocks, Index, ObjectIndex},
+    blocks::{Blocks, Index},
     Handle,
 };
 
@@ -61,10 +61,7 @@ impl<T> Store<T> {
     pub fn iter(&self) -> Iter<T> {
         Iter {
             store: self.inner.clone(),
-            next_index: Index {
-                block_index: BlockIndex(0),
-                object_index: ObjectIndex(0),
-            },
+            next_index: Index::zero(),
             _a: PhantomData,
         }
     }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -112,10 +112,7 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         let inner = self.store.read();
 
-        let block = inner.blocks.get(self.next_index.block_index.0)?;
-        let object = block.get(self.next_index.object_index);
-
-        self.next_index.inc(block);
+        let object = inner.blocks.get_and_inc(&mut self.next_index)?;
 
         Some(Handle {
             store: self.store.clone(),

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -115,10 +115,7 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
         let block = inner.blocks.get(self.next_index.block_index.0)?;
         let object = block.get(self.next_index.object_index);
 
-        self.next_index.object_index.0 += 1;
-        if self.next_index.object_index.0 >= block.len() {
-            self.next_index.block_index.0 += 1;
-        }
+        self.next_index.inc(block);
 
         Some(Handle {
             store: self.store.clone(),

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -39,7 +39,7 @@ pub struct Store<T> {
 impl<T> Store<T> {
     /// Construct a new instance of `Store`
     pub fn new() -> Self {
-        Self::with_block_size(BLOCK_SIZE)
+        Self::with_block_size(16384)
     }
 
     /// Construct a new instance of `Store` using the provided block size
@@ -171,8 +171,6 @@ pub type StoreInner<T> = Arc<RwLock<StoreInnerInner<T>>>;
 pub struct StoreInnerInner<T> {
     blocks: Blocks<T>,
 }
-
-const BLOCK_SIZE: usize = 16384;
 
 #[cfg(test)]
 mod tests {

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn insert_and_handle() {
-        let store = Store::new();
+        let store = Store::with_block_size(1);
 
         let object = 0;
         let handle = store.insert(object);
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn insert_and_iter() {
-        let store = Store::new();
+        let store = Store::with_block_size(1);
 
         let a = store.insert(0);
         let b = store.insert(1);

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -39,8 +39,13 @@ pub struct Store<T> {
 impl<T> Store<T> {
     /// Construct a new instance of `Store`
     pub fn new() -> Self {
+        Self::with_block_size(BLOCK_SIZE)
+    }
+
+    /// Construct a new instance of `Store` using the provided block size
+    pub fn with_block_size(block_size: usize) -> Self {
         let inner = Arc::new(RwLock::new(StoreInnerInner {
-            blocks: Blocks::new(BLOCK_SIZE),
+            blocks: Blocks::new(block_size),
         }));
 
         Self { inner }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -38,6 +38,9 @@ pub struct Store<T> {
 
 impl<T> Store<T> {
     /// Construct a new instance of `Store`
+    ///
+    /// Equivalent to calling [`Store::with_block_size`] with a default block
+    /// size.
     pub fn new() -> Self {
         Self::with_block_size(16384)
     }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -113,7 +113,7 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
         let inner = self.store.read();
 
         let block = inner.blocks.get(self.next_index.block_index.0)?;
-        let object = block.get(self.next_index.object_index.0);
+        let object = block.get(self.next_index.object_index);
 
         self.next_index.object_index.0 += 1;
         if self.next_index.object_index.0 >= block.len() {


### PR DESCRIPTION
From a commit message:
> The previous code was only correctly iterating over a single block, ignoring any others.

This pull request also features some clean-up of the code that was surrounding the bug.