### PR TITLE
Simplify `CycleBuilder`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -238,8 +238,6 @@ mod tests {
 
                     back.write().surface_form =
                         bottom.vertices[1].read().surface_form.clone();
-                    side_up.global_form.write().vertices[0] =
-                        back.read().surface_form.read().global_form.clone();
 
                     let mut front = front.write();
                     let mut front = front.surface_form.write();
@@ -247,6 +245,7 @@ mod tests {
                     front.surface = surface.clone();
                 }
 
+                side_up.infer_global_form();
                 side_up.update_as_line_segment();
 
                 side_up
@@ -265,10 +264,9 @@ mod tests {
 
                     front.write().surface_form =
                         side_up.vertices[1].read().surface_form.clone();
-                    top.global_form.write().vertices[1] =
-                        front.read().surface_form.read().global_form.clone();
                 }
 
+                top.infer_global_form();
                 top.update_as_line_segment();
 
                 Partial::from(
@@ -287,14 +285,10 @@ mod tests {
 
                 back.write().surface_form =
                     bottom.vertices[0].read().surface_form.clone();
-                side_down.global_form.write().vertices[0] =
-                    back.read().surface_form.read().global_form.clone();
-
                 front.write().surface_form =
                     top.vertices[1].read().surface_form.clone();
-                side_down.global_form.write().vertices[1] =
-                    front.read().surface_form.read().global_form.clone();
 
+                side_down.infer_global_form();
                 side_down.update_as_line_segment();
 
                 Partial::from(

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -1,9 +1,8 @@
-use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
-    objects::{HalfEdge, Surface, SurfaceVertex},
-    partial::{Partial, PartialCycle, PartialHalfEdge, PartialSurfaceVertex},
+    objects::{HalfEdge, Surface},
+    partial::{Partial, PartialCycle},
 };
 
 use super::HalfEdgeBuilder;
@@ -37,97 +36,22 @@ impl CycleBuilder for PartialCycle {
 
         let mut cycle = PartialCycle::default();
 
-        let vertices =
-            points.into_iter().map(|position| PartialSurfaceVertex {
-                position: Some(position.into()),
-                surface: surface.clone(),
-                ..Default::default()
-            });
+        for point in points.into_iter().map(Into::into) {
+            let mut half_edge = cycle.add_half_edge();
+            let mut half_edge = half_edge.write();
 
-        let mut previous: Option<Partial<SurfaceVertex>> =
-            cycle.half_edges.last().map(|half_edge| {
-                let [_, last] = &half_edge.read().vertices;
-                let last = last.read();
-                last.surface_form.clone()
-            });
+            half_edge.curve().write().surface = surface.clone();
 
-        let mut half_edges = Vec::new();
-        for vertex_next in vertices {
-            let vertex_next = Partial::from_partial(vertex_next);
+            let mut back = half_edge.back_mut().write();
+            let mut back_surface = back.surface_form.write();
 
-            if let Some(vertex_prev) = previous {
-                let surface = vertex_prev.read().surface.clone();
-
-                previous = Some(vertex_next.clone());
-                let surface_vertices = [vertex_prev, vertex_next];
-
-                let mut half_edge = PartialHalfEdge::default();
-                half_edge.curve().write().surface = surface;
-
-                {
-                    let global_vertices =
-                        &mut half_edge.global_form.write().vertices;
-
-                    for ((vertex, surface_form), global_form) in half_edge
-                        .vertices
-                        .each_mut_ext()
-                        .zip_ext(surface_vertices)
-                        .zip_ext(global_vertices.each_mut_ext())
-                    {
-                        *global_form = surface_form.read().global_form.clone();
-                        vertex.write().surface_form = surface_form;
-                    }
-                }
-
-                half_edge.update_as_line_segment();
-                half_edges.push(Partial::from_partial(half_edge));
-
-                continue;
-            }
-
-            previous = Some(vertex_next);
+            back_surface.position = Some(point);
+            back_surface.surface = surface.clone();
         }
 
-        cycle.half_edges.extend(half_edges);
-
-        let first = cycle.half_edges.first();
-        let last = cycle.half_edges.last();
-
-        let vertices = [first, last].map(|option| {
-            option.map(|half_edge| {
-                half_edge
-                    .read()
-                    .vertices
-                    .each_ref_ext()
-                    .map(|vertex| vertex.read().surface_form.clone())
-            })
-        });
-
-        let [Some([first, _]), Some([_, last])] = vertices else {
-            return cycle;
-        };
-
-        let mut half_edge = PartialHalfEdge::default();
-        half_edge.curve().write().surface =
-            cycle.surface().expect("Need surface to close cycle");
-
-        {
-            let global_vertices = &mut half_edge.global_form.write().vertices;
-
-            for ((vertex, surface_form), global_form) in half_edge
-                .vertices
-                .each_mut_ext()
-                .zip_ext([last, first])
-                .zip_ext(global_vertices.each_mut_ext())
-            {
-                *global_form = surface_form.read().global_form.clone();
-                vertex.write().surface_form = surface_form;
-            }
+        for half_edge in &mut cycle.half_edges {
+            half_edge.write().update_as_line_segment();
         }
-
-        half_edge.update_as_line_segment();
-
-        cycle.half_edges.push(Partial::from_partial(half_edge));
 
         cycle
     }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -10,6 +10,12 @@ use super::HalfEdgeBuilder;
 
 /// Builder API for [`PartialCycle`]
 pub trait CycleBuilder {
+    /// Create a cycle as a polygonal chain from the provided points
+    fn from_poly_chain(
+        surface: impl Into<Partial<Surface>>,
+        points: impl IntoIterator<Item = impl Into<Point<2>>>,
+    ) -> Self;
+
     /// Update the partial cycle with a polygonal chain from the provided points
     fn with_poly_chain(
         &mut self,
@@ -30,6 +36,18 @@ pub trait CycleBuilder {
 }
 
 impl CycleBuilder for PartialCycle {
+    fn from_poly_chain(
+        surface: impl Into<Partial<Surface>>,
+        points: impl IntoIterator<Item = impl Into<Point<2>>>,
+    ) -> Self {
+        let mut cycle = PartialCycle::default();
+
+        cycle.with_poly_chain_from_points(surface, points);
+        cycle.close_with_line_segment();
+
+        cycle
+    }
+
     fn with_poly_chain(
         &mut self,
         vertices: impl IntoIterator<Item = PartialSurfaceVertex>,

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -2,7 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
-    objects::{Surface, SurfaceVertex},
+    objects::{HalfEdge, Surface, SurfaceVertex},
     partial::{Partial, PartialCycle, PartialHalfEdge, PartialSurfaceVertex},
 };
 
@@ -15,6 +15,17 @@ pub trait CycleBuilder {
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self;
+
+    /// Add a new half-edge to the cycle
+    ///
+    /// Creates a half-edge and adds it to the cycle. The new half-edge is
+    /// connected to the front vertex of the last half-edge , and the back
+    /// vertex of the first edge, making sure the half-edges actually form a
+    /// cycle.
+    ///
+    /// If this is the first half-edge being added, it is connected to itself,
+    /// meaning its front and back vertices are the same.
+    fn add_half_edge(&mut self) -> Partial<HalfEdge>;
 }
 
 impl CycleBuilder for PartialCycle {
@@ -119,5 +130,54 @@ impl CycleBuilder for PartialCycle {
         cycle.half_edges.push(Partial::from_partial(half_edge));
 
         cycle
+    }
+
+    fn add_half_edge(&mut self) -> Partial<HalfEdge> {
+        let mut new_half_edge = Partial::<HalfEdge>::new();
+
+        let (first_half_edge, mut last_half_edge) =
+            match self.half_edges.first() {
+                Some(first_half_edge) => {
+                    let first_half_edge = first_half_edge.clone();
+                    let last_half_edge = self
+                        .half_edges
+                        .last()
+                        .cloned()
+                        .unwrap_or_else(|| first_half_edge.clone());
+
+                    (first_half_edge, last_half_edge)
+                }
+                None => (new_half_edge.clone(), new_half_edge.clone()),
+            };
+
+        let shared_surface =
+            first_half_edge.read().curve().read().surface.clone();
+
+        {
+            let shared_surface_vertex =
+                new_half_edge.read().back().read().surface_form.clone();
+
+            let mut last_half_edge = last_half_edge.write();
+            last_half_edge.curve().write().surface = shared_surface.clone();
+            last_half_edge.front_mut().write().surface_form =
+                shared_surface_vertex;
+
+            last_half_edge.infer_global_form();
+        }
+
+        {
+            let shared_surface_vertex =
+                first_half_edge.read().back().read().surface_form.clone();
+
+            let mut new_half_edge = new_half_edge.write();
+
+            new_half_edge.curve().write().surface = shared_surface;
+            new_half_edge.front_mut().write().surface_form =
+                shared_surface_vertex;
+            new_half_edge.infer_global_form();
+        }
+
+        self.half_edges.push(new_half_edge.clone());
+        new_half_edge
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -58,9 +58,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             vertex.surface_form = surface_vertex.clone();
         }
 
-        let global_vertex = surface_vertex.read().global_form.clone();
-        self.global_form.write().vertices =
-            [global_vertex.clone(), global_vertex];
+        self.infer_global_form();
     }
 
     fn update_as_line_segment_from_points(
@@ -94,12 +92,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let mut curve = self.curve();
         curve.write().update_as_line_from_points(points_surface);
-        self.global_form.write().curve = curve.read().global_form.clone();
 
         for (vertex, position) in self.vertices.each_mut_ext().zip_ext([0., 1.])
         {
             vertex.write().position = Some([position].into());
         }
+
+        self.infer_global_form();
     }
 
     fn infer_global_form(&mut self) -> Partial<GlobalEdge> {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -90,8 +90,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .expect("Can't infer line segment without surface position")
         });
 
-        let mut curve = self.curve();
-        curve.write().update_as_line_from_points(points_surface);
+        self.curve()
+            .write()
+            .update_as_line_from_points(points_surface);
 
         for (vertex, position) in self.vertices.each_mut_ext().zip_ext([0., 1.])
         {

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -30,10 +30,7 @@ impl FaceBuilder for PartialFace {
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
-        let mut cycle = PartialCycle::default();
-        cycle.with_poly_chain_from_points(surface, points);
-        cycle.close_with_line_segment();
-
+        let cycle = PartialCycle::from_poly_chain(surface, points);
         self.exterior = Partial::from_partial(cycle);
     }
 
@@ -42,10 +39,7 @@ impl FaceBuilder for PartialFace {
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) {
-        let mut cycle = PartialCycle::default();
-        cycle.with_poly_chain_from_points(surface, points);
-        cycle.close_with_line_segment();
-
+        let cycle = PartialCycle::from_poly_chain(surface, points);
         self.interiors = vec![Partial::from_partial(cycle)];
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -138,19 +138,15 @@ impl ShellBuilder {
 
                     {
                         let [from, to] = &mut half_edge.vertices;
-                        from.write().surface_form = from_surface.clone();
+                        from.write().surface_form = from_surface;
 
                         let mut to = to.write();
                         let mut to_surface = to.surface_form.write();
                         to_surface.position = Some(to_position);
                         to_surface.surface = surface.clone();
-
-                        half_edge.global_form.write().vertices = [
-                            from_surface.read().global_form.clone(),
-                            to_surface.global_form.clone(),
-                        ];
                     }
 
+                    half_edge.infer_global_form();
                     half_edge.update_as_line_segment();
 
                     Partial::from_partial(half_edge)
@@ -205,16 +201,12 @@ impl ShellBuilder {
                                         + [Z, edge_length],
                                 );
                                 from_surface.surface = surface.clone();
-                                from_surface.global_form = from_global.clone();
+                                from_surface.global_form = from_global;
 
-                                to.write().surface_form = to_surface.clone();
-
-                                half_edge.global_form.write().vertices = [
-                                    from_global,
-                                    to_surface.read().global_form.clone(),
-                                ];
+                                to.write().surface_form = to_surface;
                             }
 
+                            half_edge.infer_global_form();
                             half_edge.update_as_line_segment();
 
                             Partial::from_partial(half_edge)

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -408,13 +408,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let object = {
-            let mut cycle = PartialCycle::default();
-            cycle.with_poly_chain_from_points(
+            let cycle = PartialCycle::from_poly_chain(
                 surface,
                 [[0., 0.], [1., 0.], [0., 1.]],
             );
-            cycle.close_with_line_segment();
-
             cycle
                 .build(&mut services.objects)
                 .insert(&mut services.objects)

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -26,6 +26,30 @@ impl PartialHalfEdge {
         let [vertex, _] = &self.vertices;
         vertex.read().curve.clone()
     }
+
+    /// Access a reference to the half-edge's back vertex
+    pub fn back(&self) -> &Partial<Vertex> {
+        let [back, _] = &self.vertices;
+        back
+    }
+
+    /// Access a reference to the half-edge's front vertex
+    pub fn front(&self) -> &Partial<Vertex> {
+        let [_, front] = &self.vertices;
+        front
+    }
+
+    /// Access a mutable reference to the half-edge's back vertex
+    pub fn back_mut(&mut self) -> &mut Partial<Vertex> {
+        let [back, _] = &mut self.vertices;
+        back
+    }
+
+    /// Access a mutable reference to the half-edge's front vertex
+    pub fn front_mut(&mut self) -> &mut Partial<Vertex> {
+        let [_, front] = &mut self.vertices;
+        front
+    }
 }
 
 impl PartialObject for PartialHalfEdge {

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -78,13 +78,10 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let mut cycle = PartialCycle::default();
-            cycle.with_poly_chain_from_points(
+            let cycle = PartialCycle::from_poly_chain(
                 services.objects.surfaces.xy_plane(),
                 [[0., 0.], [1., 0.], [0., 1.]],
             );
-            cycle.close_with_line_segment();
-
             cycle.build(&mut services.objects)
         };
         let invalid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -133,12 +133,10 @@ mod tests {
             face.build(&mut services.objects)
         };
         let invalid = {
-            let mut cycle = PartialCycle::default();
-            cycle.with_poly_chain_from_points(
+            let cycle = PartialCycle::from_poly_chain(
                 services.objects.surfaces.xz_plane(),
                 [[1., 1.], [1., 2.], [2., 1.]],
             );
-            cycle.close_with_line_segment();
             let cycle = cycle
                 .build(&mut services.objects)
                 .insert(&mut services.objects);


### PR DESCRIPTION
Also includes some minor additions to the partial object API, to enable the cleanups in `CycleBuilder`. This is another step towards addressing #1249.