### PR TITLE
Simplify `Store`

### DIFF
--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -29,7 +29,8 @@ macro_rules! impl_insert {
                     objects: &Objects,
                 ) -> Result<Handle<Self>, <Self as Validate>::Error> {
                     let handle = objects.$store.reserve();
-                    objects.$store.insert(handle, self)
+                    objects.$store.insert(handle.clone(), self)?;
+                    Ok(handle)
                 }
             }
         )*

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -28,7 +28,8 @@ macro_rules! impl_insert {
                     self,
                     objects: &Objects,
                 ) -> Result<Handle<Self>, <Self as Validate>::Error> {
-                    objects.$store.insert(self)
+                    let handle = objects.$store.reserve();
+                    objects.$store.insert(handle, self)
                 }
             }
         )*

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -86,6 +86,11 @@
 //! [Fornjot]: https://www.fornjot.app/
 
 #![warn(missing_docs)]
+// I've made a simple change that put `ValidationError` over the threshold for
+// this warning. I couldn't come up with an easy fix, and figured that silencing
+// the warning is the most practical solution for now, as the validation
+// infrastructure is in flux anyway. Maybe the problem will take care of itself.
+#![allow(clippy::result_large_err)]
 
 pub mod algorithms;
 pub mod builder;

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -86,9 +86,13 @@ impl Curves {
     }
 
     /// Insert a [`Curve`] into the store
-    pub fn insert(&self, curve: Curve) -> Result<Handle<Curve>, Infallible> {
+    pub fn insert(
+        &self,
+        handle: Handle<Curve>,
+        curve: Curve,
+    ) -> Result<Handle<Curve>, Infallible> {
         curve.validate()?;
-        Ok(self.store.insert(curve))
+        Ok(self.store.insert(handle, curve))
     }
 }
 
@@ -107,10 +111,11 @@ impl Cycles {
     /// Insert a [`Cycle`] into the store
     pub fn insert(
         &self,
+        handle: Handle<Cycle>,
         cycle: Cycle,
     ) -> Result<Handle<Cycle>, CycleValidationError> {
         cycle.validate()?;
-        Ok(self.store.insert(cycle))
+        Ok(self.store.insert(handle, cycle))
     }
 }
 
@@ -129,10 +134,11 @@ impl Faces {
     /// Insert a [`Face`] into the store
     pub fn insert(
         &self,
+        handle: Handle<Face>,
         face: Face,
     ) -> Result<Handle<Face>, FaceValidationError> {
         face.validate()?;
-        Ok(self.store.insert(face))
+        Ok(self.store.insert(handle, face))
     }
 }
 
@@ -151,10 +157,11 @@ impl GlobalCurves {
     /// Insert a [`GlobalCurve`] into the store
     pub fn insert(
         &self,
+        handle: Handle<GlobalCurve>,
         global_curve: GlobalCurve,
     ) -> Result<Handle<GlobalCurve>, Infallible> {
         global_curve.validate()?;
-        Ok(self.store.insert(global_curve))
+        Ok(self.store.insert(handle, global_curve))
     }
 }
 
@@ -173,10 +180,11 @@ impl GlobalEdges {
     /// Insert a [`GlobalEdge`] into the store
     pub fn insert(
         &self,
+        handle: Handle<GlobalEdge>,
         global_edge: GlobalEdge,
     ) -> Result<Handle<GlobalEdge>, Infallible> {
         global_edge.validate()?;
-        Ok(self.store.insert(global_edge))
+        Ok(self.store.insert(handle, global_edge))
     }
 }
 
@@ -195,10 +203,11 @@ impl GlobalVertices {
     /// Insert a [`GlobalVertex`] into the store
     pub fn insert(
         &self,
+        handle: Handle<GlobalVertex>,
         global_vertex: GlobalVertex,
     ) -> Result<Handle<GlobalVertex>, Infallible> {
         global_vertex.validate()?;
-        Ok(self.store.insert(global_vertex))
+        Ok(self.store.insert(handle, global_vertex))
     }
 }
 
