### PR TITLE
Fix rust-analyzer configuration in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "rust-analyzer.diagnostics.disabled": [
         "mismatched-arg-count"
     ],
-    "rust-analyzer.checkOnSave.command": "clippy"
+    "rust-analyzer.check.command": "clippy"
 }


### PR DESCRIPTION
Seems like the configuration key changed at some point.