### PR TITLE
Update `justfile`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,12 @@ cargo test -p fj-kernel
 You can run the full suite of checks and tests like this:
 
 ``` sh
-just build
+just ci
+```
+
+You can also run a lighter version that just checks for code correctness:
+``` sh
+just test
 ```
 
 This requires [`just`](https://crates.io/crates/just), which you can install like this:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 export RUSTDOCFLAGS := "-D warnings"
 
-build:
+ci:
     cargo fmt --check
     cargo clippy --all-features -- -D warnings
     cargo test --all-features

--- a/justfile
+++ b/justfile
@@ -1,15 +1,24 @@
 export RUSTDOCFLAGS := "-D warnings"
 
+# Run all tests, including end-to-end export validation tests.
+#
+# This command is designed to be used regularly during CAD kernel development.
+# It runs tests to check for code correctness, but accepts warnings in the code
+# and does not check formatting or documentation.
+#
+# For a full build that mirrors the CI build, see `just ci`.
+test:
+    cargo test --all-features
+    cargo run --package export-validator
+
 # Run a full build that mirrors the CI build
 #
 # Basically, if this passes locally, then the CI build should pass too, once you
 # submit your work as a pull request. Please note that the CI build is
 # maintained separately from this file. Most deviations in behavior should
 # probably be considered a bug in this file.
-ci:
+ci: test
     cargo fmt --check
     cargo clippy --all-features -- -D warnings
-    cargo test --all-features
     cargo doc --no-deps --document-private-items --all-features --workspace
     cargo run --package cross-compiler
-    cargo run --package export-validator

--- a/justfile
+++ b/justfile
@@ -1,5 +1,11 @@
 export RUSTDOCFLAGS := "-D warnings"
 
+# Run a full build that mirrors the CI build
+#
+# Basically, if this passes locally, then the CI build should pass too, once you
+# submit your work as a pull request. Please note that the CI build is
+# maintained separately from this file. Most deviations in behavior should
+# probably be considered a bug in this file.
 ci:
     cargo fmt --check
     cargo clippy --all-features -- -D warnings


### PR DESCRIPTION
Rename `just build` to `just ci`, and add `just test` as a lighter alternative to be used during development.