@@ -217,10 +226,11 @@ impl HalfEdges {
     /// Insert a [`HalfEdge`] into the store
     pub fn insert(
         &self,
+        handle: Handle<HalfEdge>,
         half_edge: HalfEdge,
     ) -> Result<Handle<HalfEdge>, HalfEdgeValidationError> {
         half_edge.validate()?;
-        Ok(self.store.insert(half_edge))
+        Ok(self.store.insert(handle, half_edge))
     }
 }
 
@@ -237,9 +247,13 @@ impl Shells {
     }
 
     /// Insert a [`Shell`] into the store
-    pub fn insert(&self, shell: Shell) -> Result<Handle<Shell>, Infallible> {
+    pub fn insert(
+        &self,
+        handle: Handle<Shell>,
+        shell: Shell,
+    ) -> Result<Handle<Shell>, Infallible> {
         shell.validate()?;
-        Ok(self.store.insert(shell))
+        Ok(self.store.insert(handle, shell))
     }
 }
 
@@ -256,9 +270,13 @@ impl Sketches {
     }
 
     /// Insert a [`Sketch`] into the store
-    pub fn insert(&self, sketch: Sketch) -> Result<Handle<Sketch>, Infallible> {
+    pub fn insert(
+        &self,
+        handle: Handle<Sketch>,
+        sketch: Sketch,
+    ) -> Result<Handle<Sketch>, Infallible> {
         sketch.validate()?;
-        Ok(self.store.insert(sketch))
+        Ok(self.store.insert(handle, sketch))
     }
 }
 
@@ -275,9 +293,13 @@ impl Solids {
     }
 
     /// Insert a [`Solid`] into the store
-    pub fn insert(&self, solid: Solid) -> Result<Handle<Solid>, Infallible> {
+    pub fn insert(
+        &self,
+        handle: Handle<Solid>,
+        solid: Solid,
+    ) -> Result<Handle<Solid>, Infallible> {
         solid.validate()?;
-        Ok(self.store.insert(solid))
+        Ok(self.store.insert(handle, solid))
     }
 }
 
@@ -296,10 +318,11 @@ impl SurfaceVertices {
     /// Insert a [`SurfaceVertex`] into the store
     pub fn insert(
         &self,
+        handle: Handle<SurfaceVertex>,
         surface_vertex: SurfaceVertex,
     ) -> Result<Handle<SurfaceVertex>, SurfaceVertexValidationError> {
         surface_vertex.validate()?;
-        Ok(self.store.insert(surface_vertex))
+        Ok(self.store.insert(handle, surface_vertex))
     }
 }
 
