### PR TITLE
Simplify return value of `Shape::compute_brep`

### DIFF
--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -8,7 +8,6 @@ use fj_kernel::{
     objects::{Face, Objects, Sketch},
     partial::HasPartial,
     services::Service,
-    validate::ValidationError,
 };
 use fj_math::Aabb;
 
@@ -21,7 +20,7 @@ impl Shape for fj::Difference2d {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
+    ) -> Self::Brep {
         // This method assumes that `b` is fully contained within `a`:
         // https://github.com/hannobraun/Fornjot/issues/92
 
@@ -33,7 +32,7 @@ impl Shape for fj::Difference2d {
         let [a, b] = self
             .shapes()
             .each_ref_ext()
-            .try_map_ext(|shape| shape.compute_brep(objects, debug_info))?;
+            .map(|shape| shape.compute_brep(objects, debug_info));
 
         if let Some(face) = a.face_iter().next() {
             // If there's at least one face to subtract from, we can proceed.
@@ -91,7 +90,7 @@ impl Shape for fj::Difference2d {
         }
 
         let difference = Sketch::builder().with_faces(faces).build(objects);
-        Ok(difference.deref().clone())
+        difference.deref().clone()
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -2,7 +2,6 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     objects::{FaceSet, Objects},
     services::Service,
-    validate::ValidationError,
 };
 use fj_math::Aabb;
 
@@ -15,16 +14,16 @@ impl Shape for fj::Group {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
+    ) -> Self::Brep {
         let mut faces = FaceSet::new();
 
-        let a = self.a.compute_brep(objects, debug_info)?;
-        let b = self.b.compute_brep(objects, debug_info)?;
+        let a = self.a.compute_brep(objects, debug_info);
+        let b = self.b.compute_brep(objects, debug_info);
 
         faces.extend(a);
         faces.extend(b);
 
-        Ok(faces)
+        faces
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -33,7 +33,6 @@ use fj_interop::debug::DebugInfo;
 use fj_kernel::{
     objects::{FaceSet, Objects, Sketch},
     services::Service,
-    validate::ValidationError,
 };
 use fj_math::Aabb;
 
@@ -47,7 +46,7 @@ pub trait Shape {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError>;
+    ) -> Self::Brep;
 
     /// Access the axis-aligned bounding box of a shape
     ///
@@ -63,21 +62,21 @@ impl Shape for fj::Shape {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
+    ) -> Self::Brep {
         match self {
             Self::Shape2d(shape) => {
-                Ok(shape.compute_brep(objects, debug_info)?.faces().clone())
+                shape.compute_brep(objects, debug_info).faces().clone()
             }
             Self::Group(shape) => shape.compute_brep(objects, debug_info),
-            Self::Sweep(shape) => Ok(shape
-                .compute_brep(objects, debug_info)?
+            Self::Sweep(shape) => shape
+                .compute_brep(objects, debug_info)
                 .shells()
                 .map(|shell| shell.faces().clone())
                 .reduce(|mut a, b| {
                     a.extend(b);
                     a
                 })
-                .unwrap_or_default()),
+                .unwrap_or_default(),
             Self::Transform(shape) => shape.compute_brep(objects, debug_info),
         }
     }
@@ -99,7 +98,7 @@ impl Shape for fj::Shape2d {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
+    ) -> Self::Brep {
         match self {
             Self::Difference(shape) => shape.compute_brep(objects, debug_info),
             Self::Sketch(shape) => shape.compute_brep(objects, debug_info),

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -45,7 +45,7 @@ impl ShapeProcessor {
 
         let mut objects = Objects::new().into_service();
         let mut debug_info = DebugInfo::new();
-        let shape = shape.compute_brep(&mut objects, &mut debug_info)?;
+        let shape = shape.compute_brep(&mut objects, &mut debug_info);
         let mesh = (&shape, tolerance).triangulate();
 
         Ok(ProcessedShape {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -7,7 +7,6 @@ use fj_kernel::{
     objects::{Cycle, Face, HalfEdge, Objects, Sketch},
     partial::{HasPartial, Replace},
     services::Service,
-    validate::ValidationError,
 };
 use fj_math::{Aabb, Point};
 
@@ -20,7 +19,7 @@ impl Shape for fj::Sketch {
         &self,
         objects: &mut Service<Objects>,
         _: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
+    ) -> Self::Brep {
         let surface = objects.surfaces.xy_plane();
 
         let face = match self.chain() {
@@ -61,7 +60,7 @@ impl Shape for fj::Sketch {
         };
 
         let sketch = Sketch::builder().with_faces([face]).build(objects);
-        Ok(sketch.deref().clone())
+        sketch.deref().clone()
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -6,7 +6,6 @@ use fj_kernel::{
     insert::Insert,
     objects::{Objects, Solid},
     services::Service,
-    validate::ValidationError,
 };
 use fj_math::{Aabb, Vector};
 
@@ -19,14 +18,14 @@ impl Shape for fj::Sweep {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
-        let sketch = self.shape().compute_brep(objects, debug_info)?;
+    ) -> Self::Brep {
+        let sketch = self.shape().compute_brep(objects, debug_info);
         let sketch = sketch.insert(objects);
 
         let path = Vector::from(self.path());
 
         let solid = sketch.sweep(path, objects);
-        Ok(solid.deref().clone())
+        solid.deref().clone()
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -3,7 +3,6 @@ use fj_kernel::{
     algorithms::transform::TransformObject,
     objects::{FaceSet, Objects},
     services::Service,
-    validate::ValidationError,
 };
 use fj_math::{Aabb, Transform, Vector};
 
@@ -16,13 +15,10 @@ impl Shape for fj::Transform {
         &self,
         objects: &mut Service<Objects>,
         debug_info: &mut DebugInfo,
-    ) -> Result<Self::Brep, ValidationError> {
-        let faces = self
-            .shape
-            .compute_brep(objects, debug_info)?
-            .transform(&make_transform(self), objects);
-
-        Ok(faces)
+    ) -> Self::Brep {
+        self.shape
+            .compute_brep(objects, debug_info)
+            .transform(&make_transform(self), objects)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {


### PR DESCRIPTION
This pull request realizes some simplifications in `fj-operations`, which were made possible by the `fj-kernel` simplifications in #1393.