### PR TITLE
Return updates paths from `CurveBuilder` methods

### DIFF
--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -5,55 +5,71 @@ use crate::{geometry::path::SurfacePath, partial::PartialCurve};
 /// Builder API for [`PartialCurve`]
 pub trait CurveBuilder {
     /// Update partial curve to represent the u-axis of the surface it is on
-    fn update_as_u_axis(&mut self);
+    fn update_as_u_axis(&mut self) -> SurfacePath;
 
     /// Update partial curve to represent the v-axis of the surface it is on
-    fn update_as_v_axis(&mut self);
+    fn update_as_v_axis(&mut self) -> SurfacePath;
 
     /// Update partial curve to be a circle, from the provided radius
-    fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>);
+    fn update_as_circle_from_radius(
+        &mut self,
+        radius: impl Into<Scalar>,
+    ) -> SurfacePath;
 
     /// Update partial curve to be a circle, from the provided radius
     fn update_as_circle_from_center_and_radius(
         &mut self,
         center: impl Into<Point<2>>,
         radius: impl Into<Scalar>,
-    );
+    ) -> SurfacePath;
 
     /// Update partial curve to be a line, from the provided points
-    fn update_as_line_from_points(&mut self, points: [impl Into<Point<2>>; 2]);
+    fn update_as_line_from_points(
+        &mut self,
+        points: [impl Into<Point<2>>; 2],
+    ) -> SurfacePath;
 }
 
 impl CurveBuilder for PartialCurve {
-    fn update_as_u_axis(&mut self) {
+    fn update_as_u_axis(&mut self) -> SurfacePath {
         let a = Point::origin();
         let b = a + Vector::unit_u();
 
         self.update_as_line_from_points([a, b])
     }
 
-    fn update_as_v_axis(&mut self) {
+    fn update_as_v_axis(&mut self) -> SurfacePath {
         let a = Point::origin();
         let b = a + Vector::unit_v();
 
         self.update_as_line_from_points([a, b])
     }
 
-    fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>) {
-        self.path = Some(SurfacePath::circle_from_radius(radius));
+    fn update_as_circle_from_radius(
+        &mut self,
+        radius: impl Into<Scalar>,
+    ) -> SurfacePath {
+        let path = SurfacePath::circle_from_radius(radius);
+        self.path = Some(path);
+        path
     }
 
     fn update_as_circle_from_center_and_radius(
         &mut self,
         center: impl Into<Point<2>>,
         radius: impl Into<Scalar>,
-    ) {
-        self.path =
-            Some(SurfacePath::circle_from_center_and_radius(center, radius));
+    ) -> SurfacePath {
+        let path = SurfacePath::circle_from_center_and_radius(center, radius);
+        self.path = Some(path);
+        path
     }
 
-    fn update_as_line_from_points(&mut self, points: [impl Into<Point<2>>; 2]) {
+    fn update_as_line_from_points(
+        &mut self,
+        points: [impl Into<Point<2>>; 2],
+    ) -> SurfacePath {
         let (path, _) = SurfacePath::line_from_points(points);
         self.path = Some(path);
+        path
     }
 }

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -5,18 +5,26 @@ use crate::{geometry::path::SurfacePath, partial::PartialCurve};
 /// Builder API for [`PartialCurve`]
 pub trait CurveBuilder {
     /// Update partial curve to represent the u-axis of the surface it is on
+    ///
+    /// Returns the updated path.
     fn update_as_u_axis(&mut self) -> SurfacePath;
 
     /// Update partial curve to represent the v-axis of the surface it is on
+    ///
+    /// Returns the updated path.
     fn update_as_v_axis(&mut self) -> SurfacePath;
 
     /// Update partial curve to be a circle, from the provided radius
+    ///
+    /// Returns the updated path.
     fn update_as_circle_from_radius(
         &mut self,
         radius: impl Into<Scalar>,
     ) -> SurfacePath;
 
     /// Update partial curve to be a circle, from the provided radius
+    ///
+    /// Returns the updated path.
     fn update_as_circle_from_center_and_radius(
         &mut self,
         center: impl Into<Point<2>>,
@@ -24,6 +32,8 @@ pub trait CurveBuilder {
     ) -> SurfacePath;
 
     /// Update partial curve to be a line, from the provided points
+    ///
+    /// Returns the updated path.
     fn update_as_line_from_points(
         &mut self,
         points: [impl Into<Point<2>>; 2],

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -59,12 +59,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>) {
         let mut curve = self.curve();
-        curve.write().update_as_circle_from_radius(radius);
-
-        let path = curve
-            .read()
-            .path
-            .expect("Expected path that was just created");
+        let path = curve.write().update_as_circle_from_radius(radius);
 
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
@@ -108,14 +103,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         );
 
         let mut curve = self.curve();
-        curve
+        let path = curve
             .write()
             .update_as_circle_from_center_and_radius(arc.center, arc.radius);
-
-        let path = curve
-            .read()
-            .path
-            .expect("Expected path that was just created");
 
         let [a_curve, b_curve] = if arc.flipped_construction {
             [arc.end_angle, arc.start_angle]


### PR DESCRIPTION
This brings those methods in line with what other builder methods do and makes some of their use sites simpler.