### PR TITLE
Fix double panic due to validation errors

### DIFF
--- a/crates/fj-kernel/src/services/validation.rs
+++ b/crates/fj-kernel/src/services/validation.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, thread};
 
 use crate::{
     objects::{BehindHandle, Object},
@@ -23,7 +23,9 @@ impl Drop for Validation {
                 println!("{err}");
             }
 
-            panic!();
+            if !thread::panicking() {
+                panic!();
+            }
         }
     }
 }


### PR DESCRIPTION
If the thread was already panicking, the `Drop` implementation for `Validation` could cause a double panic. This would cause the thread to abort without any useful output, which is the opposite of what this `Drop` implementation tried to achieve.