### PR TITLE
Continue replacing old partial object API with new one

### DIFF
--- a/crates/fj-interop/src/ext.rs
+++ b/crates/fj-interop/src/ext.rs
@@ -7,6 +7,11 @@ pub trait ArrayExt<T, const N: usize> {
     /// <https://doc.rust-lang.org/std/primitive.array.html#method.each_ref>
     fn each_ref_ext(&self) -> [&T; N];
 
+    /// Stable replacement for `each_mut`
+    ///
+    /// <https://doc.rust-lang.org/std/primitive.array.html#method.each_mut>
+    fn each_mut_ext(&mut self) -> [&mut T; N];
+
     /// Stable replacement for `try_map`
     ///
     /// <https://doc.rust-lang.org/std/primitive.array.html#method.try_map>
@@ -22,6 +27,11 @@ pub trait ArrayExt<T, const N: usize> {
 
 impl<T> ArrayExt<T, 2> for [T; 2] {
     fn each_ref_ext(&self) -> [&T; 2] {
+        let [a, b] = self;
+        [a, b]
+    }
+
+    fn each_mut_ext(&mut self) -> [&mut T; 2] {
         let [a, b] = self;
         [a, b]
     }
@@ -43,6 +53,11 @@ impl<T> ArrayExt<T, 2> for [T; 2] {
 
 impl<T> ArrayExt<T, 4> for [T; 4] {
     fn each_ref_ext(&self) -> [&T; 4] {
+        let [a, b, c, d] = self;
+        [a, b, c, d]
+    }
+
+    fn each_mut_ext(&mut self) -> [&mut T; 4] {
         let [a, b, c, d] = self;
         [a, b, c, d]
     }

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -72,12 +72,15 @@ impl CurveEdgeIntersection {
 
 #[cfg(test)]
 mod tests {
+    use std::array;
+
+    use fj_interop::ext::ArrayExt;
     use fj_math::Point;
 
     use crate::{
         builder::{CurveBuilder, HalfEdgeBuilder},
-        objects::HalfEdge,
-        partial::HasPartial,
+        objects::Vertex,
+        partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
         partial2::{Partial, PartialCurve, PartialObject},
         services::Services,
     };
@@ -97,9 +100,31 @@ mod tests {
         };
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
-        let half_edge = HalfEdge::partial()
-            .update_as_line_segment_from_points(surface, [[1., -1.], [1., 1.]])
-            .build(&mut services.objects);
+        let half_edge = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    surface,
+                    [[1., -1.], [1., 1.]],
+                )
+                .build(&mut services.objects)
+        };
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -124,12 +149,31 @@ mod tests {
         };
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
-        let half_edge = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                surface,
-                [[-1., -1.], [-1., 1.]],
-            )
-            .build(&mut services.objects);
+        let half_edge = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    surface,
+                    [[-1., -1.], [-1., 1.]],
+                )
+                .build(&mut services.objects)
+        };
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -154,12 +198,31 @@ mod tests {
         };
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
-        let half_edge = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                surface,
-                [[-1., -1.], [1., -1.]],
-            )
-            .build(&mut services.objects);
+        let half_edge = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    surface,
+                    [[-1., -1.], [1., -1.]],
+                )
+                .build(&mut services.objects)
+        };
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -179,9 +242,31 @@ mod tests {
         };
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
-        let half_edge = HalfEdge::partial()
-            .update_as_line_segment_from_points(surface, [[-1., 0.], [1., 0.]])
-            .build(&mut services.objects);
+        let half_edge = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    surface,
+                    [[-1., 0.], [1., 0.]],
+                )
+                .build(&mut services.objects)
+        };
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -80,8 +80,8 @@ mod tests {
     use crate::{
         builder::{CurveBuilder, HalfEdgeBuilder},
         objects::Vertex,
-        partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
-        partial2::{Partial, PartialCurve, PartialObject},
+        partial::PartialHalfEdge,
+        partial2::{Partial, PartialCurve, PartialGlobalEdge, PartialObject},
         services::Services,
     };
 
@@ -112,7 +112,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -161,7 +161,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -210,7 +210,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -254,7 +254,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -184,15 +184,19 @@ impl Sweep for (Handle<HalfEdge>, Color) {
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::mesh::Color;
+    use std::array;
+
+    use fj_interop::{ext::ArrayExt, mesh::Color};
     use pretty_assertions::assert_eq;
 
     use crate::{
         algorithms::{reverse::Reverse, sweep::Sweep},
         builder::HalfEdgeBuilder,
         insert::Insert,
-        objects::{Cycle, Face, HalfEdge},
-        partial::HasPartial,
+        objects::{Cycle, Face, Vertex},
+        partial::{
+            HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge,
+        },
         partial2::{
             Partial, PartialCurve, PartialSurfaceVertex, PartialVertex,
         },
@@ -203,15 +207,34 @@ mod tests {
     fn sweep() {
         let mut services = Services::new();
 
-        let half_edge = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
-                [[0., 0.], [1., 0.]],
-            )
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
+        let half_edge = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    Partial::from_full_entry_point(
+                        services.objects.surfaces.xy_plane(),
+                    ),
+                    [[0., 0.], [1., 0.]],
+                )
+                .build(&mut services.objects)
+                .insert(&mut services.objects)
+        };
 
         let face = (half_edge, Color::default())
             .sweep([0., 0., 1.], &mut services.objects);
@@ -221,17 +244,35 @@ mod tests {
                 services.objects.surfaces.xz_plane(),
             );
 
-            let bottom = HalfEdge::partial()
-                .update_as_line_segment_from_points(
-                    surface.clone(),
-                    [[0., 0.], [1., 0.]],
-                )
-                .build(&mut services.objects)
-                .insert(&mut services.objects);
+            let bottom = {
+                let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+                let global_curve = {
+                    let [vertex, _] = &vertices;
+                    vertex.read().curve.read().global_form.clone()
+                };
+                let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                    vertex.read().surface_form.read().global_form.clone()
+                });
+
+                let half_edge = PartialHalfEdge {
+                    vertices,
+                    global_form: MaybePartial::from(PartialGlobalEdge {
+                        curve: global_curve,
+                        vertices: global_vertices,
+                    }),
+                };
+
+                half_edge
+                    .update_as_line_segment_from_points(
+                        surface.clone(),
+                        [[0., 0.], [1., 0.]],
+                    )
+                    .build(&mut services.objects)
+                    .insert(&mut services.objects)
+            };
             let side_up = {
-                let side_up = HalfEdge::partial();
-                side_up
-                    .with_back_vertex(Partial::from_partial(PartialVertex {
+                let vertices = [
+                    PartialVertex {
                         curve: Partial::from_partial(PartialCurve {
                             surface: Partial::from_full_entry_point(
                                 bottom.front().surface_form().surface().clone(),
@@ -242,8 +283,8 @@ mod tests {
                             bottom.front().surface_form().clone(),
                         ),
                         ..Default::default()
-                    }))
-                    .with_front_vertex(Partial::from_partial(PartialVertex {
+                    },
+                    PartialVertex {
                         surface_form: Partial::from_partial(
                             PartialSurfaceVertex {
                                 position: Some([1., 1.].into()),
@@ -252,42 +293,86 @@ mod tests {
                             },
                         ),
                         ..Default::default()
-                    }))
+                    },
+                ]
+                .map(Partial::<Vertex>::from_partial);
+
+                let global_curve = {
+                    let [vertex, _] = &vertices;
+                    vertex.read().curve.read().global_form.clone()
+                };
+                let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                    vertex.read().surface_form.read().global_form.clone()
+                });
+
+                let side_up = PartialHalfEdge {
+                    vertices,
+                    global_form: MaybePartial::from(PartialGlobalEdge {
+                        curve: global_curve,
+                        vertices: global_vertices,
+                    }),
+                };
+
+                side_up
                     .update_as_line_segment()
                     .build(&mut services.objects)
                     .insert(&mut services.objects)
             };
             let top = {
-                let top = HalfEdge::partial();
-                top.with_back_vertex(Partial::from_partial(PartialVertex {
-                    curve: Partial::from_partial(PartialCurve {
-                        surface: Partial::from_full_entry_point(
-                            side_up.front().surface_form().surface().clone(),
+                let vertices = [
+                    PartialVertex {
+                        curve: Partial::from_partial(PartialCurve {
+                            surface: Partial::from_full_entry_point(
+                                side_up
+                                    .front()
+                                    .surface_form()
+                                    .surface()
+                                    .clone(),
+                            ),
+                            ..Default::default()
+                        }),
+                        surface_form: Partial::from_partial(
+                            PartialSurfaceVertex {
+                                position: Some([0., 1.].into()),
+                                surface,
+                                ..Default::default()
+                            },
                         ),
                         ..Default::default()
-                    }),
-                    surface_form: Partial::from_partial(PartialSurfaceVertex {
-                        position: Some([0., 1.].into()),
-                        surface,
+                    },
+                    PartialVertex {
+                        surface_form: Partial::from_full_entry_point(
+                            side_up.front().surface_form().clone(),
+                        ),
                         ..Default::default()
+                    },
+                ]
+                .map(Partial::<Vertex>::from_partial);
+
+                let global_curve = {
+                    let [vertex, _] = &vertices;
+                    vertex.read().curve.read().global_form.clone()
+                };
+                let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                    vertex.read().surface_form.read().global_form.clone()
+                });
+
+                let top = PartialHalfEdge {
+                    vertices,
+                    global_form: MaybePartial::from(PartialGlobalEdge {
+                        curve: global_curve,
+                        vertices: global_vertices,
                     }),
-                    ..Default::default()
-                }))
-                .with_front_vertex(Partial::from_partial(PartialVertex {
-                    surface_form: Partial::from_full_entry_point(
-                        side_up.front().surface_form().clone(),
-                    ),
-                    ..Default::default()
-                }))
-                .update_as_line_segment()
-                .build(&mut services.objects)
-                .insert(&mut services.objects)
-                .reverse(&mut services.objects)
+                };
+
+                top.update_as_line_segment()
+                    .build(&mut services.objects)
+                    .insert(&mut services.objects)
+                    .reverse(&mut services.objects)
             };
             let side_down = {
-                let side_down = HalfEdge::partial();
-                side_down
-                    .with_back_vertex(Partial::from_partial(PartialVertex {
+                let vertices = [
+                    PartialVertex {
                         curve: Partial::from_partial(PartialCurve {
                             surface: Partial::from_full_entry_point(
                                 bottom.back().surface_form().surface().clone(),
@@ -298,13 +383,33 @@ mod tests {
                             bottom.back().surface_form().clone(),
                         ),
                         ..Default::default()
-                    }))
-                    .with_front_vertex(Partial::from_partial(PartialVertex {
+                    },
+                    PartialVertex {
                         surface_form: Partial::from_full_entry_point(
                             top.front().surface_form().clone(),
                         ),
                         ..Default::default()
-                    }))
+                    },
+                ]
+                .map(Partial::<Vertex>::from_partial);
+
+                let global_curve = {
+                    let [vertex, _] = &vertices;
+                    vertex.read().curve.read().global_form.clone()
+                };
+                let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                    vertex.read().surface_form.read().global_form.clone()
+                });
+
+                let side_down = PartialHalfEdge {
+                    vertices,
+                    global_form: MaybePartial::from(PartialGlobalEdge {
+                        curve: global_curve,
+                        vertices: global_vertices,
+                    }),
+                };
+
+                side_down
                     .update_as_line_segment()
                     .build(&mut services.objects)
                     .insert(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -194,11 +194,10 @@ mod tests {
         builder::HalfEdgeBuilder,
         insert::Insert,
         objects::{Cycle, Face, Vertex},
-        partial::{
-            HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge,
-        },
+        partial::{HasPartial, PartialHalfEdge},
         partial2::{
-            Partial, PartialCurve, PartialSurfaceVertex, PartialVertex,
+            Partial, PartialCurve, PartialGlobalEdge, PartialSurfaceVertex,
+            PartialVertex,
         },
         services::Services,
     };
@@ -219,7 +218,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -256,7 +255,7 @@ mod tests {
 
                 let half_edge = PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: global_curve,
                         vertices: global_vertices,
                     }),
@@ -307,7 +306,7 @@ mod tests {
 
                 let side_up = PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: global_curve,
                         vertices: global_vertices,
                     }),
@@ -359,7 +358,7 @@ mod tests {
 
                 let top = PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: global_curve,
                         vertices: global_vertices,
                     }),
@@ -403,7 +402,7 @@ mod tests {
 
                 let side_down = PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: global_curve,
                         vertices: global_vertices,
                     }),

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -92,10 +92,8 @@ mod tests {
         builder::{FaceBuilder, HalfEdgeBuilder},
         insert::Insert,
         objects::{Face, Sketch, Vertex},
-        partial::{
-            HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge,
-        },
-        partial2::Partial,
+        partial::{HasPartial, PartialHalfEdge},
+        partial2::{Partial, PartialGlobalEdge},
         services::Services,
     };
 
@@ -150,7 +148,7 @@ mod tests {
 
                 let half_edge = PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: global_curve,
                         vertices: global_vertices,
                     }),
@@ -218,7 +216,7 @@ mod tests {
 
                 let half_edge = PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: global_curve,
                         vertices: global_vertices,
                     }),

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -167,10 +167,10 @@ mod tests {
         builder::{CurveBuilder, HalfEdgeBuilder},
         insert::Insert,
         objects::Vertex,
-        partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
+        partial::PartialHalfEdge,
         partial2::{
-            Partial, PartialCurve, PartialObject, PartialSurfaceVertex,
-            PartialVertex,
+            Partial, PartialCurve, PartialGlobalEdge, PartialObject,
+            PartialSurfaceVertex, PartialVertex,
         },
         services::Services,
     };