@@ -322,10 +345,11 @@ impl Surfaces {
     /// Insert a [`Surface`] into the store
     pub fn insert(
         &self,
+        handle: Handle<Surface>,
         surface: Surface,
     ) -> Result<Handle<Surface>, Infallible> {
         surface.validate()?;
-        Ok(self.store.insert(surface))
+        Ok(self.store.insert(handle, surface))
     }
 
     /// Access the xy-plane
@@ -346,20 +370,33 @@ impl Surfaces {
 
 impl Default for Surfaces {
     fn default() -> Self {
-        let store = Store::new();
+        let store: Store<Surface> = Store::new();
 
-        let xy_plane = store.insert(Surface::new(SurfaceGeometry {
-            u: GlobalPath::x_axis(),
-            v: Vector::unit_y(),
-        }));
-        let xz_plane = store.insert(Surface::new(SurfaceGeometry {
-            u: GlobalPath::x_axis(),
-            v: Vector::unit_z(),
-        }));
-        let yz_plane = store.insert(Surface::new(SurfaceGeometry {
-            u: GlobalPath::y_axis(),
-            v: Vector::unit_z(),
-        }));
+        let xy_plane = store.reserve();
+        store.insert(
+            xy_plane.clone(),
+            Surface::new(SurfaceGeometry {
+                u: GlobalPath::x_axis(),
+                v: Vector::unit_y(),
+            }),
+        );
+
+        let xz_plane = store.reserve();
+        store.insert(
+            xz_plane.clone(),
+            Surface::new(SurfaceGeometry {
+                u: GlobalPath::x_axis(),
+                v: Vector::unit_z(),
+            }),
+        );
+        let yz_plane = store.reserve();
+        store.insert(
+            yz_plane.clone(),
+            Surface::new(SurfaceGeometry {
+                u: GlobalPath::y_axis(),
+                v: Vector::unit_z(),
+            }),
+        );
 
         Self {
             store,
@@ -385,9 +422,10 @@ impl Vertices {
     /// Insert a [`Vertex`] into the store
     pub fn insert(
         &self,
+        handle: Handle<Vertex>,
         vertex: Vertex,
     ) -> Result<Handle<Vertex>, VertexValidationError> {
         vertex.validate()?;
-        Ok(self.store.insert(vertex))
+        Ok(self.store.insert(handle, vertex))
     }
 }

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -90,9 +90,10 @@ impl Curves {
         &self,
         handle: Handle<Curve>,
         curve: Curve,
-    ) -> Result<Handle<Curve>, Infallible> {
+    ) -> Result<(), Infallible> {
         curve.validate()?;
-        Ok(self.store.insert(handle, curve))
+        self.store.insert(handle, curve);
+        Ok(())
     }
 }
 
@@ -113,9 +114,10 @@ impl Cycles {
         &self,
         handle: Handle<Cycle>,
         cycle: Cycle,
-    ) -> Result<Handle<Cycle>, CycleValidationError> {
+    ) -> Result<(), CycleValidationError> {
         cycle.validate()?;
-        Ok(self.store.insert(handle, cycle))
+        self.store.insert(handle, cycle);
+        Ok(())
     }
 }
 
@@ -136,9 +138,10 @@ impl Faces {
         &self,
         handle: Handle<Face>,
         face: Face,
-    ) -> Result<Handle<Face>, FaceValidationError> {
+    ) -> Result<(), FaceValidationError> {
         face.validate()?;
-        Ok(self.store.insert(handle, face))
+        self.store.insert(handle, face);
+        Ok(())
     }
 }
 
@@ -159,9 +162,10 @@ impl GlobalCurves {
         &self,
         handle: Handle<GlobalCurve>,
         global_curve: GlobalCurve,
-    ) -> Result<Handle<GlobalCurve>, Infallible> {
+    ) -> Result<(), Infallible> {
         global_curve.validate()?;
-        Ok(self.store.insert(handle, global_curve))
+        self.store.insert(handle, global_curve);
+        Ok(())
     }
 }
 
@@ -182,9 +186,10 @@ impl GlobalEdges {
         &self,
         handle: Handle<GlobalEdge>,
         global_edge: GlobalEdge,
-    ) -> Result<Handle<GlobalEdge>, Infallible> {
+    ) -> Result<(), Infallible> {
         global_edge.validate()?;
-        Ok(self.store.insert(handle, global_edge))
+        self.store.insert(handle, global_edge);
+        Ok(())
     }
 }
 
@@ -205,9 +210,10 @@ impl GlobalVertices {
         &self,
         handle: Handle<GlobalVertex>,
         global_vertex: GlobalVertex,
-    ) -> Result<Handle<GlobalVertex>, Infallible> {
+    ) -> Result<(), Infallible> {
         global_vertex.validate()?;
-        Ok(self.store.insert(handle, global_vertex))
+        self.store.insert(handle, global_vertex);
+        Ok(())
     }
 }
 
