### PR TITLE
Continue cleanup of builder API

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -186,8 +186,8 @@ mod tests {
         ];
 
         let face = {
-            let mut face = PartialFace::default()
-                .with_exterior_polygon_from_points(surface.clone(), exterior);
+            let mut face = PartialFace::default();
+            face.with_exterior_polygon_from_points(surface.clone(), exterior);
             face.with_interior_polygon_from_points(surface, interior);
 
             face.build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -187,7 +187,10 @@ mod tests {
 
         let face = {
             let mut face = PartialFace::default();
-            face.with_exterior_polygon_from_points(surface.clone(), exterior);
+            face.with_exterior_polygon_from_points(
+                Partial::from_full_entry_point(surface.clone()),
+                exterior,
+            );
             face.with_interior_polygon_from_points(
                 Partial::from_full_entry_point(surface),
                 interior,

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -188,7 +188,10 @@ mod tests {
         let face = {
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(surface.clone(), exterior);
-            face.with_interior_polygon_from_points(surface, interior);
+            face.with_interior_polygon_from_points(
+                Partial::from_full_entry_point(surface),
+                interior,
+            );
 
             face.build(&mut services.objects)
         };

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -185,10 +185,10 @@ mod tests {
             [ 1., -1.],
         ];
 
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface.clone(), exterior)
-            .with_interior_polygon_from_points(surface, interior)
-            .build(&mut services.objects);
+        let mut face = PartialFace::default()
+            .with_exterior_polygon_from_points(surface.clone(), exterior);
+        face.with_interior_polygon_from_points(surface, interior);
+        let face = face.build(&mut services.objects);
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -185,10 +185,13 @@ mod tests {
             [ 1., -1.],
         ];
 
-        let mut face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface.clone(), exterior);
-        face.with_interior_polygon_from_points(surface, interior);
-        let face = face.build(&mut services.objects);
+        let face = {
+            let mut face = PartialFace::default()
+                .with_exterior_polygon_from_points(surface.clone(), exterior);
+            face.with_interior_polygon_from_points(surface, interior);
+
+            face.build(&mut services.objects)
+        };
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -93,9 +93,10 @@ mod tests {
             services.objects.surfaces.xz_plane(),
         ]
         .map(|surface| {
-            PartialFace::default()
-                .with_exterior_polygon_from_points(surface, points)
-                .build(&mut services.objects)
+            let mut face = PartialFace::default();
+            face.with_exterior_polygon_from_points(surface, points);
+
+            face.build(&mut services.objects)
         });
 
         let intersection =
@@ -120,9 +121,10 @@ mod tests {
             services.objects.surfaces.xz_plane(),
         ];
         let [a, b] = surfaces.clone().map(|surface| {
-            PartialFace::default()
-                .with_exterior_polygon_from_points(surface, points)
-                .build(&mut services.objects)
+            let mut face = PartialFace::default();
+            face.with_exterior_polygon_from_points(surface, points);
+
+            face.build(&mut services.objects)
         });
 
         let intersection =

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -94,7 +94,10 @@ mod tests {
         ]
         .map(|surface| {
             let mut face = PartialFace::default();
-            face.with_exterior_polygon_from_points(surface, points);
+            face.with_exterior_polygon_from_points(
+                Partial::from_full_entry_point(surface),
+                points,
+            );
 
             face.build(&mut services.objects)
         });
@@ -122,7 +125,10 @@ mod tests {
         ];
         let [a, b] = surfaces.clone().map(|surface| {
             let mut face = PartialFace::default();
-            face.with_exterior_polygon_from_points(surface, points);
+            face.with_exterior_polygon_from_points(
+                Partial::from_full_entry_point(surface),
+                points,
+            );
 
             face.build(&mut services.objects)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -139,7 +139,7 @@ mod tests {
         builder::FaceBuilder,
         insert::Insert,
         iter::ObjectIters,
-        partial::{PartialFace, PartialObject},
+        partial::{Partial, PartialFace, PartialObject},
         services::Services,
     };
 
@@ -150,7 +150,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [1., 1.], [0., 2.]],
         );
         let face = face
@@ -169,7 +169,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [2., 1.], [0., 2.]],
         );
         let face = face
@@ -191,7 +191,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[4., 2.], [0., 4.], [0., 0.]],
         );
         let face = face
@@ -213,7 +213,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
         );
         let face = face
@@ -235,7 +235,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
         );
         let face = face
@@ -257,7 +257,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
         );
         let face = face
@@ -279,7 +279,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [2., 0.], [0., 1.]],
         );
         let face = face
