### PR TITLE
Introduce new partial object API

### DIFF
--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -100,6 +100,7 @@ pub mod insert;
 pub mod iter;
 pub mod objects;
 pub mod partial;
+pub mod partial2;
 pub mod services;
 pub mod storage;
 pub mod validate;

--- a/crates/fj-kernel/src/partial2/mod.rs
+++ b/crates/fj-kernel/src/partial2/mod.rs
@@ -12,6 +12,7 @@
 
 mod objects;
 mod traits;
+mod wrapper;
 
 pub use self::{
     objects::{
@@ -26,4 +27,5 @@ pub use self::{
         vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     },
     traits::HasPartial,
+    wrapper::Partial,
 };

--- a/crates/fj-kernel/src/partial2/mod.rs
+++ b/crates/fj-kernel/src/partial2/mod.rs
@@ -11,15 +11,19 @@
 //! API][crate::partial]. This is still a work in progress.
 
 mod objects;
+mod traits;
 
-pub use self::objects::{
-    curve::{PartialCurve, PartialGlobalCurve},
-    cycle::PartialCycle,
-    edge::{PartialGlobalEdge, PartialHalfEdge},
-    face::PartialFace,
-    shell::PartialShell,
-    sketch::PartialSketch,
-    solid::PartialSolid,
-    surface::PartialSurface,
-    vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
+pub use self::{
+    objects::{
+        curve::{PartialCurve, PartialGlobalCurve},
+        cycle::PartialCycle,
+        edge::{PartialGlobalEdge, PartialHalfEdge},
+        face::PartialFace,
+        shell::PartialShell,
+        sketch::PartialSketch,
+        solid::PartialSolid,
+        surface::PartialSurface,
+        vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
+    },
+    traits::HasPartial,
 };

--- a/crates/fj-kernel/src/partial2/mod.rs
+++ b/crates/fj-kernel/src/partial2/mod.rs
@@ -1,0 +1,11 @@
+//! Partially defined objects
+//!
+//! This module contains types that mirror the full object types from
+//! [`crate::objects`], only the types from this module can be defined only
+//! partially, with the non-defined parts being inferred when a full object is
+//! constructed.
+//!
+//! # Implementation Note
+//!
+//! This API was created as a replacement for the [original partial object
+//! API][crate::partial]. This is still a work in progress.

--- a/crates/fj-kernel/src/partial2/mod.rs
+++ b/crates/fj-kernel/src/partial2/mod.rs
@@ -9,3 +9,17 @@
 //!
 //! This API was created as a replacement for the [original partial object
 //! API][crate::partial]. This is still a work in progress.
+
+mod objects;
+
+pub use self::objects::{
+    curve::{PartialCurve, PartialGlobalCurve},
+    cycle::PartialCycle,
+    edge::{PartialGlobalEdge, PartialHalfEdge},
+    face::PartialFace,
+    shell::PartialShell,
+    sketch::PartialSketch,
+    solid::PartialSolid,
+    surface::PartialSurface,
+    vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
+};

--- a/crates/fj-kernel/src/partial2/mod.rs
+++ b/crates/fj-kernel/src/partial2/mod.rs
@@ -27,5 +27,5 @@ pub use self::{
         vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     },
     traits::{HasPartial, PartialObject},
-    wrapper::Partial,
+    wrapper::{FullToPartialCache, Partial},
 };

--- a/crates/fj-kernel/src/partial2/mod.rs
+++ b/crates/fj-kernel/src/partial2/mod.rs
@@ -26,6 +26,6 @@ pub use self::{
         surface::PartialSurface,
         vertex::{PartialGlobalVertex, PartialSurfaceVertex, PartialVertex},
     },
-    traits::HasPartial,
+    traits::{HasPartial, PartialObject},
     wrapper::Partial,
 };

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -1,7 +1,7 @@
 use crate::{
     geometry::path::SurfacePath,
     objects::{Curve, GlobalCurve, Objects, Surface},
-    partial2::{Partial, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -39,6 +39,14 @@ impl PartialCurve {
 impl PartialObject for PartialCurve {
     type Full = Curve;
 
+    fn from_full(curve: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            Some(curve.path()),
+            Some(Partial::from_full(curve.surface().clone(), cache)),
+            Some(Partial::from_full(curve.global_form().clone(), cache)),
+        )
+    }
+
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let path = self.path.expect("Need path to build curve");
         let surface = self.surface.build(objects);
@@ -67,6 +75,10 @@ impl PartialGlobalCurve {
 
 impl PartialObject for PartialGlobalCurve {
     type Full = GlobalCurve;
+
+    fn from_full(_: &Self::Full, _: &mut FullToPartialCache) -> Self {
+        Self::new()
+    }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
         GlobalCurve

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -1,7 +1,8 @@
 use crate::{
     geometry::path::SurfacePath,
-    objects::{Curve, GlobalCurve, Surface},
+    objects::{Curve, GlobalCurve, Objects, Surface},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Curve`]
@@ -19,6 +20,14 @@ pub struct PartialCurve {
 
 impl PartialObject for PartialCurve {
     type Full = Curve;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let path = self.path.expect("Need path to build curve");
+        let surface = self.surface.build(objects);
+        let global_form = self.global_form.build(objects);
+
+        Curve::new(surface, path, global_form)
+    }
 }
 
 /// A partial [`GlobalCurve`]
@@ -27,4 +36,8 @@ pub struct PartialGlobalCurve;
 
 impl PartialObject for PartialGlobalCurve {
     type Full = GlobalCurve;
+
+    fn build(self, _: &mut Service<Objects>) -> Self::Full {
+        GlobalCurve
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -1,0 +1,9 @@
+/// A partial [`Curve`]
+///
+/// [`Curve`]: crate::objects::Curve
+pub struct PartialCurve;
+
+/// A partial [`GlobalCurve`]
+///
+/// [`GlobalCurve`]: crate::objects::GlobalCurve
+pub struct PartialGlobalCurve;

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -1,7 +1,22 @@
+use crate::{
+    geometry::path::SurfacePath,
+    objects::{GlobalCurve, Surface},
+    partial2::Partial,
+};
+
 /// A partial [`Curve`]
 ///
 /// [`Curve`]: crate::objects::Curve
-pub struct PartialCurve;
+pub struct PartialCurve {
+    /// The path that defines the curve
+    pub path: Option<SurfacePath>,
+
+    /// The surface the curve is defined in
+    pub surface: Partial<Surface>,
+
+    /// The global form of the curve
+    pub global_form: Partial<GlobalCurve>,
+}
 
 /// A partial [`GlobalCurve`]
 ///

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -5,8 +5,6 @@ use crate::{
 };
 
 /// A partial [`Curve`]
-///
-/// [`Curve`]: crate::objects::Curve
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<SurfacePath>,
@@ -23,8 +21,6 @@ impl PartialObject for PartialCurve {
 }
 
 /// A partial [`GlobalCurve`]
-///
-/// [`GlobalCurve`]: crate::objects::GlobalCurve
 pub struct PartialGlobalCurve;
 
 impl PartialObject for PartialGlobalCurve {

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -1,7 +1,7 @@
 use crate::{
     geometry::path::SurfacePath,
-    objects::{GlobalCurve, Surface},
-    partial2::Partial,
+    objects::{Curve, GlobalCurve, Surface},
+    partial2::{Partial, PartialObject},
 };
 
 /// A partial [`Curve`]
@@ -18,7 +18,15 @@ pub struct PartialCurve {
     pub global_form: Partial<GlobalCurve>,
 }
 
+impl PartialObject for PartialCurve {
+    type Full = Curve;
+}
+
 /// A partial [`GlobalCurve`]
 ///
 /// [`GlobalCurve`]: crate::objects::GlobalCurve
 pub struct PartialGlobalCurve;
+
+impl PartialObject for PartialGlobalCurve {
+    type Full = GlobalCurve;
+}

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Curve`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<SurfacePath>,
@@ -48,8 +48,14 @@ impl PartialObject for PartialCurve {
     }
 }
 
+impl Default for PartialCurve {
+    fn default() -> Self {
+        Self::new(None, None, None)
+    }
+}
+
 /// A partial [`GlobalCurve`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialGlobalCurve;
 
 impl PartialGlobalCurve {
@@ -64,5 +70,11 @@ impl PartialObject for PartialGlobalCurve {
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
         GlobalCurve
+    }
+}
+
+impl Default for PartialGlobalCurve {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 /// A partial [`Curve`]
+#[derive(Clone)]
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<SurfacePath>,
@@ -21,6 +22,7 @@ impl PartialObject for PartialCurve {
 }
 
 /// A partial [`GlobalCurve`]
+#[derive(Clone)]
 pub struct PartialGlobalCurve;
 
 impl PartialObject for PartialGlobalCurve {

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Curve`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<SurfacePath>,
@@ -31,7 +31,7 @@ impl PartialObject for PartialCurve {
 }
 
 /// A partial [`GlobalCurve`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalCurve;
 
 impl PartialObject for PartialGlobalCurve {

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Curve`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<SurfacePath>,
@@ -22,7 +22,7 @@ impl PartialObject for PartialCurve {
 }
 
 /// A partial [`GlobalCurve`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialGlobalCurve;
 
 impl PartialObject for PartialGlobalCurve {

--- a/crates/fj-kernel/src/partial2/objects/curve.rs
+++ b/crates/fj-kernel/src/partial2/objects/curve.rs
@@ -18,6 +18,24 @@ pub struct PartialCurve {
     pub global_form: Partial<GlobalCurve>,
 }
 
+impl PartialCurve {
+    /// Construct an instance of `PartialCurve`
+    pub fn new(
+        path: Option<SurfacePath>,
+        surface: Option<Partial<Surface>>,
+        global_form: Option<Partial<GlobalCurve>>,
+    ) -> Self {
+        let surface = surface.unwrap_or_default();
+        let global_form = global_form.unwrap_or_default();
+
+        Self {
+            path,
+            surface,
+            global_form,
+        }
+    }
+}
+
 impl PartialObject for PartialCurve {
     type Full = Curve;
 
@@ -33,6 +51,13 @@ impl PartialObject for PartialCurve {
 /// A partial [`GlobalCurve`]
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalCurve;
+
+impl PartialGlobalCurve {
+    /// Construct an instance of `PartialGlobalCurve`
+    pub fn new() -> Self {
+        Self
+    }
+}
 
 impl PartialObject for PartialGlobalCurve {
     type Full = GlobalCurve;

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,
@@ -28,5 +28,11 @@ impl PartialObject for PartialCycle {
             .map(|half_edge| half_edge.build(objects));
 
         Cycle::new(half_edges)
+    }
+}
+
+impl Default for PartialCycle {
+    fn default() -> Self {
+        Self::new(Vec::new())
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Cycle, HalfEdge, Objects},
-    partial2::{Partial, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -20,6 +20,16 @@ impl PartialCycle {
 
 impl PartialObject for PartialCycle {
     type Full = Cycle;
+
+    fn from_full(cycle: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            cycle
+                .half_edges()
+                .cloned()
+                .map(|half_edge| Partial::from_full(half_edge, cache))
+                .collect(),
+        )
+    }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let half_edges = self

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -1,4 +1,9 @@
+use crate::{objects::HalfEdge, partial2::Partial};
+
 /// A partial [`Cycle`]
 ///
 /// [`Cycle`]: crate::objects::Cycle
-pub struct PartialCycle;
+pub struct PartialCycle {
+    /// The half-edges that make up the cycle
+    pub half_edges: Vec<Partial<HalfEdge>>,
+}

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -1,4 +1,7 @@
-use crate::{objects::HalfEdge, partial2::Partial};
+use crate::{
+    objects::{Cycle, HalfEdge},
+    partial2::{Partial, PartialObject},
+};
 
 /// A partial [`Cycle`]
 ///
@@ -6,4 +9,8 @@ use crate::{objects::HalfEdge, partial2::Partial};
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,
+}
+
+impl PartialObject for PartialCycle {
+    type Full = Cycle;
 }

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -11,6 +11,13 @@ pub struct PartialCycle {
     pub half_edges: Vec<Partial<HalfEdge>>,
 }
 
+impl PartialCycle {
+    /// Construct an instance of `PartialCycle`
+    pub fn new(half_edges: Vec<Partial<HalfEdge>>) -> Self {
+        Self { half_edges }
+    }
+}
+
 impl PartialObject for PartialCycle {
     type Full = Cycle;
 

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
+#[derive(Clone)]
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -1,6 +1,7 @@
 use crate::{
-    objects::{Cycle, HalfEdge},
+    objects::{Cycle, HalfEdge, Objects},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Cycle`]
@@ -12,4 +13,13 @@ pub struct PartialCycle {
 
 impl PartialObject for PartialCycle {
     type Full = Cycle;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let half_edges = self
+            .half_edges
+            .into_iter()
+            .map(|half_edge| half_edge.build(objects));
+
+        Cycle::new(half_edges)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -1,0 +1,4 @@
+/// A partial [`Cycle`]
+///
+/// [`Cycle`]: crate::objects::Cycle
+pub struct PartialCycle;

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,

--- a/crates/fj-kernel/src/partial2/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial2/objects/cycle.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
-///
-/// [`Cycle`]: crate::objects::Cycle
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -3,8 +3,11 @@ use std::array;
 use fj_interop::ext::ArrayExt;
 
 use crate::{
-    objects::{GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Vertex},
+    objects::{
+        GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects, Vertex,
+    },
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`HalfEdge`]
@@ -19,6 +22,13 @@ pub struct PartialHalfEdge {
 
 impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let vertices = self.vertices.map(|vertex| vertex.build(objects));
+        let global_form = self.global_form.build(objects);
+
+        HalfEdge::new(vertices, global_form)
+    }
 }
 
 impl Default for PartialHalfEdge {
@@ -64,4 +74,11 @@ pub struct PartialGlobalEdge {
 
 impl PartialObject for PartialGlobalEdge {
     type Full = GlobalEdge;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let curve = self.curve.build(objects);
+        let vertices = self.vertices.map(|vertex| vertex.build(objects));
+
+        GlobalEdge::new(curve, vertices)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -1,9 +1,26 @@
+use crate::{
+    objects::{GlobalCurve, GlobalEdge, GlobalVertex, Vertex},
+    partial2::Partial,
+};
+
 /// A partial [`HalfEdge`]
 ///
 /// [`HalfEdge`]: crate::objects::HalfEdge
-pub struct PartialHalfEdge;
+pub struct PartialHalfEdge {
+    /// The vertices that bound the half-edge on the curve
+    pub vertices: [Partial<Vertex>; 2],
+
+    /// The global form of the half-edge
+    pub global_form: Partial<GlobalEdge>,
+}
 
 /// A partial [`GlobalEdge`]
 ///
 /// [`GlobalEdge`]: crate::objects::GlobalEdge
-pub struct PartialGlobalEdge;
+pub struct PartialGlobalEdge {
+    /// The curve that defines the edge's geometry
+    pub curve: Partial<GlobalCurve>,
+
+    /// The vertices that bound the edge on the curve
+    pub vertices: [Partial<GlobalVertex>; 2],
+}

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 /// A partial [`HalfEdge`]
-///
-/// [`HalfEdge`]: crate::objects::HalfEdge
 pub struct PartialHalfEdge {
     /// The vertices that bound the half-edge on the curve
     pub vertices: [Partial<Vertex>; 2],
@@ -19,8 +17,6 @@ impl PartialObject for PartialHalfEdge {
 }
 
 /// A partial [`GlobalEdge`]
-///
-/// [`GlobalEdge`]: crate::objects::GlobalEdge
 pub struct PartialGlobalEdge {
     /// The curve that defines the edge's geometry
     pub curve: Partial<GlobalCurve>,

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -1,6 +1,6 @@
 use crate::{
-    objects::{GlobalCurve, GlobalEdge, GlobalVertex, Vertex},
-    partial2::Partial,
+    objects::{GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Vertex},
+    partial2::{Partial, PartialObject},
 };
 
 /// A partial [`HalfEdge`]
@@ -14,6 +14,10 @@ pub struct PartialHalfEdge {
     pub global_form: Partial<GlobalEdge>,
 }
 
+impl PartialObject for PartialHalfEdge {
+    type Full = HalfEdge;
+}
+
 /// A partial [`GlobalEdge`]
 ///
 /// [`GlobalEdge`]: crate::objects::GlobalEdge
@@ -23,4 +27,8 @@ pub struct PartialGlobalEdge {
 
     /// The vertices that bound the edge on the curve
     pub vertices: [Partial<GlobalVertex>; 2],
+}
+
+impl PartialObject for PartialGlobalEdge {
+    type Full = GlobalEdge;
 }

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 /// A partial [`HalfEdge`]
+#[derive(Clone)]
 pub struct PartialHalfEdge {
     /// The vertices that bound the half-edge on the curve
     pub vertices: [Partial<Vertex>; 2],
@@ -17,6 +18,7 @@ impl PartialObject for PartialHalfEdge {
 }
 
 /// A partial [`GlobalEdge`]
+#[derive(Clone)]
 pub struct PartialGlobalEdge {
     /// The curve that defines the edge's geometry
     pub curve: Partial<GlobalCurve>,

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -71,7 +71,7 @@ impl Default for PartialHalfEdge {
 }
 
 /// A partial [`GlobalEdge`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialGlobalEdge {
     /// The curve that defines the edge's geometry
     pub curve: Partial<GlobalCurve>,
@@ -101,5 +101,11 @@ impl PartialObject for PartialGlobalEdge {
         let vertices = self.vertices.map(|vertex| vertex.build(objects));
 
         GlobalEdge::new(curve, vertices)
+    }
+}
+
+impl Default for PartialGlobalEdge {
+    fn default() -> Self {
+        Self::new(None, [None, None])
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -1,5 +1,3 @@
-use std::array;
-
 use fj_interop::ext::ArrayExt;
 
 use crate::{
@@ -20,21 +18,14 @@ pub struct PartialHalfEdge {
     pub global_form: Partial<GlobalEdge>,
 }
 
-impl PartialObject for PartialHalfEdge {
-    type Full = HalfEdge;
-
-    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
-        let vertices = self.vertices.map(|vertex| vertex.build(objects));
-        let global_form = self.global_form.build(objects);
-
-        HalfEdge::new(vertices, global_form)
-    }
-}
-
-impl Default for PartialHalfEdge {
-    fn default() -> Self {
-        let mut vertices = array::from_fn(|_| Partial::<Vertex>::new());
-        let mut global_form = Partial::<GlobalEdge>::new();
+impl PartialHalfEdge {
+    /// Construct an instance of `PartialHalfEdge`
+    pub fn new(
+        vertices: [Option<Partial<Vertex>>; 2],
+        global_form: Option<Partial<GlobalEdge>>,
+    ) -> Self {
+        let mut vertices = vertices.map(Option::unwrap_or_default);
+        let mut global_form = global_form.unwrap_or_default();
 
         let curve = Partial::new();
         for vertex in &mut vertices {
@@ -62,6 +53,23 @@ impl Default for PartialHalfEdge {
     }
 }
 
+impl PartialObject for PartialHalfEdge {
+    type Full = HalfEdge;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let vertices = self.vertices.map(|vertex| vertex.build(objects));
+        let global_form = self.global_form.build(objects);
+
+        HalfEdge::new(vertices, global_form)
+    }
+}
+
+impl Default for PartialHalfEdge {
+    fn default() -> Self {
+        Self::new([None, None], None)
+    }
+}
+
 /// A partial [`GlobalEdge`]
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {
@@ -70,6 +78,19 @@ pub struct PartialGlobalEdge {
 
     /// The vertices that bound the edge on the curve
     pub vertices: [Partial<GlobalVertex>; 2],
+}
+
+impl PartialGlobalEdge {
+    /// Construct an instance of `PartialGlobalEdge`
+    pub fn new(
+        curve: Option<Partial<GlobalCurve>>,
+        vertices: [Option<Partial<GlobalVertex>>; 2],
+    ) -> Self {
+        let curve = curve.unwrap_or_default();
+        let vertices = vertices.map(Option::unwrap_or_default);
+
+        Self { curve, vertices }
+    }
 }
 
 impl PartialObject for PartialGlobalEdge {

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// A partial [`HalfEdge`]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PartialHalfEdge {
     /// The vertices that bound the half-edge on the curve
     pub vertices: [Partial<Vertex>; 2],
@@ -63,7 +63,7 @@ impl Default for PartialHalfEdge {
 }
 
 /// A partial [`GlobalEdge`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {
     /// The curve that defines the edge's geometry
     pub curve: Partial<GlobalCurve>,

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -1,0 +1,9 @@
+/// A partial [`HalfEdge`]
+///
+/// [`HalfEdge`]: crate::objects::HalfEdge
+pub struct PartialHalfEdge;
+
+/// A partial [`GlobalEdge`]
+///
+/// [`GlobalEdge`]: crate::objects::GlobalEdge
+pub struct PartialGlobalEdge;

--- a/crates/fj-kernel/src/partial2/objects/edge.rs
+++ b/crates/fj-kernel/src/partial2/objects/edge.rs
@@ -1,3 +1,7 @@
+use std::array;
+
+use fj_interop::ext::ArrayExt;
+
 use crate::{
     objects::{GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Vertex},
     partial2::{Partial, PartialObject},
@@ -17,8 +21,39 @@ impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
 }
 
+impl Default for PartialHalfEdge {
+    fn default() -> Self {
+        let mut vertices = array::from_fn(|_| Partial::<Vertex>::new());
+        let mut global_form = Partial::<GlobalEdge>::new();
+
+        let curve = Partial::new();
+        for vertex in &mut vertices {
+            vertex.write().curve = curve.clone();
+        }
+
+        let global_curve = curve.read().global_form.clone();
+        let global_vertices =
+            vertices.each_ref_ext().map(|vertex: &Partial<Vertex>| {
+                let surface_vertex = vertex.read().surface_form.clone();
+                let global_vertex = surface_vertex.read().global_form.clone();
+                global_vertex
+            });
+
+        {
+            let mut global_form = global_form.write();
+            global_form.curve = global_curve;
+            global_form.vertices = global_vertices;
+        }
+
+        Self {
+            vertices,
+            global_form,
+        }
+    }
+}
+
 /// A partial [`GlobalEdge`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialGlobalEdge {
     /// The curve that defines the edge's geometry
     pub curve: Partial<GlobalCurve>,

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A partial [`Face`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialFace {
     /// The cycle that bounds the face on the outside
     pub exterior: Partial<Cycle>,
@@ -48,5 +48,11 @@ impl PartialObject for PartialFace {
         let color = self.color.unwrap_or_default();
 
         Face::new(exterior, interiors, color)
+    }
+}
+
+impl Default for PartialFace {
+    fn default() -> Self {
+        Self::new(None, Vec::new(), None)
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -21,6 +21,23 @@ pub struct PartialFace {
     pub color: Option<Color>,
 }
 
+impl PartialFace {
+    /// Construct an instance of `PartialFace`
+    pub fn new(
+        exterior: Option<Partial<Cycle>>,
+        interiors: Vec<Partial<Cycle>>,
+        color: Option<Color>,
+    ) -> Self {
+        let exterior = exterior.unwrap_or_default();
+
+        Self {
+            exterior,
+            interiors,
+            color,
+        }
+    }
+}
+
 impl PartialObject for PartialFace {
     type Full = Face;
 

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -1,0 +1,4 @@
+/// A partial [`Face`]
+///
+/// [`Face`]: crate::objects::Face
+pub struct PartialFace;

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -2,7 +2,7 @@ use fj_interop::mesh::Color;
 
 use crate::{
     objects::{Cycle, Face, Objects},
-    partial2::{Partial, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -40,6 +40,16 @@ impl PartialFace {
 
 impl PartialObject for PartialFace {
     type Full = Face;
+
+    fn from_full(face: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            Some(Partial::from_full(face.exterior().clone(), cache)),
+            face.interiors()
+                .map(|cycle| Partial::from_full(cycle.clone(), cache))
+                .collect(),
+            Some(face.color()),
+        )
+    }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let exterior = self.exterior.build(objects);

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -1,8 +1,9 @@
 use fj_interop::mesh::Color;
 
 use crate::{
-    objects::{Cycle, Face},
+    objects::{Cycle, Face, Objects},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Face`]
@@ -22,4 +23,13 @@ pub struct PartialFace {
 
 impl PartialObject for PartialFace {
     type Full = Face;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let exterior = self.exterior.build(objects);
+        let interiors =
+            self.interiors.into_iter().map(|cycle| cycle.build(objects));
+        let color = self.color.unwrap_or_default();
+
+        Face::new(exterior, interiors, color)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A partial [`Face`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialFace {
     /// The cycle that bounds the face on the outside
     pub exterior: Partial<Cycle>,

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -1,6 +1,9 @@
 use fj_interop::mesh::Color;
 
-use crate::{objects::Cycle, partial2::Partial};
+use crate::{
+    objects::{Cycle, Face},
+    partial2::{Partial, PartialObject},
+};
 
 /// A partial [`Face`]
 ///
@@ -16,4 +19,8 @@ pub struct PartialFace {
 
     /// The color of the face
     pub color: Option<Color>,
+}
+
+impl PartialObject for PartialFace {
+    type Full = Face;
 }

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 /// A partial [`Face`]
+#[derive(Clone)]
 pub struct PartialFace {
     /// The cycle that bounds the face on the outside
     pub exterior: Partial<Cycle>,

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Face`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialFace {
     /// The cycle that bounds the face on the outside
     pub exterior: Partial<Cycle>,

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -1,4 +1,19 @@
+use fj_interop::mesh::Color;
+
+use crate::{objects::Cycle, partial2::Partial};
+
 /// A partial [`Face`]
 ///
 /// [`Face`]: crate::objects::Face
-pub struct PartialFace;
+pub struct PartialFace {
+    /// The cycle that bounds the face on the outside
+    pub exterior: Partial<Cycle>,
+
+    /// The cycles that bound the face on the inside
+    ///
+    /// Each of these cycles defines a hole in the face.
+    pub interiors: Vec<Partial<Cycle>>,
+
+    /// The color of the face
+    pub color: Option<Color>,
+}

--- a/crates/fj-kernel/src/partial2/objects/face.rs
+++ b/crates/fj-kernel/src/partial2/objects/face.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 
 /// A partial [`Face`]
-///
-/// [`Face`]: crate::objects::Face
 pub struct PartialFace {
     /// The cycle that bounds the face on the outside
     pub exterior: Partial<Cycle>,

--- a/crates/fj-kernel/src/partial2/objects/mod.rs
+++ b/crates/fj-kernel/src/partial2/objects/mod.rs
@@ -1,0 +1,9 @@
+pub mod curve;
+pub mod cycle;
+pub mod edge;
+pub mod face;
+pub mod shell;
+pub mod sketch;
+pub mod solid;
+pub mod surface;
+pub mod vertex;

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A partial [`Shell`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -1,4 +1,7 @@
-use crate::{objects::Face, partial2::Partial};
+use crate::{
+    objects::{Face, Shell},
+    partial2::{Partial, PartialObject},
+};
 
 /// A partial [`Shell`]
 ///
@@ -6,4 +9,8 @@ use crate::{objects::Face, partial2::Partial};
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,
+}
+
+impl PartialObject for PartialShell {
+    type Full = Shell;
 }

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Shell`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 /// A partial [`Shell`]
-///
-/// [`Shell`]: crate::objects::Shell
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -1,0 +1,4 @@
+/// A partial [`Shell`]
+///
+/// [`Shell`]: crate::objects::Shell
+pub struct PartialShell;

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -11,6 +11,13 @@ pub struct PartialShell {
     pub faces: Vec<Partial<Face>>,
 }
 
+impl PartialShell {
+    /// Construct an instance of `PartialShell`
+    pub fn new(faces: Vec<Partial<Face>>) -> Self {
+        Self { faces }
+    }
+}
+
 impl PartialObject for PartialShell {
     type Full = Shell;
 

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -1,6 +1,7 @@
 use crate::{
-    objects::{Face, Shell},
+    objects::{Face, Objects, Shell},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Shell`]
@@ -12,4 +13,9 @@ pub struct PartialShell {
 
 impl PartialObject for PartialShell {
     type Full = Shell;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let faces = self.faces.into_iter().map(|face| face.build(objects));
+        Shell::new(faces)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Face, Objects, Shell},
-    partial2::{Partial, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -20,6 +20,16 @@ impl PartialShell {
 
 impl PartialObject for PartialShell {
     type Full = Shell;
+
+    fn from_full(shell: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            shell
+                .faces()
+                .into_iter()
+                .map(|face| Partial::from_full(face.clone(), cache))
+                .collect(),
+        )
+    }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let faces = self.faces.into_iter().map(|face| face.build(objects));

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -1,4 +1,9 @@
+use crate::{objects::Face, partial2::Partial};
+
 /// A partial [`Shell`]
 ///
 /// [`Shell`]: crate::objects::Shell
-pub struct PartialShell;
+pub struct PartialShell {
+    /// The faces that make up the shell
+    pub faces: Vec<Partial<Face>>,
+}

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Shell`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,
@@ -24,5 +24,11 @@ impl PartialObject for PartialShell {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let faces = self.faces.into_iter().map(|face| face.build(objects));
         Shell::new(faces)
+    }
+}
+
+impl Default for PartialShell {
+    fn default() -> Self {
+        Self::new(Vec::new())
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/shell.rs
+++ b/crates/fj-kernel/src/partial2/objects/shell.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 /// A partial [`Shell`]
+#[derive(Clone)]
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -11,6 +11,13 @@ pub struct PartialSketch {
     pub faces: Vec<Partial<Face>>,
 }
 
+impl PartialSketch {
+    /// Construct an instance of `PartialSketch`
+    pub fn new(faces: Vec<Partial<Face>>) -> Self {
+        Self { faces }
+    }
+}
+
 impl PartialObject for PartialSketch {
     type Full = Sketch;
 

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -1,6 +1,7 @@
 use crate::{
-    objects::{Face, Sketch},
+    objects::{Face, Objects, Sketch},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Sketch`]
@@ -12,4 +13,9 @@ pub struct PartialSketch {
 
 impl PartialObject for PartialSketch {
     type Full = Sketch;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let faces = self.faces.into_iter().map(|face| face.build(objects));
+        Sketch::new(faces)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
-///
-/// [`Sketch`]: crate::objects::Sketch
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Face, Objects, Sketch},
-    partial2::{Partial, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -20,6 +20,16 @@ impl PartialSketch {
 
 impl PartialObject for PartialSketch {
     type Full = Sketch;
+
+    fn from_full(sketch: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            sketch
+                .faces()
+                .into_iter()
+                .map(|face| Partial::from_full(face.clone(), cache))
+                .collect(),
+        )
+    }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let faces = self.faces.into_iter().map(|face| face.build(objects));

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -1,4 +1,9 @@
+use crate::{objects::Face, partial2::Partial};
+
 /// A partial [`Sketch`]
 ///
 /// [`Sketch`]: crate::objects::Sketch
-pub struct PartialSketch;
+pub struct PartialSketch {
+    /// The faces that make up the sketch
+    pub faces: Vec<Partial<Face>>,
+}

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -1,4 +1,7 @@
-use crate::{objects::Face, partial2::Partial};
+use crate::{
+    objects::{Face, Sketch},
+    partial2::{Partial, PartialObject},
+};
 
 /// A partial [`Sketch`]
 ///
@@ -6,4 +9,8 @@ use crate::{objects::Face, partial2::Partial};
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,
+}
+
+impl PartialObject for PartialSketch {
+    type Full = Sketch;
 }

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
+#[derive(Clone)]
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -1,0 +1,4 @@
+/// A partial [`Sketch`]
+///
+/// [`Sketch`]: crate::objects::Sketch
+pub struct PartialSketch;

--- a/crates/fj-kernel/src/partial2/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial2/objects/sketch.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,
@@ -24,5 +24,11 @@ impl PartialObject for PartialSketch {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let faces = self.faces.into_iter().map(|face| face.build(objects));
         Sketch::new(faces)
+    }
+}
+
+impl Default for PartialSketch {
+    fn default() -> Self {
+        Self::new(Vec::new())
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -1,6 +1,7 @@
 use crate::{
-    objects::{Shell, Solid},
+    objects::{Objects, Shell, Solid},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Solid`]
@@ -12,4 +13,9 @@ pub struct PartialSolid {
 
 impl PartialObject for PartialSolid {
     type Full = Solid;
+
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let shells = self.shells.into_iter().map(|shell| shell.build(objects));
+        Solid::new(shells)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -1,0 +1,4 @@
+/// A partial [`Solid`]
+///
+/// [`Solid`]: crate::objects::Solid
+pub struct PartialSolid;

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -1,4 +1,9 @@
+use crate::{objects::Shell, partial2::Partial};
+
 /// A partial [`Solid`]
 ///
 /// [`Solid`]: crate::objects::Solid
-pub struct PartialSolid;
+pub struct PartialSolid {
+    /// The shells that make up the solid
+    pub shells: Vec<Partial<Shell>>,
+}

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 /// A partial [`Solid`]
-///
-/// [`Solid`]: crate::objects::Solid
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Objects, Shell, Solid},
-    partial2::{Partial, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -20,6 +20,15 @@ impl PartialSolid {
 
 impl PartialObject for PartialSolid {
     type Full = Solid;
+
+    fn from_full(solid: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            solid
+                .shells()
+                .map(|shell| Partial::from_full(shell.clone(), cache))
+                .collect(),
+        )
+    }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let shells = self.shells.into_iter().map(|shell| shell.build(objects));

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Solid`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 /// A partial [`Solid`]
+#[derive(Clone)]
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A partial [`Solid`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -1,4 +1,7 @@
-use crate::{objects::Shell, partial2::Partial};
+use crate::{
+    objects::{Shell, Solid},
+    partial2::{Partial, PartialObject},
+};
 
 /// A partial [`Solid`]
 ///
@@ -6,4 +9,8 @@ use crate::{objects::Shell, partial2::Partial};
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,
+}
+
+impl PartialObject for PartialSolid {
+    type Full = Solid;
 }

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Solid`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,
@@ -24,5 +24,11 @@ impl PartialObject for PartialSolid {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let shells = self.shells.into_iter().map(|shell| shell.build(objects));
         Solid::new(shells)
+    }
+}
+
+impl Default for PartialSolid {
+    fn default() -> Self {
+        Self::new(Vec::new())
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/solid.rs
+++ b/crates/fj-kernel/src/partial2/objects/solid.rs
@@ -11,6 +11,13 @@ pub struct PartialSolid {
     pub shells: Vec<Partial<Shell>>,
 }
 
+impl PartialSolid {
+    /// Construct an instance of `PartialSolid`
+    pub fn new(shells: Vec<Partial<Shell>>) -> Self {
+        Self { shells }
+    }
+}
+
 impl PartialObject for PartialSolid {
     type Full = Solid;
 

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -4,8 +4,6 @@ use crate::{
 };
 
 /// A partial [`Surface`]
-///
-/// [`Surface`]: crate::objects::Surface
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Surface`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 /// A partial [`Surface`]
+#[derive(Clone)]
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -1,4 +1,7 @@
-use crate::geometry::surface::SurfaceGeometry;
+use crate::{
+    geometry::surface::SurfaceGeometry, objects::Surface,
+    partial2::PartialObject,
+};
 
 /// A partial [`Surface`]
 ///
@@ -6,4 +9,8 @@ use crate::geometry::surface::SurfaceGeometry;
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,
+}
+
+impl PartialObject for PartialSurface {
+    type Full = Surface;
 }

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -1,4 +1,9 @@
+use crate::geometry::surface::SurfaceGeometry;
+
 /// A partial [`Surface`]
 ///
 /// [`Surface`]: crate::objects::Surface
-pub struct PartialSurface;
+pub struct PartialSurface {
+    /// The surface's geometry
+    pub geometry: Option<SurfaceGeometry>,
+}

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -1,6 +1,8 @@
 use crate::{
-    geometry::surface::SurfaceGeometry, objects::Surface,
+    geometry::surface::SurfaceGeometry,
+    objects::{Objects, Surface},
     partial2::PartialObject,
+    services::Service,
 };
 
 /// A partial [`Surface`]
@@ -12,4 +14,12 @@ pub struct PartialSurface {
 
 impl PartialObject for PartialSurface {
     type Full = Surface;
+
+    fn build(self, _: &mut Service<Objects>) -> Self::Full {
+        let geometry = self
+            .geometry
+            .expect("Can't build `Surface` without geometry");
+
+        Surface::new(geometry)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A partial [`Surface`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -1,7 +1,7 @@
 use crate::{
     geometry::surface::SurfaceGeometry,
     objects::{Objects, Surface},
-    partial2::PartialObject,
+    partial2::{FullToPartialCache, PartialObject},
     services::Service,
 };
 
@@ -21,6 +21,10 @@ impl PartialSurface {
 
 impl PartialObject for PartialSurface {
     type Full = Surface;
+
+    fn from_full(surface: &Self::Full, _: &mut FullToPartialCache) -> Self {
+        Self::new(Some(surface.geometry()))
+    }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
         let geometry = self

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -12,6 +12,13 @@ pub struct PartialSurface {
     pub geometry: Option<SurfaceGeometry>,
 }
 
+impl PartialSurface {
+    /// Construct an instance of `PartialSurface`
+    pub fn new(geometry: Option<SurfaceGeometry>) -> Self {
+        Self { geometry }
+    }
+}
+
 impl PartialObject for PartialSurface {
     type Full = Surface;
 

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Surface`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,
@@ -28,5 +28,11 @@ impl PartialObject for PartialSurface {
             .expect("Can't build `Surface` without geometry");
 
         Surface::new(geometry)
+    }
+}
+
+impl Default for PartialSurface {
+    fn default() -> Self {
+        Self::new(None)
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/surface.rs
+++ b/crates/fj-kernel/src/partial2/objects/surface.rs
@@ -1,0 +1,4 @@
+/// A partial [`Surface`]
+///
+/// [`Surface`]: crate::objects::Surface
+pub struct PartialSurface;

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -1,14 +1,42 @@
+use fj_math::Point;
+
+use crate::{
+    objects::{Curve, GlobalVertex, Surface, SurfaceVertex},
+    partial2::Partial,
+};
+
 /// A partial [`Vertex`]
 ///
 /// [`Vertex`]: crate::objects::Vertex
-pub struct PartialVertex;
+pub struct PartialVertex {
+    /// The position of the vertex on the curve
+    pub position: Option<Point<1>>,
+
+    /// The curve that the vertex is defined in
+    pub curve: Partial<Curve>,
+
+    /// The surface form of the vertex
+    pub surface_form: Partial<SurfaceVertex>,
+}
 
 /// A partial [`SurfaceVertex`]
 ///
 /// [`SurfaceVertex`]: crate::objects::SurfaceVertex
-pub struct PartialSurfaceVertex;
+pub struct PartialSurfaceVertex {
+    /// The position of the vertex on the surface
+    pub position: Option<Point<2>>,
+
+    /// The surface that the vertex is defined in
+    pub surface: Partial<Surface>,
+
+    /// The global form of the vertex
+    pub global_form: Partial<GlobalVertex>,
+}
 
 /// A partial [`GlobalVertex`]
 ///
 /// [`GlobalVertex`]: crate::objects::GlobalVertex
-pub struct PartialGlobalVertex;
+pub struct PartialGlobalVertex {
+    /// The position of the vertex
+    pub position: Option<Point<3>>,
+}

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -22,8 +22,25 @@ impl PartialObject for PartialVertex {
     type Full = Vertex;
 }
 
+impl Default for PartialVertex {
+    fn default() -> Self {
+        let mut curve = Partial::<Curve>::new();
+        let mut surface_form = Partial::<SurfaceVertex>::new();
+
+        let surface = Partial::new();
+        curve.write().surface = surface.clone();
+        surface_form.write().surface = surface;
+
+        Self {
+            position: None,
+            curve,
+            surface_form,
+        }
+    }
+}
+
 /// A partial [`SurfaceVertex`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
@@ -40,7 +57,7 @@ impl PartialObject for PartialSurfaceVertex {
 }
 
 /// A partial [`GlobalVertex`]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -1,0 +1,14 @@
+/// A partial [`Vertex`]
+///
+/// [`Vertex`]: crate::objects::Vertex
+pub struct PartialVertex;
+
+/// A partial [`SurfaceVertex`]
+///
+/// [`SurfaceVertex`]: crate::objects::SurfaceVertex
+pub struct PartialSurfaceVertex;
+
+/// A partial [`GlobalVertex`]
+///
+/// [`GlobalVertex`]: crate::objects::GlobalVertex
+pub struct PartialGlobalVertex;

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 
 /// A partial [`Vertex`]
-///
-/// [`Vertex`]: crate::objects::Vertex
 pub struct PartialVertex {
     /// The position of the vertex on the curve
     pub position: Option<Point<1>>,
@@ -24,8 +22,6 @@ impl PartialObject for PartialVertex {
 }
 
 /// A partial [`SurfaceVertex`]
-///
-/// [`SurfaceVertex`]: crate::objects::SurfaceVertex
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
@@ -42,8 +38,6 @@ impl PartialObject for PartialSurfaceVertex {
 }
 
 /// A partial [`GlobalVertex`]
-///
-/// [`GlobalVertex`]: crate::objects::GlobalVertex
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -19,6 +19,28 @@ pub struct PartialVertex {
     pub surface_form: Partial<SurfaceVertex>,
 }
 
+impl PartialVertex {
+    /// Construct an instance of `PartialVertex`
+    pub fn new(
+        position: Option<Point<1>>,
+        curve: Option<Partial<Curve>>,
+        surface_form: Option<Partial<SurfaceVertex>>,
+    ) -> Self {
+        let mut curve = curve.unwrap_or_default();
+        let mut surface_form = surface_form.unwrap_or_default();
+
+        let surface = Partial::new();
+        curve.write().surface = surface.clone();
+        surface_form.write().surface = surface;
+
+        Self {
+            position,
+            curve,
+            surface_form,
+        }
+    }
+}
+
 impl PartialObject for PartialVertex {
     type Full = Vertex;
 
@@ -42,18 +64,7 @@ impl PartialObject for PartialVertex {
 
 impl Default for PartialVertex {
     fn default() -> Self {
-        let mut curve = Partial::<Curve>::new();
-        let mut surface_form = Partial::<SurfaceVertex>::new();
-
-        let surface = Partial::new();
-        curve.write().surface = surface.clone();
-        surface_form.write().surface = surface;
-
-        Self {
-            position: None,
-            curve,
-            surface_form,
-        }
+        Self::new(None, None, None)
     }
 }
 
@@ -68,6 +79,24 @@ pub struct PartialSurfaceVertex {
 
     /// The global form of the vertex
     pub global_form: Partial<GlobalVertex>,
+}
+
+impl PartialSurfaceVertex {
+    /// Construct an instance of `PartialSurfaceVertex`
+    pub fn new(
+        position: Option<Point<2>>,
+        surface: Option<Partial<Surface>>,
+        global_form: Option<Partial<GlobalVertex>>,
+    ) -> Self {
+        let surface = surface.unwrap_or_default();
+        let global_form = global_form.unwrap_or_default();
+
+        Self {
+            position,
+            surface,
+            global_form,
+        }
+    }
 }
 
 impl PartialObject for PartialSurfaceVertex {
@@ -96,6 +125,13 @@ impl PartialObject for PartialSurfaceVertex {
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,
+}
+
+impl PartialGlobalVertex {
+    /// Construct an instance of `PartialGlobalVertex`
+    pub fn new(position: Option<Point<3>>) -> Self {
+        Self { position }
+    }
 }
 
 impl PartialObject for PartialGlobalVertex {

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -69,7 +69,7 @@ impl Default for PartialVertex {
 }
 
 /// A partial [`SurfaceVertex`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
@@ -120,8 +120,14 @@ impl PartialObject for PartialSurfaceVertex {
     }
 }
 
+impl Default for PartialSurfaceVertex {
+    fn default() -> Self {
+        Self::new(None, None, None)
+    }
+}
+
 /// A partial [`GlobalVertex`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,
@@ -143,5 +149,11 @@ impl PartialObject for PartialGlobalVertex {
             .expect("Can't build `GlobalVertex` without position");
 
         GlobalVertex::new(position)
+    }
+}
+
+impl Default for PartialGlobalVertex {
+    fn default() -> Self {
+        Self::new(None)
     }
 }

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -1,8 +1,8 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Curve, GlobalVertex, Surface, SurfaceVertex},
-    partial2::Partial,
+    objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex},
+    partial2::{Partial, PartialObject},
 };
 
 /// A partial [`Vertex`]
@@ -19,6 +19,10 @@ pub struct PartialVertex {
     pub surface_form: Partial<SurfaceVertex>,
 }
 
+impl PartialObject for PartialVertex {
+    type Full = Vertex;
+}
+
 /// A partial [`SurfaceVertex`]
 ///
 /// [`SurfaceVertex`]: crate::objects::SurfaceVertex
@@ -33,10 +37,18 @@ pub struct PartialSurfaceVertex {
     pub global_form: Partial<GlobalVertex>,
 }
 
+impl PartialObject for PartialSurfaceVertex {
+    type Full = SurfaceVertex;
+}
+
 /// A partial [`GlobalVertex`]
 ///
 /// [`GlobalVertex`]: crate::objects::GlobalVertex
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,
+}
+
+impl PartialObject for PartialGlobalVertex {
+    type Full = GlobalVertex;
 }

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A partial [`Vertex`]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PartialVertex {
     /// The position of the vertex on the curve
     pub position: Option<Point<1>>,
@@ -58,7 +58,7 @@ impl Default for PartialVertex {
 }
 
 /// A partial [`SurfaceVertex`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
@@ -92,7 +92,7 @@ impl PartialObject for PartialSurfaceVertex {
 }
 
 /// A partial [`GlobalVertex`]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 /// A partial [`Vertex`]
+#[derive(Clone)]
 pub struct PartialVertex {
     /// The position of the vertex on the curve
     pub position: Option<Point<1>>,
@@ -22,6 +23,7 @@ impl PartialObject for PartialVertex {
 }
 
 /// A partial [`SurfaceVertex`]
+#[derive(Clone)]
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
@@ -38,6 +40,7 @@ impl PartialObject for PartialSurfaceVertex {
 }
 
 /// A partial [`GlobalVertex`]
+#[derive(Clone)]
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -1,8 +1,9 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Curve, GlobalVertex, Surface, SurfaceVertex, Vertex},
+    objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
     partial2::{Partial, PartialObject},
+    services::Service,
 };
 
 /// A partial [`Vertex`]
@@ -20,6 +21,23 @@ pub struct PartialVertex {
 
 impl PartialObject for PartialVertex {
     type Full = Vertex;
+
+    fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
+        let position = self
+            .position
+            .expect("Can't build `Vertex` without position");
+        let curve = self.curve.build(objects);
+
+        // Infer surface position, if not available.
+        if self.surface_form.read().position.is_none() {
+            self.surface_form.write().position =
+                Some(curve.path().point_from_path_coords(position));
+        }
+
+        let surface_form = self.surface_form.build(objects);
+
+        Vertex::new(position, curve, surface_form)
+    }
 }
 
 impl Default for PartialVertex {
@@ -54,6 +72,23 @@ pub struct PartialSurfaceVertex {
 
 impl PartialObject for PartialSurfaceVertex {
     type Full = SurfaceVertex;
+
+    fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
+        let position = self
+            .position
+            .expect("Can't build `SurfaceVertex` without position");
+        let surface = self.surface.build(objects);
+
+        // Infer global position, if not available.
+        if self.global_form.read().position.is_none() {
+            self.global_form.write().position =
+                Some(surface.geometry().point_from_surface_coords(position));
+        }
+
+        let global_form = self.global_form.build(objects);
+
+        SurfaceVertex::new(position, surface, global_form)
+    }
 }
 
 /// A partial [`GlobalVertex`]
@@ -65,4 +100,12 @@ pub struct PartialGlobalVertex {
 
 impl PartialObject for PartialGlobalVertex {
     type Full = GlobalVertex;
+
+    fn build(self, _: &mut Service<Objects>) -> Self::Full {
+        let position = self
+            .position
+            .expect("Can't build `GlobalVertex` without position");
+
+        GlobalVertex::new(position)
+    }
 }

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
-    partial2::{Partial, PartialCurve, PartialObject},
+    partial2::{FullToPartialCache, Partial, PartialCurve, PartialObject},
     services::Service,
 };
 
@@ -53,6 +53,14 @@ impl PartialVertex {
 
 impl PartialObject for PartialVertex {
     type Full = Vertex;
+
+    fn from_full(vertex: &Self::Full, cache: &mut FullToPartialCache) -> Self {
+        Self::new(
+            Some(vertex.position()),
+            Some(Partial::from_full(vertex.curve().clone(), cache)),
+            Some(Partial::from_full(vertex.surface_form().clone(), cache)),
+        )
+    }
 
     fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
         let position = self
@@ -112,6 +120,20 @@ impl PartialSurfaceVertex {
 impl PartialObject for PartialSurfaceVertex {
     type Full = SurfaceVertex;
 
+    fn from_full(
+        surface_vertex: &Self::Full,
+        cache: &mut FullToPartialCache,
+    ) -> Self {
+        Self::new(
+            Some(surface_vertex.position()),
+            Some(Partial::from_full(surface_vertex.surface().clone(), cache)),
+            Some(Partial::from_full(
+                surface_vertex.global_form().clone(),
+                cache,
+            )),
+        )
+    }
+
     fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
         let position = self
             .position
@@ -152,6 +174,13 @@ impl PartialGlobalVertex {
 
 impl PartialObject for PartialGlobalVertex {
     type Full = GlobalVertex;
+
+    fn from_full(
+        global_vertex: &Self::Full,
+        _: &mut FullToPartialCache,
+    ) -> Self {
+        Self::new(Some(global_vertex.position()))
+    }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
         let position = self

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
-    partial2::{Partial, PartialObject},
+    partial2::{Partial, PartialCurve, PartialObject},
     services::Service,
 };
 
@@ -26,12 +26,22 @@ impl PartialVertex {
         curve: Option<Partial<Curve>>,
         surface_form: Option<Partial<SurfaceVertex>>,
     ) -> Self {
-        let mut curve = curve.unwrap_or_default();
-        let mut surface_form = surface_form.unwrap_or_default();
-
         let surface = Partial::new();
-        curve.write().surface = surface.clone();
-        surface_form.write().surface = surface;
+
+        let curve = curve.unwrap_or_else(|| {
+            Partial::from_partial(PartialCurve::new(
+                None,
+                Some(surface.clone()),
+                None,
+            ))
+        });
+        let surface_form = surface_form.unwrap_or_else(|| {
+            Partial::from_partial(PartialSurfaceVertex::new(
+                None,
+                Some(surface),
+                None,
+            ))
+        });
 
         Self {
             position,

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::{objects::Objects, services::Service};
 
 /// Implemented for objects that a partial object variant exists for
@@ -7,7 +9,7 @@ pub trait HasPartial {
 }
 
 /// Implemented for partial objects
-pub trait PartialObject: Clone + Default {
+pub trait PartialObject: Clone + Debug + Default {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
 

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -5,7 +5,7 @@ pub trait HasPartial {
 }
 
 /// Implemented for partial objects
-pub trait PartialObject: Clone {
+pub trait PartialObject: Clone + Default {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
 }

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -1,3 +1,5 @@
+use crate::{objects::Objects, services::Service};
+
 /// Implemented for objects that a partial object variant exists for
 pub trait HasPartial {
     /// The type representing the partial variant of this object
@@ -8,6 +10,9 @@ pub trait HasPartial {
 pub trait PartialObject: Clone + Default {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
+
+    /// Build a full object from the partial object
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full;
 }
 
 macro_rules! impl_trait {

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -5,7 +5,7 @@ pub trait HasPartial {
 }
 
 /// Implemented for partial objects
-pub trait PartialObject {
+pub trait PartialObject: Clone {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
 }

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -1,7 +1,13 @@
 /// Implemented for objects that a partial object variant exists for
 pub trait HasPartial {
     /// The type representing the partial variant of this object
-    type Partial;
+    type Partial: PartialObject<Full = Self>;
+}
+
+/// Implemented for partial objects
+pub trait PartialObject {
+    /// The type representing the full object
+    type Full: HasPartial<Partial = Self>;
 }
 
 macro_rules! impl_trait {

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -1,0 +1,31 @@
+/// Implemented for objects that a partial object variant exists for
+pub trait HasPartial {
+    /// The type representing the partial variant of this object
+    type Partial;
+}
+
+macro_rules! impl_trait {
+    ($($full:ident, $partial:ident;)*) => {
+        $(
+            impl HasPartial for crate::objects::$full {
+                type Partial = super::$partial;
+            }
+        )*
+    };
+}
+
+impl_trait!(
+    Curve, PartialCurve;
+    Cycle, PartialCycle;
+    Face, PartialFace;
+    GlobalCurve, PartialGlobalCurve;
+    GlobalEdge, PartialGlobalEdge;
+    GlobalVertex, PartialGlobalVertex;
+    HalfEdge, PartialHalfEdge;
+    Shell, PartialShell;
+    Sketch, PartialSketch;
+    Solid, PartialSolid;
+    Surface, PartialSurface;
+    SurfaceVertex, PartialSurfaceVertex;
+    Vertex, PartialVertex;
+);

--- a/crates/fj-kernel/src/partial2/traits.rs
+++ b/crates/fj-kernel/src/partial2/traits.rs
@@ -2,6 +2,8 @@ use std::fmt::Debug;
 
 use crate::{objects::Objects, services::Service};
 
+use super::FullToPartialCache;
+
 /// Implemented for objects that a partial object variant exists for
 pub trait HasPartial {
     /// The type representing the partial variant of this object
@@ -12,6 +14,9 @@ pub trait HasPartial {
 pub trait PartialObject: Clone + Debug + Default {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
+
+    /// Construct a partial object from a full one
+    fn from_full(full: &Self::Full, cache: &mut FullToPartialCache) -> Self;
 
     /// Build a full object from the partial object
     fn build(self, objects: &mut Service<Objects>) -> Self::Full;

--- a/crates/fj-kernel/src/partial2/wrapper.rs
+++ b/crates/fj-kernel/src/partial2/wrapper.rs
@@ -60,6 +60,17 @@ impl<T: HasPartial + 'static> Partial<T> {
         Self { inner }
     }
 
+    /// Construct a partial from the entry point to an object graph
+    ///
+    /// This is a convenience wrapper around [`Self::from_full`], passing an
+    /// empty cache to that method. It it not appropriate to call this method,
+    /// unless to start a conversion of an object graph by passing its entry
+    /// point.
+    pub fn from_full_entry_point(full: Handle<T>) -> Self {
+        let mut cache = FullToPartialCache::default();
+        Self::from_full(full, &mut cache)
+    }
+
     /// Access the partial object
     pub fn read(&self) -> impl Deref<Target = T::Partial> + '_ {
         RwLockReadGuard::map(self.inner.read(), |inner| &inner.partial)

--- a/crates/fj-kernel/src/partial2/wrapper.rs
+++ b/crates/fj-kernel/src/partial2/wrapper.rs
@@ -71,6 +71,11 @@ impl<T: HasPartial + 'static> Partial<T> {
         Self::from_full(full, &mut cache)
     }
 
+    /// Access the ID of this partial object
+    pub fn id(&self) -> ObjectId {
+        self.inner.id()
+    }
+
     /// Access the partial object
     pub fn read(&self) -> impl Deref<Target = T::Partial> + '_ {
         RwLockReadGuard::map(self.inner.read(), |inner| &inner.partial)
@@ -134,6 +139,10 @@ struct Inner<T: HasPartial>(Arc<RwLock<InnerObject<T>>>);
 impl<T: HasPartial> Inner<T> {
     fn new(inner: InnerObject<T>) -> Self {
         Self(Arc::new(RwLock::new(inner)))
+    }
+
+    fn id(&self) -> ObjectId {
+        ObjectId::from_ptr(Arc::as_ptr(&self.0))
     }
 
     fn read(&self) -> RwLockReadGuard<InnerObject<T>> {

--- a/crates/fj-kernel/src/partial2/wrapper.rs
+++ b/crates/fj-kernel/src/partial2/wrapper.rs
@@ -16,6 +16,7 @@ use super::HasPartial;
 ///
 /// Controls access to the partial object. Can be cloned, to access the same
 /// partial object from multiple locations.
+#[derive(Debug)]
 pub struct Partial<T: HasPartial> {
     inner: Inner<T>,
 }
@@ -86,6 +87,7 @@ impl<T: HasPartial> Default for Partial<T> {
     }
 }
 
+#[derive(Debug)]
 struct Inner<T: HasPartial>(Arc<RwLock<InnerObject<T>>>);
 
 impl<T: HasPartial> Inner<T> {
@@ -110,6 +112,7 @@ impl<T: HasPartial> Clone for Inner<T> {
     }
 }
 
+#[derive(Debug)]
 struct InnerObject<T: HasPartial> {
     partial: T::Partial,
     full: Option<Handle<T>>,

--- a/crates/fj-kernel/src/partial2/wrapper.rs
+++ b/crates/fj-kernel/src/partial2/wrapper.rs
@@ -1,0 +1,75 @@
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use super::HasPartial;
+
+/// Wrapper around a partial object
+///
+/// Controls access to the partial object. Can be cloned, to access the same
+/// partial object from multiple locations.
+pub struct Partial<T: HasPartial> {
+    inner: Inner<T>,
+}
+
+impl<T: HasPartial> Partial<T> {
+    /// Construct a `Partial` from a partial object
+    pub fn from_partial(partial: T::Partial) -> Self {
+        let inner = Inner::new(InnerObject { partial });
+        Self { inner }
+    }
+
+    /// Access the partial object
+    pub fn read(&self) -> impl Deref<Target = T::Partial> + '_ {
+        RwLockReadGuard::map(self.inner.read(), |inner| &inner.partial)
+    }
+
+    /// Access the partial object mutably
+    ///
+    /// # Panics
+    ///
+    /// Panics, if this method is called while the return value from a previous
+    /// call is still borrowed.
+    pub fn write(&mut self) -> impl DerefMut<Target = T::Partial> + '_ {
+        RwLockWriteGuard::map(self.inner.write(), |inner| &mut inner.partial)
+    }
+}
+
+impl<T: HasPartial> Clone for Partial<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+struct Inner<T: HasPartial>(Arc<RwLock<InnerObject<T>>>);
+
+impl<T: HasPartial> Inner<T> {
+    fn new(inner: InnerObject<T>) -> Self {
+        Self(Arc::new(RwLock::new(inner)))
+    }
+
+    fn read(&self) -> RwLockReadGuard<InnerObject<T>> {
+        self.0.read()
+    }
+
+    fn write(&self) -> RwLockWriteGuard<InnerObject<T>> {
+        self.0
+            .try_write()
+            .expect("Tried to modify `Partial` that is already being modified")
+    }
+}
+
+impl<T: HasPartial> Clone for Inner<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+struct InnerObject<T: HasPartial> {
+    partial: T::Partial,
+}

--- a/crates/fj-kernel/src/partial2/wrapper.rs
+++ b/crates/fj-kernel/src/partial2/wrapper.rs
@@ -16,6 +16,11 @@ pub struct Partial<T: HasPartial> {
 }
 
 impl<T: HasPartial> Partial<T> {
+    /// Construct a `Partial` with a default inner partial object
+    pub fn new() -> Self {
+        Self::from_partial(T::Partial::default())
+    }
+
     /// Construct a `Partial` from a partial object
     pub fn from_partial(partial: T::Partial) -> Self {
         let inner = Inner::new(InnerObject { partial });
@@ -43,6 +48,12 @@ impl<T: HasPartial> Clone for Partial<T> {
         Self {
             inner: self.inner.clone(),
         }
+    }
+}
+
+impl<T: HasPartial> Default for Partial<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -30,7 +30,7 @@ pub struct Handle<T> {
 impl<T> Handle<T> {
     /// Access this pointer's unique id
     pub fn id(&self) -> ObjectId {
-        ObjectId(self.ptr as u64)
+        ObjectId::from_ptr(self.ptr)
     }
 
     /// Return a clone of the object this handle refers to
@@ -169,6 +169,12 @@ unsafe impl<T> Sync for Handle<T> {}
 /// See [`Handle::id`].
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct ObjectId(u64);
+
+impl ObjectId {
+    pub(crate) fn from_ptr<T>(ptr: *const T) -> ObjectId {
+        Self(ptr as u64)
+    }
+}
 
 impl fmt::Debug for ObjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This is a completely new partial object API, meant to replace the old one. The goal is to fully address #1249.

The core innovation of this API, compared to the old one, is that there is a notion of object identity which parallels the same notion that exists with full objects. Thanks to this, a partial object graph can directly map to the full object graph that is constructed from it. This removes the need for complicated build code, which the old API uses to make sure that the full object graph being built is connected correctly. With this new API, objects can be connected correctly from the start, and this is carried through the complete construction process.

The new API is not complete yet, but the design is there and has been partially proven. So far, it is clear that the design works in principle, and that the new approach is capable of delivering at least some simplifications. I will submit the branch where I've done this work after this pull request is merged.

What is not proven yet, is that this new design is indeed capable of taking care of #1249 completely. So far, I haven't seen any evidence to the contrary though, and I remain optimistic.

This pull request is only the start. It adds the new infrastructure, but the work to replace the old partial object API is not included.