### PR TITLE
Simplify partial object constructions

### DIFF
--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -343,7 +343,7 @@ impl ShellBuilder {
             }
 
             PartialFace {
-                exterior: Partial::from_partial(PartialCycle::new(half_edges)),
+                exterior: Partial::from_partial(PartialCycle { half_edges }),
                 ..Default::default()
             }
         };

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -313,7 +313,7 @@ impl ShellBuilder {
                 [a.clone(), b, c, d, a]
             };
 
-            let mut edges = Vec::new();
+            let mut half_edges = Vec::new();
             for (surface_vertices, edge) in surface_vertices
                 .as_slice()
                 .array_windows_ext()
@@ -339,11 +339,11 @@ impl ShellBuilder {
 
                 half_edge.update_as_line_segment();
 
-                edges.push(Partial::from_partial(half_edge));
+                half_edges.push(Partial::from_partial(half_edge));
             }
 
             PartialFace {
-                exterior: Partial::from_partial(PartialCycle::new(edges)),
+                exterior: Partial::from_partial(PartialCycle::new(half_edges)),
                 ..Default::default()
             }
         };

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Curve`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<SurfacePath>,
@@ -21,11 +21,7 @@ pub struct PartialCurve {
 impl PartialCurve {
     /// Construct an instance of `PartialCurve`
     pub fn new() -> Self {
-        Self {
-            path: None,
-            surface: Partial::default(),
-            global_form: Partial::default(),
-        }
+        Self::default()
     }
 }
 
@@ -49,20 +45,14 @@ impl PartialObject for PartialCurve {
     }
 }
 
-impl Default for PartialCurve {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// A partial [`GlobalCurve`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalCurve;
 
 impl PartialGlobalCurve {
     /// Construct an instance of `PartialGlobalCurve`
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 }
 
@@ -75,11 +65,5 @@ impl PartialObject for PartialGlobalCurve {
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
         GlobalCurve
-    }
-}
-
-impl Default for PartialGlobalCurve {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -18,13 +18,6 @@ pub struct PartialCurve {
     pub global_form: Partial<GlobalCurve>,
 }
 
-impl PartialCurve {
-    /// Construct an instance of `PartialCurve`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialCurve {
     type Full = Curve;
 
@@ -48,13 +41,6 @@ impl PartialObject for PartialCurve {
 /// A partial [`GlobalCurve`]
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalCurve;
-
-impl PartialGlobalCurve {
-    /// Construct an instance of `PartialGlobalCurve`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
 
 impl PartialObject for PartialGlobalCurve {
     type Full = GlobalCurve;

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -40,11 +40,11 @@ impl PartialObject for PartialCurve {
     type Full = Curve;
 
     fn from_full(curve: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            Some(curve.path()),
-            Some(Partial::from_full(curve.surface().clone(), cache)),
-            Some(Partial::from_full(curve.global_form().clone(), cache)),
-        )
+        Self {
+            path: Some(curve.path()),
+            surface: Partial::from_full(curve.surface().clone(), cache),
+            global_form: Partial::from_full(curve.global_form().clone(), cache),
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
@@ -77,7 +77,7 @@ impl PartialObject for PartialGlobalCurve {
     type Full = GlobalCurve;
 
     fn from_full(_: &Self::Full, _: &mut FullToPartialCache) -> Self {
-        Self::new()
+        Self
     }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -20,18 +20,11 @@ pub struct PartialCurve {
 
 impl PartialCurve {
     /// Construct an instance of `PartialCurve`
-    pub fn new(
-        path: Option<SurfacePath>,
-        surface: Option<Partial<Surface>>,
-        global_form: Option<Partial<GlobalCurve>>,
-    ) -> Self {
-        let surface = surface.unwrap_or_default();
-        let global_form = global_form.unwrap_or_default();
-
+    pub fn new() -> Self {
         Self {
-            path,
-            surface,
-            global_form,
+            path: None,
+            surface: Partial::default(),
+            global_form: Partial::default(),
         }
     }
 }
@@ -58,7 +51,7 @@ impl PartialObject for PartialCurve {
 
 impl Default for PartialCurve {
     fn default() -> Self {
-        Self::new(None, None, None)
+        Self::new()
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -13,8 +13,10 @@ pub struct PartialCycle {
 
 impl PartialCycle {
     /// Construct an instance of `PartialCycle`
-    pub fn new(half_edges: Vec<Partial<HalfEdge>>) -> Self {
-        Self { half_edges }
+    pub fn new() -> Self {
+        Self {
+            half_edges: Vec::new(),
+        }
     }
 
     /// Access the surface of the [`Cycle`]
@@ -50,6 +52,6 @@ impl PartialObject for PartialCycle {
 
 impl Default for PartialCycle {
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -29,13 +29,13 @@ impl PartialObject for PartialCycle {
     type Full = Cycle;
 
     fn from_full(cycle: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            cycle
+        Self {
+            half_edges: cycle
                 .half_edges()
                 .cloned()
                 .map(|half_edge| Partial::from_full(half_edge, cache))
                 .collect(),
-        )
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -12,11 +12,6 @@ pub struct PartialCycle {
 }
 
 impl PartialCycle {
-    /// Construct an instance of `PartialCycle`
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Access the surface of the [`Cycle`]
     pub fn surface(&self) -> Option<Partial<Surface>> {
         self.half_edges

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,
@@ -14,9 +14,7 @@ pub struct PartialCycle {
 impl PartialCycle {
     /// Construct an instance of `PartialCycle`
     pub fn new() -> Self {
-        Self {
-            half_edges: Vec::new(),
-        }
+        Self::default()
     }
 
     /// Access the surface of the [`Cycle`]
@@ -47,11 +45,5 @@ impl PartialObject for PartialCycle {
             .map(|half_edge| half_edge.build(objects));
 
         Cycle::new(half_edges)
-    }
-}
-
-impl Default for PartialCycle {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -21,11 +21,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Construct an instance of `PartialHalfEdge`
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Access the curve the partial edge is defined on
     pub fn curve(&self) -> Partial<Curve> {
         let [vertex, _] = &self.vertices;
@@ -99,13 +94,6 @@ pub struct PartialGlobalEdge {
 
     /// The vertices that bound the edge on the curve
     pub vertices: [Partial<GlobalVertex>; 2],
-}
-
-impl PartialGlobalEdge {
-    /// Construct an instance of `PartialGlobalEdge`
-    pub fn new() -> Self {
-        Self::default()
-    }
 }
 
 impl PartialObject for PartialGlobalEdge {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -1,3 +1,5 @@
+use std::array;
+
 use fj_interop::ext::ArrayExt;
 
 use crate::{
@@ -20,18 +22,13 @@ pub struct PartialHalfEdge {
 
 impl PartialHalfEdge {
     /// Construct an instance of `PartialHalfEdge`
-    pub fn new(
-        vertices: [Option<Partial<Vertex>>; 2],
-        global_form: Option<Partial<GlobalEdge>>,
-    ) -> Self {
+    pub fn new() -> Self {
         let curve = Partial::<Curve>::new();
 
-        let vertices = vertices.map(|vertex| {
-            vertex.unwrap_or_else(|| {
-                Partial::from_partial(PartialVertex {
-                    curve: curve.clone(),
-                    ..Default::default()
-                })
+        let vertices = array::from_fn(|_| {
+            Partial::from_partial(PartialVertex {
+                curve: curve.clone(),
+                ..Default::default()
             })
         });
 
@@ -43,11 +40,9 @@ impl PartialHalfEdge {
                 global_vertex
             });
 
-        let global_form = global_form.unwrap_or_else(|| {
-            Partial::from_partial(PartialGlobalEdge {
-                curve: global_curve,
-                vertices: global_vertices,
-            })
+        let global_form = Partial::from_partial(PartialGlobalEdge {
+            curve: global_curve,
+            vertices: global_vertices,
         });
 
         Self {
@@ -92,7 +87,7 @@ impl PartialObject for PartialHalfEdge {
 
 impl Default for PartialHalfEdge {
     fn default() -> Self {
-        Self::new([None, None], None)
+        Self::new()
     }
 }
 
@@ -108,14 +103,11 @@ pub struct PartialGlobalEdge {
 
 impl PartialGlobalEdge {
     /// Construct an instance of `PartialGlobalEdge`
-    pub fn new(
-        curve: Option<Partial<GlobalCurve>>,
-        vertices: [Option<Partial<GlobalVertex>>; 2],
-    ) -> Self {
-        let curve = curve.unwrap_or_default();
-        let vertices = vertices.map(Option::unwrap_or_default);
-
-        Self { curve, vertices }
+    pub fn new() -> Self {
+        Self {
+            curve: Partial::new(),
+            vertices: array::from_fn(|_| Partial::new()),
+        }
     }
 }
 
@@ -145,6 +137,6 @@ impl PartialObject for PartialGlobalEdge {
 
 impl Default for PartialGlobalEdge {
     fn default() -> Self {
-        Self::new(None, [None, None])
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -28,11 +28,10 @@ impl PartialHalfEdge {
 
         let vertices = vertices.map(|vertex| {
             vertex.unwrap_or_else(|| {
-                Partial::from_partial(PartialVertex::new(
-                    None,
-                    Some(curve.clone()),
-                    None,
-                ))
+                Partial::from_partial(PartialVertex {
+                    curve: curve.clone(),
+                    ..Default::default()
+                })
             })
         });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -71,13 +71,16 @@ impl PartialObject for PartialHalfEdge {
         half_edge: &Self::Full,
         cache: &mut FullToPartialCache,
     ) -> Self {
-        Self::new(
-            half_edge
+        Self {
+            vertices: half_edge
                 .vertices()
                 .clone()
-                .map(|vertex| Some(Partial::from_full(vertex, cache))),
-            Some(Partial::from_full(half_edge.global_form().clone(), cache)),
-        )
+                .map(|vertex| Partial::from_full(vertex, cache)),
+            global_form: Partial::from_full(
+                half_edge.global_form().clone(),
+                cache,
+            ),
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
@@ -124,13 +127,13 @@ impl PartialObject for PartialGlobalEdge {
         global_edge: &Self::Full,
         cache: &mut FullToPartialCache,
     ) -> Self {
-        Self::new(
-            Some(Partial::from_full(global_edge.curve().clone(), cache)),
-            global_edge
+        Self {
+            curve: Partial::from_full(global_edge.curve().clone(), cache),
+            vertices: global_edge
                 .vertices()
                 .access_in_normalized_order()
-                .map(|vertex| Some(Partial::from_full(vertex, cache))),
-        )
+                .map(|vertex| Partial::from_full(vertex, cache)),
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -40,14 +40,14 @@ impl PartialHalfEdge {
             vertices.each_ref_ext().map(|vertex: &Partial<Vertex>| {
                 let surface_vertex = vertex.read().surface_form.clone();
                 let global_vertex = surface_vertex.read().global_form.clone();
-                Some(global_vertex)
+                global_vertex
             });
 
         let global_form = global_form.unwrap_or_else(|| {
-            Partial::from_partial(PartialGlobalEdge::new(
-                Some(global_curve),
-                global_vertices,
-            ))
+            Partial::from_partial(PartialGlobalEdge {
+                curve: global_curve,
+                vertices: global_vertices,
+            })
         });
 
         Self {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -23,32 +23,7 @@ pub struct PartialHalfEdge {
 impl PartialHalfEdge {
     /// Construct an instance of `PartialHalfEdge`
     pub fn new() -> Self {
-        let curve = Partial::<Curve>::new();
-
-        let vertices = array::from_fn(|_| {
-            Partial::from_partial(PartialVertex {
-                curve: curve.clone(),
-                ..Default::default()
-            })
-        });
-
-        let global_curve = curve.read().global_form.clone();
-        let global_vertices =
-            vertices.each_ref_ext().map(|vertex: &Partial<Vertex>| {
-                let surface_vertex = vertex.read().surface_form.clone();
-                let global_vertex = surface_vertex.read().global_form.clone();
-                global_vertex
-            });
-
-        let global_form = Partial::from_partial(PartialGlobalEdge {
-            curve: global_curve,
-            vertices: global_vertices,
-        });
-
-        Self {
-            vertices,
-            global_form,
-        }
+        Self::default()
     }
 
     /// Access the curve the partial edge is defined on
@@ -87,12 +62,37 @@ impl PartialObject for PartialHalfEdge {
 
 impl Default for PartialHalfEdge {
     fn default() -> Self {
-        Self::new()
+        let curve = Partial::<Curve>::new();
+
+        let vertices = array::from_fn(|_| {
+            Partial::from_partial(PartialVertex {
+                curve: curve.clone(),
+                ..Default::default()
+            })
+        });
+
+        let global_curve = curve.read().global_form.clone();
+        let global_vertices =
+            vertices.each_ref_ext().map(|vertex: &Partial<Vertex>| {
+                let surface_vertex = vertex.read().surface_form.clone();
+                let global_vertex = surface_vertex.read().global_form.clone();
+                global_vertex
+            });
+
+        let global_form = Partial::from_partial(PartialGlobalEdge {
+            curve: global_curve,
+            vertices: global_vertices,
+        });
+
+        Self {
+            vertices,
+            global_form,
+        }
     }
 }
 
 /// A partial [`GlobalEdge`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {
     /// The curve that defines the edge's geometry
     pub curve: Partial<GlobalCurve>,
@@ -104,10 +104,7 @@ pub struct PartialGlobalEdge {
 impl PartialGlobalEdge {
     /// Construct an instance of `PartialGlobalEdge`
     pub fn new() -> Self {
-        Self {
-            curve: Partial::new(),
-            vertices: array::from_fn(|_| Partial::new()),
-        }
+        Self::default()
     }
 }
 
@@ -132,11 +129,5 @@ impl PartialObject for PartialGlobalEdge {
         let vertices = self.vertices.map(|vertex| vertex.build(objects));
 
         GlobalEdge::new(curve, vertices)
-    }
-}
-
-impl Default for PartialGlobalEdge {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -21,13 +21,6 @@ pub struct PartialFace {
     pub color: Option<Color>,
 }
 
-impl PartialFace {
-    /// Construct an instance of `PartialFace`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialFace {
     type Full = Face;
 

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -42,13 +42,14 @@ impl PartialObject for PartialFace {
     type Full = Face;
 
     fn from_full(face: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            Some(Partial::from_full(face.exterior().clone(), cache)),
-            face.interiors()
+        Self {
+            exterior: Partial::from_full(face.exterior().clone(), cache),
+            interiors: face
+                .interiors()
                 .map(|cycle| Partial::from_full(cycle.clone(), cache))
                 .collect(),
-            Some(face.color()),
-        )
+            color: Some(face.color()),
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -23,17 +23,11 @@ pub struct PartialFace {
 
 impl PartialFace {
     /// Construct an instance of `PartialFace`
-    pub fn new(
-        exterior: Option<Partial<Cycle>>,
-        interiors: Vec<Partial<Cycle>>,
-        color: Option<Color>,
-    ) -> Self {
-        let exterior = exterior.unwrap_or_default();
-
+    pub fn new() -> Self {
         Self {
-            exterior,
-            interiors,
-            color,
+            exterior: Partial::new(),
+            interiors: Vec::new(),
+            color: None,
         }
     }
 }
@@ -64,6 +58,6 @@ impl PartialObject for PartialFace {
 
 impl Default for PartialFace {
     fn default() -> Self {
-        Self::new(None, Vec::new(), None)
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A partial [`Face`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialFace {
     /// The cycle that bounds the face on the outside
     pub exterior: Partial<Cycle>,
@@ -24,11 +24,7 @@ pub struct PartialFace {
 impl PartialFace {
     /// Construct an instance of `PartialFace`
     pub fn new() -> Self {
-        Self {
-            exterior: Partial::new(),
-            interiors: Vec::new(),
-            color: None,
-        }
+        Self::default()
     }
 }
 
@@ -53,11 +49,5 @@ impl PartialObject for PartialFace {
         let color = self.color.unwrap_or_default();
 
         Face::new(exterior, interiors, color)
-    }
-}
-
-impl Default for PartialFace {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -13,8 +13,8 @@ pub struct PartialShell {
 
 impl PartialShell {
     /// Construct an instance of `PartialShell`
-    pub fn new(faces: Vec<Partial<Face>>) -> Self {
-        Self { faces }
+    pub fn new() -> Self {
+        Self { faces: Vec::new() }
     }
 }
 
@@ -39,6 +39,6 @@ impl PartialObject for PartialShell {
 
 impl Default for PartialShell {
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Shell`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,
@@ -14,7 +14,7 @@ pub struct PartialShell {
 impl PartialShell {
     /// Construct an instance of `PartialShell`
     pub fn new() -> Self {
-        Self { faces: Vec::new() }
+        Self::default()
     }
 }
 
@@ -34,11 +34,5 @@ impl PartialObject for PartialShell {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let faces = self.faces.into_iter().map(|face| face.build(objects));
         Shell::new(faces)
-    }
-}
-
-impl Default for PartialShell {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -22,13 +22,13 @@ impl PartialObject for PartialShell {
     type Full = Shell;
 
     fn from_full(shell: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            shell
+        Self {
+            faces: shell
                 .faces()
                 .into_iter()
                 .map(|face| Partial::from_full(face.clone(), cache))
                 .collect(),
-        )
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -11,13 +11,6 @@ pub struct PartialShell {
     pub faces: Vec<Partial<Face>>,
 }
 
-impl PartialShell {
-    /// Construct an instance of `PartialShell`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialShell {
     type Full = Shell;
 

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -13,8 +13,8 @@ pub struct PartialSketch {
 
 impl PartialSketch {
     /// Construct an instance of `PartialSketch`
-    pub fn new(faces: Vec<Partial<Face>>) -> Self {
-        Self { faces }
+    pub fn new() -> Self {
+        Self { faces: Vec::new() }
     }
 }
 
@@ -39,6 +39,6 @@ impl PartialObject for PartialSketch {
 
 impl Default for PartialSketch {
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -11,13 +11,6 @@ pub struct PartialSketch {
     pub faces: Vec<Partial<Face>>,
 }
 
-impl PartialSketch {
-    /// Construct an instance of `PartialSketch`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialSketch {
     type Full = Sketch;
 

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -22,13 +22,13 @@ impl PartialObject for PartialSketch {
     type Full = Sketch;
 
     fn from_full(sketch: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            sketch
+        Self {
+            faces: sketch
                 .faces()
                 .into_iter()
                 .map(|face| Partial::from_full(face.clone(), cache))
                 .collect(),
-        )
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,
@@ -14,7 +14,7 @@ pub struct PartialSketch {
 impl PartialSketch {
     /// Construct an instance of `PartialSketch`
     pub fn new() -> Self {
-        Self { faces: Vec::new() }
+        Self::default()
     }
 }
 
@@ -34,11 +34,5 @@ impl PartialObject for PartialSketch {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let faces = self.faces.into_iter().map(|face| face.build(objects));
         Sketch::new(faces)
-    }
-}
-
-impl Default for PartialSketch {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Solid`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,
@@ -14,7 +14,7 @@ pub struct PartialSolid {
 impl PartialSolid {
     /// Construct an instance of `PartialSolid`
     pub fn new() -> Self {
-        Self { shells: Vec::new() }
+        Self::default()
     }
 }
 
@@ -33,11 +33,5 @@ impl PartialObject for PartialSolid {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let shells = self.shells.into_iter().map(|shell| shell.build(objects));
         Solid::new(shells)
-    }
-}
-
-impl Default for PartialSolid {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -22,12 +22,12 @@ impl PartialObject for PartialSolid {
     type Full = Solid;
 
     fn from_full(solid: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            solid
+        Self {
+            shells: solid
                 .shells()
                 .map(|shell| Partial::from_full(shell.clone(), cache))
                 .collect(),
-        )
+        }
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -11,13 +11,6 @@ pub struct PartialSolid {
     pub shells: Vec<Partial<Shell>>,
 }
 
-impl PartialSolid {
-    /// Construct an instance of `PartialSolid`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialSolid {
     type Full = Solid;
 

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -13,8 +13,8 @@ pub struct PartialSolid {
 
 impl PartialSolid {
     /// Construct an instance of `PartialSolid`
-    pub fn new(shells: Vec<Partial<Shell>>) -> Self {
-        Self { shells }
+    pub fn new() -> Self {
+        Self { shells: Vec::new() }
     }
 }
 
@@ -38,6 +38,6 @@ impl PartialObject for PartialSolid {
 
 impl Default for PartialSolid {
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -14,8 +14,8 @@ pub struct PartialSurface {
 
 impl PartialSurface {
     /// Construct an instance of `PartialSurface`
-    pub fn new(geometry: Option<SurfaceGeometry>) -> Self {
-        Self { geometry }
+    pub fn new() -> Self {
+        Self { geometry: None }
     }
 }
 
@@ -39,6 +39,6 @@ impl PartialObject for PartialSurface {
 
 impl Default for PartialSurface {
     fn default() -> Self {
-        Self::new(None)
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -23,7 +23,9 @@ impl PartialObject for PartialSurface {
     type Full = Surface;
 
     fn from_full(surface: &Self::Full, _: &mut FullToPartialCache) -> Self {
-        Self::new(Some(surface.geometry()))
+        Self {
+            geometry: Some(surface.geometry()),
+        }
     }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -12,13 +12,6 @@ pub struct PartialSurface {
     pub geometry: Option<SurfaceGeometry>,
 }
 
-impl PartialSurface {
-    /// Construct an instance of `PartialSurface`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialSurface {
     type Full = Surface;
 

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Surface`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,
@@ -15,7 +15,7 @@ pub struct PartialSurface {
 impl PartialSurface {
     /// Construct an instance of `PartialSurface`
     pub fn new() -> Self {
-        Self { geometry: None }
+        Self::default()
     }
 }
 
@@ -34,11 +34,5 @@ impl PartialObject for PartialSurface {
             .expect("Can't build `Surface` without geometry");
 
         Surface::new(geometry)
-    }
-}
-
-impl Default for PartialSurface {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -30,11 +30,10 @@ impl PartialVertex {
         let surface = Partial::new();
 
         let curve = curve.unwrap_or_else(|| {
-            Partial::from_partial(PartialCurve::new(
-                None,
-                Some(surface.clone()),
-                None,
-            ))
+            Partial::from_partial(PartialCurve {
+                surface: surface.clone(),
+                ..Default::default()
+            })
         });
         let surface_form = surface_form.unwrap_or_else(|| {
             Partial::from_partial(PartialSurfaceVertex::new(

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -20,13 +20,6 @@ pub struct PartialVertex {
     pub surface_form: Partial<SurfaceVertex>,
 }
 
-impl PartialVertex {
-    /// Construct an instance of `PartialVertex`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialVertex {
     type Full = Vertex;
 
@@ -93,13 +86,6 @@ pub struct PartialSurfaceVertex {
     pub global_form: Partial<GlobalVertex>,
 }
 
-impl PartialSurfaceVertex {
-    /// Construct an instance of `PartialSurfaceVertex`
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl PartialObject for PartialSurfaceVertex {
     type Full = SurfaceVertex;
 
@@ -140,13 +126,6 @@ impl PartialObject for PartialSurfaceVertex {
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,
-}
-
-impl PartialGlobalVertex {
-    /// Construct an instance of `PartialGlobalVertex`
-    pub fn new() -> Self {
-        Self::default()
-    }
 }
 
 impl PartialObject for PartialGlobalVertex {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -23,22 +23,7 @@ pub struct PartialVertex {
 impl PartialVertex {
     /// Construct an instance of `PartialVertex`
     pub fn new() -> Self {
-        let surface = Partial::new();
-
-        let curve = Partial::from_partial(PartialCurve {
-            surface: surface.clone(),
-            ..Default::default()
-        });
-        let surface_form = Partial::from_partial(PartialSurfaceVertex {
-            surface,
-            ..Default::default()
-        });
-
-        Self {
-            position: None,
-            curve,
-            surface_form,
-        }
+        Self::default()
     }
 }
 
@@ -76,12 +61,27 @@ impl PartialObject for PartialVertex {
 
 impl Default for PartialVertex {
     fn default() -> Self {
-        Self::new()
+        let surface = Partial::new();
+
+        let curve = Partial::from_partial(PartialCurve {
+            surface: surface.clone(),
+            ..Default::default()
+        });
+        let surface_form = Partial::from_partial(PartialSurfaceVertex {
+            surface,
+            ..Default::default()
+        });
+
+        Self {
+            position: None,
+            curve,
+            surface_form,
+        }
     }
 }
 
 /// A partial [`SurfaceVertex`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
@@ -96,11 +96,7 @@ pub struct PartialSurfaceVertex {
 impl PartialSurfaceVertex {
     /// Construct an instance of `PartialSurfaceVertex`
     pub fn new() -> Self {
-        Self {
-            position: None,
-            surface: Partial::new(),
-            global_form: Partial::new(),
-        }
+        Self::default()
     }
 }
 
@@ -139,14 +135,8 @@ impl PartialObject for PartialSurfaceVertex {
     }
 }
 
-impl Default for PartialSurfaceVertex {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// A partial [`GlobalVertex`]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PartialGlobalVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,
@@ -155,7 +145,7 @@ pub struct PartialGlobalVertex {
 impl PartialGlobalVertex {
     /// Construct an instance of `PartialGlobalVertex`
     pub fn new() -> Self {
-        Self { position: None }
+        Self::default()
     }
 }
 
@@ -177,11 +167,5 @@ impl PartialObject for PartialGlobalVertex {
             .expect("Can't build `GlobalVertex` without position");
 
         GlobalVertex::new(position)
-    }
-}
-
-impl Default for PartialGlobalVertex {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -36,11 +36,10 @@ impl PartialVertex {
             })
         });
         let surface_form = surface_form.unwrap_or_else(|| {
-            Partial::from_partial(PartialSurfaceVertex::new(
-                None,
-                Some(surface),
-                None,
-            ))
+            Partial::from_partial(PartialSurfaceVertex {
+                surface,
+                ..Default::default()
+            })
         });
 
         Self {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -56,11 +56,14 @@ impl PartialObject for PartialVertex {
     type Full = Vertex;
 
     fn from_full(vertex: &Self::Full, cache: &mut FullToPartialCache) -> Self {
-        Self::new(
-            Some(vertex.position()),
-            Some(Partial::from_full(vertex.curve().clone(), cache)),
-            Some(Partial::from_full(vertex.surface_form().clone(), cache)),
-        )
+        Self {
+            position: Some(vertex.position()),
+            curve: Partial::from_full(vertex.curve().clone(), cache),
+            surface_form: Partial::from_full(
+                vertex.surface_form().clone(),
+                cache,
+            ),
+        }
     }
 
     fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
@@ -125,14 +128,17 @@ impl PartialObject for PartialSurfaceVertex {
         surface_vertex: &Self::Full,
         cache: &mut FullToPartialCache,
     ) -> Self {
-        Self::new(
-            Some(surface_vertex.position()),
-            Some(Partial::from_full(surface_vertex.surface().clone(), cache)),
-            Some(Partial::from_full(
+        Self {
+            position: Some(surface_vertex.position()),
+            surface: Partial::from_full(
+                surface_vertex.surface().clone(),
+                cache,
+            ),
+            global_form: Partial::from_full(
                 surface_vertex.global_form().clone(),
                 cache,
-            )),
-        )
+            ),
+        }
     }
 
     fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
@@ -177,7 +183,9 @@ impl PartialObject for PartialGlobalVertex {
         global_vertex: &Self::Full,
         _: &mut FullToPartialCache,
     ) -> Self {
-        Self::new(Some(global_vertex.position()))
+        Self {
+            position: Some(global_vertex.position()),
+        }
     }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -22,28 +22,20 @@ pub struct PartialVertex {
 
 impl PartialVertex {
     /// Construct an instance of `PartialVertex`
-    pub fn new(
-        position: Option<Point<1>>,
-        curve: Option<Partial<Curve>>,
-        surface_form: Option<Partial<SurfaceVertex>>,
-    ) -> Self {
+    pub fn new() -> Self {
         let surface = Partial::new();
 
-        let curve = curve.unwrap_or_else(|| {
-            Partial::from_partial(PartialCurve {
-                surface: surface.clone(),
-                ..Default::default()
-            })
+        let curve = Partial::from_partial(PartialCurve {
+            surface: surface.clone(),
+            ..Default::default()
         });
-        let surface_form = surface_form.unwrap_or_else(|| {
-            Partial::from_partial(PartialSurfaceVertex {
-                surface,
-                ..Default::default()
-            })
+        let surface_form = Partial::from_partial(PartialSurfaceVertex {
+            surface,
+            ..Default::default()
         });
 
         Self {
-            position,
+            position: None,
             curve,
             surface_form,
         }
@@ -84,7 +76,7 @@ impl PartialObject for PartialVertex {
 
 impl Default for PartialVertex {
     fn default() -> Self {
-        Self::new(None, None, None)
+        Self::new()
     }
 }
 
@@ -103,18 +95,11 @@ pub struct PartialSurfaceVertex {
 
 impl PartialSurfaceVertex {
     /// Construct an instance of `PartialSurfaceVertex`
-    pub fn new(
-        position: Option<Point<2>>,
-        surface: Option<Partial<Surface>>,
-        global_form: Option<Partial<GlobalVertex>>,
-    ) -> Self {
-        let surface = surface.unwrap_or_default();
-        let global_form = global_form.unwrap_or_default();
-
+    pub fn new() -> Self {
         Self {
-            position,
-            surface,
-            global_form,
+            position: None,
+            surface: Partial::new(),
+            global_form: Partial::new(),
         }
     }
 }
@@ -156,7 +141,7 @@ impl PartialObject for PartialSurfaceVertex {
 
 impl Default for PartialSurfaceVertex {
     fn default() -> Self {
-        Self::new(None, None, None)
+        Self::new()
     }
 }
 
@@ -169,8 +154,8 @@ pub struct PartialGlobalVertex {
 
 impl PartialGlobalVertex {
     /// Construct an instance of `PartialGlobalVertex`
-    pub fn new(position: Option<Point<3>>) -> Self {
-        Self { position }
+    pub fn new() -> Self {
+        Self { position: None }
     }
 }
 
@@ -197,6 +182,6 @@ impl PartialObject for PartialGlobalVertex {
 
 impl Default for PartialGlobalVertex {
     fn default() -> Self {
-        Self::new(None)
+        Self::new()
     }
 }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -42,8 +42,9 @@ impl Shape for fj::Sketch {
 
                     Partial::from_partial(half_edge)
                 };
-                let cycle =
-                    Partial::from_partial(PartialCycle::new(vec![half_edge]));
+                let cycle = Partial::from_partial(PartialCycle {
+                    half_edges: vec![half_edge],
+                });
 
                 let face = PartialFace {
                     exterior: cycle,


### PR DESCRIPTION
Remove their constructors and replace them with their `Default` implementations. Derive those `Default` implementations, where possible.

This is another step towards addressing #1249.