### PR TITLE
Update old-style builder APIs

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -84,10 +84,9 @@ mod tests {
 
     use crate::{
         algorithms::{reverse::Reverse, transform::TransformObject},
-        builder::{FaceBuilder, HalfEdgeBuilder},
+        builder::{FaceBuilder, HalfEdgeBuilder, SketchBuilder},
         insert::Insert,
-        objects::Sketch,
-        partial::{PartialFace, PartialHalfEdge, PartialObject},
+        partial::{PartialFace, PartialHalfEdge, PartialObject, PartialSketch},
         services::Services,
     };
 
@@ -103,13 +102,14 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let solid = Sketch::builder()
+        let solid = PartialSketch::default()
             .with_polygon_from_points(
                 surface.clone(),
                 TRIANGLE,
                 &mut services.objects,
             )
             .build(&mut services.objects)
+            .insert(&mut services.objects)
             .sweep(UP, &mut services.objects);
 
         let mut bottom = PartialFace::default();
@@ -156,13 +156,14 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let solid = Sketch::builder()
+        let solid = PartialSketch::default()
             .with_polygon_from_points(
                 surface.clone(),
                 TRIANGLE,
                 &mut services.objects,
             )
             .build(&mut services.objects)
+            .insert(&mut services.objects)
             .sweep(DOWN, &mut services.objects);
 
         let mut bottom = PartialFace::default();

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -102,8 +102,9 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let solid = PartialSketch::default()
-            .with_polygon_from_points(surface.clone(), TRIANGLE)
+        let mut sketch = PartialSketch::default();
+        sketch.with_polygon_from_points(surface.clone(), TRIANGLE);
+        let solid = sketch
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .sweep(UP, &mut services.objects);
@@ -152,8 +153,9 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let solid = PartialSketch::default()
-            .with_polygon_from_points(surface.clone(), TRIANGLE)
+        let mut sketch = PartialSketch::default();
+        sketch.with_polygon_from_points(surface.clone(), TRIANGLE);
+        let solid = sketch
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .sweep(DOWN, &mut services.objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -103,11 +103,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let solid = PartialSketch::default()
-            .with_polygon_from_points(
-                surface.clone(),
-                TRIANGLE,
-                &mut services.objects,
-            )
+            .with_polygon_from_points(surface.clone(), TRIANGLE)
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .sweep(UP, &mut services.objects);
@@ -157,11 +153,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let solid = PartialSketch::default()
-            .with_polygon_from_points(
-                surface.clone(),
-                TRIANGLE,
-                &mut services.objects,
-            )
+            .with_polygon_from_points(surface.clone(), TRIANGLE)
             .build(&mut services.objects)
             .insert(&mut services.objects)
             .sweep(DOWN, &mut services.objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -2,8 +2,11 @@ use fj_math::{Scalar, Vector};
 
 use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
+    builder::ShellBuilder,
     geometry::path::GlobalPath,
+    insert::Insert,
     objects::{Face, Objects, Shell},
+    partial::{PartialObject, PartialShell},
     services::Service,
     storage::Handle,
 };
@@ -74,7 +77,10 @@ impl Sweep for Handle<Face> {
             }
         }
 
-        Shell::builder().with_faces(faces).build(objects)
+        PartialShell::default()
+            .with_faces(faces)
+            .build(objects)
+            .insert(objects)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -2,11 +2,10 @@ use fj_math::{Scalar, Vector};
 
 use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
-    builder::ShellBuilder,
     geometry::path::GlobalPath,
     insert::Insert,
     objects::{Face, Objects, Shell},
-    partial::{PartialObject, PartialShell},
+    partial::{Partial, PartialObject, PartialShell},
     services::Service,
     storage::Handle,
 };
@@ -77,10 +76,8 @@ impl Sweep for Handle<Face> {
             }
         }
 
-        PartialShell::default()
-            .with_faces(faces)
-            .build(objects)
-            .insert(objects)
+        let faces = faces.into_iter().map(Partial::from).collect();
+        PartialShell { faces }.build(objects).insert(objects)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -103,7 +103,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut sketch = PartialSketch::default();
-        sketch.with_polygon_from_points(surface.clone(), TRIANGLE);
+        sketch.add_polygon_from_points(surface.clone(), TRIANGLE);
         let solid = sketch
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -154,7 +154,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
         let mut sketch = PartialSketch::default();
