### PR TITLE
Add `Object` enum

### DIFF
--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -74,6 +74,7 @@
 //! [#1021]: https://github.com/hannobraun/Fornjot/issues/1021
 
 mod full;
+mod object;
 mod stores;
 
 pub use self::{
@@ -88,6 +89,7 @@ pub use self::{
         surface::Surface,
         vertex::{GlobalVertex, SurfaceVertex, Vertex},
     },
+    object::{Bare, BehindHandle, Form, Object, WithHandle},
     stores::{
         Curves, Cycles, Faces, GlobalCurves, GlobalEdges, GlobalVertices,
         HalfEdges, Objects, Shells, Sketches, Solids, SurfaceVertices,

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use crate::{
     insert::Insert,
     objects::{
@@ -21,6 +23,23 @@ macro_rules! object {
                 #[doc = concat!("A ", $name)]
                 $ty(F::Form<$ty>),
             )*
+        }
+
+        impl<F: Form> Object<F> {
+            /// Convert the `Object` into the requested inner type
+            pub fn as_inner<T>(&self) -> Option<&F::Form<T>>
+                where
+                    Self: 'static,
+                    F::Form<T>: Any,
+            {
+                match self {
+                    $(
+                        Self::$ty(object) =>
+                            (object as &dyn Any).downcast_ref(),
+
+                    )*
+                }
+            }
         }
 
         impl Object<WithHandle> {

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -1,0 +1,93 @@
+use crate::{
+    objects::{
+        Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
+        Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
+    },
+    storage::Handle,
+};
+
+macro_rules! object {
+    ($($ty:ident, $name:expr;)*) => {
+        /// An object
+        ///
+        /// This enum is generic over the form that the object takes. An
+        /// `Object<Bare>` contains bare objects, like `Curve`. An
+        /// `Object<BehindHandle>` contains handles, like `Handle<Curve>`.
+        #[derive(Clone)]
+        pub enum Object<F: Form> {
+            $(
+                #[doc = concat!("A ", $name)]
+                $ty(F::Form<$ty>),
+            )*
+        }
+
+        $(
+            impl From<$ty> for Object<Bare> {
+                fn from(object: $ty) -> Self {
+                    Self::$ty(object)
+                }
+            }
+
+            impl From<Handle<$ty>> for Object<BehindHandle> {
+                fn from(object: Handle<$ty>) -> Self {
+                    Self::$ty(object)
+                }
+            }
+
+            impl From<(Handle<$ty>, $ty)> for Object<WithHandle> {
+                fn from((handle, object): (Handle<$ty>, $ty)) -> Self {
+                    Self::$ty((handle, object))
+                }
+            }
+        )*
+    };
+}
+
+object!(
+    Curve, "curve";
+    Cycle, "cycle";
+    Face, "face";
+    GlobalCurve, "global curve";
+    GlobalEdge, "global edge";
+    GlobalVertex, "global vertex";
+    HalfEdge, "half-edge";
+    Shell, "shell";
+    Sketch, "sketch";
+    Solid, "solid";
+    Surface, "surface";
+    SurfaceVertex, "surface vertex";
+    Vertex, "vertex";
+);
+
+/// The form that an object can take
+///
+/// An object can be bare (see [`Bare`]) or behind a [`Handle`] (see
+/// [`BehindHandle`]).
+pub trait Form {
+    /// The form that the object takes
+    type Form<T>;
+}
+
+/// Implementation of [`Form`] for bare objects
+#[derive(Clone)]
+pub struct Bare;
+
+impl Form for Bare {
+    type Form<T> = T;
+}
+
+/// Implementation of [`Form`] for objects behind a handle
+#[derive(Clone)]
+pub struct BehindHandle;
+
+impl Form for BehindHandle {
+    type Form<T> = Handle<T>;
+}
+
+/// Implementation of [`Form`] for objects that are paired with their handle
+#[derive(Clone)]
+pub struct WithHandle;
+
+impl Form for WithHandle {
+    type Form<T> = (Handle<T>, T);
+}

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -1,13 +1,15 @@
 use crate::{
+    insert::Insert,
     objects::{
         Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
-        Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
+        Objects, Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
     },
     storage::Handle,
+    validate::{Validate, ValidationError},
 };
 
 macro_rules! object {
-    ($($ty:ident, $name:expr;)*) => {
+    ($($ty:ident, $name:expr, $store:ident;)*) => {
         /// An object
         ///
         /// This enum is generic over the form that the object takes. An
@@ -19,6 +21,29 @@ macro_rules! object {
                 #[doc = concat!("A ", $name)]
                 $ty(F::Form<$ty>),
             )*
+        }
+
+        impl Object<WithHandle> {
+            /// Insert the object into its respective store
+            pub fn insert(
+                self,
+                objects: &mut Objects,
+            ) -> Result<Object<BehindHandle>, ValidationError>
+            where
+                $(
+                    crate::objects::$ty: Insert,
+                    ValidationError: From<<$ty as Validate>::Error>,
+                )*
+            {
+                match self {
+                    $(
+                        Self::$ty((handle, object)) => {
+                            objects.$store.insert(handle.clone(), object)?;
+                            Ok(handle.into())
+                        }
+                    )*
+                }
+            }
         }
 
         $(
@@ -44,19 +69,19 @@ macro_rules! object {
 }
 
 object!(
-    Curve, "curve";
-    Cycle, "cycle";
-    Face, "face";
-    GlobalCurve, "global curve";
-    GlobalEdge, "global edge";
-    GlobalVertex, "global vertex";
-    HalfEdge, "half-edge";
-    Shell, "shell";
-    Sketch, "sketch";
-    Solid, "solid";
-    Surface, "surface";
-    SurfaceVertex, "surface vertex";
-    Vertex, "vertex";
+    Curve, "curve", curves;
+    Cycle, "cycle", cycles;
+    Face, "face", faces;
+    GlobalCurve, "global curve", global_curves;
+    GlobalEdge, "global edge", global_edges;
+    GlobalVertex, "global vertex", global_vertices;
+    HalfEdge, "half-edge", half_edges;
+    Shell, "shell", shells;
+    Sketch, "sketch", sketches;
+    Solid, "solid", solids;
+    Surface, "surface", surfaces;
+    SurfaceVertex, "surface vertex", surface_vertices;
+    Vertex, "vertex", vertices;
 );
 
 /// The form that an object can take


### PR DESCRIPTION
This enum helps abstracting over objects in situations where generics can't be used. I'm already using this in a local branch.