### PR TITLE
Simplify conversion from full to partial objects

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -215,7 +215,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface),
+            surface: Partial::from(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
@@ -240,7 +240,7 @@ mod tests {
         .build(&mut services.objects)
         .insert(&mut services.objects);
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface),
+            surface: Partial::from(surface),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
@@ -263,7 +263,7 @@ mod tests {
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface.clone()),
+            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
@@ -296,7 +296,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface),
+            surface: Partial::from(surface),
             ..Default::default()
         };
         curve.update_as_circle_from_radius(1.);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -86,9 +86,7 @@ mod tests {
     fn compute_edge_in_front_of_curve_origin() {
         let mut services = Services::new();
 
-        let surface = Partial::from_full_entry_point(
-            services.objects.surfaces.xy_plane(),
-        );
+        let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
             surface: surface.clone(),
             ..Default::default()
@@ -119,9 +117,7 @@ mod tests {
     fn compute_edge_behind_curve_origin() {
         let mut services = Services::new();
 
-        let surface = Partial::from_full_entry_point(
-            services.objects.surfaces.xy_plane(),
-        );
+        let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
             surface: surface.clone(),
             ..Default::default()
@@ -152,9 +148,7 @@ mod tests {
     fn compute_edge_parallel_to_curve() {
         let mut services = Services::new();
 
-        let surface = Partial::from_full_entry_point(
-            services.objects.surfaces.xy_plane(),
-        );
+        let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
             surface: surface.clone(),
             ..Default::default()
@@ -180,9 +174,7 @@ mod tests {
     fn compute_edge_on_curve() {
         let mut services = Services::new();
 
-        let surface = Partial::from_full_entry_point(
-            services.objects.surfaces.xy_plane(),
-        );
+        let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
             surface: surface.clone(),
             ..Default::default()

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -164,7 +164,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface.clone()),
+            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);
@@ -187,14 +187,8 @@ mod tests {
 
         let face = {
             let mut face = PartialFace::default();
-            face.with_exterior_polygon_from_points(
-                Partial::from_full_entry_point(surface.clone()),
-                exterior,
-            );
-            face.with_interior_polygon_from_points(
-                Partial::from_full_entry_point(surface),
-                interior,
-            );
+            face.with_exterior_polygon_from_points(surface.clone(), exterior);
+            face.with_interior_polygon_from_points(surface, interior);
 
             face.build(&mut services.objects)
         };

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -94,10 +94,7 @@ mod tests {
         ]
         .map(|surface| {
             let mut face = PartialFace::default();
-            face.with_exterior_polygon_from_points(
-                Partial::from_full_entry_point(surface),
-                points,
-            );
+            face.with_exterior_polygon_from_points(surface, points);
 
             face.build(&mut services.objects)
         });
@@ -125,10 +122,7 @@ mod tests {
         ];
         let [a, b] = surfaces.clone().map(|surface| {
             let mut face = PartialFace::default();
-            face.with_exterior_polygon_from_points(
-                Partial::from_full_entry_point(surface),
-                points,
-            );
+            face.with_exterior_polygon_from_points(surface, points);
 
             face.build(&mut services.objects)
         });
@@ -138,7 +132,7 @@ mod tests {
 
         let expected_curves = surfaces.map(|surface| {
             let mut curve = PartialCurve {
-                surface: Partial::from_full_entry_point(surface),
+                surface: Partial::from(surface),
                 ..Default::default()
             };
             curve.update_as_line_from_points([[0., 0.], [1., 0.]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -139,7 +139,7 @@ mod tests {
         builder::FaceBuilder,
         insert::Insert,
         iter::ObjectIters,
-        partial::{Partial, PartialFace, PartialObject},
+        partial::{PartialFace, PartialObject},
         services::Services,
     };
 
@@ -150,7 +150,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [1., 1.], [0., 2.]],
         );
         let face = face
@@ -169,7 +169,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [2., 1.], [0., 2.]],
         );
         let face = face
@@ -191,7 +191,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[4., 2.], [0., 4.], [0., 0.]],
         );
         let face = face
@@ -213,7 +213,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
         );
         let face = face
@@ -235,7 +235,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
         );
         let face = face
@@ -257,7 +257,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
         );
         let face = face
@@ -279,7 +279,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [2., 0.], [0., 1.]],
         );
         let face = face
@@ -310,7 +310,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [1., 0.], [0., 1.]],
         );
         let face = face

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -155,7 +155,7 @@ mod tests {
         builder::FaceBuilder,
         insert::Insert,
         iter::ObjectIters,
-        partial::{Partial, PartialFace, PartialObject},
+        partial::{PartialFace, PartialObject},
         services::Services,
     };
 