-        sketch.with_polygon_from_points(surface.clone(), TRIANGLE);
+        sketch.add_polygon_from_points(surface.clone(), TRIANGLE);
         let solid = sketch
             .build(&mut services.objects)
             .insert(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -1,10 +1,9 @@
 use fj_math::Vector;
 
 use crate::{
-    builder::SolidBuilder,
     insert::Insert,
     objects::{Objects, Sketch, Solid},
-    partial::{PartialObject, PartialSolid},
+    partial::{Partial, PartialObject, PartialSolid},
     services::Service,
     storage::Handle,
 };
@@ -28,9 +27,7 @@ impl Sweep for Handle<Sketch> {
             shells.push(shell);
         }
 
-        PartialSolid::default()
-            .with_shells(shells)
-            .build(objects)
-            .insert(objects)
+        let shells = shells.into_iter().map(Partial::from).collect();
+        PartialSolid { shells }.build(objects).insert(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -1,7 +1,10 @@
 use fj_math::Vector;
 
 use crate::{
+    builder::SolidBuilder,
+    insert::Insert,
     objects::{Objects, Sketch, Solid},
+    partial::{PartialObject, PartialSolid},
     services::Service,
     storage::Handle,
 };
@@ -25,6 +28,9 @@ impl Sweep for Handle<Sketch> {
             shells.push(shell);
         }
 
-        Solid::builder().with_shells(shells).build(objects)
+        PartialSolid::default()
+            .with_shells(shells)
+            .build(objects)
+            .insert(objects)
     }
 }

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -1,10 +1,5 @@
 //! API for building objects
 
-// These are the old-style builders that need to be transferred to the partial
-// object API. Issue:
-// https://github.com/hannobraun/Fornjot/issues/1147
-mod solid;
-
 // These are new-style builders that build on top of the partial object API.
 mod curve;
 mod cycle;
@@ -12,6 +7,7 @@ mod edge;
 mod face;
 mod shell;
 mod sketch;
+mod solid;
 mod surface;
 mod vertex;
 

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -3,7 +3,6 @@
 // These are the old-style builders that need to be transferred to the partial
 // object API. Issue:
 // https://github.com/hannobraun/Fornjot/issues/1147
-mod shell;
 mod solid;
 
 // These are new-style builders that build on top of the partial object API.
@@ -11,6 +10,7 @@ mod curve;
 mod cycle;
 mod edge;
 mod face;
+mod shell;
 mod sketch;
 mod surface;
 mod vertex;

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -4,7 +4,6 @@
 // object API. Issue:
 // https://github.com/hannobraun/Fornjot/issues/1147
 mod shell;
-mod sketch;
 mod solid;
 
 // These are new-style builders that build on top of the partial object API.
@@ -12,6 +11,7 @@ mod curve;
 mod cycle;
 mod edge;
 mod face;
