### PR TITLE
Simplify transform code by using cache instead of partial objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,7 @@ dependencies = [
  "robust-predicates",
  "spade",
  "thiserror",
+ "type-map",
 ]
 
 [[package]]

--- a/crates/fj-kernel/Cargo.toml
+++ b/crates/fj-kernel/Cargo.toml
@@ -20,6 +20,7 @@ pretty_assertions = "1.3.0"
 robust-predicates = "0.1.4"
 spade = "2.0.0"
 thiserror = "1.0.35"
+type-map = "0.5.0"
 
 [dev-dependencies]
 anyhow = "1.0.66"

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -28,12 +28,14 @@ impl TransformObject for PartialCurve {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let surface = self
-            .surface
-            .map(|surface| surface.transform(transform, objects));
-        let global_form = self.global_form.transform(transform, objects);
+        let surface = self.surface.map(|surface| {
+            surface.transform_with_cache(transform, objects, cache)
+        });
+        let global_form = self
+            .global_form
+            .transform_with_cache(transform, objects, cache);
 
         // Don't need to transform `self.path`, as that's defined in surface
         // coordinates, and thus transforming `surface` takes care of it.

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -8,21 +8,6 @@ use crate::{
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialGlobalCurve {
-    fn transform_with_cache(
-        self,
-        _: &Transform,
-        _: &mut Service<Objects>,
-        _: &mut TransformCache,
-    ) -> Self {
-        // `GlobalCurve` doesn't contain any internal geometry. If it did, that
-        // would just be redundant with the geometry of other objects, and this
-        // other geometry is already being transformed by other implementations
-        // of this trait.
-        self
-    }
-}
-
 impl TransformObject for PartialCurve {
     fn transform_with_cache(
         self,
@@ -44,5 +29,20 @@ impl TransformObject for PartialCurve {
             surface,
             global_form,
         }
+    }
+}
+
+impl TransformObject for PartialGlobalCurve {
+    fn transform_with_cache(
+        self,
+        _: &Transform,
+        _: &mut Service<Objects>,
+        _: &mut TransformCache,
+    ) -> Self {
+        // `GlobalCurve` doesn't contain any internal geometry. If it did, that
+        // would just be redundant with the geometry of other objects, and this
+        // other geometry is already being transformed by other implementations
+        // of this trait.
+        self
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -6,10 +6,15 @@ use crate::{
     services::Service,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for PartialGlobalCurve {
-    fn transform(self, _: &Transform, _: &mut Service<Objects>) -> Self {
+    fn transform_with_cache(
+        self,
+        _: &Transform,
+        _: &mut Service<Objects>,
+        _: &mut TransformCache,
+    ) -> Self {
         // `GlobalCurve` doesn't contain any internal geometry. If it did, that
         // would just be redundant with the geometry of other objects, and this
         // other geometry is already being transformed by other implementations
@@ -19,10 +24,11 @@ impl TransformObject for PartialGlobalCurve {
 }
 
 impl TransformObject for PartialCurve {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let surface = self
             .surface

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -1,38 +1,37 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::Objects,
-    partial::{PartialCurve, PartialGlobalCurve},
+    objects::{Curve, GlobalCurve, Objects},
     services::Service,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialCurve {
+impl TransformObject for Curve {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let surface = self.surface.map(|surface| {
-            surface.transform_with_cache(transform, objects, cache)
-        });
+        // Don't need to transform path, as that's defined in surface
+        // coordinates, and thus transforming `surface` takes care of it.
+        let path = self.path();
+
+        let surface = self
+            .surface()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
         let global_form = self
-            .global_form
+            .global_form()
+            .clone()
             .transform_with_cache(transform, objects, cache);
 
-        // Don't need to transform `self.path`, as that's defined in surface
-        // coordinates, and thus transforming `surface` takes care of it.
-        PartialCurve {
-            path: self.path,
-            surface,
-            global_form,
-        }
+        Self::new(surface, path, global_form)
     }
 }
 
-impl TransformObject for PartialGlobalCurve {
+impl TransformObject for GlobalCurve {
     fn transform_with_cache(
         self,
         _: &Transform,

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -1,21 +1,25 @@
 use fj_math::Transform;
 
-use crate::{objects::Objects, partial::PartialCycle, services::Service};
+use crate::{
+    objects::{Cycle, Objects},
+    services::Service,
+};
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialCycle {
+impl TransformObject for Cycle {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let half_edges = self.half_edges().map(|edge| {
-            edge.into_partial()
+        let half_edges = self.half_edges().map(|half_edge| {
+            half_edge
+                .clone()
                 .transform_with_cache(transform, objects, cache)
         });
 
-        Self::default().with_half_edges(half_edges)
+        Self::new(half_edges)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -2,13 +2,14 @@ use fj_math::Transform;
 
 use crate::{objects::Objects, partial::PartialCycle, services::Service};
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for PartialCycle {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let half_edges = self
             .half_edges()

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -9,11 +9,12 @@ impl TransformObject for PartialCycle {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let half_edges = self
-            .half_edges()
-            .map(|edge| edge.into_partial().transform(transform, objects));
+        let half_edges = self.half_edges().map(|edge| {
+            edge.into_partial()
+                .transform_with_cache(transform, objects, cache)
+        });
 
         Self::default().with_half_edges(half_edges)
     }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -13,13 +13,15 @@ impl TransformObject for PartialHalfEdge {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let curve = self.curve.transform(transform, objects);
-        let vertices = self
-            .vertices
-            .map(|vertex| vertex.transform(transform, objects));
-        let global_form = self.global_form.transform(transform, objects);
+        let curve = self.curve.transform_with_cache(transform, objects, cache);
+        let vertices = self.vertices.map(|vertex| {
+            vertex.transform_with_cache(transform, objects, cache)
+        });
+        let global_form = self
+            .global_form
+            .transform_with_cache(transform, objects, cache);
 
         Self {
             curve,
@@ -34,12 +36,12 @@ impl TransformObject for PartialGlobalEdge {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let curve = self.curve.transform(transform, objects);
-        let vertices = self
-            .vertices
-            .map(|vertex| vertex.transform(transform, objects));
+        let curve = self.curve.transform_with_cache(transform, objects, cache);
+        let vertices = self.vertices.map(|vertex| {
+            vertex.transform_with_cache(transform, objects, cache)
+        });
 
         Self { curve, vertices }
     }

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -6,13 +6,14 @@ use crate::{
     services::Service,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for PartialHalfEdge {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let curve = self.curve.transform(transform, objects);
         let vertices = self
@@ -29,10 +30,11 @@ impl TransformObject for PartialHalfEdge {
 }
 
 impl TransformObject for PartialGlobalEdge {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let curve = self.curve.transform(transform, objects);
         let vertices = self

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -1,48 +1,47 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::Objects,
-    partial::{PartialGlobalEdge, PartialHalfEdge},
+    objects::{GlobalEdge, HalfEdge, Objects},
     services::Service,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialHalfEdge {
+impl TransformObject for HalfEdge {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let curve = self.curve.transform_with_cache(transform, objects, cache);
-        let vertices = self.vertices.map(|vertex| {
+        let vertices = self.vertices().clone().map(|vertex| {
             vertex.transform_with_cache(transform, objects, cache)
         });
         let global_form = self
-            .global_form
+            .global_form()
+            .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self {
-            curve,
-            vertices,
-            global_form,
-        }
+        Self::new(vertices, global_form)
     }
 }
 
-impl TransformObject for PartialGlobalEdge {
+impl TransformObject for GlobalEdge {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let curve = self.curve.transform_with_cache(transform, objects, cache);
-        let vertices = self.vertices.map(|vertex| {
-            vertex.transform_with_cache(transform, objects, cache)
-        });
+        let curve = self
+            .curve()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
+        let vertices =
+            self.vertices().access_in_normalized_order().map(|vertex| {
+                vertex.transform_with_cache(transform, objects, cache)
+            });
 
-        Self { curve, vertices }
+        Self::new(curve, vertices)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -7,13 +7,14 @@ use crate::{
     services::Service,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for PartialFace {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let surface = self
             .surface()
@@ -49,10 +50,11 @@ impl TransformObject for PartialFace {
 }
 
 impl TransformObject for FaceSet {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let mut faces = FaceSet::new();
         faces.extend(

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -14,20 +14,20 @@ impl TransformObject for PartialFace {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let surface = self
-            .surface()
-            .map(|surface| surface.transform(transform, objects));
+        let surface = self.surface().map(|surface| {
+            surface.transform_with_cache(transform, objects, cache)
+        });
         let exterior = self
             .exterior()
             .into_partial()
-            .transform(transform, objects)
+            .transform_with_cache(transform, objects, cache)
             .with_surface(surface.clone());
         let interiors = self.interiors().map(|cycle| {
             cycle
                 .into_partial()
-                .transform(transform, objects)
+                .transform_with_cache(transform, objects, cache)
                 .with_surface(surface.clone())
                 .build(objects)
                 .insert(objects)
@@ -54,12 +54,13 @@ impl TransformObject for FaceSet {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
         let mut faces = FaceSet::new();
         faces.extend(
-            self.into_iter()
-                .map(|face| face.transform(transform, objects)),
+            self.into_iter().map(|face| {
+                face.transform_with_cache(transform, objects, cache)
+            }),
         );
         faces
     }

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -1,51 +1,31 @@
 use fj_math::Transform;
 
 use crate::{
-    insert::Insert,
     objects::{Face, FaceSet, Objects},
-    partial::{HasPartial, PartialFace},
     services::Service,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialFace {
+impl TransformObject for Face {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let surface = self.surface().map(|surface| {
-            surface.transform_with_cache(transform, objects, cache)
-        });
-        let exterior = self
-            .exterior()
-            .into_partial()
-            .transform_with_cache(transform, objects, cache)
-            .with_surface(surface.clone());
-        let interiors = self.interiors().map(|cycle| {
-            cycle
-                .into_partial()
-                .transform_with_cache(transform, objects, cache)
-                .with_surface(surface.clone())
-                .build(objects)
-                .insert(objects)
-        });
-
+        // Color does not need to be transformed.
         let color = self.color();
 
-        let mut face = Face::partial()
-            .with_exterior(exterior)
-            .with_interiors(interiors);
-        if let Some(surface) = surface {
-            face = face.with_surface(surface);
-        }
-        if let Some(color) = color {
-            face = face.with_color(color);
-        }
+        let exterior = self
+            .exterior()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
+        let interiors = self.interiors().cloned().map(|interior| {
+            interior.transform_with_cache(transform, objects, cache)
+        });
 
-        face
+        Self::new(exterior, interiors, color)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -10,15 +10,16 @@ mod solid;
 mod surface;
 mod vertex;
 
+use std::collections::BTreeMap;
+
 use fj_math::{Transform, Vector};
+use type_map::TypeMap;
 
 use crate::{
     insert::Insert,
     objects::Objects,
-    partial::{HasPartial, MaybePartial, Partial},
     services::Service,
-    storage::Handle,
-    validate::{Validate, ValidationError},
+    storage::{Handle, ObjectId},
 };
 
 /// Transform an object
@@ -74,9 +75,7 @@ pub trait TransformObject: Sized {
 
 impl<T> TransformObject for Handle<T>
 where
-    T: HasPartial + Insert,
-    T::Partial: TransformObject,
-    ValidationError: From<<T as Validate>::Error>,
+    T: Clone + Insert + TransformObject + 'static,
 {
     fn transform_with_cache(
         self,
@@ -84,39 +83,18 @@ where
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        self.to_partial()
+        if let Some(object) = cache.get(&self) {
+            return object.clone();
+        }
+
+        let transformed = self
+            .clone_object()
             .transform_with_cache(transform, objects, cache)
-            .build(objects)
-            .insert(objects)
-    }
-}
+            .insert(objects);
 
-impl<T> TransformObject for MaybePartial<T>
-where
-    T: HasPartial,
-    Handle<T>: TransformObject,
-    T::Partial: TransformObject,
-{
-    fn transform_with_cache(
-        self,
-        transform: &Transform,
-        objects: &mut Service<Objects>,
-        cache: &mut TransformCache,
-    ) -> Self {
-        let transformed = match self {
-            Self::Full(full) => full
-                .to_partial()
-                .transform_with_cache(transform, objects, cache),
-            Self::Partial(partial) => {
-                partial.transform_with_cache(transform, objects, cache)
-            }
-        };
+        cache.insert(self.clone(), transformed.clone());
 
-        // Transforming a `MaybePartial` *always* results in a partial object.
-        // This provides the most flexibility to the caller, who might want to
-        // use the transformed partial object for merging or whatever else,
-        // before building it themselves.
-        Self::Partial(transformed)
+        transformed
     }
 }
 
@@ -124,4 +102,24 @@ where
 ///
 /// See [`TransformObject`].
 #[derive(Default)]
-pub struct TransformCache;
+pub struct TransformCache(TypeMap);
+
+impl TransformCache {
+    fn get<T: 'static>(&mut self, key: &Handle<T>) -> Option<&Handle<T>> {
+        let map = self
+            .0
+            .entry::<BTreeMap<ObjectId, Handle<T>>>()
+            .or_insert_with(BTreeMap::new);
+
+        map.get(&key.id())
+    }
+
+    fn insert<T: 'static>(&mut self, key: Handle<T>, value: Handle<T>) {
+        let map = self
+            .0
+            .entry::<BTreeMap<ObjectId, Handle<T>>>()
+            .or_insert_with(BTreeMap::new);
+
+        map.insert(key.id(), value);
+    }
+}

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -82,10 +82,10 @@ where
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
         self.to_partial()
-            .transform(transform, objects)
+            .transform_with_cache(transform, objects, cache)
             .build(objects)
             .insert(objects)
     }
@@ -101,11 +101,15 @@ where
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
         let transformed = match self {
-            Self::Full(full) => full.to_partial().transform(transform, objects),
-            Self::Partial(partial) => partial.transform(transform, objects),
+            Self::Full(full) => full
+                .to_partial()
+                .transform_with_cache(transform, objects, cache),
+            Self::Partial(partial) => {
+                partial.transform_with_cache(transform, objects, cache)
+            }
         };
 
         // Transforming a `MaybePartial` *always* results in a partial object.

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -102,3 +102,9 @@ where
         Self::Partial(transformed)
     }
 }
+
+/// A cache for transformed objects
+///
+/// See [`TransformObject`].
+#[derive(Default)]
+pub struct TransformCache;

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -36,6 +36,17 @@ pub trait TransformObject: Sized {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+    ) -> Self {
+        let mut cache = TransformCache::default();
+        self.transform_with_cache(transform, objects, &mut cache)
+    }
+
+    /// Transform the object using the provided cache
+    fn transform_with_cache(
+        self,
+        transform: &Transform,
+        objects: &mut Service<Objects>,
+        cache: &mut TransformCache,
     ) -> Self;
 
     /// Translate the object
@@ -67,10 +78,11 @@ where
     T::Partial: TransformObject,
     ValidationError: From<<T as Validate>::Error>,
 {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         self.to_partial()
             .transform(transform, objects)
@@ -85,10 +97,11 @@ where
     Handle<T>: TransformObject,
     T::Partial: TransformObject,
 {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let transformed = match self {
             Self::Full(full) => full.to_partial().transform(transform, objects),

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -3,12 +3,11 @@ use fj_math::Transform;
 use crate::{
     objects::{Objects, Shell},
     services::Service,
-    storage::Handle,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Handle<Shell> {
+impl TransformObject for Shell {
     fn transform_with_cache(
         self,
         transform: &Transform,
@@ -19,6 +18,7 @@ impl TransformObject for Handle<Shell> {
             self.faces().clone().into_iter().map(|face| {
                 face.transform_with_cache(transform, objects, cache)
             });
-        Shell::builder().with_faces(faces).build(objects)
+
+        Shell::new(faces)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -6,13 +6,14 @@ use crate::{
     storage::Handle,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for Handle<Shell> {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let faces = self
             .faces()

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -13,13 +13,12 @@ impl TransformObject for Handle<Shell> {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let faces = self
-            .faces()
-            .clone()
-            .into_iter()
-            .map(|face| face.transform(transform, objects));
+        let faces =
+            self.faces().clone().into_iter().map(|face| {
+                face.transform_with_cache(transform, objects, cache)
+            });
         Shell::builder().with_faces(faces).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -6,13 +6,14 @@ use crate::{
     storage::Handle,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for Handle<Sketch> {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let faces = self
             .faces()

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -3,12 +3,11 @@ use fj_math::Transform;
 use crate::{
     objects::{Objects, Sketch},
     services::Service,
-    storage::Handle,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Handle<Sketch> {
+impl TransformObject for Sketch {
     fn transform_with_cache(
         self,
         transform: &Transform,
@@ -19,6 +18,7 @@ impl TransformObject for Handle<Sketch> {
             self.faces().into_iter().cloned().map(|face| {
                 face.transform_with_cache(transform, objects, cache)
             });
-        Sketch::builder().with_faces(faces).build(objects)
+
+        Sketch::new(faces)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -13,13 +13,12 @@ impl TransformObject for Handle<Sketch> {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let faces = self
-            .faces()
-            .into_iter()
-            .cloned()
-            .map(|face| face.transform(transform, objects));
+        let faces =
+            self.faces().into_iter().cloned().map(|face| {
+                face.transform_with_cache(transform, objects, cache)
+            });
         Sketch::builder().with_faces(faces).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -15,10 +15,10 @@ impl TransformObject for Handle<Solid> {
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let faces = self
+        let shells = self
             .shells()
             .cloned()
             .map(|shell| shell.transform_with_cache(transform, objects, cache));
-        Solid::builder().with_shells(faces).build(objects)
+        Solid::builder().with_shells(shells).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -6,13 +6,14 @@ use crate::{
     storage::Handle,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for Handle<Solid> {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let faces = self
             .shells()

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -13,12 +13,12 @@ impl TransformObject for Handle<Solid> {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
         let faces = self
             .shells()
             .cloned()
-            .map(|shell| shell.transform(transform, objects));
+            .map(|shell| shell.transform_with_cache(transform, objects, cache));
         Solid::builder().with_shells(faces).build(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -3,12 +3,11 @@ use fj_math::Transform;
 use crate::{
     objects::{Objects, Solid},
     services::Service,
-    storage::Handle,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Handle<Solid> {
+impl TransformObject for Solid {
     fn transform_with_cache(
         self,
         transform: &Transform,
@@ -19,6 +18,7 @@ impl TransformObject for Handle<Solid> {
             .shells()
             .cloned()
             .map(|shell| shell.transform_with_cache(transform, objects, cache));
-        Solid::builder().with_shells(shells).build(objects)
+
+        Solid::new(shells)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -1,19 +1,20 @@
 use fj_math::Transform;
 
-use crate::{objects::Objects, partial::PartialSurface, services::Service};
+use crate::{
+    objects::{Objects, Surface},
+    services::Service,
+};
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialSurface {
+impl TransformObject for Surface {
     fn transform_with_cache(
         self,
         transform: &Transform,
         _: &mut Service<Objects>,
         _: &mut TransformCache,
     ) -> Self {
-        let geometry =
-            self.geometry.map(|geometry| geometry.transform(transform));
-
-        Self { geometry }
+        let geometry = self.geometry().transform(transform);
+        Self::new(geometry)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -5,13 +5,14 @@ use crate::{
     partial::PartialSurface, services::Service,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for PartialSurface {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         _: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let geometry = self.geometry.map(|geometry| {
             let u = geometry.u.transform(transform);

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    geometry::surface::SurfaceGeometry, objects::Objects,
-    partial::PartialSurface, services::Service,
-};
+use crate::{objects::Objects, partial::PartialSurface, services::Service};
 
 use super::{TransformCache, TransformObject};
 
@@ -14,12 +11,8 @@ impl TransformObject for PartialSurface {
         _: &mut Service<Objects>,
         _: &mut TransformCache,
     ) -> Self {
-        let geometry = self.geometry.map(|geometry| {
-            let u = geometry.u.transform(transform);
-            let v = transform.transform_vector(&geometry.v);
-
-            SurfaceGeometry { u, v }
-        });
+        let geometry =
+            self.geometry.map(|geometry| geometry.transform(transform));
 
         Self { geometry }
     }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -1,71 +1,68 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::Objects,
-    partial::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
+    objects::{GlobalVertex, Objects, SurfaceVertex, Vertex},
     services::Service,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for PartialVertex {
+impl TransformObject for Vertex {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let curve = self.curve.transform_with_cache(transform, objects, cache);
-        let surface_form = self
-            .surface_form
-            .into_partial()
-            .transform_with_cache(transform, objects, cache);
-
-        // Don't need to transform `self.position`, as that is in curve
+        // Don't need to transform position, as that is defined in curve
         // coordinates and thus transforming the curve takes care of it.
-        Self {
-            position: self.position,
-            curve,
-            surface_form: surface_form.into(),
-        }
+        let position = self.position();
+
+        let curve = self
+            .curve()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
+        let surface_form = self
+            .surface_form()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
+
+        Self::new(position, curve, surface_form)
     }
 }
 
-impl TransformObject for PartialSurfaceVertex {
+impl TransformObject for SurfaceVertex {
     fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        let surface = self.surface.clone().map(|surface| {
-            surface.transform_with_cache(transform, objects, cache)
-        });
+        // Don't need to transform position, as that is defined in surface
+        // coordinates and thus transforming the surface takes care of it.
+        let position = self.position();
+
+        let surface = self
+            .surface()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
         let global_form = self
-            .global_form
+            .global_form()
+            .clone()
             .transform_with_cache(transform, objects, cache);
 
-        // Don't need to transform `self.position`, as that is in surface
-        // coordinates and thus transforming the surface takes care of it.
-        Self {
-            position: self.position,
-            surface,
-            global_form,
-        }
+        Self::new(position, surface, global_form)
     }
 }
 
-impl TransformObject for PartialGlobalVertex {
+impl TransformObject for GlobalVertex {
     fn transform_with_cache(
         self,
         transform: &Transform,
         _: &mut Service<Objects>,
         _: &mut TransformCache,
     ) -> Self {
-        let position = self
-            .position
-            .map(|position| transform.transform_point(&position));
-
-        Self { position }
+        let position = transform.transform_point(&self.position());
+        Self::from_position(position)
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -6,13 +6,14 @@ use crate::{
     services::Service,
 };
 
-use super::TransformObject;
+use super::{TransformCache, TransformObject};
 
 impl TransformObject for PartialVertex {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let curve = self.curve.transform(transform, objects);
         let surface_form = self
@@ -31,10 +32,11 @@ impl TransformObject for PartialVertex {
 }
 
 impl TransformObject for PartialSurfaceVertex {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let surface = self
             .surface
@@ -53,10 +55,11 @@ impl TransformObject for PartialSurfaceVertex {
 }
 
 impl TransformObject for PartialGlobalVertex {
-    fn transform(
+    fn transform_with_cache(
         self,
         transform: &Transform,
         _: &mut Service<Objects>,
+        _: &mut TransformCache,
     ) -> Self {
         let position = self
             .position

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -13,13 +13,13 @@ impl TransformObject for PartialVertex {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let curve = self.curve.transform(transform, objects);
+        let curve = self.curve.transform_with_cache(transform, objects, cache);
         let surface_form = self
             .surface_form
             .into_partial()
-            .transform(transform, objects);
+            .transform_with_cache(transform, objects, cache);
 
         // Don't need to transform `self.position`, as that is in curve
         // coordinates and thus transforming the curve takes care of it.
@@ -36,13 +36,14 @@ impl TransformObject for PartialSurfaceVertex {
         self,
         transform: &Transform,
         objects: &mut Service<Objects>,
-        _: &mut TransformCache,
+        cache: &mut TransformCache,
     ) -> Self {
-        let surface = self
-            .surface
-            .clone()
-            .map(|surface| surface.transform(transform, objects));
-        let global_form = self.global_form.transform(transform, objects);
+        let surface = self.surface.clone().map(|surface| {
+            surface.transform_with_cache(transform, objects, cache)
+        });
+        let global_form = self
+            .global_form
+            .transform_with_cache(transform, objects, cache);
 
         // Don't need to transform `self.position`, as that is in surface
         // coordinates and thus transforming the surface takes care of it.

--- a/crates/fj-kernel/src/geometry/surface.rs
+++ b/crates/fj-kernel/src/geometry/surface.rs
@@ -1,6 +1,6 @@
 //! The geometry that defines a surface
 
-use fj_math::{Line, Point, Vector};
+use fj_math::{Line, Point, Transform, Vector};
 
 use super::path::GlobalPath;
 
@@ -37,6 +37,14 @@ impl SurfaceGeometry {
 
     fn path_to_line(&self) -> Line<3> {
         Line::from_origin_and_direction(self.u.origin(), self.v)
+    }
+
+    /// Transform the surface geometry
+    #[must_use]
+    pub fn transform(self, transform: &Transform) -> Self {
+        let u = self.u.transform(transform);
+        let v = transform.transform_vector(&self.v);
+        Self { u, v }
     }
 }
 


### PR DESCRIPTION
The core problem of transforming objects is that references in an object graph that were the same before transformation must be the same after transformation. For example, if the two vertices of a half-edge reference a single curve (which they must, otherwise the half-edge is invalid), then after transforming the half-edge, the vertices of the transformed half-edge must still reference a single (now transformed) curve.

Previously, this was achieved by converting full objects into partial objects before transformation, then transforming those, updating them as necessary (e.g. make sure the two vertices reference the same curve), then convert that back into a full object. In fact, this was the first use case for the partial object API.

This pull request changes that, making the transform logic much simpler. Instead of making the detour through partial objects, a simple cache is used, to make sure that each object in the object graph results in exactly one transformed object in the transformed object graph. The new transform code is extremely simple and hard to get wrong.

Beyond the benefits for the transform code itself, this pull request assists in advancing #1249, by taking some pressure off the partial object API. Although I haven't looked into it yet, I assume that some cleanup attempts that have previously stalled can now be made, as the partial object API has to support fewer use cases.