### PR TITLE
Update all dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -580,12 +579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "copyless"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,10 +917,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui"
-version = "0.19.0"
+name = "ecolor"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9fcd393c3daaaf5909008a1d948319d538b79c51871e4df0993260260a94e4"
+checksum = "b601108bca3af7650440ace4ca55b2daf52c36f2635be3587d77b16efd8d0691"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "egui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65a5e883a316e53866977450eecfbcac9c48109c2ab3394af29feb83fcde4ea9"
 dependencies = [
  "ahash 0.8.2",
  "epaint",
@@ -937,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a8d8f92a429e2e9399003bc01d48f54aefa6fec126cbd3462e313c0ee0e91"
+checksum = "d3a6edfac4c02455f5024dc7cda997629b94748571935773d1a0cfab8213c80a"
 dependencies = [
  "bytemuck",
  "egui",
@@ -950,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ddc525334c416e11580123e147b970f738507f427c9fb1cd09ea2dd7416a3a"
+checksum = "5696bdbe60898b81157f07ae34fe02dbfd522174bd6e620942c269cd7307901f"
 dependencies = [
  "egui",
  "instant",
@@ -968,9 +970,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "emath"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9542a40106fdba943a055f418d1746a050e1a903a049b030c2b097d4686a33cf"
+checksum = "5277249c8c3430e7127e4f2c40a77485e7baf11ae132ce9b3253a8ed710df0a0"
 dependencies = [
  "bytemuck",
 ]
@@ -1020,14 +1022,15 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba04741be7f6602b1a1b28f1082cce45948a7032961c52814f8946b28493300"
+checksum = "de14b65fe5e423e0058f77a8beb2c863b056d0566d6c4ce0d097aa5814cb705a"
 dependencies = [
  "ab_glyph",
  "ahash 0.8.2",
  "atomic_refcell",
  "bytemuck",
+ "ecolor",
  "emath",
  "nohash-hasher",
  "parking_lot",
@@ -1249,7 +1252,7 @@ dependencies = [
  "fj-interop",
  "fj-math",
  "getrandom",
- "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
  "rfd",
  "thiserror",
  "tracing",
@@ -1829,12 +1832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inplace_it"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e567468c50f3d4bc7397702e09b380139f9b9288b4e909b070571007f8b5bf78"
-
-[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f50357e1167a3ab92d6b3c7f4bf5f7fd13fde3f4b28bf0d5ea07b5100fdb6c0"
+checksum = "262d2840e72dbe250e8cf2f522d080988dfca624c4112c096238a4845f591707"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -4216,17 +4213,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277e967bf8b7820a76852645a6bce8bbd31c32fda2042e82d8e3ea75fda8892d"
+checksum = "81f643110d228fd62a60c5ed2ab56c4d5b3704520bd50561174ec4ec74932937"
 dependencies = [
  "arrayvec 0.7.2",
  "js-sys",
  "log",
  "naga",
  "parking_lot",
- "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
  "smallvec",
+ "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4237,22 +4235,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.13.2"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b92788dec9d0c1bed849a1b83f01b2ee12819bf04a79c90f68e4173f7b5ba2"
+checksum = "6000d1284ef8eec6076fd5544a73125fd7eb9b635f18dceeb829d826f41724ca"
 dependencies = [
  "arrayvec 0.7.2",
  "bit-vec",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
- "copyless",
  "fxhash",
  "log",
  "naga",
  "parking_lot",
  "profiling",
- "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
  "smallvec",
  "thiserror",
  "web-sys",
@@ -4262,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cbdfc3d0637dba3d5536b93adef3d26023a0b96f0e1ee5ee9560a401d9f646"
+checksum = "3cc320a61acb26be4f549c9b1b53405c10a223fbfea363ec39474c32c348d12f"
 dependencies = [
  "android_system_properties",
  "arrayvec 0.7.2",
@@ -4279,7 +4276,6 @@ dependencies = [
  "glow",
  "gpu-alloc",
  "gpu-descriptor",
- "inplace_it",
  "js-sys",
  "khronos-egl",
  "libloading",
@@ -4290,8 +4286,9 @@ dependencies = [
  "parking_lot",
  "profiling",
  "range-alloc",
- "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
  "renderdoc-sys",
+ "smallvec",
  "thiserror",
  "wasm-bindgen",
  "web-sys",
@@ -4301,18 +4298,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.13.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f762cbc08e1a51389859cf9c199c7aef544789cf3510889aab12c607f701604"
+checksum = "fb6b28ef22cac17b9109b25b3bf8c9a103eeb293d7c5f78653979b09140375f6"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "wgpu_glyph"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362152ff06b11372ddfdfc706606fb0f3b6f1b540f017675443a61d074a0a5df"
+checksum = "0cafb82773e0f124a33674dab5de4dff73175aeb921949047ab014efb58fb446"
 dependencies = [
  "bytemuck",
  "glyph_brush",

--- a/crates/fj-viewer/Cargo.toml
+++ b/crates/fj-viewer/Cargo.toml
@@ -14,14 +14,14 @@ categories.workspace = true
 bytemuck = "1.12.3"
 chrono = "0.4.23"
 crossbeam-channel = "0.5.6"
-egui = "0.19.0"
-egui-wgpu = "0.19.0"
+egui = "0.20.1"
+egui-wgpu = "0.20.0"
 fj-interop.workspace = true
 fj-math.workspace = true
-raw-window-handle = "0.4.3"
+raw-window-handle = "0.5.0"
 thiserror = "1.0.35"
 tracing = "0.1.37"
-wgpu_glyph = "0.17.0"
+wgpu_glyph = "0.18.0"
 
 [dependencies.rfd]
 version = "0.10.0"
@@ -29,7 +29,7 @@ default_features = false
 features = ["xdg-portal"]
 
 [dependencies.wgpu]
-version = "0.13.1"
+version = "0.14.2"
 features = ["webgl"]
 
 # We don't depend on `getrandom` directly, but we need this to enable the `js`

--- a/crates/fj-viewer/src/graphics/mod.rs
+++ b/crates/fj-viewer/src/graphics/mod.rs
@@ -15,5 +15,5 @@ pub use self::{
     renderer::{DrawError, Renderer, RendererInitError},
 };
 
-const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
-const SAMPLE_COUNT: u32 = 4;
+pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+pub const SAMPLE_COUNT: u32 = 4;

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -113,7 +113,7 @@ impl Renderer {
             supported_formats
                 .into_iter()
                 .next()
-                .expect("Error determining preferred color format")
+                .expect("No color formats supported")
         };
 
         let ScreenSize { width, height } = screen.size();

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -239,6 +239,16 @@ impl Renderer {
             &wgpu::CommandEncoderDescriptor { label: None },
         );
 
+        let screen_descriptor = egui_wgpu::renderer::ScreenDescriptor {
+            size_in_pixels: [
+                self.surface_config.width,
+                self.surface_config.height,
+            ],
+            pixels_per_point: scale_factor,
+        };
+        let clipped_primitives =
+            gui.prepare_draw(&self.device, &self.queue, &screen_descriptor);
+
         // Need this block here, as a render pass only takes effect once it's
         // dropped.
         {
@@ -286,17 +296,10 @@ impl Renderer {
         };
 
         gui.draw(
-            &self.device,
-            &self.queue,
             &mut encoder,
             &color_view,
-            &egui_wgpu::renderer::ScreenDescriptor {
-                size_in_pixels: [
-                    self.surface_config.width,
-                    self.surface_config.height,
-                ],
-                pixels_per_point: scale_factor,
-            },
+            &clipped_primitives,
+            &screen_descriptor,
         );
 
         let command_buffer = encoder.finish();

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -290,7 +290,7 @@ impl Renderer {
             &self.queue,
             &mut encoder,
             &color_view,
-            egui_wgpu::renderer::ScreenDescriptor {
+            &egui_wgpu::renderer::ScreenDescriptor {
                 size_in_pixels: [
                     self.surface_config.width,
                     self.surface_config.height,

--- a/crates/fj-viewer/src/graphics/renderer.rs
+++ b/crates/fj-viewer/src/graphics/renderer.rs
@@ -91,11 +91,30 @@ impl Renderer {
             )
             .await?;
 
-        let color_format = surface
-            .get_supported_formats(&adapter)
-            .get(0)
-            .copied()
-            .expect("Error determining preferred color format");
+        let color_format = 'color_format: {
+            let supported_formats = surface.get_supported_formats(&adapter);
+
+            // We don't really care which color format we use, as long as we
+            // find one that's supported. `egui_wgpu` prints a warning though,
+            // unless we choose one of the following ones.
+            let preferred_formats = [
+                wgpu::TextureFormat::Rgba8Unorm,
+                wgpu::TextureFormat::Bgra8Unorm,
+            ];
+
+            for format in preferred_formats {
+                if supported_formats.contains(&format) {
+                    break 'color_format format;
+                }
+            }
+
+            // None of the preferred color formats are supported. Just use one
+            // of the supported ones then.
+            supported_formats
+                .into_iter()
+                .next()
+                .expect("Error determining preferred color format")
+        };
 
         let ScreenSize { width, height } = screen.size();
         let surface_config = wgpu::SurfaceConfiguration {

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -278,14 +278,12 @@ impl Gui {
         new_model_path
     }
 
-    pub(crate) fn draw(
+    pub(crate) fn prepare_draw(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        encoder: &mut wgpu::CommandEncoder,
-        color_view: &wgpu::TextureView,
         screen_descriptor: &egui_wgpu::renderer::ScreenDescriptor,
-    ) {
+    ) -> Vec<egui::ClippedPrimitive> {
         let egui_output = self.context.end_frame();
         let clipped_primitives = self.context.tessellate(egui_output.shapes);
 
@@ -304,10 +302,20 @@ impl Gui {
             screen_descriptor,
         );
 
+        clipped_primitives
+    }
+
+    pub(crate) fn draw(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        color_view: &wgpu::TextureView,
+        clipped_primitives: &[egui::ClippedPrimitive],
+        screen_descriptor: &egui_wgpu::renderer::ScreenDescriptor,
+    ) {
         self.render_pass.execute(
             encoder,
             color_view,
-            &clipped_primitives,
+            clipped_primitives,
             screen_descriptor,
             None,
         );

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -284,7 +284,7 @@ impl Gui {
         queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         color_view: &wgpu::TextureView,
-        screen_descriptor: egui_wgpu::renderer::ScreenDescriptor,
+        screen_descriptor: &egui_wgpu::renderer::ScreenDescriptor,
     ) {
         let egui_output = self.context.end_frame();
         let clipped_primitives = self.context.tessellate(egui_output.shapes);
@@ -301,14 +301,14 @@ impl Gui {
             device,
             queue,
             &clipped_primitives,
-            &screen_descriptor,
+            screen_descriptor,
         );
 
         self.render_pass.execute(
             encoder,
             color_view,
             &clipped_primitives,
-            &screen_descriptor,
+            screen_descriptor,
             None,
         );
     }

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -60,18 +60,6 @@ impl Gui {
         // - https://github.com/emilk/egui/blob/eeae485629fca24a81a7251739460b671e1420f7/README.md#how-do-i-render-3d-stuff-in-an-egui-area
 
         let context = egui::Context::default();
-
-        // We need to hold on to this, otherwise it might cause the egui font
-        // texture to get dropped after drawing one frame.
-        //
-        // This then results in an `egui_wgpu_backend` error of
-        // `BackendError::Internal` with message:
-        //
-        // ```
-        // Texture 0 used but not live
-        // ```
-        //
-        // See also: <https://github.com/hasenbanck/egui_wgpu_backend/blob/b2d3e7967351690c6425f37cd6d4ffb083a7e8e6/src/lib.rs#L373>
         let renderer = egui_wgpu::Renderer::new(
             device,
             texture_format,

--- a/crates/fj-viewer/src/gui.rs
+++ b/crates/fj-viewer/src/gui.rs
@@ -32,7 +32,7 @@ use crate::{
 /// The GUI
 pub struct Gui {
     context: egui::Context,
-    render_pass: egui_wgpu::Renderer,
+    renderer: egui_wgpu::Renderer,
     options: Options,
 }
 
@@ -72,7 +72,7 @@ impl Gui {
         // ```
         //
         // See also: <https://github.com/hasenbanck/egui_wgpu_backend/blob/b2d3e7967351690c6425f37cd6d4ffb083a7e8e6/src/lib.rs#L373>
-        let render_pass = egui_wgpu::Renderer::new(
+        let renderer = egui_wgpu::Renderer::new(
             device,
             texture_format,
             Some(DEPTH_FORMAT),
@@ -81,7 +81,7 @@ impl Gui {
 
         Self {
             context,
-            render_pass,
+            renderer,
             options: Options::default(),
         }
     }
@@ -296,14 +296,14 @@ impl Gui {
         let clipped_primitives = self.context.tessellate(egui_output.shapes);
 
         for (id, image_delta) in &egui_output.textures_delta.set {
-            self.render_pass
+            self.renderer
                 .update_texture(device, queue, *id, image_delta);
         }
         for id in &egui_output.textures_delta.free {
-            self.render_pass.free_texture(id);
+            self.renderer.free_texture(id);
         }
 
-        self.render_pass.update_buffers(
+        self.renderer.update_buffers(
             device,
             queue,
             encoder,
@@ -320,7 +320,7 @@ impl Gui {
         clipped_primitives: &[egui::ClippedPrimitive],
         screen_descriptor: &egui_wgpu::renderer::ScreenDescriptor,
     ) {
-        self.render_pass.render(
+        self.renderer.render(
             render_pass,
             clipped_primitives,
             screen_descriptor,

--- a/crates/fj-viewer/src/screen.rs
+++ b/crates/fj-viewer/src/screen.rs
@@ -1,11 +1,12 @@
 //! Types that describe aspects of the screen
 
+use raw_window_handle::HasRawDisplayHandle;
 pub use raw_window_handle::HasRawWindowHandle;
 
 /// Needs to be implemented by types that can serve as a screen to render to
 pub trait Screen {
     /// The window
-    type Window: HasRawWindowHandle;
+    type Window: HasRawDisplayHandle + HasRawWindowHandle;
 
     /// Access the size of the screen
     fn size(&self) -> ScreenSize;

--- a/crates/fj-window/Cargo.toml
+++ b/crates/fj-window/Cargo.toml
@@ -22,5 +22,5 @@ tracing = "0.1.37"
 winit = "0.27.5"
 
 [dependencies.egui-winit]
-version = "0.19.0"
+version = "0.20.1"
 default-features = false

--- a/crates/fj-window/src/event_loop_handler.rs
+++ b/crates/fj-window/src/event_loop_handler.rs
@@ -90,7 +90,15 @@ impl EventLoopHandler {
             // The primary visible impact of this currently is that if you drag
             // a title bar that overlaps the model then both the model & window
             // get moved.
-            self.egui_winit_state
+            let egui_winit::EventResponse {
+                consumed: _,
+                // This flag was introduced in egui-winit 0.20. I don't think we
+                // need to handle this, as we already do a full update of the
+                // GUI every frame. It might be possible to do less repainting
+                // though, if we only did it here, if the flag was set.
+                repaint: _,
+            } = self
+                .egui_winit_state
                 .on_event(self.viewer.gui.context(), event);
         }
 

--- a/crates/fj-window/src/event_loop_handler.rs
+++ b/crates/fj-window/src/event_loop_handler.rs
@@ -82,16 +82,8 @@ impl EventLoopHandler {
         }
 
         if let Event::WindowEvent { event, .. } = &event {
-            // In theory we could/should check if `egui` wants "exclusive" use
-            // of this event here. But with the current integration with Fornjot
-            // we're kinda blurring the lines between "app" and "platform", so
-            // for the moment we pass every event to both `egui` & Fornjot.
-            //
-            // The primary visible impact of this currently is that if you drag
-            // a title bar that overlaps the model then both the model & window
-            // get moved.
             let egui_winit::EventResponse {
-                consumed: _,
+                consumed,
                 // This flag was introduced in egui-winit 0.20. I don't think we
                 // need to handle this, as we already do a full update of the
                 // GUI every frame. It might be possible to do less repainting
@@ -100,6 +92,10 @@ impl EventLoopHandler {
             } = self
                 .egui_winit_state
                 .on_event(self.viewer.gui.context(), event);
+
+            if consumed {
+                return Ok(());
+            }
         }
 
         // fj-window events


### PR DESCRIPTION
This includes `wgpu`, `wgpu_glyph`, `raw-window-handle`, `egui`, `egui-wgpu`, and `egui-winit`.

Close #807 
Close #976 