### PR TITLE
Box large error variants

### DIFF
--- a/crates/fj-host/src/model.rs
+++ b/crates/fj-host/src/model.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use std::{
     io,
     path::{Path, PathBuf},
@@ -257,7 +255,6 @@ fn ambiguous_path_error(
 }
 
 /// An error that can occur when loading or reloading a model
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error loading model library

--- a/crates/fj-host/src/watcher.rs
+++ b/crates/fj-host/src/watcher.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::result_large_err)]
-
 use std::{collections::HashSet, ffi::OsStr, path::Path};
 
 use crossbeam_channel::Sender;

--- a/crates/fj-kernel/src/lib.rs
+++ b/crates/fj-kernel/src/lib.rs
@@ -86,11 +86,6 @@
 //! [Fornjot]: https://www.fornjot.app/
 
 #![warn(missing_docs)]
-// I've made a simple change that put `ValidationError` over the threshold for
-// this warning. I couldn't come up with an easy fix, and figured that silencing
-// the warning is the most practical solution for now, as the validation
-// infrastructure is in flux anyway. Maybe the problem will take care of itself.
-#![allow(clippy::result_large_err)]
 
 pub mod algorithms;
 pub mod builder;

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -130,11 +130,11 @@ impl HalfEdgeValidationError {
 
         if back_curve.id() != front_curve.id() {
             errors.push(
-                Self::CurveMismatch {
+                Box::new(Self::CurveMismatch {
                     back_curve: back_curve.clone(),
                     front_curve: front_curve.clone(),
                     half_edge: half_edge.clone(),
-                }
+                })
                 .into(),
             );
         }
@@ -149,12 +149,12 @@ impl HalfEdgeValidationError {
 
         if global_curve_from_curve.id() != global_curve_from_global_form.id() {
             errors.push(
-                Self::GlobalCurveMismatch {
+                Box::new(Self::GlobalCurveMismatch {
                     global_curve_from_curve: global_curve_from_curve.clone(),
                     global_curve_from_global_form:
                         global_curve_from_global_form.clone(),
                     half_edge: half_edge.clone(),
-                }
+                })
                 .into(),
             );
         }
@@ -188,11 +188,11 @@ impl HalfEdgeValidationError {
 
         if ids_from_vertices != ids_from_global_form {
             errors.push(
-                Self::GlobalVertexMismatch {
+                Box::new(Self::GlobalVertexMismatch {
                     global_vertices_from_vertices,
                     global_vertices_from_global_form,
                     half_edge: half_edge.clone(),
-                }
+                })
                 .into(),
             );
         }
@@ -210,12 +210,12 @@ impl HalfEdgeValidationError {
 
         if distance < config.distinct_min_distance {
             errors.push(
-                Self::VerticesAreCoincident {
+                Box::new(Self::VerticesAreCoincident {
                     back_position,
                     front_position,
                     distance,
                     half_edge: half_edge.clone(),
-                }
+                })
                 .into(),
             );
         }

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -65,11 +65,11 @@ impl FaceValidationError {
         for interior in face.interiors() {
             if surface.id() != interior.surface().id() {
                 errors.push(
-                    Self::SurfaceMismatch {
+                    Box::new(Self::SurfaceMismatch {
                         surface: surface.clone(),
                         interior: interior.clone(),
                         face: face.clone(),
-                    }
+                    })
                     .into(),
                 );
             }
@@ -84,11 +84,11 @@ impl FaceValidationError {
 
             if exterior_winding == interior_winding {
                 errors.push(
-                    Self::InvalidInteriorWinding {
+                    Box::new(Self::InvalidInteriorWinding {
                         exterior_winding,
                         interior_winding,
                         face: face.clone(),
-                    }
+                    })
                     .into(),
                 );
             }

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -91,19 +91,19 @@ pub enum ValidationError {
 
     /// `Face` validation error
     #[error(transparent)]
-    Face(#[from] FaceValidationError),
+    Face(#[from] Box<FaceValidationError>),
 
     /// `HalfEdge` validation error
     #[error(transparent)]
-    HalfEdge(#[from] HalfEdgeValidationError),
+    HalfEdge(#[from] Box<HalfEdgeValidationError>),
 
     /// `SurfaceVertex` validation error
     #[error(transparent)]
-    SurfaceVertex(#[from] SurfaceVertexValidationError),
+    SurfaceVertex(#[from] Box<SurfaceVertexValidationError>),
 
     /// `Vertex` validation error
     #[error(transparent)]
-    Vertex(#[from] VertexValidationError),
+    Vertex(#[from] Box<VertexValidationError>),
 }
 
 impl From<Infallible> for ValidationError {

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -87,10 +87,10 @@ impl VertexValidationError {
 
         if curve_surface.id() != surface_form_surface.id() {
             errors.push(
-                Self::SurfaceMismatch {
+                Box::new(Self::SurfaceMismatch {
                     curve_surface: curve_surface.clone(),
                     surface_form_surface: surface_form_surface.clone(),
-                }
+                })
                 .into(),
             );
         }
@@ -111,12 +111,12 @@ impl VertexValidationError {
 
         if distance > config.identical_max_distance {
             errors.push(
-                Self::PositionMismatch {
+                Box::new(Self::PositionMismatch {
                     vertex: vertex.clone(),
                     surface_vertex: vertex.surface_form().clone_object(),
                     curve_position_as_surface,
                     distance,
-                }
+                })
                 .into(),
             );
         }
@@ -165,12 +165,12 @@ impl SurfaceVertexValidationError {
 
         if distance > config.identical_max_distance {
             errors.push(
-                Self::PositionMismatch {
+                Box::new(Self::PositionMismatch {
                     surface_vertex: surface_vertex.clone(),
                     global_vertex: surface_vertex.global_form().clone_object(),
                     surface_position_as_global,
                     distance,
-                }
+                })
                 .into(),
             );
         }

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -15,11 +15,6 @@
 //! [`fj`]: https://crates.io/crates/fj
 
 #![warn(missing_docs)]
-// I've made a simple change that put `ValidationError` over the threshold for
-// this warning. I couldn't come up with an easy fix, and figured that silencing
-// the warning is the most practical solution for now, as the validation
-// infrastructure is in flux anyway. Maybe the problem will take care of itself.
-#![allow(clippy::result_large_err)]
 
 pub mod shape_processor;
 

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -56,7 +56,6 @@ impl ShapeProcessor {
 }
 
 /// A shape processing error
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Error converting to shape

--- a/crates/fj-window/src/event_loop_handler.rs
+++ b/crates/fj-window/src/event_loop_handler.rs
@@ -33,7 +33,6 @@ pub struct EventLoopHandler {
 }
 
 impl EventLoopHandler {
-    #[allow(clippy::result_large_err)]
     pub fn handle_event(
         &mut self,
         event: Event<ModelEvent>,

--- a/crates/fj-window/src/run.rs
+++ b/crates/fj-window/src/run.rs
@@ -3,8 +3,6 @@
 //! Provides the functionality to create a window and perform basic viewing
 //! with programmed models.
 
-#![allow(clippy::result_large_err)]
-
 use std::{
     error,
     fmt::{self, Write},


### PR DESCRIPTION
Remove all `#[allow(clippy::result_large_err)]` and `#[allow(clippy::large_enum_variant)]` directives by boxing large variants of `fj_kernel::validate::ValidationError`.