### PR TITLE
Remove redundant struct fields in partial object API

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -187,9 +187,8 @@ mod tests {
         ];
 
         let face = Face::partial()
-            .with_surface(surface.clone())
-            .with_exterior_polygon_from_points(surface, exterior)
-            .with_interior_polygon_from_points(interior)
+            .with_exterior_polygon_from_points(surface.clone(), exterior)
+            .with_interior_polygon_from_points(surface, interior)
             .build(&mut services.objects);
 
         let expected =

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -187,8 +187,8 @@ mod tests {
         ];
 
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points(exterior)
+            .with_surface(surface.clone())
+            .with_exterior_polygon_from_points(surface, exterior)
             .with_interior_polygon_from_points(interior)
             .build(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -95,8 +95,7 @@ mod tests {
         ]
         .map(|surface| {
             Face::partial()
-                .with_surface(surface)
-                .with_exterior_polygon_from_points(points)
+                .with_exterior_polygon_from_points(surface, points)
                 .build(&mut services.objects)
         });
 
@@ -123,8 +122,7 @@ mod tests {
         ];
         let [a, b] = surfaces.clone().map(|surface| {
             Face::partial()
-                .with_surface(surface)
-                .with_exterior_polygon_from_points(points)
+                .with_exterior_polygon_from_points(surface, points)
                 .build(&mut services.objects)
         });
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -150,8 +150,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [1., 1.], [0., 2.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [1., 1.], [0., 2.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([2., 1.]);
@@ -166,8 +168,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [2., 1.], [0., 2.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [2., 1.], [0., 2.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -185,8 +189,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[4., 2.], [0., 4.], [0., 0.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[4., 2.], [0., 4.], [0., 0.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 2.]);
@@ -204,13 +210,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [0., 0.],
-                [2., 1.],
-                [3., 0.],
-                [3., 4.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -228,13 +231,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [0., 0.],
-                [2., 1.],
-                [3., 1.],
-                [0., 2.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -252,14 +252,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [0., 0.],
-                [2., 1.],
-                [3., 1.],
-                [4., 0.],
-                [4., 5.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -277,8 +273,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [2., 0.], [0., 1.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [2., 0.], [0., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 0.]);
@@ -305,8 +303,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [1., 0.], [0., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 0.]);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -168,13 +168,10 @@ mod tests {
 
         let surface = services.objects.surfaces.yz_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([-1., 0., 0.], &mut services.objects);
@@ -190,13 +187,10 @@ mod tests {
 
         let surface = services.objects.surfaces.yz_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([1., 0., 0.], &mut services.objects);
@@ -215,13 +209,10 @@ mod tests {
 
         let surface = services.objects.surfaces.yz_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([0., 0., 2.], &mut services.objects);
@@ -237,13 +228,10 @@ mod tests {
 
         let surface = services.objects.surfaces.yz_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([1., 1., 0.], &mut services.objects);
@@ -270,13 +258,10 @@ mod tests {
 
         let surface = services.objects.surfaces.yz_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([1., 1., 1.], &mut services.objects);
@@ -301,13 +286,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -325,13 +307,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([
-                [-1., -1.],
-                [1., -1.],
-                [1., 1.],
-                [-1., 1.],
-            ])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([0., 0., 1.], &mut services.objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -110,14 +110,15 @@ mod tests {
             .sweep(UP, &mut services.objects);
 
         let bottom = Face::partial()
-            .with_surface(surface.clone())
-            .with_exterior_polygon_from_points(TRIANGLE)
+            .with_exterior_polygon_from_points(surface.clone(), TRIANGLE)
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
         let top = Face::partial()
-            .with_surface(surface.translate(UP, &mut services.objects))
-            .with_exterior_polygon_from_points(TRIANGLE)
+            .with_exterior_polygon_from_points(
+                surface.translate(UP, &mut services.objects),
+                TRIANGLE,
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -153,16 +154,15 @@ mod tests {
             .sweep(DOWN, &mut services.objects);
 
         let bottom = Face::partial()
-            .with_surface(
+            .with_exterior_polygon_from_points(
                 surface.clone().translate(DOWN, &mut services.objects),
+                TRIANGLE,
             )
-            .with_exterior_polygon_from_points(TRIANGLE)
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
         let top = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points(TRIANGLE)
+            .with_exterior_polygon_from_points(surface, TRIANGLE)
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -133,9 +133,8 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface.clone())
             .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d])
-            .with_interior_polygon_from_points([e, f, g, h])
+            .with_interior_polygon_from_points(surface.clone(), [e, f, g, h])
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -98,8 +98,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([a, b, c, d])
+            .with_exterior_polygon_from_points(surface, [a, b, c, d])
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -135,7 +134,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
             .with_surface(surface.clone())
-            .with_exterior_polygon_from_points([a, b, c, d])
+            .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d])
             .with_interior_polygon_from_points([e, f, g, h])
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -193,8 +192,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface.clone())
-            .with_exterior_polygon_from_points([a, b, c, d, e])
+            .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d, e])
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -83,7 +83,6 @@ impl CycleBuilder for PartialCycle {
                 );
 
                 half_edges.push(PartialHalfEdge {
-                    curve: curve.into(),
                     vertices: vertices.map(Into::into),
                     ..Default::default()
                 });

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -98,7 +98,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 surface_form: surface_vertex.clone().into(),
             });
 
-        self.curve = curve.into();
         self.vertices = [back, front].map(Into::into);
 
         self
@@ -201,7 +200,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 })
         };
 
-        self.curve = curve.into();
         self.vertices = [back, front];
 
         self

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -73,7 +73,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         radius: impl Into<Scalar>,
         objects: &mut Service<Objects>,
     ) -> Self {
-        let mut curve = self.curve.clone().into_partial();
+        let mut curve = self.curve().into_partial();
         curve.update_as_circle_from_radius(radius);
 
         let path = curve.path.expect("Expected path that was just created");
@@ -133,7 +133,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             [&from, &to].map(|vertex| vertex.surface_form());
 
         let surface = self
-            .curve
+            .curve()
             .surface()
             .merge_with(from_surface.surface())
             .merge_with(to_surface.surface())
@@ -144,7 +144,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .expect("Can't infer line segment without surface position")
         });
 
-        let mut curve = self.curve.clone().into_partial();
+        let mut curve = self.curve().into_partial();
         curve.surface = Some(surface);
         curve.update_as_line_from_points(points);
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,8 +1,9 @@
 use fj_math::Point;
 
 use crate::{
-    objects::Cycle,
+    objects::{Cycle, Surface},
     partial::{HasPartial, PartialFace},
+    storage::Handle,
 };
 
 use super::CycleBuilder;
@@ -12,6 +13,7 @@ pub trait FaceBuilder {
     /// Update the [`PartialFace`] with an exterior polygon
     fn with_exterior_polygon_from_points(
         self,
+        surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self;
 
@@ -25,10 +27,9 @@ pub trait FaceBuilder {
 impl FaceBuilder for PartialFace {
     fn with_exterior_polygon_from_points(
         self,
+        surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        let surface = self.surface().expect("Need surface to create polygon");
-
         self.with_exterior(
             Cycle::partial()
                 .with_poly_chain_from_points(surface, points)

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -20,6 +20,7 @@ pub trait FaceBuilder {
     /// Update the [`PartialFace`] with an interior polygon
     fn with_interior_polygon_from_points(
         self,
+        surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self;
 }
@@ -39,10 +40,9 @@ impl FaceBuilder for PartialFace {
 
     fn with_interior_polygon_from_points(
         self,
+        surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        let surface = self.surface().expect("Need surface to build polygon.");
-
         self.with_interiors([Cycle::partial()
             .with_poly_chain_from_points(surface, points)
             .close_with_line_segment()])

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -162,7 +162,6 @@ impl ShellBuilder {
                         };
 
                         PartialHalfEdge {
-                            curve: curve.clone().into(),
                             vertices: [
                                 PartialVertex {
                                     curve: curve.clone().into(),
@@ -290,7 +289,6 @@ impl ShellBuilder {
                     PartialHalfEdge {
                         vertices: vertices.map(Into::into),
                         global_form: edge.global_form().clone().into(),
-                        ..Default::default()
                     }
                     .update_as_line_segment()
                     .build(objects)

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -162,13 +162,15 @@ impl ShellBuilder {
                         };
 
                         PartialHalfEdge {
-                            curve: curve.into(),
+                            curve: curve.clone().into(),
                             vertices: [
                                 PartialVertex {
+                                    curve: curve.clone().into(),
                                     surface_form: from.into(),
                                     ..Default::default()
                                 },
                                 PartialVertex {
+                                    curve: curve.into(),
                                     surface_form: to.into(),
                                     ..Default::default()
                                 },

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -52,13 +52,10 @@ impl ShellBuilder {
                 objects.surfaces.xy_plane().translate([Z, Z, -h], objects);
 
             Face::partial()
-                .with_surface(surface)
-                .with_exterior_polygon_from_points([
-                    [-h, -h],
-                    [h, -h],
-                    [h, h],
-                    [-h, h],
-                ])
+                .with_exterior_polygon_from_points(
+                    surface,
+                    [[-h, -h], [h, -h], [h, h], [-h, h]],
+                )
                 .build(objects)
                 .insert(objects)
         };

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -48,8 +48,7 @@ impl SketchBuilder {
             .as_ref()
             .expect("Can't build `Sketch` without `Surface`");
         self.faces.extend([Face::partial()
-            .with_surface(surface.clone())
-            .with_exterior_polygon_from_points(points)
+            .with_exterior_polygon_from_points(surface.clone(), points)
             .build(objects)
             .insert(objects)]);
         self

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -432,8 +432,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let object = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [1., 0.], [0., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -541,8 +543,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let face = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]])
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [1., 0.], [0., 1.]],
+            )
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let object = Sketch::builder()

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -5,7 +5,7 @@ use crate::{
     get::Get,
     insert::Insert,
     objects::{
-        Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
+        Curve, Cycle, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex, Vertex,
     },
     services::Service,
@@ -179,6 +179,16 @@ impl MaybePartial<Curve> {
         match self {
             Self::Full(full) => full.global_form().clone().into(),
             Self::Partial(partial) => partial.global_form.clone(),
+        }
+    }
+}
+
+impl MaybePartial<Cycle> {
+    /// Access the surface
+    pub fn surface(&self) -> Option<Handle<Surface>> {
+        match self {
+            Self::Full(full) => full.surface().clone().into(),
+            Self::Partial(partial) => partial.surface(),
         }
     }
 }

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -279,6 +279,14 @@ impl MaybePartial<SurfaceVertex> {
 }
 
 impl MaybePartial<Vertex> {
+    /// Access the curve
+    pub fn curve(&self) -> MaybePartial<Curve> {
+        match self {
+            Self::Full(full) => full.curve().clone().into(),
+            Self::Partial(partial) => partial.curve.clone(),
+        }
+    }
+
     /// Access the surface form
     pub fn surface_form(&self) -> MaybePartial<SurfaceVertex> {
         match self {

--- a/crates/fj-kernel/src/partial/maybe_partial.rs
+++ b/crates/fj-kernel/src/partial/maybe_partial.rs
@@ -218,7 +218,7 @@ impl MaybePartial<HalfEdge> {
     pub fn curve(&self) -> MaybePartial<Curve> {
         match self {
             Self::Full(full) => full.curve().clone().into(),
-            Self::Partial(partial) => partial.curve.clone(),
+            Self::Partial(partial) => partial.curve(),
         }
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -25,15 +25,20 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
+    /// Access the partial half-edge's curve
+    pub fn curve(&self) -> MaybePartial<Curve> {
+        self.curve.clone()
+    }
+
     /// Build a full [`HalfEdge`] from the partial half-edge
     pub fn build(mut self, objects: &mut Service<Objects>) -> HalfEdge {
         let global_curve = self
-            .curve
+            .curve()
             .global_form()
             .merge_with(self.global_form.curve());
 
         let curve = {
-            self.curve = self.curve.merge_with(PartialCurve {
+            self.curve = self.curve().merge_with(PartialCurve {
                 global_form: global_curve,
                 ..Default::default()
             });

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -14,9 +14,6 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialHalfEdge {
-    /// The curve that the [`HalfEdge`] is defined in
-    pub curve: MaybePartial<Curve>,
-
     /// The vertices that bound the [`HalfEdge`] in the curve
     pub vertices: [MaybePartial<Vertex>; 2],
 
@@ -27,24 +24,24 @@ pub struct PartialHalfEdge {
 impl PartialHalfEdge {
     /// Access the partial half-edge's curve
     pub fn curve(&self) -> MaybePartial<Curve> {
-        self.curve.clone()
+        let [a, b] = &self.vertices;
+        a.curve().merge_with(b.curve())
     }
 
     /// Build a full [`HalfEdge`] from the partial half-edge
-    pub fn build(mut self, objects: &mut Service<Objects>) -> HalfEdge {
+    pub fn build(self, objects: &mut Service<Objects>) -> HalfEdge {
         let global_curve = self
             .curve()
             .global_form()
             .merge_with(self.global_form.curve());
 
-        let curve = {
-            self.curve = self.curve().merge_with(PartialCurve {
+        let curve = self
+            .curve()
+            .merge_with(PartialCurve {
                 global_form: global_curve,
                 ..Default::default()
-            });
-
-            self.curve.into_full(objects)
-        };
+            })
+            .into_full(objects);
         let vertices = self.vertices.map(|vertex| {
             vertex
                 .merge_with(PartialVertex {
@@ -70,7 +67,6 @@ impl MergeWith for PartialHalfEdge {
         let other = other.into();
 
         Self {
-            curve: self.curve.merge_with(other.curve),
             vertices: self.vertices.merge_with(other.vertices),
             global_form: self.global_form.merge_with(other.global_form),
         }
@@ -79,8 +75,6 @@ impl MergeWith for PartialHalfEdge {
 
 impl Replace<Surface> for PartialHalfEdge {
     fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
-        self.curve.replace(surface.clone());
-
         for vertex in &mut self.vertices {
             vertex.replace(surface.clone());
         }
@@ -95,7 +89,6 @@ impl From<&HalfEdge> for PartialHalfEdge {
             half_edge.vertices().clone().map(Into::into);
 
         Self {
-            curve: half_edge.curve().clone().into(),
             vertices: [back_vertex, front_vertex],
             global_form: half_edge.global_form().clone().into(),
         }

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -39,12 +39,6 @@ impl PartialFace {
         self.color
     }
 
-    /// Build the [`Face`] with the provided surface
-    pub fn with_surface(mut self, surface: Handle<Surface>) -> Self {
-        self.surface = Some(surface);
-        self
-    }
-
     /// Build the [`Face`] with the provided exterior
     pub fn with_exterior(
         mut self,

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -12,7 +12,6 @@ use crate::{
 /// See [`crate::partial`] for more information.
 #[derive(Clone, Debug, Default)]
 pub struct PartialFace {
-    surface: Option<Handle<Surface>>,
     exterior: MaybePartial<Cycle>,
     interiors: Vec<MaybePartial<Cycle>>,
     color: Option<Color>,
@@ -21,7 +20,7 @@ pub struct PartialFace {
 impl PartialFace {
     /// Access th surface that the [`Face`] is defined in
     pub fn surface(&self) -> Option<Handle<Surface>> {
-        self.surface.clone()
+        self.exterior.surface()
     }
 
     /// Access the [`Face`]'s exterior cycle
@@ -83,7 +82,6 @@ impl MergeWith for PartialFace {
         let other = other.into();
 
         Self {
-            surface: self.surface.merge_with(other.surface),
             exterior: self.exterior.merge_with(other.exterior),
             interiors: Mergeable(self.interiors)
                 .merge_with(Mergeable(other.interiors))
@@ -96,7 +94,6 @@ impl MergeWith for PartialFace {
 impl From<&Face> for PartialFace {
     fn from(face: &Face) -> Self {
         Self {
-            surface: Some(face.surface().clone()),
             exterior: face.exterior().clone().into(),
             interiors: face.interiors().cloned().map(Into::into).collect(),
             color: Some(face.color()),

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -69,6 +69,7 @@ impl MergeWith for PartialVertex {
 
 impl Replace<Surface> for PartialVertex {
     fn replace(&mut self, surface: Handle<Surface>) -> &mut Self {
+        self.curve.replace(surface.clone());
         self.surface_form.replace(surface);
         self
     }

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -120,8 +120,11 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let valid = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
+            .with_surface(surface.clone())
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [3., 0.], [0., 3.]],
+            )
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
             .build(&mut services.objects);
         let invalid = {
@@ -148,8 +151,11 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let valid = Face::partial()
-            .with_surface(surface)
-            .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
+            .with_surface(surface.clone())
+            .with_exterior_polygon_from_points(
+                surface,
+                [[0., 0.], [3., 0.], [0., 3.]],
+            )
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
             .build(&mut services.objects);
         let invalid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -117,8 +117,10 @@ mod tests {
     fn face_surface_mismatch() {
         let mut services = Services::new();
 
+        let surface = services.objects.surfaces.xy_plane();
+
         let valid = Face::partial()
-            .with_surface(services.objects.surfaces.xy_plane())
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
             .build(&mut services.objects);
@@ -143,8 +145,10 @@ mod tests {
     fn face_invalid_interior_winding() {
         let mut services = Services::new();
 
+        let surface = services.objects.surfaces.xy_plane();
+
         let valid = Face::partial()
-            .with_surface(services.objects.surfaces.xy_plane())
+            .with_surface(surface)
             .with_exterior_polygon_from_points([[0., 0.], [3., 0.], [0., 3.]])
             .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
             .build(&mut services.objects);

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -120,12 +120,14 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let valid = Face::partial()
-            .with_surface(surface.clone())
             .with_exterior_polygon_from_points(
-                surface,
+                surface.clone(),
                 [[0., 0.], [3., 0.], [0., 3.]],
             )
-            .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
+            .with_interior_polygon_from_points(
+                surface,
+                [[1., 1.], [1., 2.], [2., 1.]],
+            )
             .build(&mut services.objects);
         let invalid = {
             let interiors = [Cycle::partial()
@@ -151,12 +153,14 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let valid = Face::partial()
-            .with_surface(surface.clone())
             .with_exterior_polygon_from_points(
-                surface,
+                surface.clone(),
                 [[0., 0.], [3., 0.], [0., 3.]],
             )
-            .with_interior_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]])
+            .with_interior_polygon_from_points(
+                surface,
+                [[1., 1.], [1., 2.], [2., 1.]],
+            )
             .build(&mut services.objects);
         let invalid = {
             let interiors = valid

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -51,8 +51,7 @@ impl Shape for fj::Sketch {
                     .map(Point::from);
 
                 Face::partial()
-                    .with_surface(surface)
-                    .with_exterior_polygon_from_points(points)
+                    .with_exterior_polygon_from_points(surface, points)
                     .with_color(Color(self.color()))
                     .build(objects)
                     .insert(objects)


### PR DESCRIPTION
Removes all redundant fields from structs in the partial object API, simplifying some code and removing some room for bugs to develop. This pull request is at least partially enabled by #1406. I tried to do some of this work before, but always ran into problems that prevented me from making progress. Thanks to #1406, this change has become practical.