### PR TITLE
Build service abstraction around `Objects`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -205,13 +205,14 @@ mod tests {
         insert::Insert,
         objects::Objects,
         partial::{PartialCurve, PartialSurface},
+        services::State,
     };
 
     use super::CurveApprox;
 
     #[test]
     fn approx_line_on_flat_surface() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
@@ -234,7 +235,7 @@ mod tests {
     #[test]
     fn approx_line_on_curved_surface_but_not_along_curve() -> anyhow::Result<()>
     {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = PartialSurface::from_axes(
             GlobalPath::circle_from_radius(1.),
@@ -258,7 +259,7 @@ mod tests {
 
     #[test]
     fn approx_line_on_curved_surface_along_curve() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let path = GlobalPath::circle_from_radius(1.);
         let surface = PartialSurface::from_axes(path, [0., 0., 1.])
@@ -293,7 +294,7 @@ mod tests {
 
     #[test]
     fn approx_circle_on_flat_surface() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -78,13 +78,14 @@ mod tests {
         builder::{CurveBuilder, HalfEdgeBuilder},
         objects::{HalfEdge, Objects},
         partial::{HasPartial, PartialCurve},
+        services::State,
     };
 
     use super::CurveEdgeIntersection;
 
     #[test]
     fn compute_edge_in_front_of_curve_origin() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -110,7 +111,7 @@ mod tests {
 
     #[test]
     fn compute_edge_behind_curve_origin() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -139,7 +140,7 @@ mod tests {
 
     #[test]
     fn compute_edge_parallel_to_curve() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
@@ -163,7 +164,7 @@ mod tests {
 
     #[test]
     fn compute_edge_on_curve() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -153,13 +153,14 @@ mod tests {
         builder::{CurveBuilder, FaceBuilder},
         objects::{Face, Objects},
         partial::{HasPartial, PartialCurve},
+        services::State,
     };
 
     use super::CurveFaceIntersection;
 
     #[test]
     fn compute() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -3,6 +3,7 @@ use iter_fixed::IntoIteratorFixed;
 
 use crate::{
     objects::{Curve, Face, Objects},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -30,7 +31,7 @@ impl FaceFaceIntersection {
     /// Compute the intersections between two faces
     pub fn compute(
         faces: [&Face; 2],
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Option<Self>, ValidationError> {
         let surfaces = faces.map(|face| face.surface().clone());
 
@@ -74,6 +75,7 @@ mod tests {
         insert::Insert,
         objects::{Face, Objects},
         partial::{HasPartial, PartialCurve},
+        services::State,
         validate::ValidationError,
     };
 
@@ -81,7 +83,7 @@ mod tests {
 
     #[test]
     fn compute_no_intersection() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         #[rustfmt::skip]
         let points = [
@@ -108,7 +110,7 @@ mod tests {
 
     #[test]
     fn compute_one_intersection() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         #[rustfmt::skip]
         let points = [

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -141,11 +141,12 @@ mod tests {
         iter::ObjectIters,
         objects::{Face, Objects},
         partial::HasPartial,
+        services::State,
     };
 
     #[test]
     fn point_is_outside_face() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -163,7 +164,7 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_while_passing_outside() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -184,7 +185,7 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_at_cycle_seam() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -205,7 +206,7 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_while_staying_inside() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -232,7 +233,7 @@ mod tests {
     #[test]
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() -> anyhow::Result<()>
     {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -259,7 +260,7 @@ mod tests {
     #[test]
     fn ray_hits_parallel_edge_and_does_not_leave_face_there(
     ) -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -286,7 +287,7 @@ mod tests {
 
     #[test]
     fn point_is_coincident_with_edge() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -316,7 +317,7 @@ mod tests {
 
     #[test]
     fn point_is_coincident_with_vertex() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -157,11 +157,12 @@ mod tests {
         iter::ObjectIters,
         objects::{Face, Objects},
         partial::HasPartial,
+        services::State,
     };
 
     #[test]
     fn ray_misses_whole_surface() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -184,7 +185,7 @@ mod tests {
 
     #[test]
     fn ray_hits_face() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -210,7 +211,7 @@ mod tests {
 
     #[test]
     fn ray_hits_surface_but_misses_face() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -233,7 +234,7 @@ mod tests {
 
     #[test]
     fn ray_hits_edge() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -267,7 +268,7 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -299,7 +300,7 @@ mod tests {
 
     #[test]
     fn ray_is_parallel_to_surface_and_hits() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
@@ -325,7 +326,7 @@ mod tests {
 
     #[test]
     fn ray_is_parallel_to_surface_and_misses() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -5,6 +5,7 @@ use crate::{
     geometry::path::{GlobalPath, SurfacePath},
     insert::Insert,
     objects::{Curve, GlobalCurve, Objects, Surface},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -20,7 +21,7 @@ impl SurfaceSurfaceIntersection {
     /// Compute the intersection between two surfaces
     pub fn compute(
         surfaces: [Handle<Surface>; 2],
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Option<Self>, ValidationError> {
         // Algorithm from Real-Time Collision Detection by Christer Ericson. See
         // section 5.4.4, Intersection of Two Planes.
@@ -92,13 +93,14 @@ mod tests {
     use crate::{
         algorithms::transform::TransformObject, builder::CurveBuilder,
         insert::Insert, objects::Objects, partial::PartialCurve,
+        services::State,
     };
 
     use super::SurfaceSurfaceIntersection;
 
     #[test]
     fn plane_plane() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let xy = objects.surfaces.xy_plane();
         let xz = objects.surfaces.xz_plane();

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -1,6 +1,7 @@
 use crate::{
     insert::Insert,
     objects::{Cycle, Objects},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -8,7 +9,10 @@ use crate::{
 use super::Reverse;
 
 impl Reverse for Handle<Cycle> {
-    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError> {
+    fn reverse(
+        self,
+        objects: &mut Service<Objects>,
+    ) -> Result<Self, ValidationError> {
         let mut edges = self
             .half_edges()
             .cloned()

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -1,6 +1,7 @@
 use crate::{
     insert::Insert,
     objects::{HalfEdge, Objects},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -8,7 +9,10 @@ use crate::{
 use super::Reverse;
 
 impl Reverse for Handle<HalfEdge> {
-    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError> {
+    fn reverse(
+        self,
+        objects: &mut Service<Objects>,
+    ) -> Result<Self, ValidationError> {
         let vertices = {
             let [a, b] = self.vertices().clone();
             [b, a]

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -2,6 +2,7 @@ use crate::{
     insert::Insert,
     objects::{Face, Objects},
     partial::HasPartial,
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -9,7 +10,10 @@ use crate::{
 use super::Reverse;
 
 impl Reverse for Handle<Face> {
-    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError> {
+    fn reverse(
+        self,
+        objects: &mut Service<Objects>,
+    ) -> Result<Self, ValidationError> {
         let exterior = self.exterior().clone().reverse(objects)?;
         let interiors = self
             .interiors()

--- a/crates/fj-kernel/src/algorithms/reverse/mod.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/mod.rs
@@ -1,6 +1,6 @@
 //! Reverse the direction/orientation of objects
 
-use crate::{objects::Objects, validate::ValidationError};
+use crate::{objects::Objects, services::Service, validate::ValidationError};
 
 mod cycle;
 mod edge;
@@ -9,5 +9,8 @@ mod face;
 /// Reverse the direction/orientation of an object
 pub trait Reverse: Sized {
     /// Reverse the direction/orientation of the object
-    fn reverse(self, objects: &mut Objects) -> Result<Self, ValidationError>;
+    fn reverse(
+        self,
+        objects: &mut Service<Objects>,
+    ) -> Result<Self, ValidationError>;
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -6,6 +6,7 @@ use crate::{
     insert::Insert,
     objects::{Curve, Objects, Surface},
     partial::PartialSurface,
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -19,7 +20,7 @@ impl Sweep for Handle<Curve> {
         self,
         path: impl Into<Vector<3>>,
         _: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         match self.surface().geometry().u {
             GlobalPath::Circle(_) => {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -11,6 +11,7 @@ use crate::{
         Vertex,
     },
     partial::HasPartial,
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -24,7 +25,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         let (edge, color) = self;
         let path = path.into();
@@ -198,11 +199,12 @@ mod tests {
         insert::Insert,
         objects::{Cycle, Face, HalfEdge, Objects},
         partial::{HasPartial, PartialSurfaceVertex, PartialVertex, Replace},
+        services::State,
     };
 
     #[test]
     fn sweep() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -4,6 +4,7 @@ use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
     geometry::path::GlobalPath,
     objects::{Face, Objects, Shell},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -17,7 +18,7 @@ impl Sweep for Handle<Face> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         let path = path.into();
 
@@ -88,6 +89,7 @@ mod tests {
         insert::Insert,
         objects::{Face, HalfEdge, Objects, Sketch},
         partial::HasPartial,
+        services::State,
     };
 
     use super::Sweep;
@@ -99,7 +101,7 @@ mod tests {
 
     #[test]
     fn sweep_up() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder()
@@ -146,7 +148,7 @@ mod tests {
 
     #[test]
     fn sweep_down() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let solid = Sketch::builder()

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -12,6 +12,7 @@ use fj_math::Vector;
 
 use crate::{
     objects::{GlobalVertex, Objects},
+    services::Service,
     storage::{Handle, ObjectId},
     validate::ValidationError,
 };
@@ -25,7 +26,7 @@ pub trait Sweep: Sized {
     fn sweep(
         self,
         path: impl Into<Vector<3>>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         let mut cache = SweepCache::default();
         self.sweep_with_cache(path, &mut cache, objects)
@@ -36,7 +37,7 @@ pub trait Sweep: Sized {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError>;
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -2,6 +2,7 @@ use fj_math::Vector;
 
 use crate::{
     objects::{Objects, Sketch, Solid},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -15,7 +16,7 @@ impl Sweep for Handle<Sketch> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         let path = path.into();
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -9,6 +9,7 @@ use crate::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex,
     },
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -22,7 +23,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         let (vertex, surface) = self;
         let path = path.into();
@@ -133,7 +134,7 @@ impl Sweep for Handle<GlobalVertex> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Swept, ValidationError> {
         let curve = GlobalCurve.insert(objects)?;
 
@@ -168,11 +169,12 @@ mod tests {
         insert::Insert,
         objects::{HalfEdge, Objects},
         partial::{HasPartial, PartialCurve, PartialVertex},
+        services::State,
     };
 
     #[test]
     fn vertex_surface() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xz_plane();
         let mut curve = PartialCurve {

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -3,6 +3,7 @@ use fj_math::Transform;
 use crate::{
     objects::Objects,
     partial::{PartialCurve, PartialGlobalCurve},
+    services::Service,
     validate::ValidationError,
 };
 
@@ -12,7 +13,7 @@ impl TransformObject for PartialGlobalCurve {
     fn transform(
         self,
         _: &Transform,
-        _: &mut Objects,
+        _: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         // `GlobalCurve` doesn't contain any internal geometry. If it did, that
         // would just be redundant with the geometry of other objects, and this
@@ -26,7 +27,7 @@ impl TransformObject for PartialCurve {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let surface = self
             .surface

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -1,7 +1,8 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::Objects, partial::PartialCycle, validate::ValidationError,
+    objects::Objects, partial::PartialCycle, services::Service,
+    validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -10,7 +11,7 @@ impl TransformObject for PartialCycle {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let half_edges = self
             .half_edges()

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -4,6 +4,7 @@ use fj_math::Transform;
 use crate::{
     objects::Objects,
     partial::{PartialGlobalEdge, PartialHalfEdge},
+    services::Service,
     validate::ValidationError,
 };
 
@@ -13,7 +14,7 @@ impl TransformObject for PartialHalfEdge {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
         let vertices = self
@@ -33,7 +34,7 @@ impl TransformObject for PartialGlobalEdge {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
         let vertices = self.vertices.try_map_ext(

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -4,6 +4,7 @@ use crate::{
     insert::Insert,
     objects::{Face, FaceSet, Objects},
     partial::{HasPartial, PartialFace},
+    services::Service,
     validate::ValidationError,
 };
 
@@ -13,7 +14,7 @@ impl TransformObject for PartialFace {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let surface = self
             .surface()
@@ -56,7 +57,7 @@ impl TransformObject for FaceSet {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let mut faces = FaceSet::new();
         faces.extend(

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     insert::Insert,
     objects::Objects,
     partial::{HasPartial, MaybePartial, Partial},
+    services::Service,
     storage::Handle,
     validate::{Validate, ValidationError},
 };
@@ -34,7 +35,7 @@ pub trait TransformObject: Sized {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError>;
 
     /// Translate the object
@@ -43,7 +44,7 @@ pub trait TransformObject: Sized {
     fn translate(
         self,
         offset: impl Into<Vector<3>>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         self.transform(&Transform::translation(offset), objects)
     }
@@ -54,7 +55,7 @@ pub trait TransformObject: Sized {
     fn rotate(
         self,
         axis_angle: impl Into<Vector<3>>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         self.transform(&Transform::rotation(axis_angle), objects)
     }
@@ -69,7 +70,7 @@ where
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         Ok(self
             .to_partial()
@@ -88,7 +89,7 @@ where
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let transformed = match self {
             Self::Full(full) => {

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Objects, Shell},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -12,7 +13,7 @@ impl TransformObject for Handle<Shell> {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let faces = self
             .faces()

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Objects, Sketch},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -12,7 +13,7 @@ impl TransformObject for Handle<Sketch> {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let faces = self
             .faces()

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -2,6 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Objects, Solid},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -12,7 +13,7 @@ impl TransformObject for Handle<Solid> {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let faces = self
             .shells()

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     geometry::surface::SurfaceGeometry, objects::Objects,
-    partial::PartialSurface, validate::ValidationError,
+    partial::PartialSurface, services::Service, validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -11,7 +11,7 @@ impl TransformObject for PartialSurface {
     fn transform(
         self,
         transform: &Transform,
-        _: &mut Objects,
+        _: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let geometry = self.geometry.map(|geometry| {
             let u = geometry.u.transform(transform);

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -3,6 +3,7 @@ use fj_math::Transform;
 use crate::{
     objects::Objects,
     partial::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
+    services::Service,
     validate::ValidationError,
 };
 
@@ -12,7 +13,7 @@ impl TransformObject for PartialVertex {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let curve = self.curve.transform(transform, objects)?;
         let surface_form = self
@@ -34,7 +35,7 @@ impl TransformObject for PartialSurfaceVertex {
     fn transform(
         self,
         transform: &Transform,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let surface = self
             .surface
@@ -57,7 +58,7 @@ impl TransformObject for PartialGlobalVertex {
     fn transform(
         self,
         transform: &Transform,
-        _: &mut Objects,
+        _: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let position = self
             .position

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -81,6 +81,7 @@ mod tests {
         insert::Insert,
         objects::{Face, Objects},
         partial::HasPartial,
+        services::State,
         storage::Handle,
     };
 
@@ -88,7 +89,7 @@ mod tests {
 
     #[test]
     fn simple() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let a = [0., 0.];
         let b = [2., 0.];
@@ -119,7 +120,7 @@ mod tests {
 
     #[test]
     fn simple_hole() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let a = [0., 0.];
         let b = [4., 0.];
@@ -171,7 +172,7 @@ mod tests {
 
     #[test]
     fn sharp_concave_shape() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         //   e       c
         //   |\     /|

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -8,6 +8,7 @@ use crate::{
         MaybePartial, MergeWith, PartialGlobalEdge, PartialHalfEdge,
         PartialSurfaceVertex, PartialVertex, Replace,
     },
+    services::{Service, State},
     storage::Handle,
     validate::ValidationError,
 };
@@ -32,7 +33,7 @@ pub trait HalfEdgeBuilder: Sized {
     fn update_as_circle_from_radius(
         self,
         radius: impl Into<Scalar>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError>;
 
     /// Update partial half-edge as a line segment, from the given points
@@ -71,7 +72,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn update_as_circle_from_radius(
         mut self,
         radius: impl Into<Scalar>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self, ValidationError> {
         let mut curve = self.curve.clone().into_partial();
         curve.update_as_circle_from_radius(radius);
@@ -162,7 +163,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             // a hack, but I can't think of something better.
             let global_forms = {
                 let must_switch_order = {
-                    let mut objects = Objects::new();
+                    let mut objects = Objects::new().into_service();
                     let vertices = vertices.clone().map(|vertex| {
                         vertex
                             .into_full(&mut objects)

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -13,6 +13,7 @@ use crate::{
         HasPartial, PartialCurve, PartialHalfEdge, PartialSurface,
         PartialSurfaceVertex, PartialVertex,
     },
+    services::Service,
     storage::Handle,
 };
 
@@ -38,7 +39,7 @@ impl ShellBuilder {
     pub fn with_cube_from_edge_length(
         mut self,
         edge_length: impl Into<Scalar>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Self {
         let edge_length = edge_length.into();
 
@@ -337,7 +338,7 @@ impl ShellBuilder {
     }
 
     /// Build the [`Shell`]
-    pub fn build(self, objects: &mut Objects) -> Handle<Shell> {
+    pub fn build(self, objects: &mut Service<Objects>) -> Handle<Shell> {
         Shell::new(self.faces).insert(objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -4,6 +4,7 @@ use crate::{
     insert::Insert,
     objects::{Face, FaceSet, Objects, Sketch, Surface},
     partial::HasPartial,
+    services::Service,
     storage::Handle,
 };
 
@@ -40,7 +41,7 @@ impl SketchBuilder {
     pub fn with_polygon_from_points(
         mut self,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Self {
         let surface = self
             .surface
@@ -57,7 +58,7 @@ impl SketchBuilder {
     }
 
     /// Build the [`Sketch`]
-    pub fn build(self, objects: &mut Objects) -> Handle<Sketch> {
+    pub fn build(self, objects: &mut Service<Objects>) -> Handle<Sketch> {
         Sketch::new(self.faces).insert(objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -5,6 +5,7 @@ use fj_math::Scalar;
 use crate::{
     insert::Insert,
     objects::{Objects, Shell, Solid},
+    services::Service,
     storage::Handle,
 };
 
@@ -30,7 +31,7 @@ impl SolidBuilder {
     pub fn with_cube_from_edge_length(
         mut self,
         edge_length: impl Into<Scalar>,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Self {
         let shell = Shell::builder()
             .with_cube_from_edge_length(edge_length, objects)
@@ -40,7 +41,7 @@ impl SolidBuilder {
     }
 
     /// Build the [`Solid`]
-    pub fn build(self, objects: &mut Objects) -> Handle<Solid> {
+    pub fn build(self, objects: &mut Service<Objects>) -> Handle<Solid> {
         Solid::new(self.shells).insert(objects).unwrap()
     }
 }

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -7,6 +7,7 @@ use crate::{
         Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
         Objects, Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
     },
+    services::{Service, ServiceObjectsExt},
     storage::Handle,
     validate::Validate,
 };
@@ -16,7 +17,7 @@ pub trait Insert: Sized + Validate {
     /// Insert the object into its respective store
     fn insert(
         self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Handle<Self>, <Self as Validate>::Error>;
 }
 
@@ -26,10 +27,10 @@ macro_rules! impl_insert {
             impl Insert for $ty {
                 fn insert(
                     self,
-                    objects: &mut Objects,
+                    objects: &mut Service<Objects>,
                 ) -> Result<Handle<Self>, <Self as Validate>::Error> {
                     let handle = objects.$store.reserve();
-                    objects.$store.insert(handle.clone(), self)?;
+                    objects.insert(handle.clone(), self);
                     Ok(handle)
                 }
             }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -367,13 +367,14 @@ mod tests {
             Sketch, Solid, SurfaceVertex, Vertex,
         },
         partial::{HasPartial, PartialCurve},
+        services::State,
     };
 
     use super::ObjectIters as _;
 
     #[test]
     fn curve() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let mut object = PartialCurve {
@@ -400,7 +401,7 @@ mod tests {
 
     #[test]
     fn cycle() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let object = Cycle::partial()
@@ -429,7 +430,7 @@ mod tests {
 
     #[test]
     fn face() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let object = Face::partial()
@@ -455,7 +456,7 @@ mod tests {
 
     #[test]
     fn global_curve() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let object = GlobalCurve.insert(&mut objects)?;
 
@@ -476,7 +477,7 @@ mod tests {
 
     #[test]
     fn global_vertex() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let object =
             GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects)?;
@@ -498,7 +499,7 @@ mod tests {
 
     #[test]
     fn half_edge() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let object = HalfEdge::partial()
             .update_as_line_segment_from_points(
@@ -525,7 +526,7 @@ mod tests {
 
     #[test]
     fn shell() {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let object = Shell::builder()
             .with_cube_from_edge_length(1., &mut objects)
@@ -546,7 +547,7 @@ mod tests {
 
     #[test]
     fn sketch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let face = Face::partial()
@@ -573,7 +574,7 @@ mod tests {
 
     #[test]
     fn solid() {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let object = Solid::builder()
             .with_cube_from_edge_length(1., &mut objects)
@@ -613,7 +614,7 @@ mod tests {
 
     #[test]
     fn vertex() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
         let mut curve = PartialCurve {

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -100,5 +100,6 @@ pub mod insert;
 pub mod iter;
 pub mod objects;
 pub mod partial;
+pub mod services;
 pub mod storage;
 pub mod validate;

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -171,13 +171,14 @@ mod tests {
 
     use crate::{
         builder::HalfEdgeBuilder, objects::Objects, partial::HasPartial,
+        services::State,
     };
 
     use super::HalfEdge;
 
     #[test]
     fn global_edge_equality() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
 

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -8,6 +8,7 @@ use crate::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex,
     },
+    services::Service,
     storage::Handle,
     validate::{Validate, ValidationError},
 };
@@ -72,7 +73,7 @@ impl<T: HasPartial> MaybePartial<T> {
     /// object, the full object is built from it, using [`Partial::build`].
     pub fn into_full(
         self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Handle<T>, ValidationError>
     where
         T: Insert,

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -2,6 +2,7 @@ use crate::{
     geometry::path::SurfacePath,
     objects::{Curve, GlobalCurve, Objects, Surface},
     partial::{MaybePartial, MergeWith, Replace},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -25,7 +26,7 @@ impl PartialCurve {
     /// Build a full [`Curve`] from the partial curve
     pub fn build(
         self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Curve, ValidationError> {
         let path = self.path.expect("Can't build `Curve` without path");
         let surface =

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -4,6 +4,7 @@ use crate::{
     partial::{
         MaybePartial, MergeWith, PartialHalfEdge, PartialVertex, Replace,
     },
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -71,7 +72,7 @@ impl PartialCycle {
     /// Build a full [`Cycle`] from the partial cycle
     pub fn build(
         mut self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Cycle, ValidationError> {
         // Check that the cycle is closed. This will lead to a panic further
         // down anyway, but that panic would be super-confusing. This one should

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -7,6 +7,7 @@ use crate::{
         Surface, Vertex,
     },
     partial::{MaybePartial, MergeWith, PartialCurve, PartialVertex, Replace},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -30,7 +31,7 @@ impl PartialHalfEdge {
     /// Build a full [`HalfEdge`] from the partial half-edge
     pub fn build(
         mut self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<HalfEdge, ValidationError> {
         let global_curve = self
             .curve
@@ -118,7 +119,7 @@ impl PartialGlobalEdge {
     /// Build a full [`GlobalEdge`] from the partial global edge
     pub fn build(
         self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<GlobalEdge, ValidationError> {
         let curve = self.curve.into_full(objects)?;
         let vertices = self

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -3,6 +3,7 @@ use fj_interop::mesh::Color;
 use crate::{
     objects::{Cycle, Face, Objects, Surface},
     partial::{MaybePartial, MergeWith, Mergeable},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -71,7 +72,10 @@ impl PartialFace {
     }
 
     /// Construct a polygon from a list of points
-    pub fn build(self, objects: &mut Objects) -> Result<Face, ValidationError> {
+    pub fn build(
+        self,
+        objects: &mut Service<Objects>,
+    ) -> Result<Face, ValidationError> {
         let exterior = self.exterior.into_full(objects)?;
         let interiors = self
             .interiors

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -5,9 +5,12 @@ pub mod face;
 pub mod surface;
 pub mod vertex;
 
-use crate::objects::{
-    Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
-    Objects, Surface, SurfaceVertex, Vertex,
+use crate::{
+    objects::{
+        Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
+        Objects, Surface, SurfaceVertex, Vertex,
+    },
+    services::Service,
 };
 
 use super::{
@@ -26,7 +29,7 @@ macro_rules! impl_traits {
             impl Partial for $partial {
                 type Full = $full;
 
-                fn build(self, objects: &mut Objects)
+                fn build(self, objects: &mut Service<Objects>)
                     -> Result<
                         Self::Full,
                         crate::validate::ValidationError

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -4,6 +4,7 @@ use crate::{
     builder::GlobalVertexBuilder,
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
     partial::{MaybePartial, MergeWith, Replace},
+    services::Service,
     storage::Handle,
     validate::ValidationError,
 };
@@ -33,7 +34,7 @@ impl PartialVertex {
     /// Panics, if curve has not been provided.
     pub fn build(
         self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Vertex, ValidationError> {
         let position = self
             .position
@@ -106,7 +107,7 @@ impl PartialSurfaceVertex {
     /// Build a full [`SurfaceVertex`] from the partial surface vertex
     pub fn build(
         mut self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<SurfaceVertex, ValidationError> {
         let position = self
             .position

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -1,4 +1,4 @@
-use crate::{objects::Objects, validate::ValidationError};
+use crate::{objects::Objects, services::Service, validate::ValidationError};
 
 /// Implemented for objects that a partial object type exists for
 ///
@@ -79,6 +79,6 @@ pub trait Partial: Default + for<'a> From<&'a Self::Full> {
     /// [`Result`].
     fn build(
         self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
     ) -> Result<Self::Full, ValidationError>;
 }

--- a/crates/fj-kernel/src/services.rs
+++ b/crates/fj-kernel/src/services.rs
@@ -4,6 +4,11 @@
 
 use std::ops::Deref;
 
+use crate::{
+    objects::{Object, Objects, WithHandle},
+    storage::Handle,
+};
+
 /// A service that controls access to some state
 ///
 /// `Service` is a generic wrapper around some state, as well as code that knows
@@ -119,4 +124,58 @@ pub trait State {
     /// decisions that go into updating the state should be made in
     /// [`State::decide`], and encoded into the event.
     fn evolve(&mut self, event: &Self::Event);
+}
+
+impl State for Objects {
+    type Command = InsertObject;
+    type Event = ObjectToInsert;
+
+    fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>) {
+        let event = ObjectToInsert {
+            object: command.object,
+        };
+        events.push(event);
+    }
+
+    fn evolve(&mut self, event: &Self::Event) {
+        // This operation being fallible goes against the spirit of the `evolve`
+        // method. The reason for that is, that `Objects` is not fully adapted
+        // to this new design yet. In the future, validation will most likely
+        // move into its own service, making this operation infallible.
+        event.object.clone().insert(self).unwrap();
+    }
+}
+
+/// Command for `Service<Objects>`
+///
+/// You might prefer to use [`ServiceObjectsExt::insert`], which is a convenient
+/// wrapper around `Service<Objects>::execute`.
+pub struct InsertObject {
+    /// The object to insert
+    pub object: Object<WithHandle>,
+}
+
+/// Event produced by `Service<Objects>`
+pub struct ObjectToInsert {
+    /// The object to insert
+    pub object: Object<WithHandle>,
+}
+
+/// Convenient API for `Service<Objects>`
+pub trait ServiceObjectsExt {
+    /// Insert an object
+    fn insert<T>(&mut self, handle: Handle<T>, object: T)
+    where
+        (Handle<T>, T): Into<Object<WithHandle>>;
+}
+
+impl ServiceObjectsExt for Service<Objects> {
+    fn insert<T>(&mut self, handle: Handle<T>, object: T)
+    where
+        (Handle<T>, T): Into<Object<WithHandle>>,
+    {
+        self.execute(InsertObject {
+            object: (handle, object).into(),
+        })
+    }
 }

--- a/crates/fj-kernel/src/services.rs
+++ b/crates/fj-kernel/src/services.rs
@@ -1,0 +1,122 @@
+//! Service API that promotes monitoring and interactivity
+//!
+//! See [`Service`].
+
+use std::ops::Deref;
+
+/// A service that controls access to some state
+///
+/// `Service` is a generic wrapper around some state, as well as code that knows
+/// how to operate on that state. It processes commands, changes the state based
+/// on those command, and produces events that capture these changes. These
+/// events are stored, providing a log of all changes to the state, and can be
+/// replayed later to re-create the state at any point in time.
+///
+/// The wrapped state must implement [`State`], which defines the type of
+/// command that this service processes, and the type of event that captures
+/// state changes. It also defines methods that operate on the state, commands,
+/// and events.
+///
+/// Implementations of [`State`] might also define an extension trait for a
+/// specific `Service<MyState>`, to provide a convenient API to callers.
+///
+/// This design takes inspiration from, and uses the nomenclature of, this
+/// article:
+/// <https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider>
+pub struct Service<S: State> {
+    state: S,
+    events: Vec<S::Event>,
+}
+
+impl<S: State> Service<S> {
+    /// Create an instance of `Service`
+    pub fn new(state: S) -> Self {
+        Self {
+            state,
+            events: Vec::new(),
+        }
+    }
+
+    /// Execute a command
+    ///
+    /// The command is executed synchronously. When this method returns, the
+    /// state has been updated and any events have been logged.
+    pub fn execute(&mut self, command: S::Command) {
+        let mut events = Vec::new();
+        self.state.decide(command, &mut events);
+
+        for event in &events {
+            self.state.evolve(event);
+        }
+
+        self.events.extend(events);
+    }
+
+    /// Access the events
+    pub fn events(&self) -> impl Iterator<Item = &S::Event> {
+        self.events.iter()
+    }
+
+    /// Replay the provided events on the given state
+    pub fn replay<'event>(
+        state: &mut S,
+        events: impl IntoIterator<Item = &'event S::Event>,
+    ) where
+        <S as State>::Event: 'event,
+    {
+        for event in events {
+            state.evolve(event);
+        }
+    }
+}
+
+impl<S: State> Deref for Service<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+/// Implemented for state that can be wrapped by a [`Service`]
+///
+/// See [`Service`] for a detailed explanation.
+pub trait State {
+    /// A command that relates to the state
+    ///
+    /// Commands are processed by [`State::decide`].
+    type Command;
+
+    /// An event that captures modifications to this state
+    ///
+    /// Events are produced by [`State::decide`] and processed by
+    /// [`State::evolve`].
+    type Event;
+
+    /// Convert this state into the service that wraps it
+    ///
+    /// This is a convenience method that just calls [`Service::new`]
+    /// internally.
+    fn into_service(self) -> Service<Self>
+    where
+        Self: Sized,
+    {
+        Service::new(self)
+    }
+
+    /// Decide how to react to the provided command
+    ///
+    /// If the command must result in changes to the state, any number of events
+    /// that describe these state changes can be produced.
+    fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>);
+
+    /// Evolve the state according to the provided event
+    ///
+    /// This is the only method gets mutable access to the state, making sure
+    /// that all changes to the state are captured as events.
+    ///
+    /// Implementations of this method are supposed to be relatively dumb. Any
+    /// decisions that go into updating the state should be made in
+    /// [`State::decide`], and encoded into the event.
+    fn evolve(&mut self, event: &Self::Event);
+}

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -70,12 +70,13 @@ mod tests {
         insert::Insert,
         objects::{Cycle, Objects},
         partial::HasPartial,
+        services::State,
         validate::{Validate, ValidationError},
     };
 
     #[test]
     fn cycle_half_edge_connections() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = Cycle::partial()
             .with_poly_chain_from_points(

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -205,12 +205,13 @@ mod tests {
         insert::Insert,
         objects::{GlobalCurve, HalfEdge, Objects},
         partial::HasPartial,
+        services::State,
         validate::{Validate, ValidationError},
     };
 
     #[test]
     fn half_edge_curve_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
@@ -236,7 +237,7 @@ mod tests {
 
     #[test]
     fn half_edge_global_curve_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
@@ -258,7 +259,7 @@ mod tests {
 
     #[test]
     fn half_edge_global_vertex_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(
@@ -285,7 +286,7 @@ mod tests {
 
     #[test]
     fn half_edge_vertices_are_coincident() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
             .update_as_line_segment_from_points(

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -109,12 +109,13 @@ mod tests {
         insert::Insert,
         objects::{Cycle, Face, Objects},
         partial::HasPartial,
+        services::State,
         validate::Validate,
     };
 
     #[test]
     fn face_surface_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = Face::partial()
             .with_surface(objects.surfaces.xy_plane())
@@ -142,7 +143,7 @@ mod tests {
 
     #[test]
     fn face_invalid_interior_winding() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = Face::partial()
             .with_surface(objects.surfaces.xy_plane())

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -186,12 +186,13 @@ mod tests {
         partial::{
             HasPartial, PartialCurve, PartialSurfaceVertex, PartialVertex,
         },
+        services::State,
         validate::Validate,
     };
 
     #[test]
     fn vertex_surface_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let mut curve = PartialCurve {
             surface: Some(objects.surfaces.xy_plane()),
@@ -219,7 +220,7 @@ mod tests {
 
     #[test]
     fn vertex_position_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = {
             let mut curve = PartialCurve {
@@ -250,7 +251,7 @@ mod tests {
 
     #[test]
     fn surface_vertex_position_mismatch() -> anyhow::Result<()> {
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
 
         let valid = PartialSurfaceVertex {
             position: Some([0., 0.].into()),

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -7,6 +7,7 @@ use fj_kernel::{
     iter::ObjectIters,
     objects::{Face, Objects, Sketch},
     partial::HasPartial,
+    services::Service,
     validate::ValidationError,
 };
 use fj_math::Aabb;
@@ -18,7 +19,7 @@ impl Shape for fj::Difference2d {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         // This method assumes that `b` is fully contained within `a`:

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -1,6 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     objects::{FaceSet, Objects},
+    services::Service,
     validate::ValidationError,
 };
 use fj_math::Aabb;
@@ -12,7 +13,7 @@ impl Shape for fj::Group {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let mut faces = FaceSet::new();

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -32,6 +32,7 @@ mod transform;
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     objects::{FaceSet, Objects, Sketch},
+    services::Service,
     validate::ValidationError,
 };
 use fj_math::Aabb;
@@ -44,7 +45,7 @@ pub trait Shape {
     /// Compute the boundary representation of the shape
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError>;
 
@@ -60,7 +61,7 @@ impl Shape for fj::Shape {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         match self {
@@ -96,7 +97,7 @@ impl Shape for fj::Shape2d {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         match self {

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -7,6 +7,7 @@ use fj_kernel::{
         triangulate::Triangulate,
     },
     objects::Objects,
+    services::State,
     validate::ValidationError,
 };
 use fj_math::Scalar;
@@ -42,7 +43,7 @@ impl ShapeProcessor {
             Some(user_defined_tolerance) => user_defined_tolerance,
         };
 
-        let mut objects = Objects::new();
+        let mut objects = Objects::new().into_service();
         let mut debug_info = DebugInfo::new();
         let shape = shape.compute_brep(&mut objects, &mut debug_info)?;
         let mesh = (&shape, tolerance).triangulate();

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -6,6 +6,7 @@ use fj_kernel::{
     insert::Insert,
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
     partial::{HasPartial, Replace},
+    services::Service,
     validate::ValidationError,
 };
 use fj_math::{Aabb, Point};
@@ -17,7 +18,7 @@ impl Shape for fj::Sketch {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         _: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let surface = objects.surfaces.xy_plane();

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -5,6 +5,7 @@ use fj_kernel::{
     algorithms::sweep::Sweep,
     insert::Insert,
     objects::{Objects, Solid},
+    services::Service,
     validate::ValidationError,
 };
 use fj_math::{Aabb, Vector};
@@ -16,7 +17,7 @@ impl Shape for fj::Sweep {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let sketch = self.shape().compute_brep(objects, debug_info)?;

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -2,6 +2,7 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     algorithms::transform::TransformObject,
     objects::{FaceSet, Objects},
+    services::Service,
     validate::ValidationError,
 };
 use fj_math::{Aabb, Transform, Vector};
@@ -13,7 +14,7 @@ impl Shape for fj::Transform {
 
     fn compute_brep(
         &self,
-        objects: &mut Objects,
+        objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let faces = self


### PR DESCRIPTION
This new service is the only code that mutates `Objects`, and it only does so through events. Those events can later be accessed and used to recreate any intermediate state. This should help with building better debugging tools (#1385), and barely complicates the code that was previously using `Objects` directly!

This has the side effect of turning validation errors into panics, for the time being. This is fine for now, as it matches how validation errors are used so far pretty well. It also enables a lot of simplifications, which I'm going to realize in follow-up pull requests.

My mid-term plan for validation is to decouple it from object insertion and move it into a service. This will enable geometry to be generated despite validation errors (which is good, because the user needs to see what's wrong; not just be confronted with an error message and no result). It will also allow any future debugging tools to provide better insight into exactly where and how these validation errors were generated.

Close #1387 