### PR TITLE
Take `&mut self` in `Store::insert`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -216,13 +216,13 @@ mod tests {
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
                 .build(&objects)?
-                .insert(&objects)?;
+                .insert(&mut objects)?;
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
-        let curve = curve.build(&mut objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -241,13 +241,13 @@ mod tests {
             [0., 0., 1.],
         )
         .build(&objects)?
-        .insert(&objects)?;
+        .insert(&mut objects)?;
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
-        let curve = curve.build(&mut objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -263,13 +263,13 @@ mod tests {
         let path = GlobalPath::circle_from_radius(1.);
         let surface = PartialSurface::from_axes(path, [0., 0., 1.])
             .build(&objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
-        let curve = curve.build(&mut objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;
@@ -298,13 +298,13 @@ mod tests {
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
                 .build(&objects)?
-                .insert(&objects)?;
+                .insert(&mut objects)?;
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_circle_from_radius(1.);
-        let curve = curve.build(&mut objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn approx_line_on_flat_surface() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
@@ -222,7 +222,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
-        let curve = curve.build(&objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn approx_line_on_curved_surface_but_not_along_curve() -> anyhow::Result<()>
     {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = PartialSurface::from_axes(
             GlobalPath::circle_from_radius(1.),
@@ -247,7 +247,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
-        let curve = curve.build(&objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&objects)?;
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn approx_line_on_curved_surface_along_curve() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let path = GlobalPath::circle_from_radius(1.);
         let surface = PartialSurface::from_axes(path, [0., 0., 1.])
@@ -269,7 +269,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
-        let curve = curve.build(&objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;
@@ -293,7 +293,7 @@ mod tests {
 
     #[test]
     fn approx_circle_on_flat_surface() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
@@ -304,7 +304,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_circle_from_radius(1.);
-        let curve = curve.build(&objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&objects)?;
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn compute_edge_in_front_of_curve_origin() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -92,10 +92,10 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&objects)?;
+        let curve = curve.build(&mut objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[1., -1.], [1., 1.]])
-            .build(&objects)?;
+            .build(&mut objects)?;
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn compute_edge_behind_curve_origin() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -118,13 +118,13 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&objects)?;
+        let curve = curve.build(&mut objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
                 [[-1., -1.], [-1., 1.]],
             )
-            .build(&objects)?;
+            .build(&mut objects)?;
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn compute_edge_parallel_to_curve() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -147,13 +147,13 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&objects)?;
+        let curve = curve.build(&mut objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
                 [[-1., -1.], [1., -1.]],
             )
-            .build(&objects)?;
+            .build(&mut objects)?;
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn compute_edge_on_curve() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -171,10 +171,10 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&objects)?;
+        let curve = curve.build(&mut objects)?;
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[-1., 0.], [1., 0.]])
-            .build(&objects)?;
+            .build(&mut objects)?;
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn compute() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
 
@@ -168,7 +168,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);
-        let curve = curve.build(&objects)?;
+        let curve = curve.build(&mut objects)?;
 
         #[rustfmt::skip]
         let exterior = [
@@ -189,7 +189,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points(exterior)
             .with_interior_polygon_from_points(interior)
-            .build(&objects)?;
+            .build(&mut objects)?;
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -30,7 +30,7 @@ impl FaceFaceIntersection {
     /// Compute the intersections between two faces
     pub fn compute(
         faces: [&Face; 2],
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Option<Self>, ValidationError> {
         let surfaces = faces.map(|face| face.surface().clone());
 
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn compute_no_intersection() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         #[rustfmt::skip]
         let points = [
@@ -98,7 +98,8 @@ mod tests {
                     .build(&objects)
             })?;
 
-        let intersection = FaceFaceIntersection::compute([&a, &b], &objects)?;
+        let intersection =
+            FaceFaceIntersection::compute([&a, &b], &mut objects)?;
 
         assert!(intersection.is_none());
 
@@ -107,7 +108,7 @@ mod tests {
 
     #[test]
     fn compute_one_intersection() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         #[rustfmt::skip]
         let points = [
@@ -125,7 +126,8 @@ mod tests {
                 .build(&objects)
         })?;
 
-        let intersection = FaceFaceIntersection::compute([&a, &b], &objects)?;
+        let intersection =
+            FaceFaceIntersection::compute([&a, &b], &mut objects)?;
 
         let expected_curves =
             surfaces.try_map_ext(|surface| -> Result<_, ValidationError> {

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -95,7 +95,7 @@ mod tests {
                 Face::partial()
                     .with_surface(surface)
                     .with_exterior_polygon_from_points(points)
-                    .build(&objects)
+                    .build(&mut objects)
             })?;
 
         let intersection =
@@ -123,7 +123,7 @@ mod tests {
             Face::partial()
                 .with_surface(surface)
                 .with_exterior_polygon_from_points(points)
-                .build(&objects)
+                .build(&mut objects)
         })?;
 
         let intersection =
@@ -136,7 +136,7 @@ mod tests {
                     ..Default::default()
                 };
                 curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
-                Ok(curve.build(&objects)?.insert(&objects)?)
+                Ok(curve.build(&mut objects)?.insert(&objects)?)
             })?;
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -136,7 +136,7 @@ mod tests {
                     ..Default::default()
                 };
                 curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
-                Ok(curve.build(&mut objects)?.insert(&objects)?)
+                Ok(curve.build(&mut objects)?.insert(&mut objects)?)
             })?;
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -145,13 +145,13 @@ mod tests {
 
     #[test]
     fn point_is_outside_face() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([2., 1.]);
 
@@ -163,13 +163,13 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_while_passing_outside() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 1.]);
 
@@ -184,13 +184,13 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_at_cycle_seam() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 2.]);
 
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_while_staying_inside() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -216,7 +216,7 @@ mod tests {
                 [3., 0.],
                 [3., 4.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 1.]);
 
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() -> anyhow::Result<()>
     {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -243,7 +243,7 @@ mod tests {
                 [3., 1.],
                 [0., 2.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 1.]);
 
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn ray_hits_parallel_edge_and_does_not_leave_face_there(
     ) -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -271,7 +271,7 @@ mod tests {
                 [4., 0.],
                 [4., 5.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 1.]);
 
@@ -286,13 +286,13 @@ mod tests {
 
     #[test]
     fn point_is_coincident_with_edge() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 0.]);
 
@@ -316,13 +316,13 @@ mod tests {
 
     #[test]
     fn point_is_coincident_with_vertex() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let point = Point::from([1., 0.]);
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -152,7 +152,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([2., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -170,7 +170,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -191,7 +191,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 2.]);
 
         let intersection = (&face, &point).intersect();
@@ -217,7 +217,7 @@ mod tests {
                 [3., 4.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -244,7 +244,7 @@ mod tests {
                 [0., 2.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -272,7 +272,7 @@ mod tests {
                 [4., 5.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -293,7 +293,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();
@@ -323,7 +323,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn ray_misses_whole_surface() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -176,7 +176,7 @@ mod tests {
             ])
             .build(&objects)?
             .insert(&objects)?
-            .translate([-1., 0., 0.], &objects)?;
+            .translate([-1., 0., 0.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
         Ok(())
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn ray_hits_face() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -199,7 +199,7 @@ mod tests {
             ])
             .build(&objects)?
             .insert(&objects)?
-            .translate([1., 0., 0.], &objects)?;
+            .translate([1., 0., 0.], &mut objects)?;
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn ray_hits_surface_but_misses_face() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -225,7 +225,7 @@ mod tests {
             ])
             .build(&objects)?
             .insert(&objects)?
-            .translate([0., 0., 2.], &objects)?;
+            .translate([0., 0., 2.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
         Ok(())
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn ray_hits_edge() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -248,7 +248,7 @@ mod tests {
             ])
             .build(&objects)?
             .insert(&objects)?
-            .translate([1., 1., 0.], &objects)?;
+            .translate([1., 1., 0.], &mut objects)?;
 
         let edge = face
             .half_edge_iter()
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -282,7 +282,7 @@ mod tests {
             ])
             .build(&objects)?
             .insert(&objects)?
-            .translate([1., 1., 1.], &objects)?;
+            .translate([1., 1., 1.], &mut objects)?;
 
         let vertex = face
             .vertex_iter()
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn ray_is_parallel_to_surface_and_misses() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -340,7 +340,7 @@ mod tests {
             ])
             .build(&objects)?
             .insert(&objects)?
-            .translate([0., 0., 1.], &objects)?;
+            .translate([0., 0., 1.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
         Ok(())

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -175,7 +175,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .translate([-1., 0., 0.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
@@ -198,7 +198,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .translate([1., 0., 0.], &mut objects)?;
 
         assert_eq!(
@@ -224,7 +224,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .translate([0., 0., 2.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
@@ -247,7 +247,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .translate([1., 1., 0.], &mut objects)?;
 
         let edge = face
@@ -281,7 +281,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .translate([1., 1., 1.], &mut objects)?;
 
         let vertex = face
@@ -313,7 +313,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -339,7 +339,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .translate([0., 0., 1.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -174,7 +174,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .translate([-1., 0., 0.], &mut objects)?;
 
@@ -197,7 +197,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .translate([1., 0., 0.], &mut objects)?;
 
@@ -223,7 +223,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .translate([0., 0., 2.], &mut objects)?;
 
@@ -246,7 +246,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .translate([1., 1., 0.], &mut objects)?;
 
@@ -280,7 +280,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .translate([1., 1., 1.], &mut objects)?;
 
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn ray_is_parallel_to_surface_and_hits() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -312,7 +312,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         assert_eq!(
@@ -338,7 +338,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .translate([0., 0., 1.], &mut objects)?;
 

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -123,13 +123,15 @@ mod tests {
             ..Default::default()
         };
         expected_xy.update_as_u_axis();
-        let expected_xy = expected_xy.build(&mut objects)?.insert(&objects)?;
+        let expected_xy =
+            expected_xy.build(&mut objects)?.insert(&mut objects)?;
         let mut expected_xz = PartialCurve {
             surface: Some(xz.clone()),
             ..Default::default()
         };
         expected_xz.update_as_u_axis();
-        let expected_xz = expected_xz.build(&mut objects)?.insert(&objects)?;
+        let expected_xz =
+            expected_xz.build(&mut objects)?.insert(&mut objects)?;
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([xy, xz], &mut objects)?,

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -110,7 +110,7 @@ mod tests {
                     xy.clone(),
                     xy.clone().transform(
                         &Transform::translation([0., 0., 1.],),
-                        &objects
+                        &mut objects
                     )?
                 ],
                 &mut objects

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -20,7 +20,7 @@ impl SurfaceSurfaceIntersection {
     /// Compute the intersection between two surfaces
     pub fn compute(
         surfaces: [Handle<Surface>; 2],
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Option<Self>, ValidationError> {
         // Algorithm from Real-Time Collision Detection by Christer Ericson. See
         // section 5.4.4, Intersection of Two Planes.
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn plane_plane() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let xy = objects.surfaces.xy_plane();
         let xz = objects.surfaces.xz_plane();
@@ -113,7 +113,7 @@ mod tests {
                         &objects
                     )?
                 ],
-                &objects
+                &mut objects
             )?,
             None,
         );
@@ -132,7 +132,7 @@ mod tests {
         let expected_xz = expected_xz.build(&objects)?.insert(&objects)?;
 
         assert_eq!(
-            SurfaceSurfaceIntersection::compute([xy, xz], &objects)?,
+            SurfaceSurfaceIntersection::compute([xy, xz], &mut objects)?,
             Some(SurfaceSurfaceIntersection {
                 intersection_curves: [expected_xy, expected_xz],
             })

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -123,13 +123,13 @@ mod tests {
             ..Default::default()
         };
         expected_xy.update_as_u_axis();
-        let expected_xy = expected_xy.build(&objects)?.insert(&objects)?;
+        let expected_xy = expected_xy.build(&mut objects)?.insert(&objects)?;
         let mut expected_xz = PartialCurve {
             surface: Some(xz.clone()),
             ..Default::default()
         };
         expected_xz.update_as_u_axis();
-        let expected_xz = expected_xz.build(&objects)?.insert(&objects)?;
+        let expected_xz = expected_xz.build(&mut objects)?.insert(&objects)?;
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([xy, xz], &mut objects)?,

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -8,7 +8,7 @@ use crate::{
 use super::Reverse;
 
 impl Reverse for Handle<Cycle> {
-    fn reverse(self, objects: &Objects) -> Result<Self, ValidationError> {
+    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError> {
         let mut edges = self
             .half_edges()
             .cloned()

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -8,7 +8,7 @@ use crate::{
 use super::Reverse;
 
 impl Reverse for Handle<HalfEdge> {
-    fn reverse(self, objects: &Objects) -> Result<Self, ValidationError> {
+    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError> {
         let vertices = {
             let [a, b] = self.vertices().clone();
             [b, a]

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -9,7 +9,7 @@ use crate::{
 use super::Reverse;
 
 impl Reverse for Handle<Face> {
-    fn reverse(self, objects: &Objects) -> Result<Self, ValidationError> {
+    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError> {
         let exterior = self.exterior().clone().reverse(objects)?;
         let interiors = self
             .interiors()

--- a/crates/fj-kernel/src/algorithms/reverse/mod.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/mod.rs
@@ -9,5 +9,5 @@ mod face;
 /// Reverse the direction/orientation of an object
 pub trait Reverse: Sized {
     /// Reverse the direction/orientation of the object
-    fn reverse(self, objects: &Objects) -> Result<Self, ValidationError>;
+    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError>;
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -19,7 +19,7 @@ impl Sweep for Handle<Curve> {
         self,
         path: impl Into<Vector<3>>,
         _: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         match self.surface().geometry().u {
             GlobalPath::Circle(_) => {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -209,7 +209,7 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         let face =
@@ -223,7 +223,7 @@ mod tests {
                     surface.clone(),
                     [[0., 0.], [1., 0.]],
                 )
-                .build(&objects)?
+                .build(&mut objects)?
                 .insert(&objects)?;
             let side_up = {
                 let mut side_up = HalfEdge::partial();
@@ -246,7 +246,7 @@ mod tests {
                         ..Default::default()
                     })
                     .update_as_line_segment()
-                    .build(&objects)?
+                    .build(&mut objects)?
                     .insert(&objects)?
             };
             let top = {
@@ -265,7 +265,7 @@ mod tests {
                     ..Default::default()
                 })
                 .update_as_line_segment()
-                .build(&objects)?
+                .build(&mut objects)?
                 .insert(&objects)?
                 .reverse(&mut objects)?
             };
@@ -286,7 +286,7 @@ mod tests {
                         ..Default::default()
                     })
                     .update_as_line_segment()
-                    .build(&objects)?
+                    .build(&mut objects)?
                     .insert(&objects)?
                     .reverse(&mut objects)?
             };
@@ -296,7 +296,7 @@ mod tests {
 
             Face::partial()
                 .with_exterior(cycle)
-                .build(&objects)?
+                .build(&mut objects)?
                 .insert(&objects)?
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -24,7 +24,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         let (edge, color) = self;
         let path = path.into();
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn sweep() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
@@ -213,7 +213,7 @@ mod tests {
             .insert(&objects)?;
 
         let face =
-            (half_edge, Color::default()).sweep([0., 0., 1.], &objects)?;
+            (half_edge, Color::default()).sweep([0., 0., 1.], &mut objects)?;
 
         let expected_face = {
             let surface = objects.surfaces.xz_plane();

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -210,7 +210,7 @@ mod tests {
                 [[0., 0.], [1., 0.]],
             )
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         let face =
             (half_edge, Color::default()).sweep([0., 0., 1.], &mut objects)?;
@@ -224,7 +224,7 @@ mod tests {
                     [[0., 0.], [1., 0.]],
                 )
                 .build(&mut objects)?
-                .insert(&objects)?;
+                .insert(&mut objects)?;
             let side_up = {
                 let mut side_up = HalfEdge::partial();
                 side_up.replace(surface.clone());
@@ -247,7 +247,7 @@ mod tests {
                     })
                     .update_as_line_segment()
                     .build(&mut objects)?
-                    .insert(&objects)?
+                    .insert(&mut objects)?
             };
             let top = {
                 let mut top = HalfEdge::partial();
@@ -266,7 +266,7 @@ mod tests {
                 })
                 .update_as_line_segment()
                 .build(&mut objects)?
-                .insert(&objects)?
+                .insert(&mut objects)?
                 .reverse(&mut objects)?
             };
             let side_down = {
@@ -287,17 +287,17 @@ mod tests {
                     })
                     .update_as_line_segment()
                     .build(&mut objects)?
-                    .insert(&objects)?
+                    .insert(&mut objects)?
                     .reverse(&mut objects)?
             };
 
             let cycle = Cycle::new([bottom, side_up, top, side_down])
-                .insert(&objects)?;
+                .insert(&mut objects)?;
 
             Face::partial()
                 .with_exterior(cycle)
                 .build(&mut objects)?
-                .insert(&objects)?
+                .insert(&mut objects)?
         };
 
         assert_eq!(face, expected_face);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -267,7 +267,7 @@ mod tests {
                 .update_as_line_segment()
                 .build(&objects)?
                 .insert(&objects)?
-                .reverse(&objects)?
+                .reverse(&mut objects)?
             };
             let side_down = {
                 let mut side_down = HalfEdge::partial();
@@ -288,7 +288,7 @@ mod tests {
                     .update_as_line_segment()
                     .build(&objects)?
                     .insert(&objects)?
-                    .reverse(&objects)?
+                    .reverse(&mut objects)?
             };
 
             let cycle = Cycle::new([bottom, side_up, top, side_down])

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -111,13 +111,13 @@ mod tests {
         let bottom = Face::partial()
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface.translate(UP, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         assert!(solid.find_face(&bottom).is_some());
@@ -132,7 +132,7 @@ mod tests {
                         objects.surfaces.xy_plane(),
                         [a, b],
                     )
-                    .build(&objects)?
+                    .build(&mut objects)?
                     .insert(&objects)?;
                 (half_edge, Color::default()).sweep(UP, &mut objects)
             })
@@ -158,13 +158,13 @@ mod tests {
         let bottom = Face::partial()
             .with_surface(surface.clone().translate(DOWN, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         assert!(solid.find_face(&bottom).is_some());
@@ -179,7 +179,7 @@ mod tests {
                         objects.surfaces.xy_plane(),
                         [a, b],
                     )
-                    .build(&objects)?
+                    .build(&mut objects)?
                     .insert(&objects)?
                     .reverse(&mut objects)?;
                 (half_edge, Color::default()).sweep(DOWN, &mut objects)

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -115,7 +115,7 @@ mod tests {
             .insert(&objects)?
             .reverse(&mut objects)?;
         let top = Face::partial()
-            .with_surface(surface.translate(UP, &objects)?)
+            .with_surface(surface.translate(UP, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&objects)?
             .insert(&objects)?;
@@ -156,7 +156,7 @@ mod tests {
             .sweep(DOWN, &mut objects)?;
 
         let bottom = Face::partial()
-            .with_surface(surface.clone().translate(DOWN, &objects)?)
+            .with_surface(surface.clone().translate(DOWN, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&objects)?
             .insert(&objects)?

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -113,7 +113,7 @@ mod tests {
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&objects)?
             .insert(&objects)?
-            .reverse(&objects)?;
+            .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface.translate(UP, &objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
@@ -160,7 +160,7 @@ mod tests {
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&objects)?
             .insert(&objects)?
-            .reverse(&objects)?;
+            .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
@@ -181,7 +181,7 @@ mod tests {
                     )
                     .build(&objects)?
                     .insert(&objects)?
-                    .reverse(&objects)?;
+                    .reverse(&mut objects)?;
                 (half_edge, Color::default()).sweep(DOWN, &mut objects)
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -105,7 +105,7 @@ mod tests {
         let solid = Sketch::builder()
             .with_surface(surface.clone())
             .with_polygon_from_points(TRIANGLE, &mut objects)
-            .build(&objects)
+            .build(&mut objects)
             .sweep(UP, &mut objects)?;
 
         let bottom = Face::partial()
@@ -152,7 +152,7 @@ mod tests {
         let solid = Sketch::builder()
             .with_surface(surface.clone())
             .with_polygon_from_points(TRIANGLE, &mut objects)
-            .build(&objects)
+            .build(&mut objects)
             .sweep(DOWN, &mut objects)?;
 
         let bottom = Face::partial()

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -104,7 +104,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder()
             .with_surface(surface.clone())
-            .with_polygon_from_points(TRIANGLE, &objects)
+            .with_polygon_from_points(TRIANGLE, &mut objects)
             .build(&objects)
             .sweep(UP, &mut objects)?;
 
@@ -151,7 +151,7 @@ mod tests {
         let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder()
             .with_surface(surface.clone())
-            .with_polygon_from_points(TRIANGLE, &objects)
+            .with_polygon_from_points(TRIANGLE, &mut objects)
             .build(&objects)
             .sweep(DOWN, &mut objects)?;
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -17,7 +17,7 @@ impl Sweep for Handle<Face> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         let path = path.into();
 
@@ -99,14 +99,14 @@ mod tests {
 
     #[test]
     fn sweep_up() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder()
             .with_surface(surface.clone())
             .with_polygon_from_points(TRIANGLE, &objects)
             .build(&objects)
-            .sweep(UP, &objects)?;
+            .sweep(UP, &mut objects)?;
 
         let bottom = Face::partial()
             .with_surface(surface.clone())
@@ -134,7 +134,7 @@ mod tests {
                     )
                     .build(&objects)?
                     .insert(&objects)?;
-                (half_edge, Color::default()).sweep(UP, &objects)
+                (half_edge, Color::default()).sweep(UP, &mut objects)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -146,14 +146,14 @@ mod tests {
 
     #[test]
     fn sweep_down() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder()
             .with_surface(surface.clone())
             .with_polygon_from_points(TRIANGLE, &objects)
             .build(&objects)
-            .sweep(DOWN, &objects)?;
+            .sweep(DOWN, &mut objects)?;
 
         let bottom = Face::partial()
             .with_surface(surface.clone().translate(DOWN, &objects)?)
@@ -182,7 +182,7 @@ mod tests {
                     .build(&objects)?
                     .insert(&objects)?
                     .reverse(&objects)?;
-                (half_edge, Color::default()).sweep(DOWN, &objects)
+                (half_edge, Color::default()).sweep(DOWN, &mut objects)
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -112,13 +112,13 @@ mod tests {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface.translate(UP, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         assert!(solid.find_face(&bottom).is_some());
         assert!(solid.find_face(&top).is_some());
@@ -133,7 +133,7 @@ mod tests {
                         [a, b],
                     )
                     .build(&mut objects)?
-                    .insert(&objects)?;
+                    .insert(&mut objects)?;
                 (half_edge, Color::default()).sweep(UP, &mut objects)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -159,13 +159,13 @@ mod tests {
             .with_surface(surface.clone().translate(DOWN, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&objects)?
+            .insert(&mut objects)?
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         assert!(solid.find_face(&bottom).is_some());
         assert!(solid.find_face(&top).is_some());
@@ -180,7 +180,7 @@ mod tests {
                         [a, b],
                     )
                     .build(&mut objects)?
-                    .insert(&objects)?
+                    .insert(&mut objects)?
                     .reverse(&mut objects)?;
                 (half_edge, Color::default()).sweep(DOWN, &mut objects)
             })

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -25,7 +25,7 @@ pub trait Sweep: Sized {
     fn sweep(
         self,
         path: impl Into<Vector<3>>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         let mut cache = SweepCache::default();
         self.sweep_with_cache(path, &mut cache, objects)
@@ -36,7 +36,7 @@ pub trait Sweep: Sized {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError>;
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -15,7 +15,7 @@ impl Sweep for Handle<Sketch> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         let path = path.into();
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -22,7 +22,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         let (vertex, surface) = self;
         let path = path.into();
@@ -133,7 +133,7 @@ impl Sweep for Handle<GlobalVertex> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self::Swept, ValidationError> {
         let curve = GlobalCurve.insert(objects)?;
 
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn vertex_surface() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xz_plane();
         let mut curve = PartialCurve {
@@ -190,7 +190,7 @@ mod tests {
         .insert(&objects)?;
 
         let half_edge =
-            (vertex, surface.clone()).sweep([0., 0., 1.], &objects)?;
+            (vertex, surface.clone()).sweep([0., 0., 1.], &mut objects)?;
 
         let expected_half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[0., 0.], [0., 1.]])

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -180,14 +180,14 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
         let vertex = PartialVertex {
             position: Some([0.].into()),
             curve: curve.into(),
             ..Default::default()
         }
         .build(&mut objects)?
-        .insert(&objects)?;
+        .insert(&mut objects)?;
 
         let half_edge =
             (vertex, surface.clone()).sweep([0., 0., 1.], &mut objects)?;
@@ -195,7 +195,7 @@ mod tests {
         let expected_half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[0., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         assert_eq!(half_edge, expected_half_edge);
         Ok(())
     }

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -180,13 +180,13 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&objects)?;
         let vertex = PartialVertex {
             position: Some([0.].into()),
             curve: curve.into(),
             ..Default::default()
         }
-        .build(&objects)?
+        .build(&mut objects)?
         .insert(&objects)?;
 
         let half_edge =
@@ -194,7 +194,7 @@ mod tests {
 
         let expected_half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[0., 0.], [0., 1.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         assert_eq!(half_edge, expected_half_edge);
         Ok(())

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -12,7 +12,7 @@ impl TransformObject for PartialGlobalCurve {
     fn transform(
         self,
         _: &Transform,
-        _: &Objects,
+        _: &mut Objects,
     ) -> Result<Self, ValidationError> {
         // `GlobalCurve` doesn't contain any internal geometry. If it did, that
         // would just be redundant with the geometry of other objects, and this
@@ -26,7 +26,7 @@ impl TransformObject for PartialCurve {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
             .surface

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -10,7 +10,7 @@ impl TransformObject for PartialCycle {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let half_edges = self
             .half_edges()

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -13,7 +13,7 @@ impl TransformObject for PartialHalfEdge {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
         let vertices = self
@@ -33,7 +33,7 @@ impl TransformObject for PartialGlobalEdge {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
         let vertices = self.vertices.try_map_ext(

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -13,7 +13,7 @@ impl TransformObject for PartialFace {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
             .surface()
@@ -56,7 +56,7 @@ impl TransformObject for FaceSet {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let mut faces = FaceSet::new();
         faces.extend(

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -34,7 +34,7 @@ pub trait TransformObject: Sized {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError>;
 
     /// Translate the object
@@ -43,7 +43,7 @@ pub trait TransformObject: Sized {
     fn translate(
         self,
         offset: impl Into<Vector<3>>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         self.transform(&Transform::translation(offset), objects)
     }
@@ -54,7 +54,7 @@ pub trait TransformObject: Sized {
     fn rotate(
         self,
         axis_angle: impl Into<Vector<3>>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         self.transform(&Transform::rotation(axis_angle), objects)
     }
@@ -69,7 +69,7 @@ where
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         Ok(self
             .to_partial()
@@ -88,7 +88,7 @@ where
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let transformed = match self {
             Self::Full(full) => {

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -12,7 +12,7 @@ impl TransformObject for Handle<Shell> {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let faces = self
             .faces()

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -12,7 +12,7 @@ impl TransformObject for Handle<Sketch> {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let faces = self
             .faces()

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -12,7 +12,7 @@ impl TransformObject for Handle<Solid> {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let faces = self
             .shells()

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -11,7 +11,7 @@ impl TransformObject for PartialSurface {
     fn transform(
         self,
         transform: &Transform,
-        _: &Objects,
+        _: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let geometry = self.geometry.map(|geometry| {
             let u = geometry.u.transform(transform);

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -12,7 +12,7 @@ impl TransformObject for PartialVertex {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
         let surface_form = self
@@ -34,7 +34,7 @@ impl TransformObject for PartialSurfaceVertex {
     fn transform(
         self,
         transform: &Transform,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let surface = self
             .surface
@@ -57,7 +57,7 @@ impl TransformObject for PartialGlobalVertex {
     fn transform(
         self,
         transform: &Transform,
-        _: &Objects,
+        _: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let position = self
             .position

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -100,7 +100,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([a, b, c, d])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
@@ -137,7 +137,7 @@ mod tests {
             .with_exterior_polygon_from_points([a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         let triangles = triangulate(face)?;
 
@@ -195,7 +195,7 @@ mod tests {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d, e])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         let triangles = triangulate(face)?;
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn simple() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let a = [0., 0.];
         let b = [2., 0.];
@@ -99,7 +99,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([a, b, c, d])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         let a = Point::from(a).to_xyz();
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn simple_hole() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let a = [0., 0.];
         let b = [4., 0.];
@@ -136,7 +136,7 @@ mod tests {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         let triangles = triangulate(face)?;
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn sharp_concave_shape() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         //   e       c
         //   |\     /|
@@ -194,7 +194,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d, e])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         let triangles = triangulate(face)?;

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -162,10 +162,10 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             // a hack, but I can't think of something better.
             let global_forms = {
                 let must_switch_order = {
-                    let objects = Objects::new();
+                    let mut objects = Objects::new();
                     let vertices = vertices.clone().map(|vertex| {
                         vertex
-                            .into_full(&objects)
+                            .into_full(&mut objects)
                             .unwrap()
                             .global_form()
                             .clone()

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -32,7 +32,7 @@ pub trait HalfEdgeBuilder: Sized {
     fn update_as_circle_from_radius(
         self,
         radius: impl Into<Scalar>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError>;
 
     /// Update partial half-edge as a line segment, from the given points
@@ -71,7 +71,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn update_as_circle_from_radius(
         mut self,
         radius: impl Into<Scalar>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Self, ValidationError> {
         let mut curve = self.curve.clone().into_partial();
         curve.update_as_circle_from_radius(radius);

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -38,7 +38,7 @@ impl ShellBuilder {
     pub fn with_cube_from_edge_length(
         mut self,
         edge_length: impl Into<Scalar>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Self {
         let edge_length = edge_length.into();
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -246,7 +246,8 @@ impl ShellBuilder {
                         .unwrap()
                         .insert(objects)
                         .unwrap()
-                });
+                })
+                .collect::<Vec<_>>();
 
             (sides, tops)
         };

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -337,7 +337,7 @@ impl ShellBuilder {
     }
 
     /// Build the [`Shell`]
-    pub fn build(self, objects: &Objects) -> Handle<Shell> {
+    pub fn build(self, objects: &mut Objects) -> Handle<Shell> {
         Shell::new(self.faces).insert(objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -57,7 +57,7 @@ impl SketchBuilder {
     }
 
     /// Build the [`Sketch`]
-    pub fn build(self, objects: &Objects) -> Handle<Sketch> {
+    pub fn build(self, objects: &mut Objects) -> Handle<Sketch> {
         Sketch::new(self.faces).insert(objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -40,7 +40,7 @@ impl SketchBuilder {
     pub fn with_polygon_from_points(
         mut self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Self {
         let surface = self
             .surface

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -30,7 +30,7 @@ impl SolidBuilder {
     pub fn with_cube_from_edge_length(
         mut self,
         edge_length: impl Into<Scalar>,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Self {
         let shell = Shell::builder()
             .with_cube_from_edge_length(edge_length, objects)

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -40,7 +40,7 @@ impl SolidBuilder {
     }
 
     /// Build the [`Solid`]
-    pub fn build(self, objects: &Objects) -> Handle<Solid> {
+    pub fn build(self, objects: &mut Objects) -> Handle<Solid> {
         Solid::new(self.shells).insert(objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -16,7 +16,7 @@ pub trait Insert: Sized + Validate {
     /// Insert the object into its respective store
     fn insert(
         self,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Handle<Self>, <Self as Validate>::Error>;
 }
 
@@ -26,7 +26,7 @@ macro_rules! impl_insert {
             impl Insert for $ty {
                 fn insert(
                     self,
-                    objects: &Objects,
+                    objects: &mut Objects,
                 ) -> Result<Handle<Self>, <Self as Validate>::Error> {
                     let handle = objects.$store.reserve();
                     objects.$store.insert(handle.clone(), self)?;

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -381,7 +381,7 @@ mod tests {
             ..Default::default()
         };
         object.update_as_u_axis();
-        let object = object.build(&mut objects)?.insert(&objects)?;
+        let object = object.build(&mut objects)?.insert(&mut objects)?;
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -410,7 +410,7 @@ mod tests {
             )
             .close_with_line_segment()
             .build(&mut objects)?
-            .insert(&objects);
+            .insert(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
@@ -436,7 +436,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
@@ -455,9 +455,9 @@ mod tests {
 
     #[test]
     fn global_curve() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
-        let object = GlobalCurve.insert(&objects)?;
+        let object = GlobalCurve.insert(&mut objects)?;
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -476,10 +476,10 @@ mod tests {
 
     #[test]
     fn global_vertex() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let object =
-            GlobalVertex::from_position([0., 0., 0.]).insert(&objects)?;
+            GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects)?;
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -506,7 +506,7 @@ mod tests {
                 [[0., 0.], [1., 0.]],
             )
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -553,7 +553,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&objects)?;
+            .insert(&mut objects)?;
         let object = Sketch::builder().with_faces([face]).build(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
@@ -621,13 +621,14 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
         let global_vertex =
-            GlobalVertex::from_position([0., 0., 0.]).insert(&objects)?;
+            GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects)?;
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex)
-                .insert(&objects)?;
-        let object = Vertex::new([0.], curve, surface_vertex).insert(&objects);
+                .insert(&mut objects)?;
+        let object =
+            Vertex::new([0.], curve, surface_vertex).insert(&mut objects);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn curve() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let mut object = PartialCurve {
@@ -381,7 +381,7 @@ mod tests {
             ..Default::default()
         };
         object.update_as_u_axis();
-        let object = object.build(&objects)?.insert(&objects)?;
+        let object = object.build(&mut objects)?.insert(&objects)?;
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn cycle() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let object = Cycle::partial()
@@ -409,7 +409,7 @@ mod tests {
                 [[0., 0.], [1., 0.], [0., 1.]],
             )
             .close_with_line_segment()
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects);
 
         assert_eq!(3, object.curve_iter().count());
@@ -429,13 +429,13 @@ mod tests {
 
     #[test]
     fn face() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let object = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         assert_eq!(3, object.curve_iter().count());
@@ -498,14 +498,14 @@ mod tests {
 
     #[test]
     fn half_edge() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let object = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
 
         assert_eq!(1, object.curve_iter().count());
@@ -552,7 +552,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
-            .build(&objects)?
+            .build(&mut objects)?
             .insert(&objects)?;
         let object = Sketch::builder().with_faces([face]).build(&mut objects);
 
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn vertex() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -621,7 +621,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&objects)?.insert(&objects)?;
+        let curve = curve.build(&mut objects)?.insert(&objects)?;
         let global_vertex =
             GlobalVertex::from_position([0., 0., 0.]).insert(&objects)?;
         let surface_vertex =

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -525,10 +525,10 @@ mod tests {
 
     #[test]
     fn shell() {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let object = Shell::builder()
-            .with_cube_from_edge_length(1., &objects)
+            .with_cube_from_edge_length(1., &mut objects)
             .build(&objects);
 
         assert_eq!(24, object.curve_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -577,7 +577,7 @@ mod tests {
 
         let object = Solid::builder()
             .with_cube_from_edge_length(1., &mut objects)
-            .build(&objects);
+            .build(&mut objects);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn sketch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -554,7 +554,7 @@ mod tests {
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&objects)?
             .insert(&objects)?;
-        let object = Sketch::builder().with_faces([face]).build(&objects);
+        let object = Sketch::builder().with_faces([face]).build(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -529,7 +529,7 @@ mod tests {
 
         let object = Shell::builder()
             .with_cube_from_edge_length(1., &mut objects)
-            .build(&objects);
+            .build(&mut objects);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -573,10 +573,10 @@ mod tests {
 
     #[test]
     fn solid() {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let object = Solid::builder()
-            .with_cube_from_edge_length(1., &objects)
+            .with_cube_from_edge_length(1., &mut objects)
             .build(&objects);
 
         assert_eq!(24, object.curve_iter().count());

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn global_edge_equality() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let surface = objects.surfaces.xy_plane();
 
@@ -186,10 +186,10 @@ mod tests {
 
         let a_to_b = HalfEdge::partial()
             .update_as_line_segment_from_points(surface.clone(), [a, b])
-            .build(&objects)?;
+            .build(&mut objects)?;
         let b_to_a = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [b, a])
-            .build(&objects)?;
+            .build(&mut objects)?;
 
         assert_eq!(a_to_b.global_form(), b_to_a.global_form());
         Ok(())

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -87,7 +87,7 @@ impl Curves {
 
     /// Insert a [`Curve`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Curve>,
         curve: Curve,
     ) -> Result<(), Infallible> {
@@ -111,7 +111,7 @@ impl Cycles {
 
     /// Insert a [`Cycle`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Cycle>,
         cycle: Cycle,
     ) -> Result<(), CycleValidationError> {
@@ -135,7 +135,7 @@ impl Faces {
 
     /// Insert a [`Face`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Face>,
         face: Face,
     ) -> Result<(), FaceValidationError> {
@@ -159,7 +159,7 @@ impl GlobalCurves {
 
     /// Insert a [`GlobalCurve`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<GlobalCurve>,
         global_curve: GlobalCurve,
     ) -> Result<(), Infallible> {
@@ -183,7 +183,7 @@ impl GlobalEdges {
 
     /// Insert a [`GlobalEdge`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<GlobalEdge>,
         global_edge: GlobalEdge,
     ) -> Result<(), Infallible> {
@@ -207,7 +207,7 @@ impl GlobalVertices {
 
     /// Insert a [`GlobalVertex`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<GlobalVertex>,
         global_vertex: GlobalVertex,
     ) -> Result<(), Infallible> {
@@ -231,7 +231,7 @@ impl HalfEdges {
 
     /// Insert a [`HalfEdge`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<HalfEdge>,
         half_edge: HalfEdge,
     ) -> Result<(), HalfEdgeValidationError> {
@@ -255,7 +255,7 @@ impl Shells {
 
     /// Insert a [`Shell`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Shell>,
         shell: Shell,
     ) -> Result<(), Infallible> {
@@ -279,7 +279,7 @@ impl Sketches {
 
     /// Insert a [`Sketch`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Sketch>,
         sketch: Sketch,
     ) -> Result<(), Infallible> {
@@ -303,7 +303,7 @@ impl Solids {
 
     /// Insert a [`Solid`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Solid>,
         solid: Solid,
     ) -> Result<(), Infallible> {
@@ -327,7 +327,7 @@ impl SurfaceVertices {
 
     /// Insert a [`SurfaceVertex`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<SurfaceVertex>,
         surface_vertex: SurfaceVertex,
     ) -> Result<(), SurfaceVertexValidationError> {
@@ -355,7 +355,7 @@ impl Surfaces {
 
     /// Insert a [`Surface`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Surface>,
         surface: Surface,
     ) -> Result<(), Infallible> {
@@ -382,7 +382,7 @@ impl Surfaces {
 
 impl Default for Surfaces {
     fn default() -> Self {
-        let store: Store<Surface> = Store::new();
+        let mut store: Store<Surface> = Store::new();
 
         let xy_plane = store.reserve();
         store.insert(
@@ -433,7 +433,7 @@ impl Vertices {
 
     /// Insert a [`Vertex`] into the store
     pub fn insert(
-        &self,
+        &mut self,
         handle: Handle<Vertex>,
         vertex: Vertex,
     ) -> Result<(), VertexValidationError> {

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -72,7 +72,7 @@ impl<T: HasPartial> MaybePartial<T> {
     /// object, the full object is built from it, using [`Partial::build`].
     pub fn into_full(
         self,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Handle<T>, ValidationError>
     where
         T: Insert,

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -23,7 +23,10 @@ pub struct PartialCurve {
 
 impl PartialCurve {
     /// Build a full [`Curve`] from the partial curve
-    pub fn build(self, objects: &Objects) -> Result<Curve, ValidationError> {
+    pub fn build(
+        self,
+        objects: &mut Objects,
+    ) -> Result<Curve, ValidationError> {
         let path = self.path.expect("Can't build `Curve` without path");
         let surface =
             self.surface.expect("Can't build `Curve` without surface");

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -71,7 +71,7 @@ impl PartialCycle {
     /// Build a full [`Cycle`] from the partial cycle
     pub fn build(
         mut self,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<Cycle, ValidationError> {
         // Check that the cycle is closed. This will lead to a panic further
         // down anyway, but that panic would be super-confusing. This one should

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -30,7 +30,7 @@ impl PartialHalfEdge {
     /// Build a full [`HalfEdge`] from the partial half-edge
     pub fn build(
         mut self,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<HalfEdge, ValidationError> {
         let global_curve = self
             .curve
@@ -118,7 +118,7 @@ impl PartialGlobalEdge {
     /// Build a full [`GlobalEdge`] from the partial global edge
     pub fn build(
         self,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<GlobalEdge, ValidationError> {
         let curve = self.curve.into_full(objects)?;
         let vertices = self

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -71,7 +71,7 @@ impl PartialFace {
     }
 
     /// Construct a polygon from a list of points
-    pub fn build(self, objects: &Objects) -> Result<Face, ValidationError> {
+    pub fn build(self, objects: &mut Objects) -> Result<Face, ValidationError> {
         let exterior = self.exterior.into_full(objects)?;
         let interiors = self
             .interiors

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -26,7 +26,7 @@ macro_rules! impl_traits {
             impl Partial for $partial {
                 type Full = $full;
 
-                fn build(self, objects: &Objects)
+                fn build(self, objects: &mut Objects)
                     -> Result<
                         Self::Full,
                         crate::validate::ValidationError

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -31,7 +31,10 @@ impl PartialVertex {
     /// Panics, if position has not been provided.
     ///
     /// Panics, if curve has not been provided.
-    pub fn build(self, objects: &Objects) -> Result<Vertex, ValidationError> {
+    pub fn build(
+        self,
+        objects: &mut Objects,
+    ) -> Result<Vertex, ValidationError> {
         let position = self
             .position
             .expect("Cant' build `Vertex` without position");
@@ -103,7 +106,7 @@ impl PartialSurfaceVertex {
     /// Build a full [`SurfaceVertex`] from the partial surface vertex
     pub fn build(
         mut self,
-        objects: &Objects,
+        objects: &mut Objects,
     ) -> Result<SurfaceVertex, ValidationError> {
         let position = self
             .position

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -77,5 +77,8 @@ pub trait Partial: Default + for<'a> From<&'a Self::Full> {
     /// Calling `build` on a partial object that can't infer its missing parts
     /// is considered a programmer error, hence why this method doesn't return a
     /// [`Result`].
-    fn build(self, objects: &Objects) -> Result<Self::Full, ValidationError>;
+    fn build(
+        self,
+        objects: &mut Objects,
+    ) -> Result<Self::Full, ValidationError>;
 }

--- a/crates/fj-kernel/src/storage/store.rs
+++ b/crates/fj-kernel/src/storage/store.rs
@@ -83,7 +83,7 @@ impl<T> Store<T> {
     /// Panics, if the passed `Handle` does not refer to a reserved slot. This
     /// can only be the case, if the handle has been used to insert an object
     /// before.
-    pub fn insert(&self, handle: Handle<T>, object: T) {
+    pub fn insert(&mut self, handle: Handle<T>, object: T) {
         let mut inner = self.inner.write();
         inner.blocks.insert(handle.index, object);
     }
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn insert_and_handle() {
-        let store = Store::with_block_size(1);
+        let mut store = Store::with_block_size(1);
 
         let handle: Handle<i32> = store.reserve();
         let object = 0;
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn insert_and_iter() {
-        let store = Store::with_block_size(1);
+        let mut store = Store::with_block_size(1);
 
         let a: Handle<i32> = store.reserve();
         let b = store.reserve();

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -105,7 +105,7 @@ mod tests {
             let half_edges = half_edges
                 .into_iter()
                 .map(|half_edge| -> anyhow::Result<_, ValidationError> {
-                    Ok(half_edge.build(&mut objects)?.insert(&objects)?)
+                    Ok(half_edge.build(&mut objects)?.insert(&mut objects)?)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn cycle_half_edge_connections() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = Cycle::partial()
             .with_poly_chain_from_points(
@@ -83,7 +83,7 @@ mod tests {
                 [[0., 0.], [1., 0.], [0., 1.]],
             )
             .close_with_line_segment()
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = {
             let mut half_edges = valid
                 .half_edges()
@@ -105,7 +105,7 @@ mod tests {
             let half_edges = half_edges
                 .into_iter()
                 .map(|half_edge| -> anyhow::Result<_, ValidationError> {
-                    Ok(half_edge.build(&objects)?.insert(&objects)?)
+                    Ok(half_edge.build(&mut objects)?.insert(&objects)?)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -210,20 +210,20 @@ mod tests {
 
     #[test]
     fn half_edge_curve_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = {
             let mut vertices = valid.vertices().clone();
             let mut vertex = vertices[1].to_partial();
             // Arranging for an equal but not identical curve here.
             vertex.curve = valid.curve().to_partial().into();
-            vertices[1] = vertex.build(&objects)?.insert(&objects)?;
+            vertices[1] = vertex.build(&mut objects)?.insert(&objects)?;
 
             HalfEdge::new(vertices, valid.global_form().clone())
         };
@@ -236,18 +236,18 @@ mod tests {
 
     #[test]
     fn half_edge_global_curve_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
             tmp.curve = GlobalCurve.insert(&objects)?.into();
-            tmp.build(&objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -258,14 +258,14 @@ mod tests {
 
     #[test]
     fn half_edge_global_vertex_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
             tmp.vertices = valid
@@ -274,7 +274,7 @@ mod tests {
                 .access_in_normalized_order()
                 // Creating equal but not identical vertices here.
                 .map(|vertex| vertex.to_partial().into());
-            tmp.build(&objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -285,21 +285,21 @@ mod tests {
 
     #[test]
     fn half_edge_vertices_are_coincident() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = HalfEdge::new(
             valid.vertices().clone().try_map_ext(
                 |vertex| -> anyhow::Result<_, ValidationError> {
                     let mut vertex = vertex.to_partial();
                     vertex.position = Some([0.].into());
                     vertex.infer_surface_form();
-                    Ok(vertex.build(&objects)?.insert(&objects)?)
+                    Ok(vertex.build(&mut objects)?.insert(&objects)?)
                 },
             )?,
             valid.global_form().clone(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -223,7 +223,7 @@ mod tests {
             let mut vertex = vertices[1].to_partial();
             // Arranging for an equal but not identical curve here.
             vertex.curve = valid.curve().to_partial().into();
-            vertices[1] = vertex.build(&mut objects)?.insert(&objects)?;
+            vertices[1] = vertex.build(&mut objects)?.insert(&mut objects)?;
 
             HalfEdge::new(vertices, valid.global_form().clone())
         };
@@ -246,8 +246,8 @@ mod tests {
             .build(&mut objects)?;
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
-            tmp.curve = GlobalCurve.insert(&objects)?.into();
-            tmp.build(&mut objects)?.insert(&objects)?
+            tmp.curve = GlobalCurve.insert(&mut objects)?.into();
+            tmp.build(&mut objects)?.insert(&mut objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -274,7 +274,7 @@ mod tests {
                 .access_in_normalized_order()
                 // Creating equal but not identical vertices here.
                 .map(|vertex| vertex.to_partial().into());
-            tmp.build(&mut objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&mut objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -299,7 +299,7 @@ mod tests {
                     let mut vertex = vertex.to_partial();
                     vertex.position = Some([0.].into());
                     vertex.infer_surface_form();
-                    Ok(vertex.build(&mut objects)?.insert(&objects)?)
+                    Ok(vertex.build(&mut objects)?.insert(&mut objects)?)
                 },
             )?,
             valid.global_form().clone(),

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn face_invalid_interior_winding() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = Face::partial()
             .with_surface(objects.surfaces.xy_plane())
@@ -153,7 +153,7 @@ mod tests {
             let interiors = valid
                 .interiors()
                 .cloned()
-                .map(|cycle| cycle.reverse(&objects))
+                .map(|cycle| cycle.reverse(&mut objects))
                 .collect::<Result<Vec<_>, _>>()?;
 
             Face::new(valid.exterior().clone(), interiors, valid.color())

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -129,7 +129,7 @@ mod tests {
                 )
                 .close_with_line_segment()
                 .build(&mut objects)?
-                .insert(&objects)?];
+                .insert(&mut objects)?];
 
             Face::new(valid.exterior().clone(), interiors, valid.color())
         };

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -114,13 +114,13 @@ mod tests {
 
     #[test]
     fn face_surface_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = Face::partial()
             .with_surface(objects.surfaces.xy_plane())
             .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = {
             let interiors = [Cycle::partial()
                 .with_poly_chain_from_points(
@@ -128,7 +128,7 @@ mod tests {
                     [[1., 1.], [1., 2.], [2., 1.]],
                 )
                 .close_with_line_segment()
-                .build(&objects)?
+                .build(&mut objects)?
                 .insert(&objects)?];
 
             Face::new(valid.exterior().clone(), interiors, valid.color())
@@ -148,7 +148,7 @@ mod tests {
             .with_surface(objects.surfaces.xy_plane())
             .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
-            .build(&objects)?;
+            .build(&mut objects)?;
         let invalid = {
             let interiors = valid
                 .interiors()

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -208,7 +208,7 @@ mod tests {
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.surface = Some(objects.surfaces.xz_plane());
-            tmp.build(&mut objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&mut objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -239,7 +239,7 @@ mod tests {
             let mut tmp = valid.surface_form().to_partial();
             tmp.position = Some([1., 0.].into());
             tmp.infer_global_form();
-            tmp.build(&mut objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&mut objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -261,7 +261,7 @@ mod tests {
         let invalid = SurfaceVertex::new(
             valid.position(),
             valid.surface().clone(),
-            GlobalVertex::from_position([1., 0., 0.]).insert(&objects)?,
+            GlobalVertex::from_position([1., 0., 0.]).insert(&mut objects)?,
         );
 
         assert!(valid.validate().is_ok());

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn vertex_surface_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let mut curve = PartialCurve {
             surface: Some(objects.surfaces.xy_plane()),
@@ -204,11 +204,11 @@ mod tests {
             curve: curve.into(),
             ..Default::default()
         }
-        .build(&objects)?;
+        .build(&mut objects)?;
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.surface = Some(objects.surfaces.xz_plane());
-            tmp.build(&objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn vertex_position_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = {
             let mut curve = PartialCurve {
@@ -233,13 +233,13 @@ mod tests {
                 curve: curve.into(),
                 ..Default::default()
             }
-            .build(&objects)?
+            .build(&mut objects)?
         };
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.position = Some([1., 0.].into());
             tmp.infer_global_form();
-            tmp.build(&objects)?.insert(&objects)?
+            tmp.build(&mut objects)?.insert(&objects)?
         });
 
         assert!(valid.validate().is_ok());
@@ -250,14 +250,14 @@ mod tests {
 
     #[test]
     fn surface_vertex_position_mismatch() -> anyhow::Result<()> {
-        let objects = Objects::new();
+        let mut objects = Objects::new();
 
         let valid = PartialSurfaceVertex {
             position: Some([0., 0.].into()),
             surface: Some(objects.surfaces.xy_plane()),
             ..Default::default()
         }
-        .build(&objects)?;
+        .build(&mut objects)?;
         let invalid = SurfaceVertex::new(
             valid.position(),
             valid.surface().clone(),


### PR DESCRIPTION
I don't think there was a good reason it took `&self`, at least not anymore. Plus, this change is going to make some things I'm working on easier.