### PR TITLE
Change from "compiling" to "evaluating"

### DIFF
--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -71,11 +71,13 @@ pub fn run(
                 match event {
                     ModelEvent::ChangeDetected => {
                         status.update_status(
-                            "Change in model detected. Compiling...",
+                            "Change in model detected. Evaluating model...",
                         );
                     }
                     ModelEvent::Evaluation(evaluation) => {
-                        status.update_status("Model compiled. Processing...");
+                        status.update_status(
+                            "Model evaluated. Processing model...",
+                        );
 
                         match shape_processor.process(&evaluation.shape) {
                             Ok(shape) => {


### PR DESCRIPTION
This step is already called "evaluation" in the code, and it makes sense that code and output should be consistent. I think "evaluate" is the better term, since future supported languages might not need to be compiled.