### PR TITLE
Return surface coordinates from `Surface::from_points`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -87,7 +87,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         // Armed with those coordinates, creating the `Curve` of the output
         // `Edge` is straight-forward.
         let curve = {
-            let path = SurfacePath::line_from_points(points_surface);
+            let (path, _) = SurfacePath::line_from_points(points_surface);
 
             Curve::new(surface.clone(), path, edge_global.curve().clone())
                 .insert(objects)

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -37,7 +37,7 @@ impl CurveBuilder for PartialCurve {
     }
 
     fn update_as_line_from_points(&mut self, points: [impl Into<Point<2>>; 2]) {
-        let path = SurfacePath::line_from_points(points);
+        let (path, _) = SurfacePath::line_from_points(points);
         self.path = Some(path);
     }
 }

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -37,6 +37,7 @@ impl CurveBuilder for PartialCurve {
     }
 
     fn update_as_line_from_points(&mut self, points: [impl Into<Point<2>>; 2]) {
-        self.path = Some(SurfacePath::line_from_points(points));
+        let path = SurfacePath::line_from_points(points);
+        self.path = Some(path);
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -67,7 +67,8 @@ impl ShellBuilder for PartialShell {
                         });
                     let c = a + [Z, Z, edge_length];
 
-                    let surface = PartialSurface::plane_from_points([a, b, c]);
+                    let (surface, _) =
+                        PartialSurface::plane_from_points([a, b, c]);
                     Partial::from_partial(surface)
                 })
                 .collect::<Vec<_>>();

--- a/crates/fj-kernel/src/builder/surface.rs
+++ b/crates/fj-kernel/src/builder/surface.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// Builder API for [`PartialSurface`]
-pub trait SurfaceBuilder {
+pub trait SurfaceBuilder: Sized {
     /// Build a surface from its two axes
     fn from_axes(u: GlobalPath, v: impl Into<Vector<3>>) -> Self;
 

--- a/crates/fj-kernel/src/builder/surface.rs
+++ b/crates/fj-kernel/src/builder/surface.rs
@@ -26,7 +26,7 @@ impl SurfaceBuilder for PartialSurface {
     fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Self {
         let [a, b, c] = points.map(Into::into);
 
-        let u = GlobalPath::line_from_points([a, b]);
+        let (u, _) = GlobalPath::line_from_points([a, b]);
         let v = c - a;
 
         Self {

--- a/crates/fj-kernel/src/geometry/path.rs
+++ b/crates/fj-kernel/src/geometry/path.rs
@@ -43,6 +43,8 @@ impl SurfacePath {
     }
 
     /// Construct a line from two points
+    ///
+    /// Also returns the coordinates of the points on the path.
     pub fn line_from_points(
         points: [impl Into<Point<2>>; 2],
     ) -> (Self, [Point<1>; 2]) {
@@ -105,6 +107,8 @@ impl GlobalPath {
     }
 
     /// Construct a line from two points
+    ///
+    /// Also returns the coordinates of the points on the path.
     pub fn line_from_points(
         points: [impl Into<Point<3>>; 2],
     ) -> (Self, [Point<1>; 2]) {

--- a/crates/fj-kernel/src/geometry/path.rs
+++ b/crates/fj-kernel/src/geometry/path.rs
@@ -43,9 +43,11 @@ impl SurfacePath {
     }
 
     /// Construct a line from two points
-    pub fn line_from_points(points: [impl Into<Point<2>>; 2]) -> Self {
-        let (line, _) = Line::from_points(points);
-        Self::Line(line)
+    pub fn line_from_points(
+        points: [impl Into<Point<2>>; 2],
+    ) -> (Self, [Point<1>; 2]) {
+        let (line, coords) = Line::from_points(points);
+        (Self::Line(line), coords)
     }
 
     /// Convert a point on the path into surface coordinates

--- a/crates/fj-kernel/src/geometry/path.rs
+++ b/crates/fj-kernel/src/geometry/path.rs
@@ -105,9 +105,11 @@ impl GlobalPath {
     }
 
     /// Construct a line from two points
-    pub fn line_from_points(points: [impl Into<Point<3>>; 2]) -> Self {
-        let (line, _) = Line::from_points(points);
-        Self::Line(line)
+    pub fn line_from_points(
+        points: [impl Into<Point<3>>; 2],
+    ) -> (Self, [Point<1>; 2]) {
+        let (line, coords) = Line::from_points(points);
+        (Self::Line(line), coords)
     }
 
     /// Access the origin of the path's coordinate system


### PR DESCRIPTION
Leverages #1455 to provide a similar capability for `Surface`.