### PR TITLE
Simplify functions that previously had to return `Result<_, ValidationError>`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -217,13 +217,13 @@ mod tests {
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
                 .build(&objects)?
-                .insert(&mut objects)?;
+                .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
-        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects);
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -242,13 +242,13 @@ mod tests {
             [0., 0., 1.],
         )
         .build(&objects)?
-        .insert(&mut objects)?;
+        .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
-        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects);
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -264,13 +264,13 @@ mod tests {
         let path = GlobalPath::circle_from_radius(1.);
         let surface = PartialSurface::from_axes(path, [0., 0., 1.])
             .build(&objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
-        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;
@@ -299,13 +299,13 @@ mod tests {
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
                 .build(&objects)?
-                .insert(&mut objects)?;
+                .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_circle_from_radius(1.);
-        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -216,14 +216,14 @@ mod tests {
 
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
-                .build(&objects)?
+                .build(&objects)
                 .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
-        let curve = curve.build(&mut objects)?.insert(&mut objects);
+        let curve = curve.build(&mut objects).insert(&mut objects);
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -241,14 +241,14 @@ mod tests {
             GlobalPath::circle_from_radius(1.),
             [0., 0., 1.],
         )
-        .build(&objects)?
+        .build(&objects)
         .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
-        let curve = curve.build(&mut objects)?.insert(&mut objects);
+        let curve = curve.build(&mut objects).insert(&mut objects);
         let range = RangeOnPath::from([[0.], [1.]]);
 
         let approx = (&curve, range).approx(1.);
@@ -263,14 +263,14 @@ mod tests {
 
         let path = GlobalPath::circle_from_radius(1.);
         let surface = PartialSurface::from_axes(path, [0., 0., 1.])
-            .build(&objects)?
+            .build(&objects)
             .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
-        let curve = curve.build(&mut objects)?.insert(&mut objects);
+        let curve = curve.build(&mut objects).insert(&mut objects);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;
@@ -298,14 +298,14 @@ mod tests {
 
         let surface =
             PartialSurface::from_axes(GlobalPath::x_axis(), [0., 0., 1.])
-                .build(&objects)?
+                .build(&objects)
                 .insert(&mut objects);
         let mut curve = PartialCurve {
             surface: Some(surface),
             ..Default::default()
         };
         curve.update_as_circle_from_radius(1.);
-        let curve = curve.build(&mut objects)?.insert(&mut objects);
+        let curve = curve.build(&mut objects).insert(&mut objects);
 
         let range = RangeOnPath::from([[0.], [TAU]]);
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -211,7 +211,7 @@ mod tests {
     use super::CurveApprox;
 
     #[test]
-    fn approx_line_on_flat_surface() -> anyhow::Result<()> {
+    fn approx_line_on_flat_surface() {
         let mut objects = Objects::new().into_service();
 
         let surface =
@@ -229,12 +229,10 @@ mod tests {
         let approx = (&curve, range).approx(1.);
 
         assert_eq!(approx, CurveApprox::empty());
-        Ok(())
     }
 
     #[test]
-    fn approx_line_on_curved_surface_but_not_along_curve() -> anyhow::Result<()>
-    {
+    fn approx_line_on_curved_surface_but_not_along_curve() {
         let mut objects = Objects::new().into_service();
 
         let surface = PartialSurface::from_axes(
@@ -254,11 +252,10 @@ mod tests {
         let approx = (&curve, range).approx(1.);
 
         assert_eq!(approx, CurveApprox::empty());
-        Ok(())
     }
 
     #[test]
-    fn approx_line_on_curved_surface_along_curve() -> anyhow::Result<()> {
+    fn approx_line_on_curved_surface_along_curve() {
         let mut objects = Objects::new().into_service();
 
         let path = GlobalPath::circle_from_radius(1.);
@@ -289,11 +286,10 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(approx.points, expected_approx);
-        Ok(())
     }
 
     #[test]
-    fn approx_circle_on_flat_surface() -> anyhow::Result<()> {
+    fn approx_circle_on_flat_surface() {
         let mut objects = Objects::new().into_service();
 
         let surface =
@@ -323,6 +319,5 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(approx.points, expected_approx);
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -93,10 +93,10 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?;
+        let curve = curve.build(&mut objects);
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[1., -1.], [1., 1.]])
-            .build(&mut objects)?;
+            .build(&mut objects);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -119,13 +119,13 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?;
+        let curve = curve.build(&mut objects);
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
                 [[-1., -1.], [-1., 1.]],
             )
-            .build(&mut objects)?;
+            .build(&mut objects);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -148,13 +148,13 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?;
+        let curve = curve.build(&mut objects);
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(
                 surface,
                 [[-1., -1.], [1., -1.]],
             )
-            .build(&mut objects)?;
+            .build(&mut objects);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -172,10 +172,10 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?;
+        let curve = curve.build(&mut objects);
         let half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[-1., 0.], [1., 0.]])
-            .build(&mut objects)?;
+            .build(&mut objects);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -84,7 +84,7 @@ mod tests {
     use super::CurveEdgeIntersection;
 
     #[test]
-    fn compute_edge_in_front_of_curve_origin() -> anyhow::Result<()> {
+    fn compute_edge_in_front_of_curve_origin() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -106,11 +106,10 @@ mod tests {
                 point_on_curve: Point::from([1.])
             })
         );
-        Ok(())
     }
 
     #[test]
-    fn compute_edge_behind_curve_origin() -> anyhow::Result<()> {
+    fn compute_edge_behind_curve_origin() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -135,11 +134,10 @@ mod tests {
                 point_on_curve: Point::from([-1.])
             })
         );
-        Ok(())
     }
 
     #[test]
-    fn compute_edge_parallel_to_curve() -> anyhow::Result<()> {
+    fn compute_edge_parallel_to_curve() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -159,11 +157,10 @@ mod tests {
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert!(intersection.is_none());
-        Ok(())
     }
 
     #[test]
-    fn compute_edge_on_curve() -> anyhow::Result<()> {
+    fn compute_edge_on_curve() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -185,6 +182,5 @@ mod tests {
                 points_on_curve: [Point::from([-1.]), Point::from([1.]),]
             })
         );
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -169,7 +169,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);
-        let curve = curve.build(&mut objects)?;
+        let curve = curve.build(&mut objects);
 
         #[rustfmt::skip]
         let exterior = [
@@ -190,7 +190,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points(exterior)
             .with_interior_polygon_from_points(interior)
-            .build(&mut objects)?;
+            .build(&mut objects);
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -159,7 +159,7 @@ mod tests {
     use super::CurveFaceIntersection;
 
     #[test]
-    fn compute() -> anyhow::Result<()> {
+    fn compute() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -195,7 +195,6 @@ mod tests {
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);
         assert_eq!(CurveFaceIntersection::compute(&curve, &face), expected);
-        Ok(())
     }
 
     #[test]

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -5,7 +5,6 @@ use crate::{
     objects::{Curve, Face, Objects},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::{CurveFaceIntersection, SurfaceSurfaceIntersection};
@@ -32,13 +31,13 @@ impl FaceFaceIntersection {
     pub fn compute(
         faces: [&Face; 2],
         objects: &mut Service<Objects>,
-    ) -> Result<Option<Self>, ValidationError> {
+    ) -> Option<Self> {
         let surfaces = faces.map(|face| face.surface().clone());
 
         let intersection_curves =
             match SurfaceSurfaceIntersection::compute(surfaces, objects) {
                 Some(intersection) => intersection.intersection_curves,
-                None => return Ok(None),
+                None => return None,
             };
 
         let curve_face_intersections = intersection_curves
@@ -54,13 +53,13 @@ impl FaceFaceIntersection {
         };
 
         if intersection_intervals.is_empty() {
-            return Ok(None);
+            return None;
         }
 
-        Ok(Some(Self {
+        Some(Self {
             intersection_curves,
             intersection_intervals,
-        }))
+        })
     }
 }
 
@@ -101,7 +100,7 @@ mod tests {
             });
 
         let intersection =
-            FaceFaceIntersection::compute([&a, &b], &mut objects)?;
+            FaceFaceIntersection::compute([&a, &b], &mut objects);
 
         assert!(intersection.is_none());
 
@@ -129,7 +128,7 @@ mod tests {
         });
 
         let intersection =
-            FaceFaceIntersection::compute([&a, &b], &mut objects)?;
+            FaceFaceIntersection::compute([&a, &b], &mut objects);
 
         let expected_curves =
             surfaces.try_map_ext(|surface| -> Result<_, ValidationError> {

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -65,7 +65,6 @@ impl FaceFaceIntersection {
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::ext::ArrayExt;
     use pretty_assertions::assert_eq;
 
     use crate::{
@@ -75,7 +74,6 @@ mod tests {
         objects::{Face, Objects},
         partial::{HasPartial, PartialCurve},
         services::State,
-        validate::ValidationError,
     };
 
     use super::FaceFaceIntersection;
@@ -130,15 +128,14 @@ mod tests {
         let intersection =
             FaceFaceIntersection::compute([&a, &b], &mut objects);
 
-        let expected_curves =
-            surfaces.try_map_ext(|surface| -> Result<_, ValidationError> {
-                let mut curve = PartialCurve {
-                    surface: Some(surface),
-                    ..Default::default()
-                };
-                curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
-                Ok(curve.build(&mut objects).insert(&mut objects))
-            })?;
+        let expected_curves = surfaces.map(|surface| {
+            let mut curve = PartialCurve {
+                surface: Some(surface),
+                ..Default::default()
+            };
+            curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
+            curve.build(&mut objects).insert(&mut objects)
+        });
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -36,7 +36,7 @@ impl FaceFaceIntersection {
         let surfaces = faces.map(|face| face.surface().clone());
 
         let intersection_curves =
-            match SurfaceSurfaceIntersection::compute(surfaces, objects)? {
+            match SurfaceSurfaceIntersection::compute(surfaces, objects) {
                 Some(intersection) => intersection.intersection_curves,
                 None => return Ok(None),
             };

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -138,7 +138,7 @@ mod tests {
                     ..Default::default()
                 };
                 curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
-                Ok(curve.build(&mut objects)?.insert(&mut objects)?)
+                Ok(curve.build(&mut objects)?.insert(&mut objects))
             })?;
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -93,12 +93,12 @@ mod tests {
             [1., 2.],
         ];
         let [a, b] = [objects.surfaces.xy_plane(), objects.surfaces.xz_plane()]
-            .try_map_ext(|surface| {
+            .map(|surface| {
                 Face::partial()
                     .with_surface(surface)
                     .with_exterior_polygon_from_points(points)
                     .build(&mut objects)
-            })?;
+            });
 
         let intersection =
             FaceFaceIntersection::compute([&a, &b], &mut objects)?;
@@ -121,12 +121,12 @@ mod tests {
         ];
         let surfaces =
             [objects.surfaces.xy_plane(), objects.surfaces.xz_plane()];
-        let [a, b] = surfaces.clone().try_map_ext(|surface| {
+        let [a, b] = surfaces.clone().map(|surface| {
             Face::partial()
                 .with_surface(surface)
                 .with_exterior_polygon_from_points(points)
                 .build(&mut objects)
-        })?;
+        });
 
         let intersection =
             FaceFaceIntersection::compute([&a, &b], &mut objects)?;
@@ -138,7 +138,7 @@ mod tests {
                     ..Default::default()
                 };
                 curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
-                Ok(curve.build(&mut objects)?.insert(&mut objects))
+                Ok(curve.build(&mut objects).insert(&mut objects))
             })?;
         let expected_intervals =
             CurveFaceIntersection::from_intervals([[[-1.], [1.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -79,7 +79,7 @@ mod tests {
     use super::FaceFaceIntersection;
 
     #[test]
-    fn compute_no_intersection() -> anyhow::Result<()> {
+    fn compute_no_intersection() {
         let mut objects = Objects::new().into_service();
 
         #[rustfmt::skip]
@@ -101,12 +101,10 @@ mod tests {
             FaceFaceIntersection::compute([&a, &b], &mut objects);
 
         assert!(intersection.is_none());
-
-        Ok(())
     }
 
     #[test]
-    fn compute_one_intersection() -> anyhow::Result<()> {
+    fn compute_one_intersection() {
         let mut objects = Objects::new().into_service();
 
         #[rustfmt::skip]
@@ -145,6 +143,5 @@ mod tests {
                 intersection_intervals: expected_intervals
             })
         );
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -153,7 +153,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([2., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -171,7 +171,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -192,7 +192,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 2.]);
 
         let intersection = (&face, &point).intersect();
@@ -218,7 +218,7 @@ mod tests {
                 [3., 4.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -245,7 +245,7 @@ mod tests {
                 [0., 2.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -273,7 +273,7 @@ mod tests {
                 [4., 5.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -294,7 +294,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();
@@ -324,7 +324,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -152,7 +152,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([2., 1.]);
 
@@ -170,7 +170,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
@@ -191,7 +191,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 2.]);
 
@@ -217,7 +217,7 @@ mod tests {
                 [3., 0.],
                 [3., 4.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
@@ -244,7 +244,7 @@ mod tests {
                 [3., 1.],
                 [0., 2.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
@@ -272,7 +272,7 @@ mod tests {
                 [4., 0.],
                 [4., 5.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 1.]);
 
@@ -293,7 +293,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 0.]);
 
@@ -323,7 +323,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let point = Point::from([1., 0.]);
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -145,7 +145,7 @@ mod tests {
     };
 
     #[test]
-    fn point_is_outside_face() -> anyhow::Result<()> {
+    fn point_is_outside_face() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -158,12 +158,10 @@ mod tests {
 
         let intersection = (&face, &point).intersect();
         assert_eq!(intersection, None);
-
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_vertex_while_passing_outside() -> anyhow::Result<()> {
+    fn ray_hits_vertex_while_passing_outside() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -179,12 +177,10 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsInsideFace)
         );
-
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_vertex_at_cycle_seam() -> anyhow::Result<()> {
+    fn ray_hits_vertex_at_cycle_seam() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -200,12 +196,10 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsInsideFace)
         );
-
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_vertex_while_staying_inside() -> anyhow::Result<()> {
+    fn ray_hits_vertex_while_staying_inside() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -226,13 +220,10 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsInsideFace)
         );
-
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_parallel_edge_and_leaves_face_at_vertex() -> anyhow::Result<()>
-    {
+    fn ray_hits_parallel_edge_and_leaves_face_at_vertex() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -253,13 +244,10 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsInsideFace)
         );
-
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_parallel_edge_and_does_not_leave_face_there(
-    ) -> anyhow::Result<()> {
+    fn ray_hits_parallel_edge_and_does_not_leave_face_there() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -281,12 +269,10 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsInsideFace)
         );
-
-        Ok(())
     }
 
     #[test]
-    fn point_is_coincident_with_edge() -> anyhow::Result<()> {
+    fn point_is_coincident_with_edge() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -311,12 +297,10 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsOnEdge(edge.clone()))
         );
-
-        Ok(())
     }
 
     #[test]
-    fn point_is_coincident_with_vertex() -> anyhow::Result<()> {
+    fn point_is_coincident_with_vertex() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -339,7 +323,5 @@ mod tests {
             intersection,
             Some(FacePointIntersection::PointIsOnVertex(vertex.clone()))
         );
-
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -176,7 +176,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .translate([-1., 0., 0.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
@@ -199,7 +199,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .translate([1., 0., 0.], &mut objects)?;
 
         assert_eq!(
@@ -225,7 +225,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .translate([0., 0., 2.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);
@@ -248,7 +248,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .translate([1., 1., 0.], &mut objects)?;
 
         let edge = face
@@ -282,7 +282,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .translate([1., 1., 1.], &mut objects)?;
 
         let vertex = face
@@ -314,7 +314,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -340,7 +340,7 @@ mod tests {
                 [-1., 1.],
             ])
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .translate([0., 0., 1.], &mut objects)?;
 
         assert_eq!((&ray, &face).intersect(), None);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -175,7 +175,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .translate([-1., 0., 0.], &mut objects)?;
 
@@ -198,7 +198,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .translate([1., 0., 0.], &mut objects)?;
 
@@ -224,7 +224,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .translate([0., 0., 2.], &mut objects)?;
 
@@ -247,7 +247,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .translate([1., 1., 0.], &mut objects)?;
 
@@ -281,7 +281,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .translate([1., 1., 1.], &mut objects)?;
 
@@ -313,7 +313,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         assert_eq!(
@@ -339,7 +339,7 @@ mod tests {
                 [1., 1.],
                 [-1., 1.],
             ])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .translate([0., 0., 1.], &mut objects)?;
 

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -177,7 +177,7 @@ mod tests {
             ])
             .build(&mut objects)
             .insert(&mut objects)
-            .translate([-1., 0., 0.], &mut objects)?;
+            .translate([-1., 0., 0.], &mut objects);
 
         assert_eq!((&ray, &face).intersect(), None);
         Ok(())
@@ -200,7 +200,7 @@ mod tests {
             ])
             .build(&mut objects)
             .insert(&mut objects)
-            .translate([1., 0., 0.], &mut objects)?;
+            .translate([1., 0., 0.], &mut objects);
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -226,7 +226,7 @@ mod tests {
             ])
             .build(&mut objects)
             .insert(&mut objects)
-            .translate([0., 0., 2.], &mut objects)?;
+            .translate([0., 0., 2.], &mut objects);
 
         assert_eq!((&ray, &face).intersect(), None);
         Ok(())
@@ -249,7 +249,7 @@ mod tests {
             ])
             .build(&mut objects)
             .insert(&mut objects)
-            .translate([1., 1., 0.], &mut objects)?;
+            .translate([1., 1., 0.], &mut objects);
 
         let edge = face
             .half_edge_iter()
@@ -283,7 +283,7 @@ mod tests {
             ])
             .build(&mut objects)
             .insert(&mut objects)
-            .translate([1., 1., 1.], &mut objects)?;
+            .translate([1., 1., 1.], &mut objects);
 
         let vertex = face
             .vertex_iter()
@@ -341,7 +341,7 @@ mod tests {
             ])
             .build(&mut objects)
             .insert(&mut objects)
-            .translate([0., 0., 1.], &mut objects)?;
+            .translate([0., 0., 1.], &mut objects);
 
         assert_eq!((&ray, &face).intersect(), None);
         Ok(())

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -161,7 +161,7 @@ mod tests {
     };
 
     #[test]
-    fn ray_misses_whole_surface() -> anyhow::Result<()> {
+    fn ray_misses_whole_surface() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -180,11 +180,10 @@ mod tests {
             .translate([-1., 0., 0.], &mut objects);
 
         assert_eq!((&ray, &face).intersect(), None);
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_face() -> anyhow::Result<()> {
+    fn ray_hits_face() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -206,11 +205,10 @@ mod tests {
             (&ray, &face).intersect(),
             Some(RayFaceIntersection::RayHitsFace)
         );
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_surface_but_misses_face() -> anyhow::Result<()> {
+    fn ray_hits_surface_but_misses_face() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -229,11 +227,10 @@ mod tests {
             .translate([0., 0., 2.], &mut objects);
 
         assert_eq!((&ray, &face).intersect(), None);
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_edge() -> anyhow::Result<()> {
+    fn ray_hits_edge() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -263,11 +260,10 @@ mod tests {
             (&ray, &face).intersect(),
             Some(RayFaceIntersection::RayHitsEdge(edge.clone()))
         );
-        Ok(())
     }
 
     #[test]
-    fn ray_hits_vertex() -> anyhow::Result<()> {
+    fn ray_hits_vertex() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -295,11 +291,10 @@ mod tests {
             (&ray, &face).intersect(),
             Some(RayFaceIntersection::RayHitsVertex(vertex.clone()))
         );
-        Ok(())
     }
 
     #[test]
-    fn ray_is_parallel_to_surface_and_hits() -> anyhow::Result<()> {
+    fn ray_is_parallel_to_surface_and_hits() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -320,12 +315,10 @@ mod tests {
             (&ray, &face).intersect(),
             Some(RayFaceIntersection::RayHitsFaceAndAreParallel)
         );
-
-        Ok(())
     }
 
     #[test]
-    fn ray_is_parallel_to_surface_and_misses() -> anyhow::Result<()> {
+    fn ray_is_parallel_to_surface_and_misses() {
         let mut objects = Objects::new().into_service();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
@@ -344,6 +337,5 @@ mod tests {
             .translate([0., 0., 1.], &mut objects);
 
         assert_eq!((&ray, &face).intersect(), None);
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -111,7 +111,7 @@ mod tests {
                     xy.clone().transform(
                         &Transform::translation([0., 0., 1.],),
                         &mut objects
-                    )?
+                    )
                 ],
                 &mut objects
             ),

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -123,13 +123,13 @@ mod tests {
             ..Default::default()
         };
         expected_xy.update_as_u_axis();
-        let expected_xy = expected_xy.build(&mut objects)?.insert(&mut objects);
+        let expected_xy = expected_xy.build(&mut objects).insert(&mut objects);
         let mut expected_xz = PartialCurve {
             surface: Some(xz.clone()),
             ..Default::default()
         };
         expected_xz.update_as_u_axis();
-        let expected_xz = expected_xz.build(&mut objects)?.insert(&mut objects);
+        let expected_xz = expected_xz.build(&mut objects).insert(&mut objects);
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([xy, xz], &mut objects),

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -1,4 +1,3 @@
-use fj_interop::ext::ArrayExt;
 use fj_math::{Line, Plane, Point, Scalar};
 
 use crate::{
@@ -59,12 +58,12 @@ impl SurfaceSurfaceIntersection {
 
         let line = Line::from_origin_and_direction(origin, direction);
 
-        let curves = surfaces_and_planes.try_map_ext(|(surface, plane)| {
+        let curves = surfaces_and_planes.map(|(surface, plane)| {
             let path = SurfacePath::Line(plane.project_line(&line));
-            let global_form = GlobalCurve.insert(objects)?;
+            let global_form = GlobalCurve.insert(objects);
 
             Curve::new(surface, path, global_form).insert(objects)
-        })?;
+        });
 
         Ok(Some(Self {
             intersection_curves: curves,
@@ -125,15 +124,13 @@ mod tests {
             ..Default::default()
         };
         expected_xy.update_as_u_axis();
-        let expected_xy =
-            expected_xy.build(&mut objects)?.insert(&mut objects)?;
+        let expected_xy = expected_xy.build(&mut objects)?.insert(&mut objects);
         let mut expected_xz = PartialCurve {
             surface: Some(xz.clone()),
             ..Default::default()
         };
         expected_xz.update_as_u_axis();
-        let expected_xz =
-            expected_xz.build(&mut objects)?.insert(&mut objects)?;
+        let expected_xz = expected_xz.build(&mut objects)?.insert(&mut objects);
 
         assert_eq!(
             SurfaceSurfaceIntersection::compute([xy, xz], &mut objects)?,

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -6,7 +6,6 @@ use crate::{
     objects::{Curve, GlobalCurve, Objects, Surface},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 /// The intersection between two surfaces
@@ -21,7 +20,7 @@ impl SurfaceSurfaceIntersection {
     pub fn compute(
         surfaces: [Handle<Surface>; 2],
         objects: &mut Service<Objects>,
-    ) -> Result<Option<Self>, ValidationError> {
+    ) -> Option<Self> {
         // Algorithm from Real-Time Collision Detection by Christer Ericson. See
         // section 5.4.4, Intersection of Two Planes.
         //
@@ -48,7 +47,7 @@ impl SurfaceSurfaceIntersection {
             // I'll just leave it like that, until we had the opportunity to
             // collect some experience with this code.
             // - @hannobraun
-            return Ok(None);
+            return None;
         }
 
         let origin = (b_normal * a_distance - a_normal * b_distance)
@@ -65,9 +64,9 @@ impl SurfaceSurfaceIntersection {
             Curve::new(surface, path, global_form).insert(objects)
         });
 
-        Ok(Some(Self {
+        Some(Self {
             intersection_curves: curves,
-        }))
+        })
     }
 }
 
@@ -115,7 +114,7 @@ mod tests {
                     )?
                 ],
                 &mut objects
-            )?,
+            ),
             None,
         );
 
@@ -133,7 +132,7 @@ mod tests {
         let expected_xz = expected_xz.build(&mut objects)?.insert(&mut objects);
 
         assert_eq!(
-            SurfaceSurfaceIntersection::compute([xy, xz], &mut objects)?,
+            SurfaceSurfaceIntersection::compute([xy, xz], &mut objects),
             Some(SurfaceSurfaceIntersection {
                 intersection_curves: [expected_xy, expected_xz],
             })

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::SurfaceSurfaceIntersection;
 
     #[test]
-    fn plane_plane() -> anyhow::Result<()> {
+    fn plane_plane() {
         let mut objects = Objects::new().into_service();
 
         let xy = objects.surfaces.xy_plane();
@@ -137,6 +137,5 @@ mod tests {
                 intersection_curves: [expected_xy, expected_xz],
             })
         );
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -21,6 +21,6 @@ impl Reverse for Handle<Cycle> {
 
         edges.reverse();
 
-        Ok(Cycle::new(edges).insert(objects)?)
+        Ok(Cycle::new(edges).insert(objects))
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -3,24 +3,20 @@ use crate::{
     objects::{Cycle, Objects},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::Reverse;
 
 impl Reverse for Handle<Cycle> {
-    fn reverse(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    fn reverse(self, objects: &mut Service<Objects>) -> Self {
         let mut edges = self
             .half_edges()
             .cloned()
             .map(|edge| edge.reverse(objects))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
 
         edges.reverse();
 
-        Ok(Cycle::new(edges).insert(objects))
+        Cycle::new(edges).insert(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -18,7 +18,6 @@ impl Reverse for Handle<HalfEdge> {
             [b, a]
         };
 
-        Ok(HalfEdge::new(vertices, self.global_form().clone())
-            .insert(objects)?)
+        Ok(HalfEdge::new(vertices, self.global_form().clone()).insert(objects))
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -3,21 +3,17 @@ use crate::{
     objects::{HalfEdge, Objects},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::Reverse;
 
 impl Reverse for Handle<HalfEdge> {
-    fn reverse(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    fn reverse(self, objects: &mut Service<Objects>) -> Self {
         let vertices = {
             let [a, b] = self.vertices().clone();
             [b, a]
         };
 
-        Ok(HalfEdge::new(vertices, self.global_form().clone()).insert(objects))
+        HalfEdge::new(vertices, self.global_form().clone()).insert(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -25,6 +25,6 @@ impl Reverse for Handle<Face> {
             .with_interiors(interiors)
             .with_color(self.color())
             .build(objects)?
-            .insert(objects)?)
+            .insert(objects))
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -24,7 +24,7 @@ impl Reverse for Handle<Face> {
             .with_exterior(exterior)
             .with_interiors(interiors)
             .with_color(self.color())
-            .build(objects)?
+            .build(objects)
             .insert(objects))
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -4,27 +4,23 @@ use crate::{
     partial::HasPartial,
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::Reverse;
 
 impl Reverse for Handle<Face> {
-    fn reverse(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
-        let exterior = self.exterior().clone().reverse(objects)?;
+    fn reverse(self, objects: &mut Service<Objects>) -> Self {
+        let exterior = self.exterior().clone().reverse(objects);
         let interiors = self
             .interiors()
             .map(|cycle| cycle.clone().reverse(objects))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
 
-        Ok(Face::partial()
+        Face::partial()
             .with_exterior(exterior)
             .with_interiors(interiors)
             .with_color(self.color())
             .build(objects)
-            .insert(objects))
+            .insert(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/mod.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/mod.rs
@@ -1,6 +1,6 @@
 //! Reverse the direction/orientation of objects
 
-use crate::{objects::Objects, services::Service, validate::ValidationError};
+use crate::{objects::Objects, services::Service};
 
 mod cycle;
 mod edge;
@@ -9,8 +9,5 @@ mod face;
 /// Reverse the direction/orientation of an object
 pub trait Reverse: Sized {
     /// Reverse the direction/orientation of the object
-    fn reverse(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError>;
+    fn reverse(self, objects: &mut Service<Objects>) -> Self;
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -83,7 +83,7 @@ impl Sweep for Handle<Curve> {
 
         let surface = PartialSurface::from_axes(u, path)
             .build(objects)?
-            .insert(objects)?;
+            .insert(objects);
         Ok(surface)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -82,7 +82,7 @@ impl Sweep for Handle<Curve> {
         };
 
         let surface = PartialSurface::from_axes(u, path)
-            .build(objects)?
+            .build(objects)
             .insert(objects);
         Ok(surface)
     }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -8,7 +8,6 @@ use crate::{
     partial::PartialSurface,
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::{Sweep, SweepCache};
@@ -21,7 +20,7 @@ impl Sweep for Handle<Curve> {
         path: impl Into<Vector<3>>,
         _: &mut SweepCache,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError> {
+    ) -> Self::Swept {
         match self.surface().geometry().u {
             GlobalPath::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
@@ -81,9 +80,8 @@ impl Sweep for Handle<Curve> {
             }
         };
 
-        let surface = PartialSurface::from_axes(u, path)
+        PartialSurface::from_axes(u, path)
             .build(objects)
-            .insert(objects);
-        Ok(surface)
+            .insert(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -182,7 +182,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         Ok(Face::partial()
             .with_exterior(cycle)
             .with_color(color)
-            .build(objects)?
+            .build(objects)
             .insert(objects))
     }
 }
@@ -210,7 +210,7 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         let face =
@@ -224,7 +224,7 @@ mod tests {
                     surface.clone(),
                     [[0., 0.], [1., 0.]],
                 )
-                .build(&mut objects)?
+                .build(&mut objects)
                 .insert(&mut objects);
             let side_up = {
                 let mut side_up = HalfEdge::partial();
@@ -247,7 +247,7 @@ mod tests {
                         ..Default::default()
                     })
                     .update_as_line_segment()
-                    .build(&mut objects)?
+                    .build(&mut objects)
                     .insert(&mut objects)
             };
             let top = {
@@ -266,7 +266,7 @@ mod tests {
                     ..Default::default()
                 })
                 .update_as_line_segment()
-                .build(&mut objects)?
+                .build(&mut objects)
                 .insert(&mut objects)
                 .reverse(&mut objects)?
             };
@@ -287,7 +287,7 @@ mod tests {
                         ..Default::default()
                     })
                     .update_as_line_segment()
-                    .build(&mut objects)?
+                    .build(&mut objects)
                     .insert(&mut objects)
                     .reverse(&mut objects)?
             };
@@ -297,7 +297,7 @@ mod tests {
 
             Face::partial()
                 .with_exterior(cycle)
-                .build(&mut objects)?
+                .build(&mut objects)
                 .insert(&mut objects)
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -13,7 +13,6 @@ use crate::{
     partial::HasPartial,
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::{Sweep, SweepCache};
@@ -26,14 +25,12 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError> {
+    ) -> Self::Swept {
         let (edge, color) = self;
         let path = path.into();
 
-        let surface = edge
-            .curve()
-            .clone()
-            .sweep_with_cache(path, cache, objects)?;
+        let surface =
+            edge.curve().clone().sweep_with_cache(path, cache, objects);
 
         // We can't use the edge we're sweeping from as the bottom edge, as that
         // is not defined in the right surface. Let's create a new bottom edge,
@@ -71,8 +68,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     .into_iter_fixed()
                     .zip(points_surface)
                     .collect::<[_; 2]>()
-                    .try_map_ext(
-                    |(vertex, point_surface)| -> Result<_, ValidationError> {
+                    .map(|(vertex, point_surface)| {
                         let surface_vertex = SurfaceVertex::new(
                             point_surface,
                             surface.clone(),
@@ -80,22 +76,21 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         )
                         .insert(objects);
 
-                        Ok(Vertex::new(
+                        Vertex::new(
                             vertex.position(),
                             curve.clone(),
                             surface_vertex,
-                        ).insert(objects))
-                    },
-                )?
+                        )
+                        .insert(objects)
+                    })
             };
 
             HalfEdge::new(vertices, edge.global_form().clone()).insert(objects)
         };
 
-        let side_edges =
-            bottom_edge.vertices().clone().try_map_ext(|vertex| {
-                (vertex, surface.clone()).sweep_with_cache(path, cache, objects)
-            })?;
+        let side_edges = bottom_edge.vertices().clone().map(|vertex| {
+            (vertex, surface.clone()).sweep_with_cache(path, cache, objects)
+        });
 
         let top_edge = {
             let bottom_vertices = bottom_edge.vertices();
@@ -179,11 +174,11 @@ impl Sweep for (Handle<HalfEdge>, Color) {
             Cycle::new(edges).insert(objects)
         };
 
-        Ok(Face::partial()
+        Face::partial()
             .with_exterior(cycle)
             .with_color(color)
             .build(objects)
-            .insert(objects))
+            .insert(objects)
     }
 }
 
@@ -214,7 +209,7 @@ mod tests {
             .insert(&mut objects);
 
         let face =
-            (half_edge, Color::default()).sweep([0., 0., 1.], &mut objects)?;
+            (half_edge, Color::default()).sweep([0., 0., 1.], &mut objects);
 
         let expected_face = {
             let surface = objects.surfaces.xz_plane();

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -170,7 +170,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 if prev_last.surface_form().id()
                     != next_first.surface_form().id()
                 {
-                    edges[j] = edges[j].clone().reverse(objects)?;
+                    edges[j] = edges[j].clone().reverse(objects);
                 }
 
                 i += 1;
@@ -268,7 +268,7 @@ mod tests {
                 .update_as_line_segment()
                 .build(&mut objects)
                 .insert(&mut objects)
-                .reverse(&mut objects)?
+                .reverse(&mut objects)
             };
             let side_down = {
                 let mut side_down = HalfEdge::partial();
@@ -289,7 +289,7 @@ mod tests {
                     .update_as_line_segment()
                     .build(&mut objects)
                     .insert(&mut objects)
-                    .reverse(&mut objects)?
+                    .reverse(&mut objects)
             };
 
             let cycle = Cycle::new([bottom, side_up, top, side_down])

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -59,7 +59,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     path,
                     edge.curve().global_form().clone(),
                 )
-                .insert(objects)?
+                .insert(objects)
             };
 
             let vertices = {
@@ -78,19 +78,18 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                             surface.clone(),
                             vertex.global_form().clone(),
                         )
-                        .insert(objects)?;
+                        .insert(objects);
 
                         Ok(Vertex::new(
                             vertex.position(),
                             curve.clone(),
                             surface_vertex,
-                        ).insert(objects)?)
+                        ).insert(objects))
                     },
                 )?
             };
 
-            HalfEdge::new(vertices, edge.global_form().clone())
-                .insert(objects)?
+            HalfEdge::new(vertices, edge.global_form().clone()).insert(objects)
         };
 
         let side_edges =
@@ -126,7 +125,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         points_curve_and_surface,
                     ));
 
-                Curve::new(surface, path, global).insert(objects)?
+                Curve::new(surface, path, global).insert(objects)
             };
 
             let global = GlobalEdge::new(
@@ -135,19 +134,19 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     .clone()
                     .map(|surface_vertex| surface_vertex.global_form().clone()),
             )
-            .insert(objects)?;
+            .insert(objects);
 
             let vertices = bottom_vertices
                 .each_ref_ext()
                 .into_iter_fixed()
                 .zip(surface_vertices)
                 .collect::<[_; 2]>()
-                .try_map_ext(|(vertex, surface_form)| {
+                .map(|(vertex, surface_form)| {
                     Vertex::new(vertex.position(), curve.clone(), surface_form)
                         .insert(objects)
-                })?;
+                });
 
-            HalfEdge::new(vertices, global).insert(objects)?
+            HalfEdge::new(vertices, global).insert(objects)
         };
 
         let cycle = {
@@ -177,14 +176,14 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 i += 1;
             }
 
-            Cycle::new(edges).insert(objects)?
+            Cycle::new(edges).insert(objects)
         };
 
         Ok(Face::partial()
             .with_exterior(cycle)
             .with_color(color)
             .build(objects)?
-            .insert(objects)?)
+            .insert(objects))
     }
 }
 
@@ -212,7 +211,7 @@ mod tests {
                 [[0., 0.], [1., 0.]],
             )
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         let face =
             (half_edge, Color::default()).sweep([0., 0., 1.], &mut objects)?;
@@ -226,7 +225,7 @@ mod tests {
                     [[0., 0.], [1., 0.]],
                 )
                 .build(&mut objects)?
-                .insert(&mut objects)?;
+                .insert(&mut objects);
             let side_up = {
                 let mut side_up = HalfEdge::partial();
                 side_up.replace(surface.clone());
@@ -249,7 +248,7 @@ mod tests {
                     })
                     .update_as_line_segment()
                     .build(&mut objects)?
-                    .insert(&mut objects)?
+                    .insert(&mut objects)
             };
             let top = {
                 let mut top = HalfEdge::partial();
@@ -268,7 +267,7 @@ mod tests {
                 })
                 .update_as_line_segment()
                 .build(&mut objects)?
-                .insert(&mut objects)?
+                .insert(&mut objects)
                 .reverse(&mut objects)?
             };
             let side_down = {
@@ -289,17 +288,17 @@ mod tests {
                     })
                     .update_as_line_segment()
                     .build(&mut objects)?
-                    .insert(&mut objects)?
+                    .insert(&mut objects)
                     .reverse(&mut objects)?
             };
 
             let cycle = Cycle::new([bottom, side_up, top, side_down])
-                .insert(&mut objects)?;
+                .insert(&mut objects);
 
             Face::partial()
                 .with_exterior(cycle)
                 .build(&mut objects)?
-                .insert(&mut objects)?
+                .insert(&mut objects)
         };
 
         assert_eq!(face, expected_face);

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -115,7 +115,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     .curve()
                     .global_form()
                     .clone()
-                    .translate(path, objects)?;
+                    .translate(path, objects);
 
                 // Please note that creating a line here is correct, even if the
                 // global curve is a circle. Projected into the side surface, it

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -197,7 +197,7 @@ mod tests {
     };
 
     #[test]
-    fn sweep() -> anyhow::Result<()> {
+    fn sweep() {
         let mut objects = Objects::new().into_service();
 
         let half_edge = HalfEdge::partial()
@@ -297,6 +297,5 @@ mod tests {
         };
 
         assert_eq!(face, expected_face);
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -114,13 +114,13 @@ mod tests {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface.translate(UP, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         assert!(solid.find_face(&bottom).is_some());
         assert!(solid.find_face(&top).is_some());
@@ -135,7 +135,7 @@ mod tests {
                         [a, b],
                     )
                     .build(&mut objects)?
-                    .insert(&mut objects)?;
+                    .insert(&mut objects);
                 (half_edge, Color::default()).sweep(UP, &mut objects)
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -161,13 +161,13 @@ mod tests {
             .with_surface(surface.clone().translate(DOWN, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&mut objects)?
+            .insert(&mut objects)
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         assert!(solid.find_face(&bottom).is_some());
         assert!(solid.find_face(&top).is_some());
@@ -182,7 +182,7 @@ mod tests {
                         [a, b],
                     )
                     .build(&mut objects)?
-                    .insert(&mut objects)?
+                    .insert(&mut objects)
                     .reverse(&mut objects)?;
                 (half_edge, Color::default()).sweep(DOWN, &mut objects)
             })

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -43,7 +43,7 @@ impl Sweep for Handle<Face> {
             if is_negative_sweep {
                 self.clone()
             } else {
-                self.clone().reverse(objects)?
+                self.clone().reverse(objects)
             }
         };
         faces.push(bottom_face);
@@ -52,7 +52,7 @@ impl Sweep for Handle<Face> {
             let mut face = self.clone().translate(path, objects)?;
 
             if is_negative_sweep {
-                face = face.reverse(objects)?;
+                face = face.reverse(objects);
             };
 
             face
@@ -63,7 +63,7 @@ impl Sweep for Handle<Face> {
         for cycle in self.all_cycles() {
             for half_edge in cycle.half_edges() {
                 let half_edge = if is_negative_sweep {
-                    half_edge.clone().reverse(objects)?
+                    half_edge.clone().reverse(objects)
                 } else {
                     half_edge.clone()
                 };
@@ -115,7 +115,7 @@ mod tests {
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)
             .insert(&mut objects)
-            .reverse(&mut objects)?;
+            .reverse(&mut objects);
         let top = Face::partial()
             .with_surface(surface.translate(UP, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
@@ -162,7 +162,7 @@ mod tests {
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)
             .insert(&mut objects)
-            .reverse(&mut objects)?;
+            .reverse(&mut objects);
         let top = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
@@ -183,7 +183,7 @@ mod tests {
                     )
                     .build(&mut objects)
                     .insert(&mut objects)
-                    .reverse(&mut objects)?;
+                    .reverse(&mut objects);
                 (half_edge, Color::default()).sweep(DOWN, &mut objects)
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -49,7 +49,7 @@ impl Sweep for Handle<Face> {
         faces.push(bottom_face);
 
         let top_face = {
-            let mut face = self.clone().translate(path, objects)?;
+            let mut face = self.clone().translate(path, objects);
 
             if is_negative_sweep {
                 face = face.reverse(objects);
@@ -117,7 +117,7 @@ mod tests {
             .insert(&mut objects)
             .reverse(&mut objects);
         let top = Face::partial()
-            .with_surface(surface.translate(UP, &mut objects)?)
+            .with_surface(surface.translate(UP, &mut objects))
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)
             .insert(&mut objects);
@@ -158,7 +158,7 @@ mod tests {
             .sweep(DOWN, &mut objects)?;
 
         let bottom = Face::partial()
-            .with_surface(surface.clone().translate(DOWN, &mut objects)?)
+            .with_surface(surface.clone().translate(DOWN, &mut objects))
             .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut objects)
             .insert(&mut objects)

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -113,13 +113,13 @@ mod tests {
         let bottom = Face::partial()
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface.translate(UP, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         assert!(solid.find_face(&bottom).is_some());
@@ -134,7 +134,7 @@ mod tests {
                         objects.surfaces.xy_plane(),
                         [a, b],
                     )
-                    .build(&mut objects)?
+                    .build(&mut objects)
                     .insert(&mut objects);
                 (half_edge, Color::default()).sweep(UP, &mut objects)
             })
@@ -160,13 +160,13 @@ mod tests {
         let bottom = Face::partial()
             .with_surface(surface.clone().translate(DOWN, &mut objects)?)
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects)
             .reverse(&mut objects)?;
         let top = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points(TRIANGLE)
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         assert!(solid.find_face(&bottom).is_some());
@@ -181,7 +181,7 @@ mod tests {
                         objects.surfaces.xy_plane(),
                         [a, b],
                     )
-                    .build(&mut objects)?
+                    .build(&mut objects)
                     .insert(&mut objects)
                     .reverse(&mut objects)?;
                 (half_edge, Color::default()).sweep(DOWN, &mut objects)

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -99,7 +99,7 @@ mod tests {
     const DOWN: [f64; 3] = [0., 0., -1.];
 
     #[test]
-    fn sweep_up() -> anyhow::Result<()> {
+    fn sweep_up() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -139,11 +139,10 @@ mod tests {
         assert!(side_faces
             .into_iter()
             .all(|face| solid.find_face(&face).is_some()));
-        Ok(())
     }
 
     #[test]
-    fn sweep_down() -> anyhow::Result<()> {
+    fn sweep_down() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -184,6 +183,5 @@ mod tests {
         assert!(side_faces
             .into_iter()
             .all(|face| solid.find_face(&face).is_some()));
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -14,7 +14,6 @@ use crate::{
     objects::{GlobalVertex, Objects},
     services::Service,
     storage::{Handle, ObjectId},
-    validate::ValidationError,
 };
 
 /// Sweep an object along a path to create another object
@@ -27,7 +26,7 @@ pub trait Sweep: Sized {
         self,
         path: impl Into<Vector<3>>,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError> {
+    ) -> Self::Swept {
         let mut cache = SweepCache::default();
         self.sweep_with_cache(path, &mut cache, objects)
     }
@@ -38,7 +37,7 @@ pub trait Sweep: Sized {
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError>;
+    ) -> Self::Swept;
 }
 
 /// A cache used for sweeping

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -4,7 +4,6 @@ use crate::{
     objects::{Objects, Sketch, Solid},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::{Sweep, SweepCache};
@@ -17,15 +16,15 @@ impl Sweep for Handle<Sketch> {
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError> {
+    ) -> Self::Swept {
         let path = path.into();
 
         let mut shells = Vec::new();
         for face in self.faces().clone() {
-            let shell = face.sweep_with_cache(path, cache, objects)?;
+            let shell = face.sweep_with_cache(path, cache, objects);
             shells.push(shell);
         }
 
-        Ok(Solid::builder().with_shells(shells).build(objects))
+        Solid::builder().with_shells(shells).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::{Sweep, SweepCache};
@@ -22,7 +21,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError> {
+    ) -> Self::Swept {
         let (vertex, surface) = self;
         let path = path.into();
 
@@ -64,7 +63,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         let (edge_global, vertices_global) = vertex
             .global_form()
             .clone()
-            .sweep_with_cache(path, cache, objects)?;
+            .sweep_with_cache(path, cache, objects);
 
         // Next, let's compute the surface coordinates of the two vertices of
         // the output `Edge`, as we're going to need these for the rest of this
@@ -121,7 +120,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.
-        Ok(HalfEdge::new(vertices, edge_global).insert(objects))
+        HalfEdge::new(vertices, edge_global).insert(objects)
     }
 }
 
@@ -133,7 +132,7 @@ impl Sweep for Handle<GlobalVertex> {
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         objects: &mut Service<Objects>,
-    ) -> Result<Self::Swept, ValidationError> {
+    ) -> Self::Swept {
         let curve = GlobalCurve.insert(objects);
 
         let a = self.clone();
@@ -153,7 +152,7 @@ impl Sweep for Handle<GlobalVertex> {
         // The vertices of the returned `GlobalEdge` are in normalized order,
         // which means the order can't be relied upon by the caller. Return the
         // ordered vertices in addition.
-        Ok((global_edge, vertices))
+        (global_edge, vertices)
     }
 }
 
@@ -190,7 +189,7 @@ mod tests {
         .insert(&mut objects);
 
         let half_edge =
-            (vertex, surface.clone()).sweep([0., 0., 1.], &mut objects)?;
+            (vertex, surface.clone()).sweep([0., 0., 1.], &mut objects);
 
         let expected_half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[0., 0.], [0., 1.]])

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -180,13 +180,13 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?.insert(&mut objects);
+        let curve = curve.build(&mut objects).insert(&mut objects);
         let vertex = PartialVertex {
             position: Some([0.].into()),
             curve: curve.into(),
             ..Default::default()
         }
-        .build(&mut objects)?
+        .build(&mut objects)
         .insert(&mut objects);
 
         let half_edge =
@@ -194,7 +194,7 @@ mod tests {
 
         let expected_half_edge = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [[0., 0.], [0., 1.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         assert_eq!(half_edge, expected_half_edge);
         Ok(())

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -170,7 +170,7 @@ mod tests {
     };
 
     #[test]
-    fn vertex_surface() -> anyhow::Result<()> {
+    fn vertex_surface() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xz_plane();
@@ -196,6 +196,5 @@ mod tests {
             .build(&mut objects)
             .insert(&mut objects);
         assert_eq!(half_edge, expected_half_edge);
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -4,22 +4,17 @@ use crate::{
     objects::Objects,
     partial::{PartialCurve, PartialGlobalCurve},
     services::Service,
-    validate::ValidationError,
 };
 
 use super::TransformObject;
 
 impl TransformObject for PartialGlobalCurve {
-    fn transform(
-        self,
-        _: &Transform,
-        _: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    fn transform(self, _: &Transform, _: &mut Service<Objects>) -> Self {
         // `GlobalCurve` doesn't contain any internal geometry. If it did, that
         // would just be redundant with the geometry of other objects, and this
         // other geometry is already being transformed by other implementations
         // of this trait.
-        Ok(self)
+        self
     }
 }
 
@@ -28,19 +23,18 @@ impl TransformObject for PartialCurve {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let surface = self
             .surface
-            .map(|surface| surface.transform(transform, objects))
-            .transpose()?;
-        let global_form = self.global_form.transform(transform, objects)?;
+            .map(|surface| surface.transform(transform, objects));
+        let global_form = self.global_form.transform(transform, objects);
 
         // Don't need to transform `self.path`, as that's defined in surface
         // coordinates, and thus transforming `surface` takes care of it.
-        Ok(PartialCurve {
+        PartialCurve {
             path: self.path,
             surface,
             global_form,
-        })
+        }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::Objects, partial::PartialCycle, services::Service,
-    validate::ValidationError,
-};
+use crate::{objects::Objects, partial::PartialCycle, services::Service};
 
 use super::TransformObject;
 
@@ -12,12 +9,11 @@ impl TransformObject for PartialCycle {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let half_edges = self
             .half_edges()
-            .map(|edge| edge.into_partial().transform(transform, objects))
-            .collect::<Result<Vec<_>, ValidationError>>()?;
+            .map(|edge| edge.into_partial().transform(transform, objects));
 
-        Ok(Self::default().with_half_edges(half_edges))
+        Self::default().with_half_edges(half_edges)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -1,11 +1,9 @@
-use fj_interop::ext::ArrayExt;
 use fj_math::Transform;
 
 use crate::{
     objects::Objects,
     partial::{PartialGlobalEdge, PartialHalfEdge},
     services::Service,
-    validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -15,18 +13,18 @@ impl TransformObject for PartialHalfEdge {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
-        let curve = self.curve.transform(transform, objects)?;
+    ) -> Self {
+        let curve = self.curve.transform(transform, objects);
         let vertices = self
             .vertices
-            .try_map_ext(|vertex| vertex.transform(transform, objects))?;
-        let global_form = self.global_form.transform(transform, objects)?;
+            .map(|vertex| vertex.transform(transform, objects));
+        let global_form = self.global_form.transform(transform, objects);
 
-        Ok(Self {
+        Self {
             curve,
             vertices,
             global_form,
-        })
+        }
     }
 }
 
@@ -35,14 +33,12 @@ impl TransformObject for PartialGlobalEdge {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
-        let curve = self.curve.transform(transform, objects)?;
-        let vertices = self.vertices.try_map_ext(
-            |vertex| -> Result<_, ValidationError> {
-                vertex.transform(transform, objects)
-            },
-        )?;
+    ) -> Self {
+        let curve = self.curve.transform(transform, objects);
+        let vertices = self
+            .vertices
+            .map(|vertex| vertex.transform(transform, objects));
 
-        Ok(Self { curve, vertices })
+        Self { curve, vertices }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -32,7 +32,7 @@ impl TransformObject for PartialFace {
                     .into_partial()
                     .transform(transform, objects)?
                     .with_surface(surface.clone())
-                    .build(objects)?
+                    .build(objects)
                     .insert(objects))
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -33,7 +33,7 @@ impl TransformObject for PartialFace {
                     .transform(transform, objects)?
                     .with_surface(surface.clone())
                     .build(objects)?
-                    .insert(objects)?)
+                    .insert(objects))
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -76,7 +76,7 @@ where
             .to_partial()
             .transform(transform, objects)?
             .build(objects)?
-            .insert(objects)?)
+            .insert(objects))
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -36,7 +36,7 @@ pub trait TransformObject: Sized {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError>;
+    ) -> Self;
 
     /// Translate the object
     ///
@@ -45,7 +45,7 @@ pub trait TransformObject: Sized {
         self,
         offset: impl Into<Vector<3>>,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         self.transform(&Transform::translation(offset), objects)
     }
 
@@ -56,7 +56,7 @@ pub trait TransformObject: Sized {
         self,
         axis_angle: impl Into<Vector<3>>,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         self.transform(&Transform::rotation(axis_angle), objects)
     }
 }
@@ -71,12 +71,11 @@ where
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
-        Ok(self
-            .to_partial()
-            .transform(transform, objects)?
+    ) -> Self {
+        self.to_partial()
+            .transform(transform, objects)
             .build(objects)
-            .insert(objects))
+            .insert(objects)
     }
 }
 
@@ -90,18 +89,16 @@ where
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let transformed = match self {
-            Self::Full(full) => {
-                full.to_partial().transform(transform, objects)?
-            }
-            Self::Partial(partial) => partial.transform(transform, objects)?,
+            Self::Full(full) => full.to_partial().transform(transform, objects),
+            Self::Partial(partial) => partial.transform(transform, objects),
         };
 
         // Transforming a `MaybePartial` *always* results in a partial object.
         // This provides the most flexibility to the caller, who might want to
         // use the transformed partial object for merging or whatever else,
         // before building it themselves.
-        Ok(Self::Partial(transformed))
+        Self::Partial(transformed)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -75,7 +75,7 @@ where
         Ok(self
             .to_partial()
             .transform(transform, objects)?
-            .build(objects)?
+            .build(objects)
             .insert(objects))
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -4,7 +4,6 @@ use crate::{
     objects::{Objects, Shell},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -14,15 +13,12 @@ impl TransformObject for Handle<Shell> {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let faces = self
             .faces()
             .clone()
             .into_iter()
-            .map(|face| -> Result<_, ValidationError> {
-                face.transform(transform, objects)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Shell::builder().with_faces(faces).build(objects))
+            .map(|face| face.transform(transform, objects));
+        Shell::builder().with_faces(faces).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -4,7 +4,6 @@ use crate::{
     objects::{Objects, Sketch},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -14,13 +13,12 @@ impl TransformObject for Handle<Sketch> {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let faces = self
             .faces()
             .into_iter()
             .cloned()
-            .map(|face| face.transform(transform, objects))
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Sketch::builder().with_faces(faces).build(objects))
+            .map(|face| face.transform(transform, objects));
+        Sketch::builder().with_faces(faces).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -4,7 +4,6 @@ use crate::{
     objects::{Objects, Solid},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -14,14 +13,11 @@ impl TransformObject for Handle<Solid> {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let faces = self
             .shells()
             .cloned()
-            .map(|shell| -> Result<_, ValidationError> {
-                shell.transform(transform, objects)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Solid::builder().with_shells(faces).build(objects))
+            .map(|shell| shell.transform(transform, objects));
+        Solid::builder().with_shells(faces).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     geometry::surface::SurfaceGeometry, objects::Objects,
-    partial::PartialSurface, services::Service, validate::ValidationError,
+    partial::PartialSurface, services::Service,
 };
 
 use super::TransformObject;
@@ -12,7 +12,7 @@ impl TransformObject for PartialSurface {
         self,
         transform: &Transform,
         _: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let geometry = self.geometry.map(|geometry| {
             let u = geometry.u.transform(transform);
             let v = transform.transform_vector(&geometry.v);
@@ -20,6 +20,6 @@ impl TransformObject for PartialSurface {
             SurfaceGeometry { u, v }
         });
 
-        Ok(Self { geometry })
+        Self { geometry }
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -4,7 +4,6 @@ use crate::{
     objects::Objects,
     partial::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     services::Service,
-    validate::ValidationError,
 };
 
 use super::TransformObject;
@@ -14,20 +13,20 @@ impl TransformObject for PartialVertex {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
-        let curve = self.curve.transform(transform, objects)?;
+    ) -> Self {
+        let curve = self.curve.transform(transform, objects);
         let surface_form = self
             .surface_form
             .into_partial()
-            .transform(transform, objects)?;
+            .transform(transform, objects);
 
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
-        Ok(Self {
+        Self {
             position: self.position,
             curve,
             surface_form: surface_form.into(),
-        })
+        }
     }
 }
 
@@ -36,21 +35,20 @@ impl TransformObject for PartialSurfaceVertex {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let surface = self
             .surface
             .clone()
-            .map(|surface| surface.transform(transform, objects))
-            .transpose()?;
-        let global_form = self.global_form.transform(transform, objects)?;
+            .map(|surface| surface.transform(transform, objects));
+        let global_form = self.global_form.transform(transform, objects);
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.
-        Ok(Self {
+        Self {
             position: self.position,
             surface,
             global_form,
-        })
+        }
     }
 }
 
@@ -59,11 +57,11 @@ impl TransformObject for PartialGlobalVertex {
         self,
         transform: &Transform,
         _: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let position = self
             .position
             .map(|position| transform.transform_point(&position));
 
-        Ok(Self { position })
+        Self { position }
     }
 }

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -101,7 +101,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([a, b, c, d])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
@@ -138,7 +138,7 @@ mod tests {
             .with_exterior_polygon_from_points([a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         let triangles = triangulate(face)?;
 
@@ -196,7 +196,7 @@ mod tests {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d, e])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         let triangles = triangulate(face)?;
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([a, b, c, d])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         let a = Point::from(a).to_xyz();
@@ -137,7 +137,7 @@ mod tests {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         let triangles = triangulate(face)?;
@@ -195,7 +195,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points([a, b, c, d, e])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         let triangles = triangulate(face)?;

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -90,7 +90,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             global_form: global_vertex,
         }
         .build(objects)?
-        .insert(objects)?;
+        .insert(objects);
 
         let [back, front] =
             [a_curve, b_curve].map(|point_curve| PartialVertex {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     services::{Service, State},
     storage::Handle,
-    validate::ValidationError,
 };
 
 use super::CurveBuilder;
@@ -34,7 +33,7 @@ pub trait HalfEdgeBuilder: Sized {
         self,
         radius: impl Into<Scalar>,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError>;
+    ) -> Self;
 
     /// Update partial half-edge as a line segment, from the given points
     fn update_as_line_segment_from_points(
@@ -73,7 +72,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         mut self,
         radius: impl Into<Scalar>,
         objects: &mut Service<Objects>,
-    ) -> Result<Self, ValidationError> {
+    ) -> Self {
         let mut curve = self.curve.clone().into_partial();
         curve.update_as_circle_from_radius(radius);
 
@@ -102,7 +101,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         self.curve = curve.into();
         self.vertices = [back, front].map(Into::into);
 
-        Ok(self)
+        self
     }
 
     fn update_as_line_segment_from_points(

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -89,7 +89,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             surface: curve.surface.clone(),
             global_form: global_vertex,
         }
-        .build(objects)?
+        .build(objects)
         .insert(objects);
 
         let [back, front] =
@@ -165,11 +165,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 let must_switch_order = {
                     let mut objects = Objects::new().into_service();
                     let vertices = vertices.clone().map(|vertex| {
-                        vertex
-                            .into_full(&mut objects)
-                            .unwrap()
-                            .global_form()
-                            .clone()
+                        vertex.into_full(&mut objects).global_form().clone()
                     });
 
                     let (_, must_switch_order) =

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -63,7 +63,6 @@ impl ShellBuilder {
                     [-h, h],
                 ])
                 .build(objects)
-                .unwrap()
                 .insert(objects)
         };
 
@@ -80,7 +79,6 @@ impl ShellBuilder {
 
                     PartialSurface::plane_from_points([a, b, c])
                         .build(objects)
-                        .unwrap()
                         .insert(objects)
                 })
                 .collect::<Vec<_>>();
@@ -99,7 +97,6 @@ impl ShellBuilder {
                         [[Z, Z], [edge_length, Z]],
                     )
                     .build(objects)
-                    .unwrap()
                     .insert(objects)
                 })
                 .collect::<Vec<_>>();
@@ -134,7 +131,6 @@ impl ShellBuilder {
                     }
                     .update_as_line_segment()
                     .build(objects)
-                    .unwrap()
                     .insert(objects)
                 })
                 .collect::<Vec<_>>();
@@ -185,7 +181,6 @@ impl ShellBuilder {
                         }
                         .update_as_line_segment()
                         .build(objects)
-                        .unwrap()
                         .insert(objects)
                     })
                     .collect::<Vec<_>>()
@@ -217,7 +212,6 @@ impl ShellBuilder {
                     }
                     .update_as_line_segment()
                     .build(objects)
-                    .unwrap()
                     .insert(objects)
                 })
                 .collect::<Vec<_>>();
@@ -231,13 +225,11 @@ impl ShellBuilder {
                     let cycle = Cycle::partial()
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(objects)
-                        .unwrap()
                         .insert(objects);
 
                     Face::partial()
                         .with_exterior(cycle)
                         .build(objects)
-                        .unwrap()
                         .insert(objects)
                 })
                 .collect::<Vec<_>>();
@@ -274,7 +266,6 @@ impl ShellBuilder {
                             global_form: vertex.global_form().clone().into(),
                         }
                         .build(objects)
-                        .unwrap()
                         .insert(objects)
                     });
 
@@ -307,7 +298,6 @@ impl ShellBuilder {
                     }
                     .update_as_line_segment()
                     .build(objects)
-                    .unwrap()
                     .insert(objects),
                 );
             }
@@ -315,7 +305,6 @@ impl ShellBuilder {
             Face::partial()
                 .with_exterior(Cycle::new(edges).insert(objects))
                 .build(objects)
-                .unwrap()
                 .insert(objects)
         };
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -65,7 +65,6 @@ impl ShellBuilder {
                 .build(objects)
                 .unwrap()
                 .insert(objects)
-                .unwrap()
         };
 
         let (sides, top_edges) = {
@@ -83,7 +82,6 @@ impl ShellBuilder {
                         .build(objects)
                         .unwrap()
                         .insert(objects)
-                        .unwrap()
                 })
                 .collect::<Vec<_>>();
 
@@ -103,7 +101,6 @@ impl ShellBuilder {
                     .build(objects)
                     .unwrap()
                     .insert(objects)
-                    .unwrap()
                 })
                 .collect::<Vec<_>>();
 
@@ -139,7 +136,6 @@ impl ShellBuilder {
                     .build(objects)
                     .unwrap()
                     .insert(objects)
-                    .unwrap()
                 })
                 .collect::<Vec<_>>();
 
@@ -191,7 +187,6 @@ impl ShellBuilder {
                         .build(objects)
                         .unwrap()
                         .insert(objects)
-                        .unwrap()
                     })
                     .collect::<Vec<_>>()
             };
@@ -224,7 +219,6 @@ impl ShellBuilder {
                     .build(objects)
                     .unwrap()
                     .insert(objects)
-                    .unwrap()
                 })
                 .collect::<Vec<_>>();
 
@@ -238,15 +232,13 @@ impl ShellBuilder {
                         .with_half_edges([bottom, side_up, top, side_down])
                         .build(objects)
                         .unwrap()
-                        .insert(objects)
-                        .unwrap();
+                        .insert(objects);
 
                     Face::partial()
                         .with_exterior(cycle)
                         .build(objects)
                         .unwrap()
                         .insert(objects)
-                        .unwrap()
                 })
                 .collect::<Vec<_>>();
 
@@ -284,7 +276,6 @@ impl ShellBuilder {
                         .build(objects)
                         .unwrap()
                         .insert(objects)
-                        .unwrap()
                     });
 
                 [a.clone(), b, c, d, a]
@@ -317,17 +308,15 @@ impl ShellBuilder {
                     .update_as_line_segment()
                     .build(objects)
                     .unwrap()
-                    .insert(objects)
-                    .unwrap(),
+                    .insert(objects),
                 );
             }
 
             Face::partial()
-                .with_exterior(Cycle::new(edges).insert(objects).unwrap())
+                .with_exterior(Cycle::new(edges).insert(objects))
                 .build(objects)
                 .unwrap()
                 .insert(objects)
-                .unwrap()
         };
 
         self.faces.extend([bottom]);
@@ -339,6 +328,6 @@ impl ShellBuilder {
 
     /// Build the [`Shell`]
     pub fn build(self, objects: &mut Service<Objects>) -> Handle<Shell> {
-        Shell::new(self.faces).insert(objects).unwrap()
+        Shell::new(self.faces).insert(objects)
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -48,11 +48,8 @@ impl ShellBuilder {
         let h = edge_length / 2.;
 
         let bottom = {
-            let surface = objects
-                .surfaces
-                .xy_plane()
-                .translate([Z, Z, -h], objects)
-                .unwrap();
+            let surface =
+                objects.surfaces.xy_plane().translate([Z, Z, -h], objects);
 
             Face::partial()
                 .with_surface(surface)
@@ -238,11 +235,8 @@ impl ShellBuilder {
         };
 
         let top = {
-            let surface = objects
-                .surfaces
-                .xy_plane()
-                .translate([Z, Z, h], objects)
-                .unwrap();
+            let surface =
+                objects.surfaces.xy_plane().translate([Z, Z, h], objects);
 
             let mut top_edges = top_edges;
             top_edges.reverse();

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -52,13 +52,12 @@ impl SketchBuilder {
             .with_exterior_polygon_from_points(points)
             .build(objects)
             .unwrap()
-            .insert(objects)
-            .unwrap()]);
+            .insert(objects)]);
         self
     }
 
     /// Build the [`Sketch`]
     pub fn build(self, objects: &mut Service<Objects>) -> Handle<Sketch> {
-        Sketch::new(self.faces).insert(objects).unwrap()
+        Sketch::new(self.faces).insert(objects)
     }
 }

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -51,7 +51,6 @@ impl SketchBuilder {
             .with_surface(surface.clone())
             .with_exterior_polygon_from_points(points)
             .build(objects)
-            .unwrap()
             .insert(objects)]);
         self
     }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -42,6 +42,6 @@ impl SolidBuilder {
 
     /// Build the [`Solid`]
     pub fn build(self, objects: &mut Service<Objects>) -> Handle<Solid> {
-        Solid::new(self.shells).insert(objects).unwrap()
+        Solid::new(self.shells).insert(objects)
     }
 }

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -15,23 +15,18 @@ use crate::{
 /// Convenience trait to insert objects into their respective stores
 pub trait Insert: Sized + Validate {
     /// Insert the object into its respective store
-    fn insert(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Handle<Self>, <Self as Validate>::Error>;
+    fn insert(self, objects: &mut Service<Objects>) -> Handle<Self>;
 }
 
 macro_rules! impl_insert {
     ($($ty:ty, $store:ident;)*) => {
         $(
             impl Insert for $ty {
-                fn insert(
-                    self,
-                    objects: &mut Service<Objects>,
-                ) -> Result<Handle<Self>, <Self as Validate>::Error> {
+                fn insert(self, objects: &mut Service<Objects>) -> Handle<Self>
+                {
                     let handle = objects.$store.reserve();
                     objects.insert(handle.clone(), self);
-                    Ok(handle)
+                    handle
                 }
             }
         )*

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -382,7 +382,7 @@ mod tests {
             ..Default::default()
         };
         object.update_as_u_axis();
-        let object = object.build(&mut objects)?.insert(&mut objects);
+        let object = object.build(&mut objects).insert(&mut objects);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -410,7 +410,7 @@ mod tests {
                 [[0., 0.], [1., 0.], [0., 1.]],
             )
             .close_with_line_segment()
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
@@ -436,7 +436,7 @@ mod tests {
         let object = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
@@ -506,7 +506,7 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
 
         assert_eq!(1, object.curve_iter().count());
@@ -553,7 +553,7 @@ mod tests {
         let face = Face::partial()
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
-            .build(&mut objects)?
+            .build(&mut objects)
             .insert(&mut objects);
         let object = Sketch::builder().with_faces([face]).build(&mut objects);
 
@@ -622,7 +622,7 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?.insert(&mut objects);
+        let curve = curve.build(&mut objects).insert(&mut objects);
         let global_vertex =
             GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects);
         let surface_vertex =

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -382,7 +382,7 @@ mod tests {
             ..Default::default()
         };
         object.update_as_u_axis();
-        let object = object.build(&mut objects)?.insert(&mut objects)?;
+        let object = object.build(&mut objects)?.insert(&mut objects);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -437,7 +437,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());
@@ -458,7 +458,7 @@ mod tests {
     fn global_curve() -> anyhow::Result<()> {
         let mut objects = Objects::new().into_service();
 
-        let object = GlobalCurve.insert(&mut objects)?;
+        let object = GlobalCurve.insert(&mut objects);
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -480,7 +480,7 @@ mod tests {
         let mut objects = Objects::new().into_service();
 
         let object =
-            GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects)?;
+            GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects);
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -507,7 +507,7 @@ mod tests {
                 [[0., 0.], [1., 0.]],
             )
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
 
         assert_eq!(1, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -554,7 +554,7 @@ mod tests {
             .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
             .build(&mut objects)?
-            .insert(&mut objects)?;
+            .insert(&mut objects);
         let object = Sketch::builder().with_faces([face]).build(&mut objects);
 
         assert_eq!(3, object.curve_iter().count());
@@ -622,12 +622,12 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve.build(&mut objects)?.insert(&mut objects)?;
+        let curve = curve.build(&mut objects)?.insert(&mut objects);
         let global_vertex =
-            GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects)?;
+            GlobalVertex::from_position([0., 0., 0.]).insert(&mut objects);
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex)
-                .insert(&mut objects)?;
+                .insert(&mut objects);
         let object =
             Vertex::new([0.], curve, surface_vertex).insert(&mut objects);
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -373,7 +373,7 @@ mod tests {
     use super::ObjectIters as _;
 
     #[test]
-    fn curve() -> anyhow::Result<()> {
+    fn curve() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -395,12 +395,10 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
-    fn cycle() -> anyhow::Result<()> {
+    fn cycle() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -424,12 +422,10 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
-    fn face() -> anyhow::Result<()> {
+    fn face() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -450,12 +446,10 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(1, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
-    fn global_curve() -> anyhow::Result<()> {
+    fn global_curve() {
         let mut objects = Objects::new().into_service();
 
         let object = GlobalCurve.insert(&mut objects);
@@ -471,12 +465,10 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
-    fn global_vertex() -> anyhow::Result<()> {
+    fn global_vertex() {
         let mut objects = Objects::new().into_service();
 
         let object =
@@ -493,12 +485,10 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(0, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
-    fn half_edge() -> anyhow::Result<()> {
+    fn half_edge() {
         let mut objects = Objects::new().into_service();
 
         let object = HalfEdge::partial()
@@ -520,8 +510,6 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(2, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
@@ -546,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn sketch() -> anyhow::Result<()> {
+    fn sketch() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -568,8 +556,6 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(1, object.surface_iter().count());
         assert_eq!(6, object.vertex_iter().count());
-
-        Ok(())
     }
 
     #[test]
@@ -613,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn vertex() -> anyhow::Result<()> {
+    fn vertex() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -642,7 +628,5 @@ mod tests {
         assert_eq!(0, object.solid_iter().count());
         assert_eq!(0, object.surface_iter().count());
         assert_eq!(1, object.vertex_iter().count());
-
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -187,10 +187,10 @@ mod tests {
 
         let a_to_b = HalfEdge::partial()
             .update_as_line_segment_from_points(surface.clone(), [a, b])
-            .build(&mut objects)?;
+            .build(&mut objects);
         let b_to_a = HalfEdge::partial()
             .update_as_line_segment_from_points(surface, [b, a])
-            .build(&mut objects)?;
+            .build(&mut objects);
 
         assert_eq!(a_to_b.global_form(), b_to_a.global_form());
         Ok(())

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -177,7 +177,7 @@ mod tests {
     use super::HalfEdge;
 
     #[test]
-    fn global_edge_equality() -> anyhow::Result<()> {
+    fn global_edge_equality() {
         let mut objects = Objects::new().into_service();
 
         let surface = objects.surfaces.xy_plane();
@@ -193,6 +193,5 @@ mod tests {
             .build(&mut objects);
 
         assert_eq!(a_to_b.global_form(), b_to_a.global_form());
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -81,7 +81,7 @@ impl<T: HasPartial> MaybePartial<T> {
     {
         match self {
             Self::Partial(partial) => {
-                Ok(partial.build(objects)?.insert(objects)?)
+                Ok(partial.build(objects)?.insert(objects))
             }
             Self::Full(full) => Ok(full),
         }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -71,19 +71,14 @@ impl<T: HasPartial> MaybePartial<T> {
     ///
     /// If this already is a full object, it is returned. If this is a partial
     /// object, the full object is built from it, using [`Partial::build`].
-    pub fn into_full(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Handle<T>, ValidationError>
+    pub fn into_full(self, objects: &mut Service<Objects>) -> Handle<T>
     where
         T: Insert,
         ValidationError: From<<T as Validate>::Error>,
     {
         match self {
-            Self::Partial(partial) => {
-                Ok(partial.build(objects)?.insert(objects))
-            }
-            Self::Full(full) => Ok(full),
+            Self::Partial(partial) => partial.build(objects).insert(objects),
+            Self::Full(full) => full,
         }
     }
 

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -4,7 +4,6 @@ use crate::{
     partial::{MaybePartial, MergeWith, Replace},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 /// A partial [`Curve`]
@@ -24,17 +23,14 @@ pub struct PartialCurve {
 
 impl PartialCurve {
     /// Build a full [`Curve`] from the partial curve
-    pub fn build(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Curve, ValidationError> {
+    pub fn build(self, objects: &mut Service<Objects>) -> Curve {
         let path = self.path.expect("Can't build `Curve` without path");
         let surface =
             self.surface.expect("Can't build `Curve` without surface");
 
-        let global_form = self.global_form.into_full(objects)?;
+        let global_form = self.global_form.into_full(objects);
 
-        Ok(Curve::new(surface, path, global_form))
+        Curve::new(surface, path, global_form)
     }
 }
 
@@ -80,8 +76,8 @@ pub struct PartialGlobalCurve;
 
 impl PartialGlobalCurve {
     /// Build a full [`GlobalCurve`] from the partial global curve
-    pub fn build(self, _: &Objects) -> Result<GlobalCurve, ValidationError> {
-        Ok(GlobalCurve)
+    pub fn build(self, _: &Objects) -> GlobalCurve {
+        GlobalCurve
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -6,7 +6,6 @@ use crate::{
     },
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 /// A partial [`Cycle`]
@@ -70,10 +69,7 @@ impl PartialCycle {
     }
 
     /// Build a full [`Cycle`] from the partial cycle
-    pub fn build(
-        mut self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Cycle, ValidationError> {
+    pub fn build(mut self, objects: &mut Service<Objects>) -> Cycle {
         // Check that the cycle is closed. This will lead to a panic further
         // down anyway, but that panic would be super-confusing. This one should
         // be a bit more explicit on what is wrong.
@@ -97,7 +93,7 @@ impl PartialCycle {
         for half_edge in &mut self.half_edges {
             let back_vertex = previous_vertex.unwrap_or_default();
             let front_vertex =
-                half_edge.front().surface_form().into_full(objects)?;
+                half_edge.front().surface_form().into_full(objects);
 
             *half_edge = half_edge.clone().merge_with(PartialHalfEdge {
                 vertices: [
@@ -133,11 +129,11 @@ impl PartialCycle {
         // All connections made! All that's left is to build the half-edges.
         let mut half_edges = Vec::new();
         for half_edge in self.half_edges {
-            let half_edge = half_edge.into_full(objects)?;
+            let half_edge = half_edge.into_full(objects);
             half_edges.push(half_edge);
         }
 
-        Ok(Cycle::new(half_edges))
+        Cycle::new(half_edges)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -5,7 +5,6 @@ use crate::{
     partial::{MaybePartial, MergeWith, Mergeable},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 /// A partial [`Face`]
@@ -72,19 +71,16 @@ impl PartialFace {
     }
 
     /// Construct a polygon from a list of points
-    pub fn build(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Face, ValidationError> {
-        let exterior = self.exterior.into_full(objects)?;
+    pub fn build(self, objects: &mut Service<Objects>) -> Face {
+        let exterior = self.exterior.into_full(objects);
         let interiors = self
             .interiors
             .into_iter()
             .map(|cycle| cycle.into_full(objects))
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Vec<_>>();
         let color = self.color.unwrap_or_default();
 
-        Ok(Face::new(exterior, interiors, color))
+        Face::new(exterior, interiors, color)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -29,12 +29,7 @@ macro_rules! impl_traits {
             impl Partial for $partial {
                 type Full = $full;
 
-                fn build(self, objects: &mut Service<Objects>)
-                    -> Result<
-                        Self::Full,
-                        crate::validate::ValidationError
-                    >
-                {
+                fn build(self, objects: &mut Service<Objects>) -> Self::Full {
                     self.build(objects)
                 }
             }

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -2,7 +2,6 @@ use crate::{
     geometry::surface::SurfaceGeometry,
     objects::{Objects, Surface},
     partial::MergeWith,
-    validate::ValidationError,
 };
 
 /// A partial [`Surface`]
@@ -16,12 +15,12 @@ pub struct PartialSurface {
 
 impl PartialSurface {
     /// Build a full [`Surface`] from the partial surface
-    pub fn build(self, _: &Objects) -> Result<Surface, ValidationError> {
+    pub fn build(self, _: &Objects) -> Surface {
         let geometry = self
             .geometry
             .expect("Can't build `Surface` without geometry");
 
-        Ok(Surface::new(geometry))
+        Surface::new(geometry)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -6,7 +6,6 @@ use crate::{
     partial::{MaybePartial, MergeWith, Replace},
     services::Service,
     storage::Handle,
-    validate::ValidationError,
 };
 
 /// A partial [`Vertex`]
@@ -32,14 +31,11 @@ impl PartialVertex {
     /// Panics, if position has not been provided.
     ///
     /// Panics, if curve has not been provided.
-    pub fn build(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Vertex, ValidationError> {
+    pub fn build(self, objects: &mut Service<Objects>) -> Vertex {
         let position = self
             .position
             .expect("Cant' build `Vertex` without position");
-        let curve = self.curve.into_full(objects)?;
+        let curve = self.curve.into_full(objects);
 
         let surface_form = self
             .surface_form
@@ -53,9 +49,9 @@ impl PartialVertex {
 
                 partial
             })
-            .into_full(objects)?;
+            .into_full(objects);
 
-        Ok(Vertex::new(position, curve, surface_form))
+        Vertex::new(position, curve, surface_form)
     }
 }
 
@@ -105,10 +101,7 @@ pub struct PartialSurfaceVertex {
 
 impl PartialSurfaceVertex {
     /// Build a full [`SurfaceVertex`] from the partial surface vertex
-    pub fn build(
-        mut self,
-        objects: &mut Service<Objects>,
-    ) -> Result<SurfaceVertex, ValidationError> {
+    pub fn build(mut self, objects: &mut Service<Objects>) -> SurfaceVertex {
         let position = self
             .position
             .expect("Can't build `SurfaceVertex` without position");
@@ -124,9 +117,9 @@ impl PartialSurfaceVertex {
                 ),
             )
         }
-        let global_form = self.global_form.into_full(objects)?;
+        let global_form = self.global_form.into_full(objects);
 
-        Ok(SurfaceVertex::new(position, surface, global_form))
+        SurfaceVertex::new(position, surface, global_form)
     }
 }
 
@@ -170,12 +163,12 @@ pub struct PartialGlobalVertex {
 
 impl PartialGlobalVertex {
     /// Build a full [`GlobalVertex`] from the partial global vertex
-    pub fn build(self, _: &Objects) -> Result<GlobalVertex, ValidationError> {
+    pub fn build(self, _: &Objects) -> GlobalVertex {
         let position = self
             .position
             .expect("Can't build a `GlobalVertex` without a position");
 
-        Ok(GlobalVertex::from_position(position))
+        GlobalVertex::from_position(position)
     }
 }
 

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -1,4 +1,4 @@
-use crate::{objects::Objects, services::Service, validate::ValidationError};
+use crate::{objects::Objects, services::Service};
 
 /// Implemented for objects that a partial object type exists for
 ///
@@ -77,8 +77,5 @@ pub trait Partial: Default + for<'a> From<&'a Self::Full> {
     /// Calling `build` on a partial object that can't infer its missing parts
     /// is considered a programmer error, hence why this method doesn't return a
     /// [`Result`].
-    fn build(
-        self,
-        objects: &mut Service<Objects>,
-    ) -> Result<Self::Full, ValidationError>;
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full;
 }

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -71,7 +71,7 @@ mod tests {
         objects::{Cycle, Objects},
         partial::HasPartial,
         services::State,
-        validate::{Validate, ValidationError},
+        validate::Validate,
     };
 
     #[test]
@@ -103,12 +103,9 @@ mod tests {
                 .with_back_vertex(first_vertex)
                 .infer_global_form();
 
-            let half_edges = half_edges
-                .into_iter()
-                .map(|half_edge| -> anyhow::Result<_, ValidationError> {
-                    Ok(half_edge.build(&mut objects).insert(&mut objects))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+            let half_edges = half_edges.into_iter().map(|half_edge| {
+                half_edge.build(&mut objects).insert(&mut objects)
+            });
 
             Cycle::new(half_edges)
         };

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -84,7 +84,7 @@ mod tests {
                 [[0., 0.], [1., 0.], [0., 1.]],
             )
             .close_with_line_segment()
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = {
             let mut half_edges = valid
                 .half_edges()
@@ -106,7 +106,7 @@ mod tests {
             let half_edges = half_edges
                 .into_iter()
                 .map(|half_edge| -> anyhow::Result<_, ValidationError> {
-                    Ok(half_edge.build(&mut objects)?.insert(&mut objects))
+                    Ok(half_edge.build(&mut objects).insert(&mut objects))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -106,7 +106,7 @@ mod tests {
             let half_edges = half_edges
                 .into_iter()
                 .map(|half_edge| -> anyhow::Result<_, ValidationError> {
-                    Ok(half_edge.build(&mut objects)?.insert(&mut objects)?)
+                    Ok(half_edge.build(&mut objects)?.insert(&mut objects))
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -75,7 +75,7 @@ mod tests {
     };
 
     #[test]
-    fn cycle_half_edge_connections() -> anyhow::Result<()> {
+    fn cycle_half_edge_connections() {
         let mut objects = Objects::new().into_service();
 
         let valid = Cycle::partial()
@@ -112,7 +112,5 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -198,15 +198,13 @@ impl HalfEdgeValidationError {
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::ext::ArrayExt;
-
     use crate::{
         builder::{HalfEdgeBuilder, VertexBuilder},
         insert::Insert,
         objects::{GlobalCurve, HalfEdge, Objects},
         partial::HasPartial,
         services::State,
-        validate::{Validate, ValidationError},
+        validate::Validate,
     };
 
     #[test]
@@ -295,14 +293,12 @@ mod tests {
             )
             .build(&mut objects);
         let invalid = HalfEdge::new(
-            valid.vertices().clone().try_map_ext(
-                |vertex| -> anyhow::Result<_, ValidationError> {
-                    let mut vertex = vertex.to_partial();
-                    vertex.position = Some([0.].into());
-                    vertex.infer_surface_form();
-                    Ok(vertex.build(&mut objects).insert(&mut objects))
-                },
-            )?,
+            valid.vertices().clone().map(|vertex| {
+                let mut vertex = vertex.to_partial();
+                vertex.position = Some([0.].into());
+                vertex.infer_surface_form();
+                vertex.build(&mut objects).insert(&mut objects)
+            }),
             valid.global_form().clone(),
         );
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -224,7 +224,7 @@ mod tests {
             let mut vertex = vertices[1].to_partial();
             // Arranging for an equal but not identical curve here.
             vertex.curve = valid.curve().to_partial().into();
-            vertices[1] = vertex.build(&mut objects)?.insert(&mut objects)?;
+            vertices[1] = vertex.build(&mut objects)?.insert(&mut objects);
 
             HalfEdge::new(vertices, valid.global_form().clone())
         };
@@ -247,8 +247,8 @@ mod tests {
             .build(&mut objects)?;
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
-            tmp.curve = GlobalCurve.insert(&mut objects)?.into();
-            tmp.build(&mut objects)?.insert(&mut objects)?
+            tmp.curve = GlobalCurve.insert(&mut objects).into();
+            tmp.build(&mut objects)?.insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -275,7 +275,7 @@ mod tests {
                 .access_in_normalized_order()
                 // Creating equal but not identical vertices here.
                 .map(|vertex| vertex.to_partial().into());
-            tmp.build(&mut objects)?.insert(&mut objects)?
+            tmp.build(&mut objects)?.insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -300,7 +300,7 @@ mod tests {
                     let mut vertex = vertex.to_partial();
                     vertex.position = Some([0.].into());
                     vertex.infer_surface_form();
-                    Ok(vertex.build(&mut objects)?.insert(&mut objects)?)
+                    Ok(vertex.build(&mut objects)?.insert(&mut objects))
                 },
             )?,
             valid.global_form().clone(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -218,13 +218,13 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = {
             let mut vertices = valid.vertices().clone();
             let mut vertex = vertices[1].to_partial();
             // Arranging for an equal but not identical curve here.
             vertex.curve = valid.curve().to_partial().into();
-            vertices[1] = vertex.build(&mut objects)?.insert(&mut objects);
+            vertices[1] = vertex.build(&mut objects).insert(&mut objects);
 
             HalfEdge::new(vertices, valid.global_form().clone())
         };
@@ -244,11 +244,11 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
             tmp.curve = GlobalCurve.insert(&mut objects).into();
-            tmp.build(&mut objects)?.insert(&mut objects)
+            tmp.build(&mut objects).insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -266,7 +266,7 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
             tmp.vertices = valid
@@ -275,7 +275,7 @@ mod tests {
                 .access_in_normalized_order()
                 // Creating equal but not identical vertices here.
                 .map(|vertex| vertex.to_partial().into());
-            tmp.build(&mut objects)?.insert(&mut objects)
+            tmp.build(&mut objects).insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -293,14 +293,14 @@ mod tests {
                 objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             )
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = HalfEdge::new(
             valid.vertices().clone().try_map_ext(
                 |vertex| -> anyhow::Result<_, ValidationError> {
                     let mut vertex = vertex.to_partial();
                     vertex.position = Some([0.].into());
                     vertex.infer_surface_form();
-                    Ok(vertex.build(&mut objects)?.insert(&mut objects))
+                    Ok(vertex.build(&mut objects).insert(&mut objects))
                 },
             )?,
             valid.global_form().clone(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -208,7 +208,7 @@ mod tests {
     };
 
     #[test]
-    fn half_edge_curve_mismatch() -> anyhow::Result<()> {
+    fn half_edge_curve_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
@@ -229,12 +229,10 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 
     #[test]
-    fn half_edge_global_curve_mismatch() -> anyhow::Result<()> {
+    fn half_edge_global_curve_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
@@ -251,12 +249,10 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 
     #[test]
-    fn half_edge_global_vertex_mismatch() -> anyhow::Result<()> {
+    fn half_edge_global_vertex_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
@@ -278,12 +274,10 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 
     #[test]
-    fn half_edge_vertices_are_coincident() -> anyhow::Result<()> {
+    fn half_edge_vertices_are_coincident() {
         let mut objects = Objects::new().into_service();
 
         let valid = HalfEdge::partial()
@@ -304,7 +298,5 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -121,7 +121,7 @@ mod tests {
             .with_surface(objects.surfaces.xy_plane())
             .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = {
             let interiors = [Cycle::partial()
                 .with_poly_chain_from_points(
@@ -129,7 +129,7 @@ mod tests {
                     [[1., 1.], [1., 2.], [2., 1.]],
                 )
                 .close_with_line_segment()
-                .build(&mut objects)?
+                .build(&mut objects)
                 .insert(&mut objects)];
 
             Face::new(valid.exterior().clone(), interiors, valid.color())
@@ -149,7 +149,7 @@ mod tests {
             .with_surface(objects.surfaces.xy_plane())
             .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
-            .build(&mut objects)?;
+            .build(&mut objects);
         let invalid = {
             let interiors = valid
                 .interiors()

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -155,7 +155,7 @@ mod tests {
                 .interiors()
                 .cloned()
                 .map(|cycle| cycle.reverse(&mut objects))
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Vec<_>>();
 
             Face::new(valid.exterior().clone(), interiors, valid.color())
         };

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -130,7 +130,7 @@ mod tests {
                 )
                 .close_with_line_segment()
                 .build(&mut objects)?
-                .insert(&mut objects)?];
+                .insert(&mut objects)];
 
             Face::new(valid.exterior().clone(), interiors, valid.color())
         };

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -114,7 +114,7 @@ mod tests {
     };
 
     #[test]
-    fn face_surface_mismatch() -> anyhow::Result<()> {
+    fn face_surface_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let valid = Face::partial()
@@ -137,12 +137,10 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 
     #[test]
-    fn face_invalid_interior_winding() -> anyhow::Result<()> {
+    fn face_invalid_interior_winding() {
         let mut objects = Objects::new().into_service();
 
         let valid = Face::partial()
@@ -162,7 +160,5 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -209,7 +209,7 @@ mod tests {
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.surface = Some(objects.surfaces.xz_plane());
-            tmp.build(&mut objects)?.insert(&mut objects)?
+            tmp.build(&mut objects)?.insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -240,7 +240,7 @@ mod tests {
             let mut tmp = valid.surface_form().to_partial();
             tmp.position = Some([1., 0.].into());
             tmp.infer_global_form();
-            tmp.build(&mut objects)?.insert(&mut objects)?
+            tmp.build(&mut objects)?.insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -262,7 +262,7 @@ mod tests {
         let invalid = SurfaceVertex::new(
             valid.position(),
             valid.surface().clone(),
-            GlobalVertex::from_position([1., 0., 0.]).insert(&mut objects)?,
+            GlobalVertex::from_position([1., 0., 0.]).insert(&mut objects),
         );
 
         assert!(valid.validate().is_ok());

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -205,11 +205,11 @@ mod tests {
             curve: curve.into(),
             ..Default::default()
         }
-        .build(&mut objects)?;
+        .build(&mut objects);
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.surface = Some(objects.surfaces.xz_plane());
-            tmp.build(&mut objects)?.insert(&mut objects)
+            tmp.build(&mut objects).insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -234,13 +234,13 @@ mod tests {
                 curve: curve.into(),
                 ..Default::default()
             }
-            .build(&mut objects)?
+            .build(&mut objects)
         };
         let invalid = Vertex::new(valid.position(), valid.curve().clone(), {
             let mut tmp = valid.surface_form().to_partial();
             tmp.position = Some([1., 0.].into());
             tmp.infer_global_form();
-            tmp.build(&mut objects)?.insert(&mut objects)
+            tmp.build(&mut objects).insert(&mut objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -258,7 +258,7 @@ mod tests {
             surface: Some(objects.surfaces.xy_plane()),
             ..Default::default()
         }
-        .build(&mut objects)?;
+        .build(&mut objects);
         let invalid = SurfaceVertex::new(
             valid.position(),
             valid.surface().clone(),

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -191,7 +191,7 @@ mod tests {
     };
 
     #[test]
-    fn vertex_surface_mismatch() -> anyhow::Result<()> {
+    fn vertex_surface_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let mut curve = PartialCurve {
@@ -214,12 +214,10 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 
     #[test]
-    fn vertex_position_mismatch() -> anyhow::Result<()> {
+    fn vertex_position_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let valid = {
@@ -245,12 +243,10 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 
     #[test]
-    fn surface_vertex_position_mismatch() -> anyhow::Result<()> {
+    fn surface_vertex_position_mismatch() {
         let mut objects = Objects::new().into_service();
 
         let valid = PartialSurfaceVertex {
@@ -267,7 +263,5 @@ mod tests {
 
         assert!(valid.validate().is_ok());
         assert!(invalid.validate().is_err());
-
-        Ok(())
     }
 }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -85,7 +85,7 @@ impl Shape for fj::Difference2d {
                     .with_exterior(exterior)
                     .with_interiors(interiors)
                     .with_color(Color(self.color()))
-                    .build(objects)?
+                    .build(objects)
                     .insert(objects),
             );
         }

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -86,7 +86,7 @@ impl Shape for fj::Difference2d {
                     .with_interiors(interiors)
                     .with_color(Color(self.color()))
                     .build(objects)?
-                    .insert(objects)?,
+                    .insert(objects),
             );
         }
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -49,7 +49,7 @@ impl Shape for fj::Difference2d {
 
                 exteriors.push(face.exterior().clone());
                 for cycle in face.interiors() {
-                    interiors.push(cycle.clone().reverse(objects)?);
+                    interiors.push(cycle.clone().reverse(objects));
                 }
             }
 
@@ -60,7 +60,7 @@ impl Shape for fj::Difference2d {
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                interiors.push(face.exterior().clone().reverse(objects)?);
+                interiors.push(face.exterior().clone().reverse(objects));
             }
 
             // Faces only support one exterior, while the code here comes from

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -33,7 +33,7 @@ impl Shape for fj::Sketch {
                     half_edge.replace(surface);
                     half_edge
                         .update_as_circle_from_radius(circle.radius(), objects)?
-                        .build(objects)?
+                        .build(objects)
                         .insert(objects)
                 };
                 let cycle = Cycle::new([half_edge]).insert(objects);
@@ -41,7 +41,7 @@ impl Shape for fj::Sketch {
                 Face::partial()
                     .with_exterior(cycle)
                     .with_color(Color(self.color()))
-                    .build(objects)?
+                    .build(objects)
                     .insert(objects)
             }
             fj::Chain::PolyChain(poly_chain) => {
@@ -55,7 +55,7 @@ impl Shape for fj::Sketch {
                     .with_surface(surface)
                     .with_exterior_polygon_from_points(points)
                     .with_color(Color(self.color()))
-                    .build(objects)?
+                    .build(objects)
                     .insert(objects)
             }
         };

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -34,15 +34,15 @@ impl Shape for fj::Sketch {
                     half_edge
                         .update_as_circle_from_radius(circle.radius(), objects)?
                         .build(objects)?
-                        .insert(objects)?
+                        .insert(objects)
                 };
-                let cycle = Cycle::new([half_edge]).insert(objects)?;
+                let cycle = Cycle::new([half_edge]).insert(objects);
 
                 Face::partial()
                     .with_exterior(cycle)
                     .with_color(Color(self.color()))
                     .build(objects)?
-                    .insert(objects)?
+                    .insert(objects)
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let points = poly_chain
@@ -56,7 +56,7 @@ impl Shape for fj::Sketch {
                     .with_exterior_polygon_from_points(points)
                     .with_color(Color(self.color()))
                     .build(objects)?
-                    .insert(objects)?
+                    .insert(objects)
             }
         };
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -32,7 +32,7 @@ impl Shape for fj::Sketch {
                     let mut half_edge = HalfEdge::partial();
                     half_edge.replace(surface);
                     half_edge
-                        .update_as_circle_from_radius(circle.radius(), objects)?
+                        .update_as_circle_from_radius(circle.radius(), objects)
                         .build(objects)
                         .insert(objects)
                 };

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -21,7 +21,7 @@ impl Shape for fj::Sweep {
         debug_info: &mut DebugInfo,
     ) -> Result<Self::Brep, ValidationError> {
         let sketch = self.shape().compute_brep(objects, debug_info)?;
-        let sketch = sketch.insert(objects)?;
+        let sketch = sketch.insert(objects);
 
         let path = Vector::from(self.path());
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -25,7 +25,7 @@ impl Shape for fj::Sweep {
 
         let path = Vector::from(self.path());
 
-        let solid = sketch.sweep(path, objects)?;
+        let solid = sketch.sweep(path, objects);
         Ok(solid.deref().clone())
     }
 

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -20,7 +20,7 @@ impl Shape for fj::Transform {
         let faces = self
             .shape
             .compute_brep(objects, debug_info)?
-            .transform(&make_transform(self), objects)?;
+            .transform(&make_transform(self), objects);
 
         Ok(faces)
     }


### PR DESCRIPTION
This is a follow-up to #1392, realizing the simplifications enabled there.