@@ -228,9 +234,10 @@ impl HalfEdges {
         &self,
         handle: Handle<HalfEdge>,
         half_edge: HalfEdge,
-    ) -> Result<Handle<HalfEdge>, HalfEdgeValidationError> {
+    ) -> Result<(), HalfEdgeValidationError> {
         half_edge.validate()?;
-        Ok(self.store.insert(handle, half_edge))
+        self.store.insert(handle, half_edge);
+        Ok(())
     }
 }
 
@@ -251,9 +258,10 @@ impl Shells {
         &self,
         handle: Handle<Shell>,
         shell: Shell,
-    ) -> Result<Handle<Shell>, Infallible> {
+    ) -> Result<(), Infallible> {
         shell.validate()?;
-        Ok(self.store.insert(handle, shell))
+        self.store.insert(handle, shell);
+        Ok(())
     }
 }
 
@@ -274,9 +282,10 @@ impl Sketches {
         &self,
         handle: Handle<Sketch>,
         sketch: Sketch,
-    ) -> Result<Handle<Sketch>, Infallible> {
+    ) -> Result<(), Infallible> {
         sketch.validate()?;
-        Ok(self.store.insert(handle, sketch))
+        self.store.insert(handle, sketch);
+        Ok(())
     }
 }
 
@@ -297,9 +306,10 @@ impl Solids {
         &self,
         handle: Handle<Solid>,
         solid: Solid,
-    ) -> Result<Handle<Solid>, Infallible> {
+    ) -> Result<(), Infallible> {
         solid.validate()?;
-        Ok(self.store.insert(handle, solid))
+        self.store.insert(handle, solid);
+        Ok(())
     }
 }
 
@@ -320,9 +330,10 @@ impl SurfaceVertices {
         &self,
         handle: Handle<SurfaceVertex>,
         surface_vertex: SurfaceVertex,
-    ) -> Result<Handle<SurfaceVertex>, SurfaceVertexValidationError> {
+    ) -> Result<(), SurfaceVertexValidationError> {
         surface_vertex.validate()?;
-        Ok(self.store.insert(handle, surface_vertex))
+        self.store.insert(handle, surface_vertex);
+        Ok(())
     }
 }
 
@@ -347,9 +358,10 @@ impl Surfaces {
         &self,
         handle: Handle<Surface>,
         surface: Surface,
-    ) -> Result<Handle<Surface>, Infallible> {
+    ) -> Result<(), Infallible> {
         surface.validate()?;
-        Ok(self.store.insert(handle, surface))
+        self.store.insert(handle, surface);
+        Ok(())
     }
 
     /// Access the xy-plane