@@ -214,7 +214,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -3,8 +3,11 @@ use fj_math::Point;
 
 use crate::{
     objects::{Curve, Surface, SurfaceVertex, Vertex},
-    partial::{MaybePartial, PartialCycle, PartialGlobalEdge, PartialHalfEdge},
-    partial2::{Partial, PartialCurve, PartialSurfaceVertex, PartialVertex},
+    partial::{PartialCycle, PartialHalfEdge},
+    partial2::{
+        Partial, PartialCurve, PartialGlobalEdge, PartialSurfaceVertex,
+        PartialVertex,
+    },
     storage::Handle,
 };
 
@@ -88,7 +91,7 @@ impl CycleBuilder for PartialCycle {
 
                 half_edges.push(PartialHalfEdge {
                     vertices,
-                    global_form: MaybePartial::from(PartialGlobalEdge {
+                    global_form: Partial::from_partial(PartialGlobalEdge {
                         curve: curve.read().global_form.clone(),
                         vertices: global_vertices,
                     }),
@@ -149,7 +152,7 @@ impl CycleBuilder for PartialCycle {
 
         let half_edge = PartialHalfEdge {
             vertices,
-            global_form: MaybePartial::from(PartialGlobalEdge {
+            global_form: Partial::from_partial(PartialGlobalEdge {
                 curve,
                 vertices: global_vertices,
             }),

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -120,22 +120,23 @@ impl CycleBuilder for PartialCycle {
         };
 
         let surface = self.surface().expect("Need surface to close cycle");
-
-        self.with_half_edges(Some(
-            PartialHalfEdge {
-                vertices: [last, first].map(|vertex| {
-                    Partial::from_partial(PartialVertex {
-                        curve: Partial::from_partial(PartialCurve {
-                            surface: surface.clone(),
-                            ..Default::default()
-                        }),
-                        surface_form: vertex.read().surface_form.clone(),
-                        ..Default::default()
-                    })
+        let vertices = [last, first].map(|vertex| {
+            Partial::from_partial(PartialVertex {
+                curve: Partial::from_partial(PartialCurve {
+                    surface: surface.clone(),
+                    ..Default::default()
                 }),
+                surface_form: vertex.read().surface_form.clone(),
                 ..Default::default()
-            }
-            .update_as_line_segment(),
-        ))
+            })
+        });
+
+        let half_edge = PartialHalfEdge {
+            vertices,
+            ..Default::default()
+        }
+        .update_as_line_segment();
+
+        self.with_half_edges(Some(half_edge))
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -71,15 +71,17 @@ impl CycleBuilder for PartialCycle {
                     .update_as_line_from_points([position_prev, position_next]);
 
                 let vertices = [(0., vertex_prev), (1., vertex_next)].map(
-                    |(position, surface_form)| PartialVertex {
-                        position: Some([position].into()),
-                        curve: curve.clone(),
-                        surface_form,
+                    |(position, surface_form)| {
+                        Partial::from_partial(PartialVertex {
+                            position: Some([position].into()),
+                            curve: curve.clone(),
+                            surface_form,
+                        })
                     },
                 );
 
                 half_edges.push(PartialHalfEdge {
-                    vertices: vertices.map(Partial::from_partial),
+                    vertices,
                     ..Default::default()
                 });
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -3,8 +3,8 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{Curve, Surface, Vertex},
-    partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
-    partial2::Partial,
+    partial::PartialHalfEdge,
+    partial2::{Partial, PartialGlobalEdge},
     storage::Handle,
 };
 
@@ -78,10 +78,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         }
 
         let global_vertex = surface_vertex.read().global_form.clone();
-        self.global_form = MaybePartial::from(PartialGlobalEdge {
-            vertices: [global_vertex.clone(), global_vertex],
-            ..self.global_form.into_partial()
-        });
+        self.global_form.write().vertices =
+            [global_vertex.clone(), global_vertex];
 
         self
     }
@@ -132,11 +130,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         self.vertices = [back, front];
 
+        self.global_form.write().curve = curve.read().global_form.clone();
+
         self
     }
 
     fn infer_global_form(mut self) -> Self {
-        self.global_form = PartialGlobalEdge::default().into();
+        self.global_form = Partial::new();
         self
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -3,7 +3,7 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{Curve, Surface, Vertex},
-    partial::{PartialGlobalEdge, PartialHalfEdge},
+    partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
     partial2::Partial,
     storage::Handle,
 };
@@ -76,6 +76,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             vertex.position = Some(point_curve);
             vertex.surface_form = surface_vertex.clone();
         }
+
+        let global_vertex = surface_vertex.read().global_form.clone();
+        self.global_form = MaybePartial::from(PartialGlobalEdge {
+            vertices: [global_vertex.clone(), global_vertex],
+            ..self.global_form.into_partial()
+        });
 
         self
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -2,10 +2,9 @@ use fj_interop::ext::ArrayExt;
 use fj_math::{Point, Scalar};
 
 use crate::{
-    objects::{Curve, Objects, Surface, Vertex},
+    objects::{Curve, Surface, Vertex},
     partial::{PartialGlobalEdge, PartialHalfEdge},
     partial2::Partial,
-    services::Service,
     storage::Handle,
 };
 
@@ -26,11 +25,7 @@ pub trait HalfEdgeBuilder: Sized {
     /// In principle, only the `build` method should take a reference to
     /// [`Objects`]. As of this writing, this method is the only one that
     /// deviates from that. I couldn't think of a way to do it better.
-    fn update_as_circle_from_radius(
-        self,
-        radius: impl Into<Scalar>,
-        objects: &mut Service<Objects>,
-    ) -> Self;
+    fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
 
     /// Update partial half-edge as a line segment, from the given points
     fn update_as_line_segment_from_points(
@@ -62,7 +57,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn update_as_circle_from_radius(
         mut self,
         radius: impl Into<Scalar>,
-        _: &mut Service<Objects>,
     ) -> Self {
         let mut curve = self.curve();
         curve.write().update_as_circle_from_radius(radius);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -108,24 +108,22 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         surface: Partial<Surface>,
         points: [impl Into<Point<2>>; 2],
     ) -> Self {
-        self.vertices =
-            self.vertices.zip_ext(points).map(|(mut vertex, point)| {
-                vertex.write().curve = {
-                    let curve = vertex.read().curve.read().clone();
-                    Partial::from_partial(PartialCurve {
-                        surface: surface.clone(),
-                        ..curve
-                    })
-                };
-                vertex.write().surface_form =
-                    Partial::from_partial(PartialSurfaceVertex {
-                        position: Some(point.into()),
-                        surface: surface.clone(),
-                        ..Default::default()
-                    });
+        for (vertex, point) in self.vertices.each_mut_ext().zip_ext(points) {
+            let mut vertex = vertex.write();
 
-                vertex
+            vertex.curve = {
+                let curve = vertex.curve.read().clone();
+                Partial::from_partial(PartialCurve {
+                    surface: surface.clone(),
+                    ..curve
+                })
+            };
+            vertex.surface_form = Partial::from_partial(PartialSurfaceVertex {
+                position: Some(point.into()),
+                surface: surface.clone(),
+                ..Default::default()
             });
+        }
 
         self.update_as_line_segment()
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -19,12 +19,6 @@ pub trait HalfEdgeBuilder: Sized {
     fn with_front_vertex(self, front: Partial<Vertex>) -> Self;
 
     /// Update partial half-edge as a circle, from the given radius
-    ///
-    /// # Implementation Note
-    ///
-    /// In principle, only the `build` method should take a reference to
-    /// [`Objects`]. As of this writing, this method is the only one that
-    /// deviates from that. I couldn't think of a way to do it better.
     fn update_as_circle_from_radius(self, radius: impl Into<Scalar>) -> Self;
 
     /// Update partial half-edge as a line segment, from the given points

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -9,10 +9,10 @@ use crate::{
     builder::{FaceBuilder, HalfEdgeBuilder, SurfaceBuilder},
     insert::Insert,
     objects::{Cycle, Face, FaceSet, Objects, Shell, Vertex},
-    partial::{HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge},
+    partial::{HasPartial, PartialHalfEdge},
     partial2::{
-        Partial, PartialCurve, PartialObject, PartialSurface,
-        PartialSurfaceVertex, PartialVertex,
+        Partial, PartialCurve, PartialGlobalEdge, PartialObject,
+        PartialSurface, PartialSurfaceVertex, PartialVertex,
     },
     services::Service,
     storage::Handle,
@@ -111,7 +111,7 @@ impl ShellBuilder {
                                 })
                             },
                         ),
-                        global_form: MaybePartial::from(PartialGlobalEdge {
+                        global_form: Partial::from_partial(PartialGlobalEdge {
                             curve: global_edge.curve,
                             vertices: global_edge.vertices,
                         }),
@@ -179,7 +179,7 @@ impl ShellBuilder {
 
                     PartialHalfEdge {
                         vertices,
-                        global_form: MaybePartial::from(PartialGlobalEdge {
+                        global_form: Partial::from_partial(PartialGlobalEdge {
                             curve: global_curve,
                             vertices: global_vertices,
                         }),
@@ -257,7 +257,7 @@ impl ShellBuilder {
 
                         PartialHalfEdge {
                             vertices,
-                            global_form: MaybePartial::from(
+                            global_form: Partial::from_partial(
                                 PartialGlobalEdge {
                                     vertices: global_vertices,
                                     curve: curve.global_form,
@@ -321,7 +321,7 @@ impl ShellBuilder {
 
                     PartialHalfEdge {
                         vertices,
-                        global_form: MaybePartial::from(PartialGlobalEdge {
+                        global_form: Partial::from_partial(PartialGlobalEdge {
                             curve: global_curve,
                             vertices: global_vertices,
                         }),
@@ -425,7 +425,7 @@ impl ShellBuilder {
                 edges.push(
                     PartialHalfEdge {
                         vertices: vertices.map(Partial::from_partial),
-                        global_form: MaybePartial::from(PartialGlobalEdge {
+                        global_form: Partial::from_partial(PartialGlobalEdge {
                             curve: global_edge.curve,
                             vertices: global_edge.vertices,
                         }),

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -141,30 +141,30 @@ impl ShellBuilder {
                         ..Default::default()
                     };
 
-                    PartialHalfEdge {
-                        vertices: [
-                            PartialVertex {
-                                curve: Partial::from_partial(PartialCurve {
-                                    surface: Partial::from_full_entry_point(
-                                        from.surface().clone(),
-                                    ),
-                                    ..Default::default()
-                                }),
-                                surface_form: Partial::from_full_entry_point(
-                                    from,
+                    let vertices = [
+                        PartialVertex {
+                            curve: Partial::from_partial(PartialCurve {
+                                surface: Partial::from_full_entry_point(
+                                    from.surface().clone(),
                                 ),
                                 ..Default::default()
-                            },
-                            PartialVertex {
-                                curve: Partial::from_partial(PartialCurve {
-                                    surface: to.surface.clone(),
-                                    ..Default::default()
-                                }),
-                                surface_form: Partial::from_partial(to),
+                            }),
+                            surface_form: Partial::from_full_entry_point(from),
+                            ..Default::default()
+                        },
+                        PartialVertex {
+                            curve: Partial::from_partial(PartialCurve {
+                                surface: to.surface.clone(),
                                 ..Default::default()
-                            },
-                        ]
-                        .map(Partial::from_partial),
+                            }),
+                            surface_form: Partial::from_partial(to),
+                            ..Default::default()
+                        },
+                    ]
+                    .map(Partial::from_partial);
+
+                    PartialHalfEdge {
+                        vertices,
                         ..Default::default()
                     }
                     .update_as_line_segment()
@@ -204,34 +204,32 @@ impl ShellBuilder {
                             ..Default::default()
                         };
 
+                        let vertices = [
+                            PartialVertex {
+                                curve: Partial::from_partial(PartialCurve {
+                                    surface: from.surface.clone(),
+                                    ..curve.clone()
+                                }),
+                                surface_form: Partial::from_partial(from),
+                                ..Default::default()
+                            },
+                            PartialVertex {
+                                curve: Partial::from_partial(PartialCurve {
+                                    surface: Partial::from_full_entry_point(
+                                        to.surface().clone(),
+                                    ),
+                                    ..curve
+                                }),
+                                surface_form: Partial::from_full_entry_point(
+                                    to,
+                                ),
+                                ..Default::default()
+                            },
+                        ]
+                        .map(Partial::from_partial);
+
                         PartialHalfEdge {
-                            vertices: [
-                                PartialVertex {
-                                    curve: Partial::from_partial(
-                                        PartialCurve {
-                                            surface: from.surface.clone(),
-                                            ..curve.clone()
-                                        },
-                                    ),
-                                    surface_form: Partial::from_partial(from),
-                                    ..Default::default()
-                                },
-                                PartialVertex {
-                                    curve: Partial::from_partial(
-                                        PartialCurve {
-                                            surface:
-                                                Partial::from_full_entry_point(
-                                                    to.surface().clone(),
-                                                ),
-                                            ..curve
-                                        },
-                                    ),
-                                    surface_form:
-                                        Partial::from_full_entry_point(to),
-                                    ..Default::default()
-                                },
-                            ]
-                            .map(Partial::from_partial),
+                            vertices,
                             ..Default::default()
                         }
                         .update_as_line_segment()
@@ -273,8 +271,10 @@ impl ShellBuilder {
                         ..Default::default()
                     };
 
+                    let vertices = [from, to].map(Partial::from_partial);
+
                     PartialHalfEdge {
-                        vertices: [from, to].map(Partial::from_partial),
+                        vertices,
                         ..Default::default()
                     }
                     .update_as_line_segment()

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -23,11 +23,30 @@ impl VertexBuilder for PartialVertex {
 
 /// Builder API for [`PartialSurfaceVertex`]
 pub trait SurfaceVertexBuilder {
+    /// Infer the position of the surface vertex' global form
+    fn infer_global_position(&mut self) -> &mut Self;
+
     /// Infer the global form of the partial vertex
     fn infer_global_form(&mut self) -> &mut Self;
 }
 
 impl SurfaceVertexBuilder for PartialSurfaceVertex {
+    fn infer_global_position(&mut self) -> &mut Self {
+        let position = self
+            .position
+            .expect("Can't infer global position without surface position");
+        let surface = self
+            .surface
+            .read()
+            .geometry
+            .expect("Can't infer global position without surface geometry");
+
+        self.global_form.write().position =
+            Some(surface.point_from_surface_coords(position));
+
+        self
+    }
+
     fn infer_global_form(&mut self) -> &mut Self {
         self.global_form = Partial::new();
         self

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -370,10 +370,8 @@ mod tests {
             Cycle, Face, GlobalCurve, GlobalVertex, Objects, Shell, Sketch,
             Solid, SurfaceVertex, Vertex,
         },
-        partial::{
-            HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge,
-        },
-        partial2::{Partial, PartialCurve, PartialObject},
+        partial::{HasPartial, PartialHalfEdge},
+        partial2::{Partial, PartialCurve, PartialGlobalEdge, PartialObject},
         services::Services,
     };
 
@@ -514,7 +512,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -163,14 +163,18 @@ impl VerticesInNormalizedOrder {
 
 #[cfg(test)]
 mod tests {
+    use std::array;
+
+    use fj_interop::ext::ArrayExt;
     use pretty_assertions::assert_eq;
 
     use crate::{
-        builder::HalfEdgeBuilder, partial::HasPartial, partial2::Partial,
+        builder::HalfEdgeBuilder,
+        objects::Vertex,
+        partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
+        partial2::Partial,
         services::Services,
     };
-
-    use super::HalfEdge;
 
     #[test]
     fn global_edge_equality() {
@@ -183,12 +187,49 @@ mod tests {
         let a = [0., 0.];
         let b = [1., 0.];
 
-        let a_to_b = HalfEdge::partial()
-            .update_as_line_segment_from_points(surface.clone(), [a, b])
-            .build(&mut services.objects);
-        let b_to_a = HalfEdge::partial()
-            .update_as_line_segment_from_points(surface, [b, a])
-            .build(&mut services.objects);
+        let a_to_b = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(surface.clone(), [a, b])
+                .build(&mut services.objects)
+        };
+        let b_to_a = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+            half_edge
+                .update_as_line_segment_from_points(surface, [b, a])
+                .build(&mut services.objects)
+        };
 
         assert_eq!(a_to_b.global_form(), b_to_a.global_form());
     }

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -171,8 +171,8 @@ mod tests {
     use crate::{
         builder::HalfEdgeBuilder,
         objects::Vertex,
-        partial::{MaybePartial, PartialGlobalEdge, PartialHalfEdge},
-        partial2::Partial,
+        partial::PartialHalfEdge,
+        partial2::{Partial, PartialGlobalEdge},
         services::Services,
     };
 
@@ -199,7 +199,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -221,7 +221,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),

--- a/crates/fj-kernel/src/partial/mod.rs
+++ b/crates/fj-kernel/src/partial/mod.rs
@@ -43,11 +43,7 @@ mod traits;
 pub use self::{
     maybe_partial::MaybePartial,
     merge::{MergeWith, Mergeable},
-    objects::{
-        cycle::PartialCycle,
-        edge::{PartialGlobalEdge, PartialHalfEdge},
-        face::PartialFace,
-    },
+    objects::{cycle::PartialCycle, edge::PartialHalfEdge, face::PartialFace},
     replace::Replace,
     traits::{HasPartial, Partial},
 };

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -1,5 +1,4 @@
 use crate::{
-    builder::GlobalEdgeBuilder,
     objects::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects, Vertex,
     },
@@ -29,15 +28,8 @@ impl PartialHalfEdge {
 
     /// Build a full [`HalfEdge`] from the partial half-edge
     pub fn build(self, objects: &mut Service<Objects>) -> HalfEdge {
-        let curve = self.curve().build(objects);
         let vertices = self.vertices.map(|vertex| vertex.build(objects));
-
-        let global_form = self
-            .global_form
-            .update_partial(|partial| {
-                partial.update_from_curve_and_vertices(&curve, &vertices)
-            })
-            .into_full(objects);
+        let global_form = self.global_form.into_full(objects);
 
         HalfEdge::new(vertices, global_form)
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -1,7 +1,5 @@
 use crate::{
-    objects::{
-        Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects, Vertex,
-    },
+    objects::{Curve, GlobalEdge, HalfEdge, Objects, Vertex},
     partial::{MaybePartial, MergeWith},
     partial2::Partial,
     services::Service,
@@ -16,7 +14,7 @@ pub struct PartialHalfEdge {
     pub vertices: [Partial<Vertex>; 2],
 
     /// The global form of the [`HalfEdge`]
-    pub global_form: MaybePartial<GlobalEdge>,
+    pub global_form: Partial<GlobalEdge>,
 }
 
 impl PartialHalfEdge {
@@ -29,19 +27,17 @@ impl PartialHalfEdge {
     /// Build a full [`HalfEdge`] from the partial half-edge
     pub fn build(self, objects: &mut Service<Objects>) -> HalfEdge {
         let vertices = self.vertices.map(|vertex| vertex.build(objects));
-        let global_form = self.global_form.into_full(objects);
+        let global_form = self.global_form.build(objects);
 
         HalfEdge::new(vertices, global_form)
     }
 }
 
 impl MergeWith for PartialHalfEdge {
-    fn merge_with(self, other: impl Into<Self>) -> Self {
-        let other = other.into();
-
+    fn merge_with(self, _: impl Into<Self>) -> Self {
         Self {
             vertices: self.vertices,
-            global_form: self.global_form.merge_with(other.global_form),
+            global_form: self.global_form,
         }
     }
 }
@@ -55,7 +51,9 @@ impl From<&HalfEdge> for PartialHalfEdge {
 
         Self {
             vertices: [back_vertex, front_vertex],
-            global_form: half_edge.global_form().clone().into(),
+            global_form: Partial::from_full_entry_point(
+                half_edge.global_form().clone(),
+            ),
         }
     }
 }
@@ -90,74 +88,6 @@ impl MaybePartial<HalfEdge> {
             Self::Full(full) => {
                 full.vertices().clone().map(Partial::from_full_entry_point)
             }
-            Self::Partial(partial) => partial.vertices.clone(),
-        }
-    }
-}
-
-/// A partial [`GlobalEdge`]
-///
-/// See [`crate::partial`] for more information.
-#[derive(Clone, Debug, Default)]
-pub struct PartialGlobalEdge {
-    /// The curve that the [`GlobalEdge`] is defined in
-    pub curve: Partial<GlobalCurve>,
-
-    /// The vertices that bound the [`GlobalEdge`] in the curve
-    pub vertices: [Partial<GlobalVertex>; 2],
-}
-
-impl PartialGlobalEdge {
-    /// Build a full [`GlobalEdge`] from the partial global edge
-    pub fn build(self, objects: &mut Service<Objects>) -> GlobalEdge {
-        let curve = self.curve.build(objects);
-        let vertices = self
-            .vertices
-            .map(|global_vertex| global_vertex.build(objects));
-
-        GlobalEdge::new(curve, vertices)
-    }
-}
-
-impl MergeWith for PartialGlobalEdge {
-    fn merge_with(self, _: impl Into<Self>) -> Self {
-        Self {
-            curve: self.curve,
-            vertices: self.vertices,
-        }
-    }
-}
-
-impl From<&GlobalEdge> for PartialGlobalEdge {
-    fn from(global_edge: &GlobalEdge) -> Self {
-        Self {
-            curve: Partial::from_full_entry_point(global_edge.curve().clone()),
-            vertices: global_edge
-                .vertices()
-                .access_in_normalized_order()
-                .map(Partial::from_full_entry_point),
-        }
-    }
-}
-
-impl MaybePartial<GlobalEdge> {
-    /// Access the curve
-    pub fn curve(&self) -> Partial<GlobalCurve> {
-        match self {
-            Self::Full(full) => {
-                Partial::from_full_entry_point(full.curve().clone())
-            }
-            Self::Partial(partial) => partial.curve.clone(),
-        }
-    }
-
-    /// Access the vertices
-    pub fn vertices(&self) -> [Partial<GlobalVertex>; 2] {
-        match self {
-            Self::Full(full) => full
-                .vertices()
-                .access_in_normalized_order()
-                .map(Partial::from_full_entry_point),
             Self::Partial(partial) => partial.vertices.clone(),
         }
     }

--- a/crates/fj-kernel/src/partial/objects/mod.rs
+++ b/crates/fj-kernel/src/partial/objects/mod.rs
@@ -3,13 +3,13 @@ pub mod edge;
 pub mod face;
 
 use crate::{
-    objects::{Cycle, Face, GlobalEdge, HalfEdge, Objects},
+    objects::{Cycle, Face, HalfEdge, Objects},
     services::Service,
 };
 
 use super::{
     HasPartial, MaybePartial, Partial, PartialCycle, PartialFace,
-    PartialGlobalEdge, PartialHalfEdge,
+    PartialHalfEdge,
 };
 
 macro_rules! impl_traits {
@@ -39,6 +39,5 @@ macro_rules! impl_traits {
 impl_traits!(
     Cycle, PartialCycle;
     Face, PartialFace;
-    GlobalEdge, PartialGlobalEdge;
     HalfEdge, PartialHalfEdge;
 );

--- a/crates/fj-kernel/src/partial2/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial2/objects/vertex.rs
@@ -1,6 +1,7 @@
 use fj_math::Point;
 
 use crate::{
+    builder::SurfaceVertexBuilder,
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
     partial2::{FullToPartialCache, Partial, PartialCurve, PartialObject},
     services::Service,
@@ -135,17 +136,14 @@ impl PartialObject for PartialSurfaceVertex {
     }
 
     fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
+        if self.global_form.read().position.is_none() {
+            self.infer_global_position();
+        }
+
         let position = self
             .position
             .expect("Can't build `SurfaceVertex` without position");
         let surface = self.surface.build(objects);
-
-        // Infer global position, if not available.
-        if self.global_form.read().position.is_none() {
-            self.global_form.write().position =
-                Some(surface.geometry().point_from_surface_coords(position));
-        }
-
         let global_form = self.global_form.build(objects);
 
         SurfaceVertex::new(position, surface, global_form)

--- a/crates/fj-kernel/src/storage/handle.rs
+++ b/crates/fj-kernel/src/storage/handle.rs
@@ -168,7 +168,7 @@ unsafe impl<T> Sync for Handle<T> {}
 ///
 /// See [`Handle::id`].
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ObjectId(u64);
+pub struct ObjectId(pub(crate) u64);
 
 impl ObjectId {
     pub(crate) fn from_ptr<T>(ptr: *const T) -> ObjectId {

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -66,12 +66,8 @@ impl CycleValidationError {
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{CycleBuilder, HalfEdgeBuilder},
-        insert::Insert,
-        objects::Cycle,
-        partial::HasPartial,
-        partial2::{Partial, PartialSurfaceVertex, PartialVertex},
-        services::Services,
+        builder::CycleBuilder, insert::Insert, objects::Cycle,
+        partial::HasPartial, partial2::Partial, services::Services,
         validate::Validate,
     };
 
@@ -92,27 +88,14 @@ mod tests {
                 .map(|half_edge| half_edge.to_partial())
                 .collect::<Vec<_>>();
 
-            let first_half_edge = &mut half_edges[0];
-            let [first_vertex, _] = first_half_edge.vertices.clone();
-
             // Sever connection between the last and first half-edge in the
             // cycle.
-            let first_vertex = PartialVertex {
-                surface_form: Partial::from_partial(PartialSurfaceVertex {
-                    surface: first_vertex
-                        .read()
-                        .surface_form
-                        .read()
-                        .surface
-                        .clone(),
-                    ..Default::default()
-                }),
-                ..first_vertex.read().clone()
-            };
-            *first_half_edge = first_half_edge
-                .clone()
-                .with_back_vertex(Partial::from_partial(first_vertex))
-                .infer_global_form();
+            let first_half_edge = half_edges.first_mut().unwrap();
+            let [first_vertex, _] = &mut first_half_edge.vertices;
+            let surface_vertex = Partial::from_partial(
+                first_vertex.read().surface_form.read().clone(),
+            );
+            first_vertex.write().surface_form = surface_vertex;
 
             let half_edges = half_edges.into_iter().map(|half_edge| {
                 half_edge

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -198,11 +198,17 @@ impl HalfEdgeValidationError {
 
 #[cfg(test)]
 mod tests {
+    use std::array;
+
+    use fj_interop::ext::ArrayExt;
+
     use crate::{
         builder::HalfEdgeBuilder,
         insert::Insert,
-        objects::{GlobalCurve, HalfEdge},
-        partial::HasPartial,
+        objects::{GlobalCurve, HalfEdge, Vertex},
+        partial::{
+            HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge,
+        },
         partial2::{
             Partial, PartialObject, PartialSurfaceVertex, PartialVertex,
         },
@@ -214,14 +220,33 @@ mod tests {
     fn half_edge_curve_mismatch() {
         let mut services = Services::new();
 
-        let valid = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
-                [[0., 0.], [1., 0.]],
-            )
-            .build(&mut services.objects);
+        let valid = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    Partial::from_full_entry_point(
+                        services.objects.surfaces.xy_plane(),
+                    ),
+                    [[0., 0.], [1., 0.]],
+                )
+                .build(&mut services.objects)
+        };
         let invalid = {
             let mut vertices = valid.vertices().clone();
             let mut vertex =
@@ -245,14 +270,33 @@ mod tests {
     fn half_edge_global_curve_mismatch() {
         let mut services = Services::new();
 
-        let valid = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
-                [[0., 0.], [1., 0.]],
-            )
-            .build(&mut services.objects);
+        let valid = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    Partial::from_full_entry_point(
+                        services.objects.surfaces.xy_plane(),
+                    ),
+                    [[0., 0.], [1., 0.]],
+                )
+                .build(&mut services.objects)
+        };
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
             tmp.curve = Partial::from_full_entry_point(
@@ -270,14 +314,33 @@ mod tests {
     fn half_edge_global_vertex_mismatch() {
         let mut services = Services::new();
 
-        let valid = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
-                [[0., 0.], [1., 0.]],
-            )
-            .build(&mut services.objects);
+        let valid = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    Partial::from_full_entry_point(
+                        services.objects.surfaces.xy_plane(),
+                    ),
+                    [[0., 0.], [1., 0.]],
+                )
+                .build(&mut services.objects)
+        };
         let invalid = HalfEdge::new(valid.vertices().clone(), {
             let mut tmp = valid.global_form().to_partial();
             tmp.vertices = valid
@@ -302,14 +365,33 @@ mod tests {
     fn half_edge_vertices_are_coincident() {
         let mut services = Services::new();
 
-        let valid = HalfEdge::partial()
-            .update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
-                [[0., 0.], [1., 0.]],
-            )
-            .build(&mut services.objects);
+        let valid = {
+            let vertices = array::from_fn(|_| Partial::<Vertex>::new());
+            let global_curve = {
+                let [vertex, _] = &vertices;
+                vertex.read().curve.read().global_form.clone()
+            };
+            let global_vertices = vertices.each_ref_ext().map(|vertex| {
+                vertex.read().surface_form.read().global_form.clone()
+            });
+
+            let half_edge = PartialHalfEdge {
+                vertices,
+                global_form: MaybePartial::from(PartialGlobalEdge {
+                    curve: global_curve,
+                    vertices: global_vertices,
+                }),
+            };
+
+            half_edge
+                .update_as_line_segment_from_points(
+                    Partial::from_full_entry_point(
+                        services.objects.surfaces.xy_plane(),
+                    ),
+                    [[0., 0.], [1., 0.]],
+                )
+                .build(&mut services.objects)
+        };
         let invalid = HalfEdge::new(
             valid.vertices().clone().map(|vertex| {
                 let vertex =

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -206,11 +206,10 @@ mod tests {
         builder::HalfEdgeBuilder,
         insert::Insert,
         objects::{GlobalCurve, HalfEdge, Vertex},
-        partial::{
-            HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge,
-        },
+        partial::PartialHalfEdge,
         partial2::{
-            Partial, PartialObject, PartialSurfaceVertex, PartialVertex,
+            Partial, PartialGlobalEdge, PartialObject, PartialSurfaceVertex,
+            PartialVertex,
         },
         services::Services,
         validate::Validate,
@@ -232,7 +231,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -282,7 +281,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -298,12 +297,12 @@ mod tests {
                 .build(&mut services.objects)
         };
         let invalid = HalfEdge::new(valid.vertices().clone(), {
-            let mut tmp = valid.global_form().to_partial();
-            tmp.curve = Partial::from_full_entry_point(
+            let mut tmp =
+                Partial::from_full_entry_point(valid.global_form().clone());
+            tmp.write().curve = Partial::from_full_entry_point(
                 GlobalCurve.insert(&mut services.objects),
             );
             tmp.build(&mut services.objects)
-                .insert(&mut services.objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -326,7 +325,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),
@@ -342,8 +341,9 @@ mod tests {
                 .build(&mut services.objects)
         };
         let invalid = HalfEdge::new(valid.vertices().clone(), {
-            let mut tmp = valid.global_form().to_partial();
-            tmp.vertices = valid
+            let mut tmp =
+                Partial::from_full_entry_point(valid.global_form().clone());
+            tmp.write().vertices = valid
                 .global_form()
                 .vertices()
                 .access_in_normalized_order()
@@ -354,7 +354,6 @@ mod tests {
                     )
                 });
             tmp.build(&mut services.objects)
-                .insert(&mut services.objects)
         });
 
         assert!(valid.validate().is_ok());
@@ -377,7 +376,7 @@ mod tests {
 
             let half_edge = PartialHalfEdge {
                 vertices,
-                global_form: MaybePartial::from(PartialGlobalEdge {
+                global_form: Partial::from_partial(PartialGlobalEdge {
                     curve: global_curve,
                     vertices: global_vertices,
                 }),

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,8 +5,11 @@ use fj_kernel::{
     builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{Cycle, Face, Objects, Sketch, Vertex},
-    partial::{HasPartial, MaybePartial, PartialGlobalEdge, PartialHalfEdge},
-    partial2::{Partial, PartialCurve, PartialSurfaceVertex, PartialVertex},
+    partial::{HasPartial, PartialHalfEdge},
+    partial2::{
+        Partial, PartialCurve, PartialGlobalEdge, PartialSurfaceVertex,
+        PartialVertex,
+    },
     services::Service,
 };
 use fj_math::{Aabb, Point};
@@ -59,7 +62,7 @@ impl Shape for fj::Sketch {
 
                     let half_edge = PartialHalfEdge {
                         vertices,
-                        global_form: MaybePartial::from(PartialGlobalEdge {
+                        global_form: Partial::from_partial(PartialGlobalEdge {
                             curve: curve.read().global_form.clone(),
                             vertices: global_vertices,
                         }),

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -6,7 +6,7 @@ use fj_kernel::{
     insert::Insert,
     objects::{Cycle, Face, Objects, Sketch},
     partial::{HasPartial, PartialHalfEdge},
-    partial2::{Partial, PartialCurve, PartialVertex},
+    partial2::{Partial, PartialCurve, PartialSurfaceVertex, PartialVertex},
     services::Service,
 };
 use fj_math::{Aabb, Point};
@@ -31,12 +31,18 @@ impl Shape for fj::Sketch {
                 let half_edge = {
                     let surface = Partial::from_full_entry_point(surface);
                     let curve = Partial::from_partial(PartialCurve {
-                        surface,
+                        surface: surface.clone(),
                         ..Default::default()
                     });
                     let vertices = array::from_fn(|_| {
                         Partial::from_partial(PartialVertex {
                             curve: curve.clone(),
+                            surface_form: Partial::from_partial(
+                                PartialSurfaceVertex {
+                                    surface: surface.clone(),
+                                    ..Default::default()
+                                },
+                            ),
                             ..Default::default()
                         })
                     });

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -52,7 +52,7 @@ impl Shape for fj::Sketch {
                         ..Default::default()
                     };
                     half_edge
-                        .update_as_circle_from_radius(circle.radius(), objects)
+                        .update_as_circle_from_radius(circle.radius())
                         .build(objects)
                         .insert(objects)
                 };

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -29,18 +29,20 @@ impl Shape for fj::Sketch {
                 // none need to be added here.
 
                 let half_edge = {
+                    let surface = Partial::from_full_entry_point(surface);
+                    let curve = Partial::from_partial(PartialCurve {
+                        surface,
+                        ..Default::default()
+                    });
+                    let vertices = array::from_fn(|_| {
+                        Partial::from_partial(PartialVertex {
+                            curve: curve.clone(),
+                            ..Default::default()
+                        })
+                    });
+
                     let half_edge = PartialHalfEdge {
-                        vertices: array::from_fn(|_| {
-                            Partial::from_partial(PartialVertex {
-                                curve: Partial::from_partial(PartialCurve {
-                                    surface: Partial::from_full_entry_point(
-                                        surface.clone(),
-                                    ),
-                                    ..Default::default()
-                                }),
-                                ..Default::default()
-                            })
-                        }),
+                        vertices,
                         ..Default::default()
                     };
                     half_edge


### PR DESCRIPTION
This is today's progress in the ongoing project of replacing the old partial object API, with the goal of eventually addressing #1249. This commit replaces the old `PartialGlobalEdge` with the new one.