### PR TITLE
Remove `Vertex::global_form`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -28,7 +28,7 @@ impl Approx for &HalfEdge {
 
         let first = ApproxPoint::new(
             a.surface_form().position(),
-            a.global_form().position(),
+            a.surface_form().global_form().position(),
         );
         let curve_approx =
             (self.curve(), range).approx_with_cache(tolerance, cache);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -295,8 +295,8 @@ mod tests {
             .half_edges()
             .find(|edge| {
                 let [a, b] = edge.vertices();
-                a.global_form().position() == Point::from([0., 0., 0.])
-                    && b.global_form().position() == Point::from([2., 0., 0.])
+                a.surface_form().position() == Point::from([0., 0.])
+                    && b.surface_form().position() == Point::from([2., 0.])
             })
             .unwrap();
         assert_eq!(
@@ -325,7 +325,7 @@ mod tests {
             .half_edges()
             .flat_map(|half_edge| half_edge.vertices())
             .find(|vertex| {
-                vertex.global_form().position() == Point::from([1., 0., 0.])
+                vertex.surface_form().position() == Point::from([1., 0.])
             })
             .unwrap();
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -255,8 +255,8 @@ mod tests {
             .half_edges()
             .find(|edge| {
                 let [a, b] = edge.vertices();
-                a.global_form().position() == Point::from([1., 0., 1.])
-                    && b.global_form().position() == Point::from([1., 0., -1.])
+                a.surface_form().position() == Point::from([-1., 1.])
+                    && b.surface_form().position() == Point::from([-1., -1.])
             })
             .unwrap();
         assert_eq!(
@@ -290,7 +290,7 @@ mod tests {
             .half_edges()
             .flat_map(|half_edge| half_edge.vertices())
             .find(|vertex| {
-                vertex.global_form().position() == Point::from([1., 0., 0.])
+                vertex.surface_form().position() == Point::from([-1., -1.])
             })
             .unwrap();
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -72,7 +72,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         let surface_vertex = SurfaceVertex::new(
                             point_surface,
                             surface.clone(),
-                            vertex.global_form().clone(),
+                            vertex.surface_form().global_form().clone(),
                         )
                         .insert(objects);
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -61,6 +61,7 @@ impl Sweep for (Handle<Vertex>, Handle<Surface>) {
         // as that is the most straight-forward part of this operations, and
         // we're going to need it soon anyway.
         let (edge_global, vertices_global) = vertex
+            .surface_form()
             .global_form()
             .clone()
             .sweep_with_cache(path, cache, objects);

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -49,11 +49,6 @@ impl Vertex {
     pub fn surface_form(&self) -> &Handle<SurfaceVertex> {
         &self.surface_form
     }
-
-    /// Access the global form of this vertex
-    pub fn global_form(&self) -> &Handle<GlobalVertex> {
-        self.surface_form.global_form()
-    }
 }
 
 /// A vertex, defined in surface (2D) coordinates

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -7,9 +7,11 @@ use crate::{
 
 /// A vertex
 ///
-/// `Vertex` is defined in terms of a 1-dimensional position on a curve. If you
-/// need the 3D position of a vertex, you can use [`Vertex::global_form`], to
-/// get access of the global form of a vertex ([`GlobalVertex`]).
+/// `Vertex` is defined in terms of a 1-dimensional position on a curve. Each
+/// `Vertex` has an associated [`SurfaceVertex`], which defines the 2D position
+/// on the surface, and a [`GlobalVertex`] which defines the global 3D position.
+///
+/// Both can be accessed through [`Vertex::surface_form`].
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     position: Point<1>,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -145,10 +145,9 @@ impl HalfEdgeValidationError {
         let global_vertices_from_vertices = {
             let (global_vertices_from_vertices, _) =
                 VerticesInNormalizedOrder::new(
-                    half_edge
-                        .vertices()
-                        .each_ref_ext()
-                        .map(|vertex| vertex.global_form().clone()),
+                    half_edge.vertices().each_ref_ext().map(|vertex| {
+                        vertex.surface_form().global_form().clone()
+                    }),
                 );
 
             global_vertices_from_vertices.access_in_normalized_order()


### PR DESCRIPTION
`vertex.global_form()` is just a short-hand for `vertex.surface_form().global_form()`. This pull request removes some uses of it that were frankly unnecessary, and I don't think the remaining ones justify the existence of such a redundant method.