@@ -424,8 +436,9 @@ impl Vertices {
         &self,
         handle: Handle<Vertex>,
         vertex: Vertex,
-    ) -> Result<Handle<Vertex>, VertexValidationError> {
+    ) -> Result<(), VertexValidationError> {
         vertex.validate()?;
-        Ok(self.store.insert(handle, vertex))
+        self.store.insert(handle, vertex);
+        Ok(())
     }
 }

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -80,6 +80,11 @@ pub struct Curves {
 }
 
 impl Curves {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Curve> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Curve`] into the store
     pub fn insert(&self, curve: Curve) -> Result<Handle<Curve>, Infallible> {
         curve.validate()?;
@@ -94,6 +99,11 @@ pub struct Cycles {
 }
 
 impl Cycles {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Cycle> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Cycle`] into the store
     pub fn insert(
         &self,
@@ -111,6 +121,11 @@ pub struct Faces {
 }
 
 impl Faces {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Face> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Face`] into the store
     pub fn insert(
         &self,
@@ -128,6 +143,11 @@ pub struct GlobalCurves {
 }
 
 impl GlobalCurves {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<GlobalCurve> {
+        self.store.reserve()
+    }
+
     /// Insert a [`GlobalCurve`] into the store
     pub fn insert(
         &self,
@@ -145,6 +165,11 @@ pub struct GlobalEdges {
 }
 
 impl GlobalEdges {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<GlobalEdge> {
+        self.store.reserve()
+    }
+
     /// Insert a [`GlobalEdge`] into the store
     pub fn insert(
         &self,
@@ -162,6 +187,11 @@ pub struct GlobalVertices {
 }
 
 impl GlobalVertices {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<GlobalVertex> {
+        self.store.reserve()
+    }
+
     /// Insert a [`GlobalVertex`] into the store
     pub fn insert(
         &self,
@@ -179,6 +209,11 @@ pub struct HalfEdges {
 }
 
 impl HalfEdges {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<HalfEdge> {
+        self.store.reserve()
+    }
+
     /// Insert a [`HalfEdge`] into the store
     pub fn insert(
         &self,
@@ -196,6 +231,11 @@ pub struct Shells {
 }
 
 impl Shells {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Shell> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Shell`] into the store
     pub fn insert(&self, shell: Shell) -> Result<Handle<Shell>, Infallible> {
         shell.validate()?;
@@ -210,6 +250,11 @@ pub struct Sketches {
 }
 
 impl Sketches {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Sketch> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Sketch`] into the store
     pub fn insert(&self, sketch: Sketch) -> Result<Handle<Sketch>, Infallible> {
         sketch.validate()?;
@@ -224,6 +269,11 @@ pub struct Solids {
 }
 
 impl Solids {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Solid> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Solid`] into the store
     pub fn insert(&self, solid: Solid) -> Result<Handle<Solid>, Infallible> {
         solid.validate()?;
@@ -238,6 +288,11 @@ pub struct SurfaceVertices {
 }
 
 impl SurfaceVertices {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<SurfaceVertex> {
+        self.store.reserve()
+    }
+
     /// Insert a [`SurfaceVertex`] into the store
     pub fn insert(
         &self,
@@ -259,6 +314,11 @@ pub struct Surfaces {
 }
 
 impl Surfaces {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Surface> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Surface`] into the store
     pub fn insert(
         &self,
@@ -317,6 +377,11 @@ pub struct Vertices {
 }
 
 impl Vertices {
+    /// Reserve a slot for an object in the store
+    pub fn reserve(&self) -> Handle<Vertex> {
+        self.store.reserve()
+    }
+
     /// Insert a [`Vertex`] into the store
     pub fn insert(
         &self,

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -91,13 +91,8 @@ impl<T> Block<T> {
         Ok((index, ptr))
     }
 
-    pub fn insert(
-        &mut self,
-        index: ObjectIndex,
-        object: T,
-    ) -> *const Option<T> {
+    pub fn insert(&mut self, index: ObjectIndex, object: T) {
         self.objects[index.0] = Some(object);
-        &self.objects[index.0]
     }
 
     pub fn get(&self, index: ObjectIndex) -> &Option<T> {

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -14,11 +14,6 @@ impl<T> Blocks<T> {
         }
     }
 
-    pub fn push(&mut self, object: T) -> *const Option<T> {
-        let (index, _) = self.reserve();
-        self.insert(index, object)
-    }
-
     pub fn reserve(&mut self) -> (Index, *const Option<T>) {
         let mut current_block = match self.inner.pop() {
             Some(block) => block,
@@ -62,11 +57,6 @@ impl<T> Blocks<T> {
         index.inc(block);
 
         Some(object)
-    }
-
-    #[cfg(test)]
-    pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
-        self.inner.iter().flat_map(|block| block.iter())
     }
 }
 
@@ -117,21 +107,6 @@ impl<T> Block<T> {
     pub fn len(&self) -> usize {
         self.next.0
     }
-
-    #[cfg(test)]
-    pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
-        let mut i = 0;
-        iter::from_fn(move || {
-            if i >= self.len() {
-                return None;
-            }
-
-            let object = self.get(ObjectIndex(i)).as_ref()?;
-            i += 1;
-
-            Some(object)
-        })
-    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -162,19 +137,3 @@ pub struct BlockIndex(usize);
 
 #[derive(Clone, Copy, Debug)]
 pub struct ObjectIndex(usize);
-
-#[cfg(test)]
-mod tests {
-    use super::Blocks;
-
-    #[test]
-    fn push() {
-        let mut blocks = Blocks::new(1);
-
-        blocks.push(0);
-        blocks.push(1);
-
-        let objects = blocks.iter().copied().collect::<Vec<_>>();
-        assert_eq!(objects, [0, 1]);
-    }
-}

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -92,7 +92,13 @@ impl<T> Block<T> {
     }
 
     pub fn insert(&mut self, index: ObjectIndex, object: T) {
-        self.objects[index.0] = Some(object);
+        let slot = &mut self.objects[index.0];
+
+        if slot.is_some() {
+            panic!("Attempting to overwrite object in store")
+        }
+
+        *slot = Some(object);
     }
 
     pub fn get(&self, index: ObjectIndex) -> &Option<T> {

--- a/crates/fj-kernel/src/storage/blocks.rs
+++ b/crates/fj-kernel/src/storage/blocks.rs
@@ -45,9 +45,9 @@ impl<T> Blocks<T> {
         ret
     }
 
-    pub fn insert(&mut self, index: Index, object: T) -> *const Option<T> {
+    pub fn insert(&mut self, index: Index, object: T) {
         let block = &mut self.inner[index.block_index.0];
-        block.insert(index.object_index, object)
+        block.insert(index.object_index, object);
     }
 
     pub fn get_and_inc(&self, index: &mut Index) -> Option<&Option<T>> {

--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -1,6 +1,6 @@
 use std::{any::type_name, cmp::Ordering, fmt, hash::Hash, ops::Deref};
 
-use super::store::StoreInner;
+use super::{blocks::Index, store::StoreInner};
 
 /// A handle for an object
 ///
@@ -23,6 +23,7 @@ use super::store::StoreInner;
 /// comparing the values returned by [`Handle::id`].
 pub struct Handle<T> {
     pub(super) store: StoreInner<T>,
+    pub(super) index: Index,
     pub(super) ptr: *const Option<T>,
 }
 
@@ -85,6 +86,7 @@ impl<T> Clone for Handle<T> {
     fn clone(&self) -> Self {
         Self {
             store: self.store.clone(),
+            index: self.index,
             ptr: self.ptr,
         }
     }

--- a/crates/fj-kernel/src/storage/mod.rs
+++ b/crates/fj-kernel/src/storage/mod.rs
@@ -6,5 +6,5 @@ mod store;
 
 pub use self::{
     handle::{Handle, HandleWrapper, ObjectId},
-    store::{Iter, Reservation, Store},
+    store::{Iter, Store},
 };

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -57,7 +57,9 @@ impl<T> Store<T> {
     /// Insert an object into the store
     pub fn insert(&self, object: T) -> Handle<T> {
         let mut inner = self.inner.write();
-        let ptr = inner.blocks.push(object);
+
+        let (index, ptr) = inner.blocks.reserve();
+        inner.blocks.insert(index, object);
 
         Handle {
             store: self.inner.clone(),

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -54,6 +54,28 @@ impl<T> Store<T> {
         Self { inner }
     }
 
+    /// Reserve a slot for an object in the store
+    ///
+    /// This method returns a handle to the reserved slot. That handle does not
+    /// refer to an object yet! Attempting to dereference the handle before it
+    /// has been used to insert an object into the store, will result in a
+    /// panic.
+    ///
+    /// Usually, you'd acquire one handle, then immediately use it to insert an
+    /// object using [`Store::insert`]. The methods are separate to support more
+    /// advanced use cases, like inserting objects that refer to each other.
+    pub fn reserve(&self) -> Handle<T> {
+        let mut inner = self.inner.write();
+
+        let (index, ptr) = inner.blocks.reserve();
+
+        Handle {
+            store: self.inner.clone(),
+            index,
+            ptr,
+        }
+    }
+
     /// Insert an object into the store
     pub fn insert(&self, object: T) -> Handle<T> {
         let mut inner = self.inner.write();

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -77,10 +77,9 @@ impl<T> Store<T> {
     }
 
     /// Insert an object into the store
-    pub fn insert(&self, handle: Handle<T>, object: T) -> Handle<T> {
+    pub fn insert(&self, handle: Handle<T>, object: T) {
         let mut inner = self.inner.write();
         inner.blocks.insert(handle.index, object);
-        handle
     }
 
     /// Iterate over all objects in this store

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -63,6 +63,7 @@ impl<T> Store<T> {
 
         Handle {
             store: self.inner.clone(),
+            index,
             ptr,
         }
     }
@@ -106,6 +107,7 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
         let inner = self.store.read();
 
         loop {
+            let index = self.next_index;
             let ptr = inner.blocks.get_and_inc(&mut self.next_index)?;
 
             if ptr.is_none() {
@@ -115,6 +117,7 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
 
             return Some(Handle {
                 store: self.store.clone(),
+                index,
                 ptr,
             });
         }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -122,12 +122,19 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         let inner = self.store.read();
 
-        let object = inner.blocks.get_and_inc(&mut self.next_index)?;
+        loop {
+            let object = inner.blocks.get_and_inc(&mut self.next_index)?;
 
-        Some(Handle {
-            store: self.store.clone(),
-            ptr: object,
-        })
+            if object.is_none() {
+                // This is a reserved slot.
+                continue;
+            }
+
+            return Some(Handle {
+                store: self.store.clone(),
+                ptr: object,
+            });
+        }
     }
 }
 

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -106,16 +106,16 @@ impl<'a, T: 'a> Iterator for Iter<'a, T> {
         let inner = self.store.read();
 
         loop {
-            let object = inner.blocks.get_and_inc(&mut self.next_index)?;
+            let ptr = inner.blocks.get_and_inc(&mut self.next_index)?;
 
-            if object.is_none() {
+            if ptr.is_none() {
                 // This is a reserved slot.
                 continue;
             }
 
             return Some(Handle {
                 store: self.store.clone(),
-                ptr: object,
+                ptr,
             });
         }
     }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -77,6 +77,12 @@ impl<T> Store<T> {
     }
 
     /// Insert an object into the store
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the passed `Handle` does not refer to a reserved slot. This
+    /// can only be the case, if the handle has been used to insert an object
+    /// before.
     pub fn insert(&self, handle: Handle<T>, object: T) {
         let mut inner = self.inner.write();
         inner.blocks.insert(handle.index, object);

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -15,6 +15,11 @@
 //! [`fj`]: https://crates.io/crates/fj
 
 #![warn(missing_docs)]
+// I've made a simple change that put `ValidationError` over the threshold for
+// this warning. I couldn't come up with an easy fix, and figured that silencing
+// the warning is the most practical solution for now, as the validation
+// infrastructure is in flux anyway. Maybe the problem will take care of itself.
+#![allow(clippy::result_large_err)]
 
 pub mod shape_processor;
 


### PR DESCRIPTION
Unify the insert and reserve operations into a single code path. This makes the implementation of `Store` simpler, at the cost of making its use a bit more complicated. I think this is a good trade-off, for two reasons:

- Most code isn't affected by that, as it's using `Store` only indirectly through `Insert` (https://github.com/hannobraun/Fornjot/pull/1377 recently completed this migration).
- The new model provides more flexibility, allowing creation of objects and insertion of them into the store to be completely separate. This is a prerequisite for some changes I'm currently prototyping (sorry, no issue for that yet; I plan to open one within the next few days).

Despite the simplification, we unfortunately end up with more code here, due to lots of repetitive code in the `Store` wrappers. I believe that the prototyping work I mentioned above will result in those wrappers to become simpler, removing all that repetitive code, so I'm fine with that too.