### PR TITLE
Expand `ObjectArgument`

### DIFF
--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -38,7 +38,7 @@ pub trait CycleBuilder {
     fn update_as_polygon_from_points<O, P>(
         &mut self,
         points: O,
-    ) -> O::ReturnValue<Partial<HalfEdge>>
+    ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<P>,
         P: Into<Point<2>>;
@@ -130,7 +130,7 @@ impl CycleBuilder for PartialCycle {
     fn update_as_polygon_from_points<O, P>(
         &mut self,
         points: O,
-    ) -> O::ReturnValue<Partial<HalfEdge>>
+    ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<P>,
         P: Into<Point<2>>,

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -40,18 +40,18 @@ pub trait ObjectArgument<T>: IntoIterator<Item = T> {
     /// The return value has the same length as the implementing type, but it is
     /// not necessarily of the same type. For this reason, this associated type
     /// is generic.
-    type ReturnValue<R>;
+    type SameSize<R>;
 
     /// Create a return value by mapping the implementing type
-    fn map<F, R>(self, f: F) -> Self::ReturnValue<R>
+    fn map<F, R>(self, f: F) -> Self::SameSize<R>
     where
         F: FnMut(T) -> R;
 }
 
 impl<T> ObjectArgument<T> for Vec<T> {
-    type ReturnValue<R> = Vec<R>;
+    type SameSize<R> = Vec<R>;
 
-    fn map<F, R>(self, mut f: F) -> Self::ReturnValue<R>
+    fn map<F, R>(self, mut f: F) -> Self::SameSize<R>
     where
         F: FnMut(T) -> R,
     {
@@ -66,9 +66,9 @@ impl<T> ObjectArgument<T> for Vec<T> {
 }
 
 impl<T, const N: usize> ObjectArgument<T> for [T; N] {
-    type ReturnValue<R> = [R; N];
+    type SameSize<R> = [R; N];
 
-    fn map<F, R>(self, f: F) -> Self::ReturnValue<R>
+    fn map<F, R>(self, f: F) -> Self::SameSize<R>
     where
         F: FnMut(T) -> R,
     {

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -47,6 +47,9 @@ pub trait ObjectArgument<T>: IntoIterator<Item = T> {
     /// A return value that has one more element thatn the argument
     type SizePlusOne<R>;
 
+    /// Return the number of objects
+    fn num_objects(&self) -> usize;
+
     /// Create a return value by mapping the implementing type
     fn map<F, R>(self, f: F) -> Self::SameSize<R>
     where
@@ -61,6 +64,10 @@ pub trait ObjectArgument<T>: IntoIterator<Item = T> {
 impl<T> ObjectArgument<T> for Vec<T> {
     type SameSize<R> = Vec<R>;
     type SizePlusOne<R> = Vec<R>;
+
+    fn num_objects(&self) -> usize {
+        self.len()
+    }
 
     fn map<F, R>(self, mut f: F) -> Self::SameSize<R>
     where
@@ -95,6 +102,10 @@ macro_rules! impl_object_argument_for_arrays {
             impl<T> ObjectArgument<T> for [T; $len] {
                 type SameSize<R> = [R; $len];
                 type SizePlusOne<R> = [R; $len_plus_one];
+
+                fn num_objects(&self) -> usize {
+                    self.len()
+                }
 
                 fn map<F, R>(self, f: F) -> Self::SameSize<R>
                 where

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -85,6 +85,10 @@ impl<T> ObjectArgument<T> for Vec<T> {
     }
 }
 
+// This macro implements `ObjectArgument` for a number of array types. This
+// should just be a single implementation, but while const generic expressions
+// are still unstable, this is unfortunately not possible:
+// <https://github.com/rust-lang/rust/issues/76560>
 macro_rules! impl_object_argument_for_arrays {
     ($($len:expr, $len_plus_one:expr;)*) => {
         $(

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -65,13 +65,30 @@ impl<T> ObjectArgument<T> for Vec<T> {
     }
 }
 
-impl<T, const N: usize> ObjectArgument<T> for [T; N] {
-    type SameSize<R> = [R; N];
+macro_rules! impl_object_argument_for_arrays {
+    ($($len:expr;)*) => {
+        $(
+            impl<T> ObjectArgument<T> for [T; $len] {
+                type SameSize<R> = [R; $len];
 
-    fn map<F, R>(self, f: F) -> Self::SameSize<R>
-    where
-        F: FnMut(T) -> R,
-    {
-        self.map(f)
-    }
+                fn map<F, R>(self, f: F) -> Self::SameSize<R>
+                where
+                    F: FnMut(T) -> R,
+                {
+                    self.map(f)
+                }
+            }
+        )*
+    };
 }
+
+impl_object_argument_for_arrays!(
+    0;
+    1;
+    2;
+    3;
+    4;
+    5;
+    6;
+    7;
+);

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -42,6 +42,9 @@ pub trait ObjectArgument<T>: IntoIterator<Item = T> {
     /// is generic.
     type SameSize<R>;
 
+    /// A return value that has one more element thatn the argument
+    type SizePlusOne<R>;
+
     /// Create a return value by mapping the implementing type
     fn map<F, R>(self, f: F) -> Self::SameSize<R>
     where
@@ -50,6 +53,7 @@ pub trait ObjectArgument<T>: IntoIterator<Item = T> {
 
 impl<T> ObjectArgument<T> for Vec<T> {
     type SameSize<R> = Vec<R>;
+    type SizePlusOne<R> = Vec<R>;
 
     fn map<F, R>(self, mut f: F) -> Self::SameSize<R>
     where
@@ -66,10 +70,11 @@ impl<T> ObjectArgument<T> for Vec<T> {
 }
 
 macro_rules! impl_object_argument_for_arrays {
-    ($($len:expr;)*) => {
+    ($($len:expr, $len_plus_one:expr;)*) => {
         $(
             impl<T> ObjectArgument<T> for [T; $len] {
                 type SameSize<R> = [R; $len];
+                type SizePlusOne<R> = [R; $len_plus_one];
 
                 fn map<F, R>(self, f: F) -> Self::SameSize<R>
                 where
@@ -83,12 +88,12 @@ macro_rules! impl_object_argument_for_arrays {
 }
 
 impl_object_argument_for_arrays!(
-    0;
-    1;
-    2;
-    3;
-    4;
-    5;
-    6;
-    7;
+    0, 1;
+    1, 2;
+    2, 3;
+    3, 4;
+    4, 5;
+    5, 6;
+    6, 7;
+    7, 8;
 );


### PR DESCRIPTION
Add more features to the `ObjectArgument` trait that are required to use it for more of the builder methods I'm working on. This is part of the work towards #1162.