+mod sketch;
 mod surface;
 mod vertex;
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -37,7 +37,7 @@ impl ShellBuilder for PartialShell {
         const Z: Scalar = Scalar::ZERO;
         let h = edge_length / 2.;
 
-        let bottom = {
+        let bottom_face = {
             let surface =
                 objects.surfaces.xy_plane().translate([Z, Z, -h], objects);
 
@@ -51,7 +51,7 @@ impl ShellBuilder for PartialShell {
         };
 
         let (sides, top_edges) = {
-            let surfaces = bottom
+            let surfaces = bottom_face
                 .exterior
                 .read()
                 .half_edges
@@ -72,7 +72,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let bottoms = bottom
+            let bottoms = bottom_face
                 .exterior
                 .read()
                 .half_edges
@@ -328,7 +328,7 @@ impl ShellBuilder for PartialShell {
         };
 
         PartialShell {
-            faces: [bottom]
+            faces: [bottom_face]
                 .into_iter()
                 .chain(sides)
                 .chain([top])

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -67,9 +67,8 @@ impl ShellBuilder for PartialShell {
                         });
                     let c = a + [Z, Z, edge_length];
 
-                    Partial::from_partial(PartialSurface::plane_from_points([
-                        a, b, c,
-                    ]))
+                    let surface = PartialSurface::plane_from_points([a, b, c]);
+                    Partial::from_partial(surface)
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -72,7 +72,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let bottoms = bottom_face
+            let bottom_edges = bottom_face
                 .exterior
                 .read()
                 .half_edges
@@ -106,7 +106,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let sides_up = bottoms
+            let sides_up = bottom_edges
                 .clone()
                 .into_iter()
                 .zip(&side_surfaces)
@@ -144,7 +144,7 @@ impl ShellBuilder for PartialShell {
                 let mut sides_up_prev = sides_up.clone();
                 sides_up_prev.rotate_right(1);
 
-                bottoms
+                bottom_edges
                     .clone()
                     .into_iter()
                     .zip(sides_up_prev)
@@ -235,7 +235,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let sides = bottoms
+            let sides = bottom_edges
                 .into_iter()
                 .zip(sides_up)
                 .zip(tops.clone())

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -106,7 +106,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let sides_up = bottom_edges
+            let side_edges_up = bottom_edges
                 .clone()
                 .into_iter()
                 .zip(&side_surfaces)
@@ -141,7 +141,7 @@ impl ShellBuilder for PartialShell {
                 .collect::<Vec<_>>();
 
             let sides_down = {
-                let mut sides_up_prev = sides_up.clone();
+                let mut sides_up_prev = side_edges_up.clone();
                 sides_up_prev.rotate_right(1);
 
                 bottom_edges
@@ -202,7 +202,7 @@ impl ShellBuilder for PartialShell {
                     .collect::<Vec<_>>()
             };
 
-            let tops = sides_up
+            let tops = side_edges_up
                 .clone()
                 .into_iter()
                 .zip(sides_down.clone())
@@ -237,7 +237,7 @@ impl ShellBuilder for PartialShell {
 
             let sides = bottom_edges
                 .into_iter()
-                .zip(sides_up)
+                .zip(side_edges_up)
                 .zip(tops.clone())
                 .zip(sides_down)
                 .map(|(((bottom, side_up), top), side_down)| {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -51,7 +51,7 @@ impl ShellBuilder for PartialShell {
         };
 
         let (sides, top_edges) = {
-            let surfaces = bottom_face
+            let side_surfaces = bottom_face
                 .exterior
                 .read()
                 .half_edges
@@ -77,7 +77,7 @@ impl ShellBuilder for PartialShell {
                 .read()
                 .half_edges
                 .iter()
-                .zip(&surfaces)
+                .zip(&side_surfaces)
                 .map(|(half_edge, surface)| {
                     let global_edge = half_edge.read().global_form.clone();
 
@@ -109,7 +109,7 @@ impl ShellBuilder for PartialShell {
             let sides_up = bottoms
                 .clone()
                 .into_iter()
-                .zip(&surfaces)
+                .zip(&side_surfaces)
                 .map(|(bottom, surface): (Partial<HalfEdge>, _)| {
                     let from_surface = {
                         let [_, from] = &bottom.read().vertices;
@@ -148,7 +148,7 @@ impl ShellBuilder for PartialShell {
                     .clone()
                     .into_iter()
                     .zip(sides_up_prev)
-                    .zip(&surfaces)
+                    .zip(&side_surfaces)
                     .map(
                         |((bottom, side_up_prev), surface): (
                             (_, Partial<HalfEdge>),

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -202,7 +202,7 @@ impl ShellBuilder for PartialShell {
                     .collect::<Vec<_>>()
             };
 
-            let tops = side_edges_up
+            let top_edges = side_edges_up
                 .clone()
                 .into_iter()
                 .zip(side_edges_down.clone())
@@ -238,7 +238,7 @@ impl ShellBuilder for PartialShell {
             let sides = bottom_edges
                 .into_iter()
                 .zip(side_edges_up)
-                .zip(tops.clone())
+                .zip(top_edges.clone())
                 .zip(side_edges_down)
                 .map(|(((bottom, side_up), top), side_down)| {
                     let mut cycle = PartialCycle::default();
@@ -251,7 +251,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            (sides, tops)
+            (sides, top_edges)
         };
 
         let top = {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -9,7 +9,7 @@ use crate::{
     builder::{
         FaceBuilder, HalfEdgeBuilder, SurfaceBuilder, SurfaceVertexBuilder,
     },
-    objects::{Face, HalfEdge, Objects},
+    objects::{HalfEdge, Objects},
     partial::{
         Partial, PartialCycle, PartialFace, PartialHalfEdge, PartialShell,
         PartialSurface, PartialSurfaceVertex,
@@ -19,12 +19,6 @@ use crate::{
 
 /// Builder API for [`PartialShell`]
 pub trait ShellBuilder {
-    /// Build the [`Shell`] with the provided faces
-    fn with_faces(
-        self,
-        faces: impl IntoIterator<Item = impl Into<Partial<Face>>>,
-    ) -> Self;
-
     /// Create a cube from the length of its edges
     fn with_cube_from_edge_length(
         self,
@@ -34,14 +28,6 @@ pub trait ShellBuilder {
 }
 
 impl ShellBuilder for PartialShell {
-    fn with_faces(
-        mut self,
-        faces: impl IntoIterator<Item = impl Into<Partial<Face>>>,
-    ) -> Self {
-        self.faces.extend(faces.into_iter().map(Into::into));
-        self
-    }
-
     fn with_cube_from_edge_length(
         mut self,
         edge_length: impl Into<Scalar>,

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -254,7 +254,7 @@ impl ShellBuilder for PartialShell {
             (side_faces, top_edges)
         };
 
-        let top = {
+        let top_face = {
             let surface = Partial::from(
                 objects.surfaces.xy_plane().translate([Z, Z, h], objects),
             );
@@ -331,7 +331,7 @@ impl ShellBuilder for PartialShell {
             faces: [bottom_face]
                 .into_iter()
                 .chain(side_faces)
-                .chain([top])
+                .chain([top_face])
                 .map(Partial::from_partial)
                 .collect(),
         }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -50,7 +50,7 @@ impl ShellBuilder for PartialShell {
             face
         };
 
-        let (sides, top_edges) = {
+        let (side_faces, top_edges) = {
             let side_surfaces = bottom_face
                 .exterior
                 .read()
@@ -330,7 +330,7 @@ impl ShellBuilder for PartialShell {
         PartialShell {
             faces: [bottom_face]
                 .into_iter()
-                .chain(sides)
+                .chain(side_faces)
                 .chain([top])
                 .map(Partial::from_partial)
                 .collect(),

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -20,16 +20,14 @@ use crate::{
 /// Builder API for [`PartialShell`]
 pub trait ShellBuilder {
     /// Create a cube from the length of its edges
-    fn with_cube_from_edge_length(
-        self,
+    fn create_cube_from_edge_length(
         edge_length: impl Into<Scalar>,
         objects: &mut Service<Objects>,
     ) -> Self;
 }
 
 impl ShellBuilder for PartialShell {
-    fn with_cube_from_edge_length(
-        mut self,
+    fn create_cube_from_edge_length(
         edge_length: impl Into<Scalar>,
         objects: &mut Service<Objects>,
     ) -> Self {
@@ -330,14 +328,13 @@ impl ShellBuilder for PartialShell {
             }
         };
 
-        self.faces.extend(
-            [bottom]
+        PartialShell {
+            faces: [bottom]
                 .into_iter()
                 .chain(sides)
                 .chain([top])
-                .map(Partial::from_partial),
-        );
-
-        self
+                .map(Partial::from_partial)
+                .collect(),
+        }
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -235,7 +235,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let sides = bottom_edges
+            let side_faces = bottom_edges
                 .into_iter()
                 .zip(side_edges_up)
                 .zip(top_edges.clone())
@@ -251,7 +251,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            (sides, top_edges)
+            (side_faces, top_edges)
         };
 
         let top = {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -140,7 +140,7 @@ impl ShellBuilder for PartialShell {
                 })
                 .collect::<Vec<_>>();
 
-            let sides_down = {
+            let side_edges_down = {
                 let mut sides_up_prev = side_edges_up.clone();
                 sides_up_prev.rotate_right(1);
 
@@ -205,7 +205,7 @@ impl ShellBuilder for PartialShell {
             let tops = side_edges_up
                 .clone()
                 .into_iter()
-                .zip(sides_down.clone())
+                .zip(side_edges_down.clone())
                 .map(|(side_up, side_down): (_, Partial<HalfEdge>)| {
                     let [_, from] = side_up.read().vertices.clone();
                     let [to, _] = side_down.read().vertices.clone();
@@ -239,7 +239,7 @@ impl ShellBuilder for PartialShell {
                 .into_iter()
                 .zip(side_edges_up)
                 .zip(tops.clone())
-                .zip(sides_down)
+                .zip(side_edges_down)
                 .map(|(((bottom, side_up), top), side_down)| {
                     let mut cycle = PartialCycle::default();
                     cycle.half_edges.extend([bottom, side_up, top, side_down]);

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -1,9 +1,8 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Objects, Surface},
+    objects::Surface,
     partial::{Partial, PartialFace, PartialSketch},
-    services::Service,
     storage::Handle,
 };
 
@@ -16,7 +15,6 @@ pub trait SketchBuilder {
         self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-        objects: &mut Service<Objects>,
     ) -> Self;
 }
 
@@ -25,7 +23,6 @@ impl SketchBuilder for PartialSketch {
         mut self,
         surface: Handle<Surface>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-        _: &mut Service<Objects>,
     ) -> Self {
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(surface, points);

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -11,22 +11,21 @@ use super::FaceBuilder;
 pub trait SketchBuilder {
     /// Construct a polygon from a list of points
     fn with_polygon_from_points(
-        self,
+        &mut self,
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self;
+    );
 }
 
 impl SketchBuilder for PartialSketch {
     fn with_polygon_from_points(
-        mut self,
+        &mut self,
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
-    ) -> Self {
+    ) {
         let mut face = PartialFace::default();
         face.with_exterior_polygon_from_points(surface, points);
 
         self.faces.extend([Partial::from_partial(face)]);
-        self
     }
 }

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -3,7 +3,6 @@ use fj_math::Point;
 use crate::{
     objects::Surface,
     partial::{Partial, PartialFace, PartialSketch},
-    storage::Handle,
 };
 
 use super::FaceBuilder;
@@ -13,7 +12,7 @@ pub trait SketchBuilder {
     /// Construct a polygon from a list of points
     fn with_polygon_from_points(
         self,
-        surface: Handle<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self;
 }
@@ -21,7 +20,7 @@ pub trait SketchBuilder {
 impl SketchBuilder for PartialSketch {
     fn with_polygon_from_points(
         mut self,
-        surface: Handle<Surface>,
+        surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
     ) -> Self {
         let mut face = PartialFace::default();

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -10,7 +10,7 @@ use super::FaceBuilder;
 /// Builder API for [`PartialSketch`]
 pub trait SketchBuilder {
     /// Construct a polygon from a list of points
-    fn with_polygon_from_points(
+    fn add_polygon_from_points(
         &mut self,
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,
@@ -18,7 +18,7 @@ pub trait SketchBuilder {
 }
 
 impl SketchBuilder for PartialSketch {
-    fn with_polygon_from_points(
+    fn add_polygon_from_points(
         &mut self,
         surface: impl Into<Partial<Surface>>,
         points: impl IntoIterator<Item = impl Into<Point<2>>>,

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Face, Objects, Surface},
+    objects::{Objects, Surface},
     partial::{Partial, PartialFace, PartialSketch},
     services::Service,
     storage::Handle,
@@ -11,9 +11,6 @@ use super::FaceBuilder;
 
 /// Builder API for [`PartialSketch`]
 pub trait SketchBuilder {
-    /// Build the [`Sketch`] with the provided faces
-    fn with_faces(self, faces: impl IntoIterator<Item = Handle<Face>>) -> Self;
-
     /// Construct a polygon from a list of points
     fn with_polygon_from_points(
         self,
@@ -24,15 +21,6 @@ pub trait SketchBuilder {
 }
 
 impl SketchBuilder for PartialSketch {
-    fn with_faces(
-        mut self,
-        faces: impl IntoIterator<Item = Handle<Face>>,
-    ) -> Self {
-        let faces = faces.into_iter().map(Partial::from);
-        self.faces.extend(faces);
-        self
-    }
-
     fn with_polygon_from_points(
         mut self,
         surface: Handle<Surface>,

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -9,7 +9,7 @@ use super::FaceBuilder;
 
 /// Builder API for [`PartialSketch`]
 pub trait SketchBuilder {
-    /// Construct a polygon from a list of points
+    /// Add a polygon to the sketch, created from the provided points
     fn add_polygon_from_points(
         &mut self,
         surface: impl Into<Partial<Surface>>,

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -5,9 +5,12 @@ use fj_math::Scalar;
 use crate::{
     insert::Insert,
     objects::{Objects, Shell, Solid},
+    partial::{PartialObject, PartialShell},
     services::Service,
     storage::Handle,
 };
+
+use super::ShellBuilder;
 
 /// API for building a [`Solid`]
 ///
@@ -33,9 +36,10 @@ impl SolidBuilder {
         edge_length: impl Into<Scalar>,
         objects: &mut Service<Objects>,
     ) -> Self {
-        let shell = Shell::builder()
+        let shell = PartialShell::default()
             .with_cube_from_edge_length(edge_length, objects)
-            .build(objects);
+            .build(objects)
+            .insert(objects);
         self.shells.insert(shell);
         self
     }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -12,21 +12,20 @@ use super::ShellBuilder;
 pub trait SolidBuilder {
     /// Create a cube from the length of its edges
     fn with_cube_from_edge_length(
-        self,
+        &mut self,
         edge_length: impl Into<Scalar>,
         objects: &mut Service<Objects>,
-    ) -> Self;
+    );
 }
 
 impl SolidBuilder for PartialSolid {
     fn with_cube_from_edge_length(
-        mut self,
+        &mut self,
         edge_length: impl Into<Scalar>,
         objects: &mut Service<Objects>,
-    ) -> Self {
+    ) {
         let shell =
             PartialShell::create_cube_from_edge_length(edge_length, objects);
         self.shells.push(Partial::from_partial(shell));
-        self
     }
 }

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -10,7 +10,7 @@ use super::ShellBuilder;
 
 /// Builder API for [`PartialSolid`]
 pub trait SolidBuilder {
-    /// Create a cube from the length of its edges
+    /// Add a cube with the given edge length to the solid
     fn with_cube_from_edge_length(
         &mut self,
         edge_length: impl Into<Scalar>,

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -1,7 +1,7 @@
 use fj_math::Scalar;
 
 use crate::{
-    objects::{Objects, Shell},
+    objects::Objects,
     partial::{Partial, PartialShell, PartialSolid},
     services::Service,
 };
@@ -10,12 +10,6 @@ use super::ShellBuilder;
 
 /// Builder API for [`PartialSolid`]
 pub trait SolidBuilder {
-    /// Build the [`Solid`] with the provided shells
-    fn with_shells(
-        self,
-        shells: impl IntoIterator<Item = impl Into<Partial<Shell>>>,
-    ) -> Self;
-
     /// Create a cube from the length of its edges
     fn with_cube_from_edge_length(
         self,
@@ -25,15 +19,6 @@ pub trait SolidBuilder {
 }
 
 impl SolidBuilder for PartialSolid {
-    fn with_shells(
-        mut self,
-        shells: impl IntoIterator<Item = impl Into<Partial<Shell>>>,
-    ) -> Self {
-        let shells = shells.into_iter().map(Into::into);
-        self.shells.extend(shells);
-        self
-    }
-
     fn with_cube_from_edge_length(
         mut self,
         edge_length: impl Into<Scalar>,

--- a/crates/fj-kernel/src/builder/solid.rs
+++ b/crates/fj-kernel/src/builder/solid.rs
@@ -36,10 +36,10 @@ impl SolidBuilder {
         edge_length: impl Into<Scalar>,
         objects: &mut Service<Objects>,
     ) -> Self {
-        let shell = PartialShell::default()
-            .with_cube_from_edge_length(edge_length, objects)
-            .build(objects)
-            .insert(objects);
+        let shell =
+            PartialShell::create_cube_from_edge_length(edge_length, objects)
+                .build(objects)
+                .insert(objects);
         self.shells.insert(shell);
         self
     }

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -360,15 +360,18 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder},
+        builder::{
+            CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder,
+            SketchBuilder,
+        },
         insert::Insert,
         objects::{
-            GlobalCurve, GlobalVertex, Objects, Shell, Sketch, Solid,
-            SurfaceVertex, Vertex,
+            GlobalCurve, GlobalVertex, Objects, Shell, Solid, SurfaceVertex,
+            Vertex,
         },
         partial::{
             Partial, PartialCurve, PartialCycle, PartialFace, PartialHalfEdge,
-            PartialObject,
+            PartialObject, PartialSketch,
         },
         services::Services,
     };
@@ -559,7 +562,7 @@ mod tests {
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
-        let object = Sketch::builder()
+        let object = PartialSketch::default()
             .with_faces([face])
             .build(&mut services.objects);
 

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -360,10 +360,7 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{
-            CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder,
-            SketchBuilder,
-        },
+        builder::{CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder},
         insert::Insert,
         objects::{
             GlobalCurve, GlobalVertex, Objects, Shell, Solid, SurfaceVertex,
@@ -559,12 +556,10 @@ mod tests {
             surface,
             [[0., 0.], [1., 0.], [0., 1.]],
         );
-        let face = face
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
-        let object = PartialSketch::default()
-            .with_faces([face])
-            .build(&mut services.objects);
+        let object = PartialSketch {
+            faces: vec![Partial::from_partial(face)],
+        }
+        .build(&mut services.objects);
 
         assert_eq!(3, object.curve_iter().count());
         assert_eq!(1, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -360,15 +360,17 @@ impl<T> Iterator for Iter<T> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder},
+        builder::{
+            CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder,
+            ShellBuilder,
+        },
         insert::Insert,
         objects::{
-            GlobalCurve, GlobalVertex, Objects, Shell, Solid, SurfaceVertex,
-            Vertex,
+            GlobalCurve, GlobalVertex, Objects, Solid, SurfaceVertex, Vertex,
         },
         partial::{
             Partial, PartialCurve, PartialCycle, PartialFace, PartialHalfEdge,
-            PartialObject, PartialSketch,
+            PartialObject, PartialShell, PartialSketch,
         },
         services::Services,
     };
@@ -529,9 +531,10 @@ mod tests {
     fn shell() {
         let mut services = Services::new();
 
-        let object = Shell::builder()
+        let object = PartialShell::default()
             .with_cube_from_edge_length(1., &mut services.objects)
-            .build(&mut services.objects);
+            .build(&mut services.objects)
+            .insert(&mut services.objects);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -581,9 +581,11 @@ mod tests {
     fn solid() {
         let mut services = Services::new();
 
-        let object = PartialSolid::default()
-            .with_cube_from_edge_length(1., &mut services.objects)
-            .build(&mut services.objects);
+        let object = {
+            let mut solid = PartialSolid::default();
+            solid.with_cube_from_edge_length(1., &mut services.objects);
+            solid.build(&mut services.objects)
+        };
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -531,10 +531,12 @@ mod tests {
     fn shell() {
         let mut services = Services::new();
 
-        let object = PartialShell::default()
-            .with_cube_from_edge_length(1., &mut services.objects)
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
+        let object = PartialShell::create_cube_from_edge_length(
+            1.,
+            &mut services.objects,
+        )
+        .build(&mut services.objects)
+        .insert(&mut services.objects);
 
         assert_eq!(24, object.curve_iter().count());
         assert_eq!(6, object.cycle_iter().count());

--- a/crates/fj-kernel/src/iter.rs
+++ b/crates/fj-kernel/src/iter.rs
@@ -362,15 +362,13 @@ mod tests {
     use crate::{
         builder::{
             CurveBuilder, CycleBuilder, FaceBuilder, HalfEdgeBuilder,
-            ShellBuilder,
+            ShellBuilder, SolidBuilder,
         },
         insert::Insert,
-        objects::{
-            GlobalCurve, GlobalVertex, Objects, Solid, SurfaceVertex, Vertex,
-        },
+        objects::{GlobalCurve, GlobalVertex, Objects, SurfaceVertex, Vertex},
         partial::{
             Partial, PartialCurve, PartialCycle, PartialFace, PartialHalfEdge,
-            PartialObject, PartialShell, PartialSketch,
+            PartialObject, PartialShell, PartialSketch, PartialSolid,
         },
         services::Services,
     };
@@ -583,7 +581,7 @@ mod tests {
     fn solid() {
         let mut services = Services::new();
 
-        let object = Solid::builder()
+        let object = PartialSolid::default()
             .with_cube_from_edge_length(1., &mut services.objects)
             .build(&mut services.objects);
 

--- a/crates/fj-kernel/src/objects/full/shell.rs
+++ b/crates/fj-kernel/src/objects/full/shell.rs
@@ -1,5 +1,4 @@
 use crate::{
-    builder::ShellBuilder,
     objects::{Face, FaceSet},
     storage::Handle,
 };
@@ -16,13 +15,6 @@ pub struct Shell {
 }
 
 impl Shell {
-    /// Build a `Shell` using [`ShellBuilder`]
-    pub fn builder() -> ShellBuilder {
-        ShellBuilder {
-            faces: FaceSet::new(),
-        }
-    }
-
     /// Construct an empty instance of `Shell`
     pub fn new(faces: impl IntoIterator<Item = Handle<Face>>) -> Self {
         Self {

--- a/crates/fj-kernel/src/objects/full/sketch.rs
+++ b/crates/fj-kernel/src/objects/full/sketch.rs
@@ -1,5 +1,4 @@
 use crate::{
-    builder::SketchBuilder,
     objects::{Face, FaceSet},
     storage::Handle,
 };
@@ -16,13 +15,6 @@ pub struct Sketch {
 }
 
 impl Sketch {
-    /// Build a `Sketch` using [`SketchBuilder`]
-    pub fn builder() -> SketchBuilder {
-        SketchBuilder {
-            faces: FaceSet::new(),
-        }
-    }
-
     /// Construct an empty instance of `Sketch`
     pub fn new(faces: impl IntoIterator<Item = Handle<Face>>) -> Self {
         Self {

--- a/crates/fj-kernel/src/objects/full/solid.rs
+++ b/crates/fj-kernel/src/objects/full/solid.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    builder::SolidBuilder,
     objects::{Face, Shell},
     storage::Handle,
 };
@@ -18,13 +17,6 @@ pub struct Solid {
 }
 
 impl Solid {
-    /// Build a `Solid` using [`SolidBuilder`]
-    pub fn builder() -> SolidBuilder {
-        SolidBuilder {
-            shells: BTreeSet::new(),
-        }
-    }
-
     /// Construct an empty instance of `Solid`
     pub fn new(shells: impl IntoIterator<Item = Handle<Shell>>) -> Self {
         Self {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -3,10 +3,11 @@ use std::ops::Deref;
 use fj_interop::{debug::DebugInfo, ext::ArrayExt, mesh::Color};
 use fj_kernel::{
     algorithms::reverse::Reverse,
+    builder::SketchBuilder,
     insert::Insert,
     iter::ObjectIters,
     objects::{Objects, Sketch},
-    partial::{Partial, PartialFace, PartialObject},
+    partial::{Partial, PartialFace, PartialObject, PartialSketch},
     services::Service,
 };
 use fj_math::Aabb;
@@ -90,7 +91,10 @@ impl Shape for fj::Difference2d {
             faces.push(face.build(objects).insert(objects));
         }
 
-        let difference = Sketch::builder().with_faces(faces).build(objects);
+        let difference = PartialSketch::default()
+            .with_faces(faces)
+            .build(objects)
+            .insert(objects);
         difference.deref().clone()
     }
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 use fj_interop::{debug::DebugInfo, ext::ArrayExt, mesh::Color};
 use fj_kernel::{
     algorithms::reverse::Reverse,
-    builder::SketchBuilder,
     insert::Insert,
     iter::ObjectIters,
     objects::{Objects, Sketch},
@@ -88,13 +87,10 @@ impl Shape for fj::Difference2d {
                 interiors,
                 color: Some(Color(self.color())),
             };
-            faces.push(face.build(objects).insert(objects));
+            faces.push(Partial::from_partial(face));
         }
 
-        let difference = PartialSketch::default()
-            .with_faces(faces)
-            .build(objects)
-            .insert(objects);
+        let difference = PartialSketch { faces }.build(objects).insert(objects);
         difference.deref().clone()
     }
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
-    builder::{FaceBuilder, HalfEdgeBuilder, SketchBuilder},
+    builder::{FaceBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{Objects, Sketch},
     partial::{
@@ -47,12 +47,11 @@ impl Shape for fj::Sketch {
                     half_edges: vec![half_edge],
                 });
 
-                let face = PartialFace {
+                PartialFace {
                     exterior: cycle,
                     color: Some(Color(self.color())),
                     ..Default::default()
-                };
-                face.build(objects).insert(objects)
+                }
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let points = poly_chain
@@ -65,14 +64,15 @@ impl Shape for fj::Sketch {
                 face.with_exterior_polygon_from_points(surface, points);
                 face.color = Some(Color(self.color()));
 
-                face.build(objects).insert(objects)
+                face
             }
         };
 
-        let sketch = PartialSketch::default()
-            .with_faces([face])
-            .build(objects)
-            .insert(objects);
+        let sketch = PartialSketch {
+            faces: vec![Partial::from_partial(face)],
+        }
+        .build(objects)
+        .insert(objects);
         sketch.deref().clone()
     }
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -2,11 +2,12 @@ use std::ops::Deref;
 
 use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
-    builder::{FaceBuilder, HalfEdgeBuilder},
+    builder::{FaceBuilder, HalfEdgeBuilder, SketchBuilder},
     insert::Insert,
     objects::{Objects, Sketch},
     partial::{
         Partial, PartialCycle, PartialFace, PartialHalfEdge, PartialObject,
+        PartialSketch,
     },
     services::Service,
 };
@@ -68,7 +69,10 @@ impl Shape for fj::Sketch {
             }
         };
 
-        let sketch = Sketch::builder().with_faces([face]).build(objects);
+        let sketch = PartialSketch::default()
+            .with_faces([face])
+            .build(objects)
+            .insert(objects);
         sketch.deref().clone()
     }
 


### PR DESCRIPTION
Bring all builder APIs in line, updating them to the latest style. This is another step towards addressing #1249.

Close #1147