### PR TITLE
Add mechanisms to make builder API more convenient

### DIFF
--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -155,16 +155,6 @@ impl CycleBuilder for PartialCycle {
             .surface
             .write()
             .update_as_plane_from_points(points_global);
-        let mut edges =
-            self.update_as_polygon_from_points(points_surface.to_vec());
-
-        // None of the following should panic, as we just created a polygon from
-        // three points, so we should have exactly three edges.
-        let c = edges.pop().unwrap();
-        let b = edges.pop().unwrap();
-        let a = edges.pop().unwrap();
-        assert!(edges.pop().is_none());
-
-        [a, b, c]
+        self.update_as_polygon_from_points(points_surface)
     }
 }

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -22,3 +22,56 @@ pub use self::{
     surface::SurfaceBuilder,
     vertex::{GlobalVertexBuilder, SurfaceVertexBuilder, VertexBuilder},
 };
+
+/// Pass objects to a builder method
+///
+/// Many builder methods receive objects as arguments, and many builder
+/// arguments return objects back, based on their input. In the general case,
+/// the number of objects passed and returned is usually arbitrary, but many
+/// callers pass a specific number of objects, and expect the same number of
+/// objects back.
+///
+/// This trait can be used to do exactly that. It is implemented for `Vec` and
+/// arrays. When passing a `Vec`, a `Vec` is returned. When passing an array, an
+/// array of the same size is returned.
+pub trait ObjectArgument<T>: IntoIterator<Item = T> {
+    /// The value returned, if the implementing type is passed on an argument
+    ///
+    /// The return value has the same length as the implementing type, but it is
+    /// not necessarily of the same type. For this reason, this associated type
+    /// is generic.
+    type ReturnValue<R>;
+
+    /// Create a return value by mapping the implementing type
+    fn map<F, R>(self, f: F) -> Self::ReturnValue<R>
+    where
+        F: FnMut(T) -> R;
+}
+
+impl<T> ObjectArgument<T> for Vec<T> {
+    type ReturnValue<R> = Vec<R>;
+
+    fn map<F, R>(self, mut f: F) -> Self::ReturnValue<R>
+    where
+        F: FnMut(T) -> R,
+    {
+        let mut ret = Vec::new();
+
+        for item in self {
+            ret.push(f(item));
+        }
+
+        ret
+    }
+}
+
+impl<T, const N: usize> ObjectArgument<T> for [T; N] {
+    type ReturnValue<R> = [R; N];
+
+    fn map<F, R>(self, f: F) -> Self::ReturnValue<R>
+    where
+        F: FnMut(T) -> R,
+    {
+        self.map(f)
+    }
+}


### PR DESCRIPTION
Add `ObjectArgument` a trait that abstracts over objects passed as arguments to builder API methods. Check out the commits for details, but the gist of it is, with the help of this trait, builder methods can now be used like this:

``` rust
// Pass an arbitrary number of points, get an arbitrary number of edges back.
// Both argument and return values are `Vec`s of the same length.
let edges = cycle.add_edges_from_points(points);

// Pass a specific number of points, and get the same number of edges back.
let [edge_a, edge_b, edge_c] =
    cycle.add_edges_from_points([point_a, point_b, point_c]);
```

This makes situation in which you are working with a specific number of objects much more easy to deal with.

This pull request adds the infrastructure to do this and applies it to one builder method, simplifying a use of that builder method significantly. I expect to use this heavily going forward, as I work towards #1162.