@@ -168,7 +168,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -188,7 +188,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -211,7 +211,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -231,7 +231,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -262,7 +262,7 @@ mod tests {
         let surface = services.objects.surfaces.yz_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -291,7 +291,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face
@@ -313,7 +313,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
         );
         let face = face

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -121,7 +121,7 @@ mod tests {
         );
 
         let mut expected_xy = PartialCurve {
-            surface: Partial::from_full_entry_point(xy.clone()),
+            surface: Partial::from(xy.clone()),
             ..Default::default()
         };
         expected_xy.update_as_u_axis();
@@ -129,7 +129,7 @@ mod tests {
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let mut expected_xz = PartialCurve {
-            surface: Partial::from_full_entry_point(xz.clone()),
+            surface: Partial::from(xz.clone()),
             ..Default::default()
         };
         expected_xz.update_as_u_axis();

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -175,7 +175,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         };
 
         let face = PartialFace {
-            exterior: Partial::from_full_entry_point(cycle),
+            exterior: Partial::from(cycle),
             color: Some(color),
             ..Default::default()
         };
@@ -205,9 +205,7 @@ mod tests {
         let half_edge = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             );
 
@@ -220,9 +218,7 @@ mod tests {
             .sweep([0., 0., 1.], &mut services.objects);
 
         let expected_face = {
-            let surface = Partial::from_full_entry_point(
-                services.objects.surfaces.xz_plane(),
-            );
+            let surface = Partial::from(services.objects.surfaces.xz_plane());
 
             let bottom = {
                 let mut half_edge = PartialHalfEdge::default();
@@ -275,7 +271,7 @@ mod tests {
 
                 top.update_as_line_segment();
 
-                Partial::from_full_entry_point(
+                Partial::from(
                     top.build(&mut services.objects)
                         .insert(&mut services.objects)
                         .reverse(&mut services.objects),
@@ -301,7 +297,7 @@ mod tests {
 
                 side_down.update_as_line_segment();
 
-                Partial::from_full_entry_point(
+                Partial::from(
                     side_down
                         .build(&mut services.objects)
                         .insert(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -87,7 +87,7 @@ mod tests {
         builder::{FaceBuilder, HalfEdgeBuilder},
         insert::Insert,
         objects::Sketch,
-        partial::{Partial, PartialFace, PartialHalfEdge, PartialObject},
+        partial::{PartialFace, PartialHalfEdge, PartialObject},
         services::Services,
     };
 
@@ -113,19 +113,14 @@ mod tests {
             .sweep(UP, &mut services.objects);
 
         let mut bottom = PartialFace::default();
-        bottom.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface.clone()),
-            TRIANGLE,
-        );
+        bottom.with_exterior_polygon_from_points(surface.clone(), TRIANGLE);
         let bottom = bottom
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
         let mut top = PartialFace::default();
         top.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(
-                surface.translate(UP, &mut services.objects),
-            ),
+            surface.translate(UP, &mut services.objects),
             TRIANGLE,
         );
         let top = top
@@ -140,9 +135,7 @@ mod tests {
             let half_edge = {
                 let mut half_edge = PartialHalfEdge::default();
                 half_edge.update_as_line_segment_from_points(
-                    Partial::from_full_entry_point(
-                        services.objects.surfaces.xy_plane(),
-                    ),
+                    services.objects.surfaces.xy_plane(),
                     [a, b],
                 );
 
@@ -174,9 +167,7 @@ mod tests {
 
         let mut bottom = PartialFace::default();
         bottom.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(
-                surface.clone().translate(DOWN, &mut services.objects),
-            ),
+            surface.clone().translate(DOWN, &mut services.objects),
             TRIANGLE,
         );
         let bottom = bottom
@@ -184,10 +175,7 @@ mod tests {
             .insert(&mut services.objects)
             .reverse(&mut services.objects);
         let mut top = PartialFace::default();
-        top.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
-            TRIANGLE,
-        );
+        top.with_exterior_polygon_from_points(surface, TRIANGLE);
         let top = top
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -200,9 +188,7 @@ mod tests {
             let half_edge = {
                 let mut half_edge = PartialHalfEdge::default();
                 half_edge.update_as_line_segment_from_points(
-                    Partial::from_full_entry_point(
-                        services.objects.surfaces.xy_plane(),
-                    ),
+                    services.objects.surfaces.xy_plane(),
                     [a, b],
                 );
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -176,7 +176,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface.clone()),
+            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_u_axis();
@@ -185,9 +185,9 @@ mod tests {
             .insert(&mut services.objects);
         let vertex = PartialVertex {
             position: Some([0.].into()),
-            curve: Partial::from_full_entry_point(curve),
+            curve: Partial::from(curve),
             surface_form: Partial::from_partial(PartialSurfaceVertex {
-                surface: Partial::from_full_entry_point(surface.clone()),
+                surface: Partial::from(surface.clone()),
                 ..Default::default()
             }),
         }
@@ -200,7 +200,7 @@ mod tests {
         let expected_half_edge = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(surface),
+                surface,
                 [[0., 0.], [0., 1.]],
             );
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -80,7 +80,7 @@ mod tests {
         builder::FaceBuilder,
         insert::Insert,
         objects::Face,
-        partial::{Partial, PartialFace, PartialObject},
+        partial::{PartialFace, PartialObject},
         services::Services,
         storage::Handle,
     };
@@ -98,10 +98,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
-        face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
-            [a, b, c, d],
-        );
+        face.with_exterior_polygon_from_points(surface, [a, b, c, d]);
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -137,14 +134,8 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
-        face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface.clone()),
-            [a, b, c, d],
-        );
-        face.with_interior_polygon_from_points(
-            Partial::from_full_entry_point(surface.clone()),
-            [e, f, g, h],
-        );
+        face.with_exterior_polygon_from_points(surface.clone(), [a, b, c, d]);
+        face.with_interior_polygon_from_points(surface.clone(), [e, f, g, h]);
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -203,7 +194,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface.clone()),
+            surface.clone(),
             [a, b, c, d, e],
         );
         let face = face

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -19,7 +19,7 @@ pub trait CycleBuilder {
     /// Update the partial cycle with a polygonal chain from the provided points
     fn with_poly_chain_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     );
 
@@ -85,9 +85,11 @@ impl CycleBuilder for PartialCycle {
 
     fn with_poly_chain_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
+        let surface = surface.into();
+
         self.with_poly_chain(points.into_iter().map(|position| {
             PartialSurfaceVertex {
                 position: Some(position.into()),

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -16,7 +16,7 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment, from the given points
     fn update_as_line_segment_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: [impl Into<Point<2>>; 2],
     );
 
@@ -59,9 +59,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: [impl Into<Point<2>>; 2],
     ) {
+        let surface = surface.into();
+
         for (vertex, point) in self.vertices.each_mut_ext().zip_ext(points) {
             let mut vertex = vertex.write();
             vertex.curve.write().surface = surface.clone();

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -12,14 +12,14 @@ pub trait FaceBuilder {
     /// Update the [`PartialFace`] with an exterior polygon
     fn with_exterior_polygon_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     );
 
     /// Update the [`PartialFace`] with an interior polygon
     fn with_interior_polygon_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     );
 }
@@ -27,7 +27,7 @@ pub trait FaceBuilder {
 impl FaceBuilder for PartialFace {
     fn with_exterior_polygon_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
         let mut cycle = PartialCycle::default();
@@ -39,7 +39,7 @@ impl FaceBuilder for PartialFace {
 
     fn with_interior_polygon_from_points(
         &mut self,
-        surface: Partial<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
         let mut cycle = PartialCycle::default();

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -55,7 +55,7 @@ impl ShellBuilder {
 
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(
-                Partial::from_full_entry_point(surface),
+                surface,
                 [[-h, -h], [h, -h], [h, h], [-h, h]],
             );
 
@@ -276,7 +276,7 @@ impl ShellBuilder {
         };
 
         let top = {
-            let surface = Partial::from_full_entry_point(
+            let surface = Partial::from(
                 objects.surfaces.xy_plane().translate([Z, Z, h], objects),
             );
 

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -3,7 +3,7 @@ use fj_math::Point;
 use crate::{
     insert::Insert,
     objects::{Face, FaceSet, Objects, Sketch, Surface},
-    partial::{Partial, PartialFace, PartialObject},
+    partial::{PartialFace, PartialObject},
     services::Service,
     storage::Handle,
 };
@@ -36,10 +36,7 @@ impl SketchBuilder {
         objects: &mut Service<Objects>,
     ) -> Self {
         let mut face = PartialFace::default();
-        face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
-            points,
-        );
+        face.with_exterior_polygon_from_points(surface, points);
         let face = face.build(objects).insert(objects);
 
         self.faces.extend([face]);

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -381,7 +381,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut object = PartialCurve {
-            surface: Partial::from_full_entry_point(surface),
+            surface: Partial::from(surface),
             ..Default::default()
         };
         object.update_as_u_axis();
@@ -410,7 +410,7 @@ mod tests {
         let object = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
-                Partial::from_full_entry_point(surface),
+                surface,
                 [[0., 0.], [1., 0.], [0., 1.]],
             );
             cycle.close_with_line_segment();
@@ -440,7 +440,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut object = PartialFace::default();
         object.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [1., 0.], [0., 1.]],
         );
         let object = object
@@ -506,9 +506,7 @@ mod tests {
         let object = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             );
 
@@ -558,7 +556,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(
-            Partial::from_full_entry_point(surface),
+            surface,
             [[0., 0.], [1., 0.], [0., 1.]],
         );
         let face = face
@@ -627,7 +625,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut curve = PartialCurve {
-            surface: Partial::from_full_entry_point(surface.clone()),
+            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_u_axis();

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -148,7 +148,7 @@ mod tests {
 
     use crate::{
         builder::HalfEdgeBuilder,
-        partial::{Partial, PartialHalfEdge, PartialObject},
+        partial::{PartialHalfEdge, PartialObject},
         services::Services,
     };
 
@@ -156,9 +156,7 @@ mod tests {
     fn global_edge_equality() {
         let mut services = Services::new();
 
-        let surface = Partial::from_full_entry_point(
-            services.objects.surfaces.xy_plane(),
-        );
+        let surface = services.objects.surfaces.xy_plane();
 
         let a = [0., 0.];
         let b = [1., 0.];

--- a/crates/fj-kernel/src/partial/wrapper.rs
+++ b/crates/fj-kernel/src/partial/wrapper.rs
@@ -61,16 +61,6 @@ impl<T: HasPartial + 'static> Partial<T> {
         Self { inner }
     }
 
-    /// Construct a partial from the entry point to an object graph
-    ///
-    /// This is a convenience wrapper around [`Self::from_full`], passing an
-    /// empty cache to that method. It it not appropriate to call this method,
-    /// unless to start a conversion of an object graph by passing its entry
-    /// point.
-    pub fn from_full_entry_point(full: Handle<T>) -> Self {
-        Self::from(full)
-    }
-
     /// Access the ID of this partial object
     pub fn id(&self) -> ObjectId {
         self.inner.id()

--- a/crates/fj-kernel/src/partial/wrapper.rs
+++ b/crates/fj-kernel/src/partial/wrapper.rs
@@ -68,8 +68,7 @@ impl<T: HasPartial + 'static> Partial<T> {
     /// unless to start a conversion of an object graph by passing its entry
     /// point.
     pub fn from_full_entry_point(full: Handle<T>) -> Self {
-        let mut cache = FullToPartialCache::default();
-        Self::from_full(full, &mut cache)
+        Self::from(full)
     }
 
     /// Access the ID of this partial object
@@ -156,6 +155,13 @@ impl<T: HasPartial> Clone for Partial<T> {
 impl<T: HasPartial + 'static> Default for Partial<T> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<T: HasPartial + 'static> From<Handle<T>> for Partial<T> {
+    fn from(full: Handle<T>) -> Self {
+        let mut cache = FullToPartialCache::default();
+        Self::from_full(full, &mut cache)
     }
 }
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -80,9 +80,7 @@ mod tests {
         let valid = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.], [0., 1.]],
             );
             cycle.close_with_line_segment();
@@ -92,9 +90,7 @@ mod tests {
         let invalid = {
             let mut half_edges = valid
                 .half_edges()
-                .map(|half_edge| {
-                    Partial::from_full_entry_point(half_edge.clone())
-                })
+                .map(|half_edge| Partial::from(half_edge.clone()))
                 .collect::<Vec<_>>();
 
             // Sever connection between the last and first half-edge in the

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -217,9 +217,7 @@ mod tests {
         let valid = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             );
 
@@ -227,13 +225,10 @@ mod tests {
         };
         let invalid = {
             let mut vertices = valid.vertices().clone();
-            let mut vertex =
-                Partial::from_full_entry_point(vertices[1].clone());
+            let mut vertex = Partial::from(vertices[1].clone());
             // Arranging for an equal but not identical curve here.
             vertex.write().curve = Partial::from_partial(
-                Partial::from_full_entry_point(valid.curve().clone())
-                    .read()
-                    .clone(),
+                Partial::from(valid.curve().clone()).read().clone(),
             );
             vertices[1] = vertex.build(&mut services.objects);
 
@@ -251,20 +246,16 @@ mod tests {
         let valid = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             );
 
             half_edge.build(&mut services.objects)
         };
         let invalid = HalfEdge::new(valid.vertices().clone(), {
-            let mut tmp =
-                Partial::from_full_entry_point(valid.global_form().clone());
-            tmp.write().curve = Partial::from_full_entry_point(
-                GlobalCurve.insert(&mut services.objects),
-            );
+            let mut tmp = Partial::from(valid.global_form().clone());
+            tmp.write().curve =
+                Partial::from(GlobalCurve.insert(&mut services.objects));
             tmp.build(&mut services.objects)
         });
 
@@ -279,26 +270,21 @@ mod tests {
         let valid = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             );
 
             half_edge.build(&mut services.objects)
         };
         let invalid = HalfEdge::new(valid.vertices().clone(), {
-            let mut tmp =
-                Partial::from_full_entry_point(valid.global_form().clone());
+            let mut tmp = Partial::from(valid.global_form().clone());
             tmp.write().vertices = valid
                 .global_form()
                 .vertices()
                 .access_in_normalized_order()
                 // Creating equal but not identical vertices here.
                 .map(|vertex| {
-                    Partial::from_partial(
-                        Partial::from_full_entry_point(vertex).read().clone(),
-                    )
+                    Partial::from_partial(Partial::from(vertex).read().clone())
                 });
             tmp.build(&mut services.objects)
         });
@@ -314,9 +300,7 @@ mod tests {
         let valid = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xy_plane(),
-                ),
+                services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.]],
             );
 
@@ -324,8 +308,7 @@ mod tests {
         };
         let invalid = HalfEdge::new(
             valid.vertices().clone().map(|vertex| {
-                let vertex =
-                    Partial::from_full_entry_point(vertex).read().clone();
+                let vertex = Partial::from(vertex).read().clone();
                 let surface = vertex.surface_form.read().surface.clone();
                 PartialVertex {
                     position: Some([0.].into()),

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -108,7 +108,7 @@ mod tests {
         builder::{CycleBuilder, FaceBuilder},
         insert::Insert,
         objects::Face,
-        partial::{Partial, PartialCycle, PartialFace, PartialObject},
+        partial::{PartialCycle, PartialFace, PartialObject},
         services::Services,
         validate::Validate,
     };
@@ -122,11 +122,11 @@ mod tests {
         let valid = {
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(
-                Partial::from_full_entry_point(surface.clone()),
+                surface.clone(),
                 [[0., 0.], [3., 0.], [0., 3.]],
             );
             face.with_interior_polygon_from_points(
-                Partial::from_full_entry_point(surface),
+                surface,
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
 
@@ -135,9 +135,7 @@ mod tests {
         let invalid = {
             let mut cycle = PartialCycle::default();
             cycle.with_poly_chain_from_points(
-                Partial::from_full_entry_point(
-                    services.objects.surfaces.xz_plane(),
-                ),
+                services.objects.surfaces.xz_plane(),
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
             cycle.close_with_line_segment();
@@ -162,11 +160,11 @@ mod tests {
         let valid = {
             let mut face = PartialFace::default();
             face.with_exterior_polygon_from_points(
-                Partial::from_full_entry_point(surface.clone()),
+                surface.clone(),
                 [[0., 0.], [3., 0.], [0., 3.]],
             );
             face.with_interior_polygon_from_points(
-                Partial::from_full_entry_point(surface),
+                surface,
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
             face.build(&mut services.objects)

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -195,9 +195,7 @@ mod tests {
     fn vertex_surface_mismatch() {
         let mut services = Services::new();
 
-        let surface = Partial::from_full_entry_point(
-            services.objects.surfaces.xy_plane(),
-        );
+        let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
             surface: surface.clone(),
             ..Default::default()
@@ -214,11 +212,9 @@ mod tests {
         }
         .build(&mut services.objects);
         let invalid = {
-            let mut surface_form =
-                Partial::from_full_entry_point(valid.surface_form().clone());
-            surface_form.write().surface = Partial::from_full_entry_point(
-                services.objects.surfaces.xz_plane(),
-            );
+            let mut surface_form = Partial::from(valid.surface_form().clone());
+            surface_form.write().surface =
+                Partial::from(services.objects.surfaces.xz_plane());
             let surface_form = surface_form.build(&mut services.objects);
 
             Vertex::new(valid.position(), valid.curve().clone(), surface_form)
@@ -233,9 +229,7 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let surface = Partial::from_full_entry_point(
-                services.objects.surfaces.xy_plane(),
-            );
+            let surface = Partial::from(services.objects.surfaces.xy_plane());
             let mut curve = PartialCurve {
                 surface: surface.clone(),
                 ..Default::default()
@@ -253,8 +247,7 @@ mod tests {
             .build(&mut services.objects)
         };
         let invalid = {
-            let mut surface_form =
-                Partial::from_full_entry_point(valid.surface_form().clone());
+            let mut surface_form = Partial::from(valid.surface_form().clone());
             surface_form.write().position = Some([1., 0.].into());
             surface_form.write().global_form = Partial::new();
             let surface_form = surface_form.build(&mut services.objects);
@@ -272,9 +265,7 @@ mod tests {
 
         let valid = PartialSurfaceVertex {
             position: Some([0., 0.].into()),
-            surface: Partial::from_full_entry_point(
-                services.objects.surfaces.xy_plane(),
-            ),
+            surface: Partial::from(services.objects.surfaces.xy_plane()),
             ..Default::default()
         }
         .build(&mut services.objects);

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -48,9 +48,8 @@ impl Shape for fj::Difference2d {
 
                 exteriors.push(face.exterior().clone());
                 for cycle in face.interiors() {
-                    interiors.push(Partial::from_full_entry_point(
-                        cycle.clone().reverse(objects),
-                    ));
+                    interiors
+                        .push(Partial::from(cycle.clone().reverse(objects)));
                 }
             }
 
@@ -61,7 +60,7 @@ impl Shape for fj::Difference2d {
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                interiors.push(Partial::from_full_entry_point(
+                interiors.push(Partial::from(
                     face.exterior().clone().reverse(objects),
                 ));
             }
@@ -84,7 +83,7 @@ impl Shape for fj::Difference2d {
             );
 
             let face = PartialFace {
-                exterior: Partial::from_full_entry_point(exterior),
+                exterior: Partial::from(exterior),
                 interiors,
                 color: Some(Color(self.color())),
             };

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -27,7 +27,7 @@ impl Shape for fj::Sketch {
         let face = match self.chain() {
             fj::Chain::Circle(circle) => {
                 let half_edge = {
-                    let surface = Partial::from_full_entry_point(surface);
+                    let surface = Partial::from(surface);
 
                     let mut half_edge = PartialHalfEdge::default();
 
@@ -61,10 +61,7 @@ impl Shape for fj::Sketch {
                     .map(Point::from);
 
                 let mut face = PartialFace::default();
-                face.with_exterior_polygon_from_points(
-                    Partial::from_full_entry_point(surface),
-                    points,
-                );
+                face.with_exterior_polygon_from_points(surface, points);
                 face.color = Some(Color(self.color()));
 
                 face.build(objects).insert(objects)


### PR DESCRIPTION
Implement `From<Handle<T>>` for `Partial<T>` and use that to replace `Partial::from_full_entry_point`.

This is another step towards #1249.