### PR TITLE
Rename `GlobalVertex::from_position` to `new`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -140,8 +140,7 @@ impl Sweep for Handle<GlobalVertex> {
             .global_vertex
             .entry(self.id())
             .or_insert_with(|| {
-                GlobalVertex::from_position(self.position() + path.into())
-                    .insert(objects)
+                GlobalVertex::new(self.position() + path.into()).insert(objects)
             })
             .clone();
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -63,6 +63,6 @@ impl TransformObject for GlobalVertex {
         _: &mut TransformCache,
     ) -> Self {
         let position = transform.transform_point(&self.position());
-        Self::from_position(position)
+        Self::new(position)
     }
 }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -475,8 +475,8 @@ mod tests {
     fn global_vertex() {
         let mut services = Services::new();
 
-        let object = GlobalVertex::from_position([0., 0., 0.])
-            .insert(&mut services.objects);
+        let object =
+            GlobalVertex::new([0., 0., 0.]).insert(&mut services.objects);
 
         assert_eq!(0, object.curve_iter().count());
         assert_eq!(0, object.cycle_iter().count());
@@ -619,8 +619,8 @@ mod tests {
         let curve = curve
             .build(&mut services.objects)
             .insert(&mut services.objects);
-        let global_vertex = GlobalVertex::from_position([0., 0., 0.])
-            .insert(&mut services.objects);
+        let global_vertex =
+            GlobalVertex::new([0., 0., 0.]).insert(&mut services.objects);
         let surface_vertex =
             SurfaceVertex::new([0., 0.], surface, global_vertex)
                 .insert(&mut services.objects);

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -164,7 +164,7 @@ pub struct GlobalVertex {
 
 impl GlobalVertex {
     /// Construct a `GlobalVertex` from a position
-    pub fn from_position(position: impl Into<Point<3>>) -> Self {
+    pub fn new(position: impl Into<Point<3>>) -> Self {
         let position = position.into();
         Self { position }
     }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -169,7 +169,7 @@ impl PartialGlobalVertex {
             .position
             .expect("Can't build a `GlobalVertex` without a position");
 
-        GlobalVertex::from_position(position)
+        GlobalVertex::new(position)
     }
 }
 

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -260,8 +260,7 @@ mod tests {
         let invalid = SurfaceVertex::new(
             valid.position(),
             valid.surface().clone(),
-            GlobalVertex::from_position([1., 0., 0.])
-                .insert(&mut services.objects),
+            GlobalVertex::new([1., 0., 0.]).insert(&mut services.objects),
         );
 
         assert!(valid.validate().is_ok());


### PR DESCRIPTION
This is consistent with the names of the other object constructors. I found that the added precision is not worth the loss of consistency in practice.