### PR TITLE
Cross-compile to Android and iOS

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.66.0"
 components = ["rustfmt", "clippy"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["aarch64-linux-android", "wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,8 @@
 [toolchain]
 channel = "1.66.0"
 components = ["rustfmt", "clippy"]
-targets = ["aarch64-linux-android", "wasm32-unknown-unknown"]
+targets = [
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+    "wasm32-unknown-unknown",
+]

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 use anyhow::anyhow;
 
 fn main() -> anyhow::Result<()> {
+    let targets = ["wasm32-unknown-unknown"];
     let crates = [
         "fj",
         "fj-export",
@@ -21,20 +22,22 @@ fn main() -> anyhow::Result<()> {
         "fj-viewer",
     ];
 
-    for crate_ in crates {
-        let mut command = Command::new("cargo");
-        command
-            .arg("build")
-            .arg("--all-features")
-            .args(["--target", "wasm32-unknown-unknown"])
-            .args(["-p", crate_])
-            .env("RUSTFLAGS", "-D warnings");
+    for target in targets {
+        for crate_ in crates {
+            let mut command = Command::new("cargo");
+            command
+                .arg("build")
+                .arg("--all-features")
+                .args(["--target", target])
+                .args(["-p", crate_])
+                .env("RUSTFLAGS", "-D warnings");
 
-        println!("Running {command:?}");
-        let status = command.status()?;
+            println!("Running {command:?}");
+            let status = command.status()?;
 
-        if !status.success() {
-            return Err(anyhow!("Cargo exited with error code: {status}"));
+            if !status.success() {
+                return Err(anyhow!("Cargo exited with error code: {status}"));
+            }
         }
     }
 

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -10,7 +10,9 @@ use std::process::Command;
 use anyhow::anyhow;
 
 fn main() -> anyhow::Result<()> {
-    let targets = ["wasm32-unknown-unknown"];
+    let targets = [Target {
+        triple: "wasm32-unknown-unknown",
+    }];
     let crates = [
         "fj",
         "fj-export",
@@ -28,7 +30,7 @@ fn main() -> anyhow::Result<()> {
             command
                 .arg("build")
                 .arg("--all-features")
-                .args(["--target", target])
+                .args(["--target", target.triple])
                 .args(["-p", crate_])
                 .env("RUSTFLAGS", "-D warnings");
 
@@ -42,4 +44,9 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+struct Target {
+    /// The target triple
+    triple: &'static str,
 }

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -12,6 +12,18 @@ use anyhow::anyhow;
 fn main() -> anyhow::Result<()> {
     let targets = [
         Target {
+            triple: "aarch64-apple-ios",
+            crates: &[
+                "fj",
+                "fj-export",
+                "fj-interop",
+                "fj-kernel",
+                "fj-math",
+                "fj-operations",
+                "fj-proc",
+            ],
+        },
+        Target {
             triple: "aarch64-linux-android",
             crates: &[
                 "fj",

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -1,7 +1,7 @@
 //! Cross-compiler for the Fornjot build
 //!
 //! This tools cross-compiles the Fornjot crates that support that to the
-//! targets they support. This is less resource-intense then using a `matrix` in
+//! targets they support. This is less resource-intense than using a `matrix` in
 //! GitHub Actions (which would start one build job per crate and target), and
 //! allows for the cross-compilation code to be re-used in `justfile`.
 

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -12,20 +12,20 @@ use anyhow::anyhow;
 fn main() -> anyhow::Result<()> {
     let targets = [Target {
         triple: "wasm32-unknown-unknown",
+        crates: &[
+            "fj",
+            "fj-export",
+            "fj-interop",
+            "fj-kernel",
+            "fj-math",
+            "fj-operations",
+            "fj-proc",
+            "fj-viewer",
+        ],
     }];
-    let crates = [
-        "fj",
-        "fj-export",
-        "fj-interop",
-        "fj-kernel",
-        "fj-math",
-        "fj-operations",
-        "fj-proc",
-        "fj-viewer",
-    ];
 
     for target in targets {
-        for crate_ in crates {
+        for crate_ in target.crates {
             let mut command = Command::new("cargo");
             command
                 .arg("build")
@@ -49,4 +49,7 @@ fn main() -> anyhow::Result<()> {
 struct Target {
     /// The target triple
     triple: &'static str,
+
+    /// The crates that are supported on this target
+    crates: &'static [&'static str],
 }

--- a/tools/cross-compiler/src/main.rs
+++ b/tools/cross-compiler/src/main.rs
@@ -10,19 +10,33 @@ use std::process::Command;
 use anyhow::anyhow;
 
 fn main() -> anyhow::Result<()> {
-    let targets = [Target {
-        triple: "wasm32-unknown-unknown",
-        crates: &[
-            "fj",
-            "fj-export",
-            "fj-interop",
-            "fj-kernel",
-            "fj-math",
-            "fj-operations",
-            "fj-proc",
-            "fj-viewer",
-        ],
-    }];
+    let targets = [
+        Target {
+            triple: "aarch64-linux-android",
+            crates: &[
+                "fj",
+                "fj-export",
+                "fj-interop",
+                "fj-kernel",
+                "fj-math",
+                "fj-operations",
+                "fj-proc",
+            ],
+        },
+        Target {
+            triple: "wasm32-unknown-unknown",
+            crates: &[
+                "fj",
+                "fj-export",
+                "fj-interop",
+                "fj-kernel",
+                "fj-math",
+                "fj-operations",
+                "fj-proc",
+                "fj-viewer",
+            ],
+        },
+    ];
 
     for target in targets {
         for crate_ in target.crates {


### PR DESCRIPTION
Add cross-compilation to Android and iOS to the CI build. Support for this is not complete. Besides the usual suspects which are not supportable on non-desktop platforms (`fj-app`, by design; and `fj-host`, until we [switch to WebAssembly](https://github.com/hannobraun/Fornjot/issues/71)), there is one notable gap in support: `fj-viewer`

`fj-viewer` *should* support mobile platforms too, but right now there are problems. On iOS, because a transitive dependency requires Apple-specific tooling. On Android, because the file dialog is not supported (which would presumably be a problem on iOS too, if the build got that far). But this can be left for future work, once there's serious interest in supporting these platforms. Until then, adding them to the CI build guarantees that we don't accidentally add more problems.

I'm going to close all the Android/iOS issues, as I think this is enough for now. Those issues have been open for a long time without anyone expressing interest, or willingness to work on them. I'm going to add a corresponding entry to the [feature wishlist](https://github.com/hannobraun/Fornjot/discussions/146) instead.

Close #152
Close #153
Close #1278