@@ -310,7 +310,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [1., 0.], [0., 1.]],
         );
         let face = face

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -148,11 +148,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [1., 1.], [0., 2.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [1., 1.], [0., 2.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([2., 1.]);
@@ -166,11 +167,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [2., 1.], [0., 2.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [2., 1.], [0., 2.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -187,11 +189,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[4., 2.], [0., 4.], [0., 0.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[4., 2.], [0., 4.], [0., 0.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 2.]);
@@ -208,11 +211,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -229,11 +233,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -250,11 +255,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -271,11 +277,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [2., 0.], [0., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [2., 0.], [0., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 0.]);
@@ -301,11 +308,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [1., 0.], [0., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let point = Point::from([1., 0.]);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -155,7 +155,7 @@ mod tests {
         builder::FaceBuilder,
         insert::Insert,
         iter::ObjectIters,
-        partial::{PartialFace, PartialObject},
+        partial::{Partial, PartialFace, PartialObject},
         services::Services,
     };
 
@@ -168,7 +168,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -188,7 +188,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -211,7 +211,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -231,7 +231,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -262,7 +262,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -291,7 +291,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -313,7 +313,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -166,11 +166,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.yz_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([-1., 0., 0.], &mut services.objects);
@@ -185,11 +186,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.yz_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([1., 0., 0.], &mut services.objects);
@@ -207,11 +209,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.yz_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([0., 0., 2.], &mut services.objects);
@@ -226,11 +229,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.yz_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([1., 1., 0.], &mut services.objects);
@@ -256,11 +260,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.yz_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([1., 1., 1.], &mut services.objects);
@@ -284,11 +289,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -305,11 +311,12 @@ mod tests {
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .translate([0., 0., 1.], &mut services.objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -113,14 +113,19 @@ mod tests {
             .sweep(UP, &mut services.objects);
 
         let mut bottom = PartialFace::default();
-        bottom.with_exterior_polygon_from_points(surface.clone(), TRIANGLE);
+        bottom.with_exterior_polygon_from_points(
+            Partial::from_full_entry_point(surface.clone()),
+            TRIANGLE,
+        );
         let bottom = bottom
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
         let mut top = PartialFace::default();
         top.with_exterior_polygon_from_points(
-            surface.translate(UP, &mut services.objects),
+            Partial::from_full_entry_point(
+                surface.translate(UP, &mut services.objects),
+            ),
             TRIANGLE,
         );
         let top = top
@@ -169,7 +174,9 @@ mod tests {
 
         let mut bottom = PartialFace::default();
         bottom.with_exterior_polygon_from_points(
-            surface.clone().translate(DOWN, &mut services.objects),
+            Partial::from_full_entry_point(
+                surface.clone().translate(DOWN, &mut services.objects),
+            ),
             TRIANGLE,
         );
         let bottom = bottom
@@ -177,7 +184,10 @@ mod tests {
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
         let mut top = PartialFace::default();
-        top.with_exterior_polygon_from_points(surface, TRIANGLE);
+        top.with_exterior_polygon_from_points(
+            Partial::from_full_entry_point(surface),
+            TRIANGLE,
+        );
         let top = top
             .build(&mut services.objects)
             .insert(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -112,16 +112,18 @@ mod tests {
             .build(&mut services.objects)
             .sweep(UP, &mut services.objects);
 
-        let bottom = PartialFace::default()
-            .with_exterior_polygon_from_points(surface.clone(), TRIANGLE)
+        let mut bottom = PartialFace::default();
+        bottom.with_exterior_polygon_from_points(surface.clone(), TRIANGLE);
+        let bottom = bottom
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
-        let top = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface.translate(UP, &mut services.objects),
-                TRIANGLE,
-            )
+        let mut top = PartialFace::default();
+        top.with_exterior_polygon_from_points(
+            surface.translate(UP, &mut services.objects),
+            TRIANGLE,
+        );
+        let top = top
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -165,16 +167,18 @@ mod tests {
             .build(&mut services.objects)
             .sweep(DOWN, &mut services.objects);
 
-        let bottom = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface.clone().translate(DOWN, &mut services.objects),
-                TRIANGLE,
-            )
+        let mut bottom = PartialFace::default();
+        bottom.with_exterior_polygon_from_points(
+            surface.clone().translate(DOWN, &mut services.objects),
+            TRIANGLE,
+        );
+        let bottom = bottom
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
-        let top = PartialFace::default()
-            .with_exterior_polygon_from_points(surface, TRIANGLE)
+        let mut top = PartialFace::default();
+        top.with_exterior_polygon_from_points(surface, TRIANGLE);
+        let top = top
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -97,8 +97,9 @@ mod tests {
         let d = [0., 1.];
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface, [a, b, c, d])
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(surface, [a, b, c, d]);
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -132,8 +133,8 @@ mod tests {
         let h = [3., 1.];
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d]);
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(surface.clone(), [a, b, c, d]);
         face.with_interior_polygon_from_points(surface.clone(), [e, f, g, h]);
         let face = face
             .build(&mut services.objects)
@@ -191,8 +192,12 @@ mod tests {
         let e = [0.0, 1.0];
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d, e])
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface.clone(),
+            [a, b, c, d, e],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -80,7 +80,7 @@ mod tests {
         builder::FaceBuilder,
         insert::Insert,
         objects::Face,
-        partial::{PartialFace, PartialObject},
+        partial::{Partial, PartialFace, PartialObject},
         services::Services,
         storage::Handle,
     };
@@ -135,7 +135,10 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(surface.clone(), [a, b, c, d]);
-        face.with_interior_polygon_from_points(surface.clone(), [e, f, g, h]);
+        face.with_interior_polygon_from_points(
+            Partial::from_full_entry_point(surface.clone()),
+            [e, f, g, h],
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -98,7 +98,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
-        face.with_exterior_polygon_from_points(surface, [a, b, c, d]);
+        face.with_exterior_polygon_from_points(
+            Partial::from_full_entry_point(surface),
+            [a, b, c, d],
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -134,7 +137,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
-        face.with_exterior_polygon_from_points(surface.clone(), [a, b, c, d]);
+        face.with_exterior_polygon_from_points(
+            Partial::from_full_entry_point(surface.clone()),
+            [a, b, c, d],
+        );
         face.with_interior_polygon_from_points(
             Partial::from_full_entry_point(surface.clone()),
             [e, f, g, h],
@@ -197,7 +203,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface.clone(),
+            Partial::from_full_entry_point(surface.clone()),
             [a, b, c, d, e],
         );
         let face = face

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -132,9 +132,10 @@ mod tests {
         let h = [3., 1.];
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d])
-            .with_interior_polygon_from_points(surface.clone(), [e, f, g, h])
+        let mut face = PartialFace::default()
+            .with_exterior_polygon_from_points(surface.clone(), [a, b, c, d]);
+        face.with_interior_polygon_from_points(surface.clone(), [e, f, g, h]);
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -19,10 +19,10 @@ pub trait CycleBuilder {
 
     /// Update the partial cycle with a polygonal chain from the provided points
     fn with_poly_chain_from_points(
-        self,
+        &mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self;
+    );
 
     /// Update the partial cycle by closing it with a line segment
     ///
@@ -86,17 +86,21 @@ impl CycleBuilder for PartialCycle {
     }
 
     fn with_poly_chain_from_points(
-        self,
+        &mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self {
-        self.with_poly_chain(points.into_iter().map(|position| {
-            PartialSurfaceVertex {
-                position: Some(position.into()),
-                surface: Partial::from_full_entry_point(surface.clone()),
-                ..Default::default()
-            }
-        }))
+    ) {
+        *self =
+            self.clone()
+                .with_poly_chain(points.into_iter().map(|position| {
+                    PartialSurfaceVertex {
+                        position: Some(position.into()),
+                        surface: Partial::from_full_entry_point(
+                            surface.clone(),
+                        ),
+                        ..Default::default()
+                    }
+                }));
     }
 
     fn close_with_line_segment(&mut self) {

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -13,9 +13,9 @@ use super::HalfEdgeBuilder;
 pub trait CycleBuilder {
     /// Update the partial cycle with a polygonal chain from the provided points
     fn with_poly_chain(
-        self,
+        &mut self,
         vertices: impl IntoIterator<Item = PartialSurfaceVertex>,
-    ) -> Self;
+    );
 
     /// Update the partial cycle with a polygonal chain from the provided points
     fn with_poly_chain_from_points(
@@ -32,9 +32,9 @@ pub trait CycleBuilder {
 
 impl CycleBuilder for PartialCycle {
     fn with_poly_chain(
-        mut self,
+        &mut self,
         vertices: impl IntoIterator<Item = PartialSurfaceVertex>,
-    ) -> Self {
+    ) {
         let vertices = vertices.into_iter();
 
         let mut previous: Option<Partial<SurfaceVertex>> =
@@ -82,7 +82,6 @@ impl CycleBuilder for PartialCycle {
         }
 
         self.half_edges.extend(half_edges);
-        self
     }
 
     fn with_poly_chain_from_points(
@@ -90,17 +89,13 @@ impl CycleBuilder for PartialCycle {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
-        *self =
-            self.clone()
-                .with_poly_chain(points.into_iter().map(|position| {
-                    PartialSurfaceVertex {
-                        position: Some(position.into()),
-                        surface: Partial::from_full_entry_point(
-                            surface.clone(),
-                        ),
-                        ..Default::default()
-                    }
-                }));
+        self.with_poly_chain(points.into_iter().map(|position| {
+            PartialSurfaceVertex {
+                position: Some(position.into()),
+                surface: Partial::from_full_entry_point(surface.clone()),
+                ..Default::default()
+            }
+        }));
     }
 
     fn close_with_line_segment(&mut self) {

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -4,7 +4,6 @@ use fj_math::Point;
 use crate::{
     objects::{Surface, SurfaceVertex},
     partial::{Partial, PartialCycle, PartialHalfEdge, PartialSurfaceVertex},
-    storage::Handle,
 };
 
 use super::HalfEdgeBuilder;
@@ -20,7 +19,7 @@ pub trait CycleBuilder {
     /// Update the partial cycle with a polygonal chain from the provided points
     fn with_poly_chain_from_points(
         &mut self,
-        surface: Handle<Surface>,
+        surface: Partial<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     );
 
@@ -86,13 +85,13 @@ impl CycleBuilder for PartialCycle {
 
     fn with_poly_chain_from_points(
         &mut self,
-        surface: Handle<Surface>,
+        surface: Partial<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
         self.with_poly_chain(points.into_iter().map(|position| {
             PartialSurfaceVertex {
                 position: Some(position.into()),
-                surface: Partial::from_full_entry_point(surface.clone()),
+                surface: surface.clone(),
                 ..Default::default()
             }
         }));

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -27,7 +27,7 @@ pub trait CycleBuilder {
     /// Update the partial cycle by closing it with a line segment
     ///
     /// Builds a line segment from the last and first vertex, closing the cycle.
-    fn close_with_line_segment(self) -> Self;
+    fn close_with_line_segment(&mut self);
 }
 
 impl CycleBuilder for PartialCycle {
@@ -99,7 +99,7 @@ impl CycleBuilder for PartialCycle {
         }))
     }
 
-    fn close_with_line_segment(mut self) -> Self {
+    fn close_with_line_segment(&mut self) {
         let first = self.half_edges.first();
         let last = self.half_edges.last();
 
@@ -114,7 +114,7 @@ impl CycleBuilder for PartialCycle {
         });
 
         let [Some([first, _]), Some([_, last])] = vertices else {
-            return self;
+            return;
         };
 
         let mut half_edge = PartialHalfEdge::default();
@@ -138,6 +138,5 @@ impl CycleBuilder for PartialCycle {
         half_edge.update_as_line_segment();
 
         self.half_edges.push(Partial::from_partial(half_edge));
-        self
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -6,7 +6,7 @@ use crate::{
     partial::{Partial, PartialGlobalEdge, PartialHalfEdge},
 };
 
-use super::{CurveBuilder, SurfaceVertexBuilder};
+use super::CurveBuilder;
 
 /// Builder API for [`PartialHalfEdge`]
 pub trait HalfEdgeBuilder {
@@ -69,7 +69,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             let mut surface_form = vertex.surface_form.write();
             surface_form.position = Some(point.into());
             surface_form.surface = surface.clone();
-            surface_form.infer_global_position();
         }
 
         self.update_as_line_segment()

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -91,7 +91,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         for (vertex, position) in self.vertices.each_mut_ext().zip_ext([0., 1.])
         {
             vertex.write().position = Some([position].into());
-            vertex.write().curve = curve.clone();
         }
 
         self.global_form.write().curve = curve.read().global_form.clone();

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -87,13 +87,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let mut curve = self.curve();
         curve.write().update_as_line_from_points(points_surface);
+        self.global_form.write().curve = curve.read().global_form.clone();
 
         for (vertex, position) in self.vertices.each_mut_ext().zip_ext([0., 1.])
         {
             vertex.write().position = Some([position].into());
         }
-
-        self.global_form.write().curve = curve.read().global_form.clone();
     }
 }
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -12,10 +12,10 @@ use super::CycleBuilder;
 pub trait FaceBuilder {
     /// Update the [`PartialFace`] with an exterior polygon
     fn with_exterior_polygon_from_points(
-        self,
+        &mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self;
+    );
 
     /// Update the [`PartialFace`] with an interior polygon
     fn with_interior_polygon_from_points(
@@ -27,10 +27,10 @@ pub trait FaceBuilder {
 
 impl FaceBuilder for PartialFace {
     fn with_exterior_polygon_from_points(
-        mut self,
+        &mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self {
+    ) {
         let mut cycle = PartialCycle::default();
         cycle.with_poly_chain_from_points(
             Partial::from_full_entry_point(surface),
@@ -39,7 +39,6 @@ impl FaceBuilder for PartialFace {
         cycle.close_with_line_segment();
 
         self.exterior = Partial::from_partial(cycle);
-        self
     }
 
     fn with_interior_polygon_from_points(

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -19,10 +19,10 @@ pub trait FaceBuilder {
 
     /// Update the [`PartialFace`] with an interior polygon
     fn with_interior_polygon_from_points(
-        self,
+        &mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self;
+    );
 }
 
 impl FaceBuilder for PartialFace {
@@ -43,10 +43,10 @@ impl FaceBuilder for PartialFace {
     }
 
     fn with_interior_polygon_from_points(
-        mut self,
+        &mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self {
+    ) {
         let mut cycle = PartialCycle::default();
         cycle.with_poly_chain_from_points(
             Partial::from_full_entry_point(surface),
@@ -55,6 +55,5 @@ impl FaceBuilder for PartialFace {
         cycle.close_with_line_segment();
 
         self.interiors = vec![Partial::from_partial(cycle)];
-        self
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -20,7 +20,7 @@ pub trait FaceBuilder {
     /// Update the [`PartialFace`] with an interior polygon
     fn with_interior_polygon_from_points(
         &mut self,
-        surface: Handle<Surface>,
+        surface: Partial<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     );
 }
@@ -43,14 +43,11 @@ impl FaceBuilder for PartialFace {
 
     fn with_interior_polygon_from_points(
         &mut self,
-        surface: Handle<Surface>,
+        surface: Partial<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
         let mut cycle = PartialCycle::default();
-        cycle.with_poly_chain_from_points(
-            Partial::from_full_entry_point(surface),
-            points,
-        );
+        cycle.with_poly_chain_from_points(surface, points);
         cycle.close_with_line_segment();
 
         self.interiors = vec![Partial::from_partial(cycle)];

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -31,9 +31,9 @@ impl FaceBuilder for PartialFace {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        let cycle = PartialCycle::default()
-            .with_poly_chain_from_points(surface, points)
-            .close_with_line_segment();
+        let mut cycle = PartialCycle::default()
+            .with_poly_chain_from_points(surface, points);
+        cycle.close_with_line_segment();
 
         self.exterior = Partial::from_partial(cycle);
         self
@@ -44,9 +44,9 @@ impl FaceBuilder for PartialFace {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        let cycle = PartialCycle::default()
-            .with_poly_chain_from_points(surface, points)
-            .close_with_line_segment();
+        let mut cycle = PartialCycle::default()
+            .with_poly_chain_from_points(surface, points);
+        cycle.close_with_line_segment();
 
         self.interiors = vec![Partial::from_partial(cycle)];
         self

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -3,7 +3,6 @@ use fj_math::Point;
 use crate::{
     objects::Surface,
     partial::{Partial, PartialCycle, PartialFace},
-    storage::Handle,
 };
 
 use super::CycleBuilder;
@@ -13,7 +12,7 @@ pub trait FaceBuilder {
     /// Update the [`PartialFace`] with an exterior polygon
     fn with_exterior_polygon_from_points(
         &mut self,
-        surface: Handle<Surface>,
+        surface: Partial<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     );
 
@@ -28,14 +27,11 @@ pub trait FaceBuilder {
 impl FaceBuilder for PartialFace {
     fn with_exterior_polygon_from_points(
         &mut self,
-        surface: Handle<Surface>,
+        surface: Partial<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
         let mut cycle = PartialCycle::default();
-        cycle.with_poly_chain_from_points(
-            Partial::from_full_entry_point(surface),
-            points,
-        );
+        cycle.with_poly_chain_from_points(surface, points);
         cycle.close_with_line_segment();
 
         self.exterior = Partial::from_partial(cycle);

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -32,7 +32,10 @@ impl FaceBuilder for PartialFace {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         let mut cycle = PartialCycle::default();
-        cycle.with_poly_chain_from_points(surface, points);
+        cycle.with_poly_chain_from_points(
+            Partial::from_full_entry_point(surface),
+            points,
+        );
         cycle.close_with_line_segment();
 
         self.exterior = Partial::from_partial(cycle);
@@ -45,7 +48,10 @@ impl FaceBuilder for PartialFace {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         let mut cycle = PartialCycle::default();
-        cycle.with_poly_chain_from_points(surface, points);
+        cycle.with_poly_chain_from_points(
+            Partial::from_full_entry_point(surface),
+            points,
+        );
         cycle.close_with_line_segment();
 
         self.interiors = vec![Partial::from_partial(cycle)];

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -31,8 +31,8 @@ impl FaceBuilder for PartialFace {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        let mut cycle = PartialCycle::default()
-            .with_poly_chain_from_points(surface, points);
+        let mut cycle = PartialCycle::default();
+        cycle.with_poly_chain_from_points(surface, points);
         cycle.close_with_line_segment();
 
         self.exterior = Partial::from_partial(cycle);
@@ -44,8 +44,8 @@ impl FaceBuilder for PartialFace {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        let mut cycle = PartialCycle::default()
-            .with_poly_chain_from_points(surface, points);
+        let mut cycle = PartialCycle::default();
+        cycle.with_poly_chain_from_points(surface, points);
         cycle.close_with_line_segment();
 
         self.interiors = vec![Partial::from_partial(cycle)];

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -31,11 +31,11 @@ impl FaceBuilder for PartialFace {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        self.exterior = Partial::from_partial(
-            PartialCycle::default()
-                .with_poly_chain_from_points(surface, points)
-                .close_with_line_segment(),
-        );
+        let cycle = PartialCycle::default()
+            .with_poly_chain_from_points(surface, points)
+            .close_with_line_segment();
+
+        self.exterior = Partial::from_partial(cycle);
         self
     }
 
@@ -44,11 +44,11 @@ impl FaceBuilder for PartialFace {
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
-        self.interiors = vec![Partial::from_partial(
-            PartialCycle::default()
-                .with_poly_chain_from_points(surface, points)
-                .close_with_line_segment(),
-        )];
+        let cycle = PartialCycle::default()
+            .with_poly_chain_from_points(surface, points)
+            .close_with_line_segment();
+
+        self.interiors = vec![Partial::from_partial(cycle)];
         self
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -55,7 +55,7 @@ impl ShellBuilder {
 
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(
-                surface,
+                Partial::from_full_entry_point(surface),
                 [[-h, -h], [h, -h], [h, h], [-h, h]],
             );
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -274,8 +274,9 @@ impl ShellBuilder {
         };
 
         let top = {
-            let surface =
-                objects.surfaces.xy_plane().translate([Z, Z, h], objects);
+            let surface = Partial::from_full_entry_point(
+                objects.surfaces.xy_plane().translate([Z, Z, h], objects),
+            );
 
             let mut top_edges = top_edges;
             top_edges.reverse();
@@ -301,9 +302,8 @@ impl ShellBuilder {
 
                         Partial::from_partial(PartialSurfaceVertex {
                             position: Some(point.into()),
-                            surface: Partial::from_full_entry_point(
-                                surface.clone(),
-                            ),
+                            surface: surface.clone(),
+
                             global_form: global_vertex,
                         })
                     });

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -230,7 +230,7 @@ impl ShellBuilder {
                     let [to, _] = side_down.read().vertices.clone();
 
                     let from_surface = from.read().surface_form.clone();
-                    let to = to.read().surface_form.clone();
+                    let to_surface = to.read().surface_form.clone();
 
                     let from = PartialVertex {
                         curve: Partial::from_partial(PartialCurve {
@@ -242,10 +242,10 @@ impl ShellBuilder {
                     };
                     let to = PartialVertex {
                         curve: Partial::from_partial(PartialCurve {
-                            surface: to.read().surface.clone(),
+                            surface: to_surface.read().surface.clone(),
                             ..Default::default()
                         }),
-                        surface_form: to.clone(),
+                        surface_form: to_surface.clone(),
                         ..Default::default()
                     };
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -229,15 +229,15 @@ impl ShellBuilder {
                     let [_, from] = side_up.read().vertices.clone();
                     let [to, _] = side_down.read().vertices.clone();
 
-                    let from = from.read().surface_form.clone();
+                    let from_surface = from.read().surface_form.clone();
                     let to = to.read().surface_form.clone();
 
                     let from = PartialVertex {
                         curve: Partial::from_partial(PartialCurve {
-                            surface: from.read().surface.clone(),
+                            surface: from_surface.read().surface.clone(),
                             ..Default::default()
                         }),
-                        surface_form: from.clone(),
+                        surface_form: from_surface.clone(),
                         ..Default::default()
                     };
                     let to = PartialVertex {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -53,10 +53,13 @@ impl ShellBuilder {
             let surface =
                 objects.surfaces.xy_plane().translate([Z, Z, -h], objects);
 
-            PartialFace::default().with_exterior_polygon_from_points(
+            let mut face = PartialFace::default();
+            face.with_exterior_polygon_from_points(
                 surface,
                 [[-h, -h], [h, -h], [h, h], [-h, h]],
-            )
+            );
+
+            face
         };
 
         let (sides, top_edges) = {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -173,10 +173,10 @@ impl ShellBuilder {
                                 side_up_prev.read().vertices.clone();
                             let [to, _] = bottom.read().vertices.clone();
 
-                            let to = to.read().surface_form.clone();
+                            let to_surface = to.read().surface_form.clone();
                             let from = PartialSurfaceVertex {
                                 position: Some(
-                                    to.read().position.unwrap()
+                                    to_surface.read().position.unwrap()
                                         + [Z, edge_length],
                                 ),
                                 surface: surface.clone(),
@@ -212,11 +212,14 @@ impl ShellBuilder {
                                 PartialVertex {
                                     curve: Partial::from_partial(
                                         PartialCurve {
-                                            surface: to.read().surface.clone(),
+                                            surface: to_surface
+                                                .read()
+                                                .surface
+                                                .clone(),
                                             ..curve.clone()
                                         },
                                     ),
-                                    surface_form: to.clone(),
+                                    surface_form: to_surface.clone(),
                                     ..Default::default()
                                 },
                             ]

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -3,7 +3,7 @@ use fj_math::Point;
 use crate::{
     insert::Insert,
     objects::{Face, FaceSet, Objects, Sketch, Surface},
-    partial::{PartialFace, PartialObject},
+    partial::{Partial, PartialFace, PartialObject},
     services::Service,
     storage::Handle,
 };
@@ -36,7 +36,10 @@ impl SketchBuilder {
         objects: &mut Service<Objects>,
     ) -> Self {
         let mut face = PartialFace::default();
-        face.with_exterior_polygon_from_points(surface, points);
+        face.with_exterior_polygon_from_points(
+            Partial::from_full_entry_point(surface),
+            points,
+        );
         let face = face.build(objects).insert(objects);
 
         self.faces.extend([face]);

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -35,10 +35,9 @@ impl SketchBuilder {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
         objects: &mut Service<Objects>,
     ) -> Self {
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(surface, points)
-            .build(objects)
-            .insert(objects);
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(surface, points);
+        let face = face.build(objects).insert(objects);
 
         self.faces.extend([face]);
         self

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -35,10 +35,12 @@ impl SketchBuilder {
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
         objects: &mut Service<Objects>,
     ) -> Self {
-        self.faces.extend([PartialFace::default()
+        let face = PartialFace::default()
             .with_exterior_polygon_from_points(surface, points)
             .build(objects)
-            .insert(objects)]);
+            .insert(objects);
+
+        self.faces.extend([face]);
         self
     }
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -407,12 +407,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let object = PartialCycle::default()
-            .with_poly_chain_from_points(
-                surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )
-            .close_with_line_segment()
+        let mut object = PartialCycle::default().with_poly_chain_from_points(
+            surface,
+            [[0., 0.], [1., 0.], [0., 1.]],
+        );
+        object.close_with_line_segment();
+        let object = object
             .build(&mut services.objects)
             .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -440,7 +440,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut object = PartialFace::default();
         object.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [1., 0.], [0., 1.]],
         );
         let object = object
@@ -558,7 +558,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            surface,
+            Partial::from_full_entry_point(surface),
             [[0., 0.], [1., 0.], [0., 1.]],
         );
         let face = face

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -410,7 +410,7 @@ mod tests {
         let object = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
-                surface,
+                Partial::from_full_entry_point(surface),
                 [[0., 0.], [1., 0.], [0., 1.]],
             );
             cycle.close_with_line_segment();

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -408,11 +408,11 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let object = {
-            let mut cycle = PartialCycle::default()
-                .with_poly_chain_from_points(
-                    surface,
-                    [[0., 0.], [1., 0.], [0., 1.]],
-                );
+            let mut cycle = PartialCycle::default();
+            cycle.with_poly_chain_from_points(
+                surface,
+                [[0., 0.], [1., 0.], [0., 1.]],
+            );
             cycle.close_with_line_segment();
 
             cycle

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -407,14 +407,18 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut object = PartialCycle::default().with_poly_chain_from_points(
-            surface,
-            [[0., 0.], [1., 0.], [0., 1.]],
-        );
-        object.close_with_line_segment();
-        let object = object
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
+        let object = {
+            let mut cycle = PartialCycle::default()
+                .with_poly_chain_from_points(
+                    surface,
+                    [[0., 0.], [1., 0.], [0., 1.]],
+                );
+            cycle.close_with_line_segment();
+
+            cycle
+                .build(&mut services.objects)
+                .insert(&mut services.objects)
+        };
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -438,11 +438,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let object = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )
+        let mut object = PartialFace::default();
+        object.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [1., 0.], [0., 1.]],
+        );
+        let object = object
             .build(&mut services.objects)
             .insert(&mut services.objects);
 
@@ -555,11 +556,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let face = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface,
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )
+        let mut face = PartialFace::default();
+        face.with_exterior_polygon_from_points(
+            surface,
+            [[0., 0.], [1., 0.], [0., 1.]],
+        );
+        let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let object = Sketch::builder()

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -80,7 +80,9 @@ mod tests {
         let valid = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
-                services.objects.surfaces.xy_plane(),
+                Partial::from_full_entry_point(
+                    services.objects.surfaces.xy_plane(),
+                ),
                 [[0., 0.], [1., 0.], [0., 1.]],
             );
             cycle.close_with_line_segment();

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -78,11 +78,11 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let mut cycle = PartialCycle::default()
-                .with_poly_chain_from_points(
-                    services.objects.surfaces.xy_plane(),
-                    [[0., 0.], [1., 0.], [0., 1.]],
-                );
+            let mut cycle = PartialCycle::default();
+            cycle.with_poly_chain_from_points(
+                services.objects.surfaces.xy_plane(),
+                [[0., 0.], [1., 0.], [0., 1.]],
+            );
             cycle.close_with_line_segment();
 
             cycle.build(&mut services.objects)

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -77,12 +77,16 @@ mod tests {
     fn cycle_half_edge_connections() {
         let mut services = Services::new();
 
-        let mut valid = PartialCycle::default().with_poly_chain_from_points(
-            services.objects.surfaces.xy_plane(),
-            [[0., 0.], [1., 0.], [0., 1.]],
-        );
-        valid.close_with_line_segment();
-        let valid = valid.build(&mut services.objects);
+        let valid = {
+            let mut cycle = PartialCycle::default()
+                .with_poly_chain_from_points(
+                    services.objects.surfaces.xy_plane(),
+                    [[0., 0.], [1., 0.], [0., 1.]],
+                );
+            cycle.close_with_line_segment();
+
+            cycle.build(&mut services.objects)
+        };
         let invalid = {
             let mut half_edges = valid
                 .half_edges()

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -77,13 +77,12 @@ mod tests {
     fn cycle_half_edge_connections() {
         let mut services = Services::new();
 
-        let valid = PartialCycle::default()
-            .with_poly_chain_from_points(
-                services.objects.surfaces.xy_plane(),
-                [[0., 0.], [1., 0.], [0., 1.]],
-            )
-            .close_with_line_segment()
-            .build(&mut services.objects);
+        let mut valid = PartialCycle::default().with_poly_chain_from_points(
+            services.objects.surfaces.xy_plane(),
+            [[0., 0.], [1., 0.], [0., 1.]],
+        );
+        valid.close_with_line_segment();
+        let valid = valid.build(&mut services.objects);
         let invalid = {
             let mut half_edges = valid
                 .half_edges()

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -130,15 +130,16 @@ mod tests {
             )
             .build(&mut services.objects);
         let invalid = {
-            let interiors = [PartialCycle::default()
+            let cycle = PartialCycle::default()
                 .with_poly_chain_from_points(
                     services.objects.surfaces.xz_plane(),
                     [[1., 1.], [1., 2.], [2., 1.]],
                 )
                 .close_with_line_segment()
                 .build(&mut services.objects)
-                .insert(&mut services.objects)];
+                .insert(&mut services.objects);
 
+            let interiors = [cycle];
             Face::new(valid.exterior().clone(), interiors, valid.color())
         };
 

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -119,16 +119,19 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
 
-        let mut valid = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface.clone(),
-                [[0., 0.], [3., 0.], [0., 3.]],
+        let valid = {
+            let mut face = PartialFace::default()
+                .with_exterior_polygon_from_points(
+                    surface.clone(),
+                    [[0., 0.], [3., 0.], [0., 3.]],
+                );
+            face.with_interior_polygon_from_points(
+                surface,
+                [[1., 1.], [1., 2.], [2., 1.]],
             );
-        valid.with_interior_polygon_from_points(
-            surface,
-            [[1., 1.], [1., 2.], [2., 1.]],
-        );
-        let valid = valid.build(&mut services.objects);
+
+            face.build(&mut services.objects)
+        };
         let invalid = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
@@ -156,16 +159,18 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
 
-        let mut valid = PartialFace::default()
-            .with_exterior_polygon_from_points(
-                surface.clone(),
-                [[0., 0.], [3., 0.], [0., 3.]],
+        let valid = {
+            let mut face = PartialFace::default()
+                .with_exterior_polygon_from_points(
+                    surface.clone(),
+                    [[0., 0.], [3., 0.], [0., 3.]],
+                );
+            face.with_interior_polygon_from_points(
+                surface,
+                [[1., 1.], [1., 2.], [2., 1.]],
             );
-        valid.with_interior_polygon_from_points(
-            surface,
-            [[1., 1.], [1., 2.], [2., 1.]],
-        );
-        let valid = valid.build(&mut services.objects);
+            face.build(&mut services.objects)
+        };
         let invalid = {
             let interiors = valid
                 .interiors()

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -120,11 +120,11 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let valid = {
-            let mut face = PartialFace::default()
-                .with_exterior_polygon_from_points(
-                    surface.clone(),
-                    [[0., 0.], [3., 0.], [0., 3.]],
-                );
+            let mut face = PartialFace::default();
+            face.with_exterior_polygon_from_points(
+                surface.clone(),
+                [[0., 0.], [3., 0.], [0., 3.]],
+            );
             face.with_interior_polygon_from_points(
                 surface,
                 [[1., 1.], [1., 2.], [2., 1.]],
@@ -160,11 +160,11 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let valid = {
-            let mut face = PartialFace::default()
-                .with_exterior_polygon_from_points(
-                    surface.clone(),
-                    [[0., 0.], [3., 0.], [0., 3.]],
-                );
+            let mut face = PartialFace::default();
+            face.with_exterior_polygon_from_points(
+                surface.clone(),
+                [[0., 0.], [3., 0.], [0., 3.]],
+            );
             face.with_interior_polygon_from_points(
                 surface,
                 [[1., 1.], [1., 2.], [2., 1.]],

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -122,7 +122,7 @@ mod tests {
         let valid = {
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(
-                surface.clone(),
+                Partial::from_full_entry_point(surface.clone()),
                 [[0., 0.], [3., 0.], [0., 3.]],
             );
             face.with_interior_polygon_from_points(
@@ -162,7 +162,7 @@ mod tests {
         let valid = {
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(
-                surface.clone(),
+                Partial::from_full_entry_point(surface.clone()),
                 [[0., 0.], [3., 0.], [0., 3.]],
             );
             face.with_interior_polygon_from_points(

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -126,7 +126,7 @@ mod tests {
                 [[0., 0.], [3., 0.], [0., 3.]],
             );
             face.with_interior_polygon_from_points(
-                surface,
+                Partial::from_full_entry_point(surface),
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
 
@@ -166,7 +166,7 @@ mod tests {
                 [[0., 0.], [3., 0.], [0., 3.]],
             );
             face.with_interior_polygon_from_points(
-                surface,
+                Partial::from_full_entry_point(surface),
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
             face.build(&mut services.objects)

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -119,16 +119,16 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
 
-        let valid = PartialFace::default()
+        let mut valid = PartialFace::default()
             .with_exterior_polygon_from_points(
                 surface.clone(),
                 [[0., 0.], [3., 0.], [0., 3.]],
-            )
-            .with_interior_polygon_from_points(
-                surface,
-                [[1., 1.], [1., 2.], [2., 1.]],
-            )
-            .build(&mut services.objects);
+            );
+        valid.with_interior_polygon_from_points(
+            surface,
+            [[1., 1.], [1., 2.], [2., 1.]],
+        );
+        let valid = valid.build(&mut services.objects);
         let invalid = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
@@ -156,16 +156,16 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
 
-        let valid = PartialFace::default()
+        let mut valid = PartialFace::default()
             .with_exterior_polygon_from_points(
                 surface.clone(),
                 [[0., 0.], [3., 0.], [0., 3.]],
-            )
-            .with_interior_polygon_from_points(
-                surface,
-                [[1., 1.], [1., 2.], [2., 1.]],
-            )
-            .build(&mut services.objects);
+            );
+        valid.with_interior_polygon_from_points(
+            surface,
+            [[1., 1.], [1., 2.], [2., 1.]],
+        );
+        let valid = valid.build(&mut services.objects);
         let invalid = {
             let interiors = valid
                 .interiors()

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -130,11 +130,11 @@ mod tests {
             )
             .build(&mut services.objects);
         let invalid = {
-            let mut cycle = PartialCycle::default()
-                .with_poly_chain_from_points(
-                    services.objects.surfaces.xz_plane(),
-                    [[1., 1.], [1., 2.], [2., 1.]],
-                );
+            let mut cycle = PartialCycle::default();
+            cycle.with_poly_chain_from_points(
+                services.objects.surfaces.xz_plane(),
+                [[1., 1.], [1., 2.], [2., 1.]],
+            );
             cycle.close_with_line_segment();
             let cycle = cycle
                 .build(&mut services.objects)

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -130,12 +130,13 @@ mod tests {
             )
             .build(&mut services.objects);
         let invalid = {
-            let cycle = PartialCycle::default()
+            let mut cycle = PartialCycle::default()
                 .with_poly_chain_from_points(
                     services.objects.surfaces.xz_plane(),
                     [[1., 1.], [1., 2.], [2., 1.]],
-                )
-                .close_with_line_segment()
+                );
+            cycle.close_with_line_segment();
+            let cycle = cycle
                 .build(&mut services.objects)
                 .insert(&mut services.objects);
 

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -108,7 +108,7 @@ mod tests {
         builder::{CycleBuilder, FaceBuilder},
         insert::Insert,
         objects::Face,
-        partial::{PartialCycle, PartialFace, PartialObject},
+        partial::{Partial, PartialCycle, PartialFace, PartialObject},
         services::Services,
         validate::Validate,
     };
@@ -132,7 +132,9 @@ mod tests {
         let invalid = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
-                services.objects.surfaces.xz_plane(),
+                Partial::from_full_entry_point(
+                    services.objects.surfaces.xz_plane(),
+                ),
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
             cycle.close_with_line_segment();

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -60,7 +60,10 @@ impl Shape for fj::Sketch {
                     .map(Point::from);
 
                 let mut face = PartialFace::default();
-                face.with_exterior_polygon_from_points(surface, points);
+                face.with_exterior_polygon_from_points(
+                    Partial::from_full_entry_point(surface),
+                    points,
+                );
                 face.color = Some(Color(self.color()));
 
                 face.build(objects).insert(objects)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -27,9 +27,6 @@ impl Shape for fj::Sketch {
 
         let face = match self.chain() {
             fj::Chain::Circle(circle) => {
-                // Circles have just a single round edge with no vertices. So
-                // none need to be added here.
-
                 let half_edge = {
                     let surface = Partial::from_full_entry_point(surface);
                     let curve = Partial::from_partial(PartialCurve {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -1,13 +1,12 @@
-use std::{array, ops::Deref};
+use std::ops::Deref;
 
-use fj_interop::{debug::DebugInfo, ext::ArrayExt, mesh::Color};
+use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
     builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{Objects, Sketch, Vertex},
+    objects::{Objects, Sketch},
     partial::{
-        Partial, PartialCurve, PartialCycle, PartialFace, PartialGlobalEdge,
-        PartialHalfEdge, PartialObject, PartialSurfaceVertex, PartialVertex,
+        Partial, PartialCycle, PartialFace, PartialHalfEdge, PartialObject,
     },
     services::Service,
 };
@@ -29,40 +28,16 @@ impl Shape for fj::Sketch {
             fj::Chain::Circle(circle) => {
                 let half_edge = {
                     let surface = Partial::from_full_entry_point(surface);
-                    let curve = Partial::from_partial(PartialCurve {
-                        surface: surface.clone(),
-                        ..Default::default()
-                    });
-                    let vertices = array::from_fn(|_| {
-                        Partial::from_partial(PartialVertex {
-                            curve: curve.clone(),
-                            surface_form: Partial::from_partial(
-                                PartialSurfaceVertex {
-                                    surface: surface.clone(),
-                                    ..Default::default()
-                                },
-                            ),
-                            ..Default::default()
-                        })
-                    });
-                    let global_vertices = vertices.each_ref_ext().map(
-                        |vertex: &Partial<Vertex>| {
-                            vertex
-                                .read()
-                                .surface_form
-                                .read()
-                                .global_form
-                                .clone()
-                        },
-                    );
 
-                    let mut half_edge = PartialHalfEdge {
-                        vertices,
-                        global_form: Partial::from_partial(PartialGlobalEdge {
-                            curve: curve.read().global_form.clone(),
-                            vertices: global_vertices,
-                        }),
-                    };
+                    let mut half_edge = PartialHalfEdge::default();
+
+                    half_edge.curve().write().surface = surface.clone();
+
+                    for vertex in &mut half_edge.vertices {
+                        vertex.write().surface_form.write().surface =
+                            surface.clone();
+                    }
+
                     half_edge.update_as_circle_from_radius(circle.radius());
 
                     Partial::from_partial(half_edge)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -59,8 +59,8 @@ impl Shape for fj::Sketch {
                     .map(|fj::SketchSegment::LineTo { point }| point)
                     .map(Point::from);
 
-                let mut face = PartialFace::default()
-                    .with_exterior_polygon_from_points(surface, points);
+                let mut face = PartialFace::default();
+                face.with_exterior_polygon_from_points(surface, points);
                 face.color = Some(Color(self.color()));
 
                 face.build(objects).insert(objects)


### PR DESCRIPTION
Continues the cleanup of the builder API, as a further step towards addressing #1249. I've reviewed all the builder extension traits, brought them up to a common standard in regards to the API style, and simplified the implementation as far as practical right now. This pull requests also includes cleanups in other parts of the code, to make some of those simplifications possible.

Some of the changes actually make the builder API more complicated to use. This is going to be just a temporary problem, as I intend to work on some improvements to the partial object API next, that can make things simpler again.