### PR TITLE
Demote `Vertex` from its status as an object, embed it in `HalfEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -48,13 +48,13 @@ impl Intersect for (&Handle<Face>, &Point<2>) {
                         ));
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = half_edge.vertices()[0].clone_object();
+                        let vertex = half_edge.vertices()[0].clone();
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = half_edge.vertices()[1].clone_object();
+                        let vertex = half_edge.vertices()[1].clone();
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
@@ -347,7 +347,7 @@ mod tests {
                 vertex.surface_form().position() == Point::from([1., 0.])
             })
             .unwrap()
-            .clone_object();
+            .clone();
         assert_eq!(
             intersection,
             Some(FacePointIntersection::PointIsOnVertex(vertex))

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -346,10 +346,11 @@ mod tests {
             .find(|vertex| {
                 vertex.surface_form().position() == Point::from([1., 0.])
             })
-            .unwrap();
+            .unwrap()
+            .clone();
         assert_eq!(
             intersection,
-            Some(FacePointIntersection::PointIsOnVertex(vertex.clone()))
+            Some(FacePointIntersection::PointIsOnVertex(vertex))
         );
     }
 }

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -48,13 +48,13 @@ impl Intersect for (&Handle<Face>, &Point<2>) {
                         ));
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let vertex = half_edge.vertices()[0].clone();
+                        let vertex = half_edge.vertices()[0].clone_object();
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let vertex = half_edge.vertices()[1].clone();
+                        let vertex = half_edge.vertices()[1].clone_object();
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
@@ -125,7 +125,7 @@ pub enum FacePointIntersection {
     PointIsOnEdge(Handle<HalfEdge>),
 
     /// The point is coincident with a vertex
-    PointIsOnVertex(Handle<Vertex>),
+    PointIsOnVertex(Vertex),
 }
 
 #[cfg(test)]
@@ -347,7 +347,7 @@ mod tests {
                 vertex.surface_form().position() == Point::from([1., 0.])
             })
             .unwrap()
-            .clone();
+            .clone_object();
         assert_eq!(
             intersection,
             Some(FacePointIntersection::PointIsOnVertex(vertex))

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -292,7 +292,7 @@ mod tests {
                 vertex.surface_form().position() == Point::from([-1., -1.])
             })
             .unwrap()
-            .clone_object();
+            .clone();
         assert_eq!(
             (&ray, &face).intersect(),
             Some(RayFaceIntersection::RayHitsVertex(vertex))

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -136,7 +136,7 @@ pub enum RayFaceIntersection {
     RayHitsEdge(Handle<HalfEdge>),
 
     /// The ray hits a vertex
-    RayHitsVertex(Handle<Vertex>),
+    RayHitsVertex(Vertex),
 }
 
 #[cfg(test)]
@@ -292,7 +292,7 @@ mod tests {
                 vertex.surface_form().position() == Point::from([-1., -1.])
             })
             .unwrap()
-            .clone();
+            .clone_object();
         assert_eq!(
             (&ray, &face).intersect(),
             Some(RayFaceIntersection::RayHitsVertex(vertex))

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -291,10 +291,11 @@ mod tests {
             .find(|vertex| {
                 vertex.surface_form().position() == Point::from([-1., -1.])
             })
-            .unwrap();
+            .unwrap()
+            .clone();
         assert_eq!(
             (&ray, &face).intersect(),
-            Some(RayFaceIntersection::RayHitsVertex(vertex.clone()))
+            Some(RayFaceIntersection::RayHitsVertex(vertex))
         );
     }
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -89,7 +89,8 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         };
 
         let side_edges = bottom_edge.vertices().clone().map(|vertex| {
-            (vertex, surface.clone()).sweep_with_cache(path, cache, objects)
+            (vertex.clone_object(), surface.clone())
+                .sweep_with_cache(path, cache, objects)
         });
 
         let top_edge = {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -237,10 +237,8 @@ mod tests {
                 {
                     let [back, front] = &mut side_up.vertices;
 
-                    back.write().surface_form =
-                        bottom.vertices[1].read().surface_form.clone();
+                    back.surface_form = bottom.vertices[1].surface_form.clone();
 
-                    let mut front = front.write();
                     let mut front = front.surface_form.write();
                     front.position = Some([1., 1.].into());
                     front.surface = surface.clone();
@@ -258,13 +256,12 @@ mod tests {
                 {
                     let [back, front] = &mut top.vertices;
 
-                    let mut back = back.write();
                     let mut back = back.surface_form.write();
                     back.position = Some([0., 1.].into());
                     back.surface = surface.clone();
 
-                    front.write().surface_form =
-                        side_up.vertices[1].read().surface_form.clone();
+                    front.surface_form =
+                        side_up.vertices[1].surface_form.clone();
                 }
 
                 top.infer_global_form();
@@ -284,10 +281,8 @@ mod tests {
 
                 let [back, front] = &mut side_down.vertices;
 
-                back.write().surface_form =
-                    bottom.vertices[0].read().surface_form.clone();
-                front.write().surface_form =
-                    top.vertices[1].read().surface_form.clone();
+                back.surface_form = bottom.vertices[0].surface_form.clone();
+                front.surface_form = top.vertices[1].surface_form.clone();
 
                 side_down.infer_global_form();
                 side_down.update_as_line_segment();

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -81,7 +81,6 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                             curve.clone(),
                             surface_vertex,
                         )
-                        .insert(objects)
                     })
             };
 
@@ -89,8 +88,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         };
 
         let side_edges = bottom_edge.vertices().clone().map(|vertex| {
-            (vertex.clone_object(), surface.clone())
-                .sweep_with_cache(path, cache, objects)
+            (vertex, surface.clone()).sweep_with_cache(path, cache, objects)
         });
 
         let top_edge = {
@@ -139,7 +137,6 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 .collect::<[_; 2]>()
                 .map(|(vertex, surface_form)| {
                     Vertex::new(vertex.position(), curve.clone(), surface_form)
-                        .insert(objects)
                 });
 
             HalfEdge::new(vertices, global).insert(objects)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -112,7 +112,6 @@ impl Sweep for (Vertex, Handle<Surface>) {
                 curve.clone(),
                 surface_form,
             )
-            .insert(objects)
         });
 
         // And finally, creating the output `Edge` is just a matter of

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for (Handle<Vertex>, Handle<Surface>) {
+impl Sweep for (Vertex, Handle<Surface>) {
     type Swept = Handle<HalfEdge>;
 
     fn sweep_with_cache(
@@ -188,8 +188,7 @@ mod tests {
                 ..Default::default()
             }),
         }
-        .build(&mut services.objects)
-        .insert(&mut services.objects);
+        .build(&mut services.objects);
 
         let half_edge = (vertex, surface.clone())
             .sweep([0., 0., 1.], &mut services.objects);

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -99,23 +99,21 @@ impl CycleBuilder for PartialCycle {
 
         {
             let shared_surface_vertex =
-                new_half_edge.read().back().read().surface_form.clone();
+                new_half_edge.read().back().surface_form.clone();
 
             let mut last_half_edge = last_half_edge.write();
 
-            last_half_edge.front_mut().write().surface_form =
-                shared_surface_vertex;
+            last_half_edge.front_mut().surface_form = shared_surface_vertex;
             last_half_edge.infer_global_form();
         }
 
         {
             let shared_surface_vertex =
-                first_half_edge.read().back().read().surface_form.clone();
+                first_half_edge.read().back().surface_form.clone();
 
             let mut new_half_edge = new_half_edge.write();
 
-            new_half_edge.front_mut().write().surface_form =
-                shared_surface_vertex;
+            new_half_edge.front_mut().surface_form = shared_surface_vertex;
             new_half_edge.replace_surface(self.surface.clone());
             new_half_edge.infer_global_form();
         }
@@ -130,13 +128,8 @@ impl CycleBuilder for PartialCycle {
     ) -> Partial<HalfEdge> {
         let mut half_edge = self.add_half_edge();
 
-        half_edge
-            .write()
-            .back_mut()
-            .write()
-            .surface_form
-            .write()
-            .position = Some(point.into());
+        half_edge.write().back_mut().surface_form.write().position =
+            Some(point.into());
 
         half_edge
     }
@@ -150,7 +143,6 @@ impl CycleBuilder for PartialCycle {
         half_edge
             .write()
             .back_mut()
-            .write()
             .surface_form
             .write()
             .global_form
@@ -198,7 +190,6 @@ impl CycleBuilder for PartialCycle {
             half_edge
                 .write()
                 .back_mut()
-                .write()
                 .surface_form
                 .write()
                 .global_form

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -109,9 +109,10 @@ impl FaceBuilder for PartialFace {
 
     fn update_surface_as_plane(&mut self) -> Partial<Surface> {
         let mut exterior = self.exterior.write();
-        let mut vertices = exterior.half_edges.iter().map(|half_edge| {
-            half_edge.read().back().read().surface_form.clone()
-        });
+        let mut vertices = exterior
+            .half_edges
+            .iter()
+            .map(|half_edge| half_edge.read().back().surface_form.clone());
 
         let vertices = {
             let array = [
@@ -164,12 +165,7 @@ impl FaceBuilder for PartialFace {
                     MaybeSurfacePath::UndefinedLine => {
                         let points_surface =
                             half_edge.vertices.each_ref_ext().map(|vertex| {
-                                vertex
-                                    .read()
-                                    .surface_form
-                                    .read()
-                                    .position
-                                    .expect(
+                                vertex.surface_form.read().position.expect(
                                     "Can't infer curve without surface points",
                                 )
                             });
@@ -182,7 +178,7 @@ impl FaceBuilder for PartialFace {
                             .each_mut_ext()
                             .zip_ext(points_curve)
                         {
-                            vertex.write().position = Some(point);
+                            vertex.position = Some(point);
                         }
                     }
                 }

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -5,7 +5,7 @@
 use crate::{
     objects::{
         Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
-        Objects, Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
+        Objects, Shell, Sketch, Solid, Surface, SurfaceVertex,
     },
     services::{Service, ServiceObjectsExt},
     storage::Handle,
@@ -46,5 +46,4 @@ impl_insert!(
     Solid, solids;
     SurfaceVertex, surface_vertices;
     Surface, surfaces;
-    Vertex, vertices;
 );

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -8,16 +8,13 @@ use crate::{
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
-    vertices: [Handle<Vertex>; 2],
+    vertices: [Vertex; 2],
     global_form: Handle<GlobalEdge>,
 }
 
 impl HalfEdge {
     /// Create an instance of `HalfEdge`
-    pub fn new(
-        vertices: [Handle<Vertex>; 2],
-        global_form: Handle<GlobalEdge>,
-    ) -> Self {
+    pub fn new(vertices: [Vertex; 2], global_form: Handle<GlobalEdge>) -> Self {
         Self {
             vertices,
             global_form,
@@ -31,18 +28,18 @@ impl HalfEdge {
     }
 
     /// Access the vertices that bound the half-edge on the curve
-    pub fn vertices(&self) -> &[Handle<Vertex>; 2] {
+    pub fn vertices(&self) -> &[Vertex; 2] {
         &self.vertices
     }
 
     /// Access the vertex at the back of the half-edge
-    pub fn back(&self) -> &Handle<Vertex> {
+    pub fn back(&self) -> &Vertex {
         let [back, _] = self.vertices();
         back
     }
 
     /// Access the vertex at the front of the half-edge
-    pub fn front(&self) -> &Handle<Vertex> {
+    pub fn front(&self) -> &Vertex {
         let [_, front] = self.vertices();
         front
     }

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use crate::{
     objects::{
         Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge,
-        Objects, Shell, Sketch, Solid, Surface, SurfaceVertex, Vertex,
+        Objects, Shell, Sketch, Solid, Surface, SurfaceVertex,
     },
     storage::{Handle, ObjectId},
     validate::{Validate, ValidationError},
@@ -120,7 +120,6 @@ object!(
     Solid, "solid", solids;
     Surface, "surface", surfaces;
     SurfaceVertex, "surface vertex", surface_vertices;
-    Vertex, "vertex", vertices;
 );
 
 /// The form that an object can take

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{
     Curve, Cycle, Face, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Shell,
-    Sketch, Solid, Surface, SurfaceVertex, Vertex,
+    Sketch, Solid, Surface, SurfaceVertex,
 };
 
 /// The available object stores
@@ -55,9 +55,6 @@ pub struct Objects {
 
     /// Store for [`Surface`]s
     pub surfaces: Surfaces,
-
-    /// Store for [`Vertex`] objects
-    pub vertices: Store<Vertex>,
 }
 
 impl Objects {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -3,7 +3,6 @@ use std::array;
 use fj_interop::ext::ArrayExt;
 
 use crate::{
-    insert::Insert,
     objects::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
     },
@@ -73,9 +72,7 @@ impl PartialObject for PartialHalfEdge {
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
-        let vertices = self
-            .vertices
-            .map(|vertex| vertex.build(objects).insert(objects));
+        let vertices = self.vertices.map(|vertex| vertex.build(objects));
         let global_form = self.global_form.build(objects);
 
         HalfEdge::new(vertices, global_form)

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -98,9 +98,9 @@ mod tests {
                 let first_half_edge = half_edges.first_mut().unwrap();
                 let [first_vertex, _] = &mut first_half_edge.write().vertices;
                 let surface_vertex = Partial::from_partial(
-                    first_vertex.read().surface_form.read().clone(),
+                    first_vertex.surface_form.read().clone(),
                 );
-                first_vertex.write().surface_form = surface_vertex;
+                first_vertex.surface_form = surface_vertex;
             }
 
             let half_edges = half_edges

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -294,7 +294,7 @@ impl HalfEdgeValidationError {
             if distance > config.identical_max_distance {
                 errors.push(
                     Box::new(Self::VertexPositionMismatch {
-                        vertex: vertex.clone_object(),
+                        vertex: vertex.clone(),
                         curve_position_on_surface,
                         distance,
                     })
@@ -314,8 +314,8 @@ mod tests {
         insert::Insert,
         objects::{GlobalCurve, HalfEdge},
         partial::{
-            Partial, PartialHalfEdge, PartialObject, PartialSurfaceVertex,
-            PartialVertex,
+            FullToPartialCache, Partial, PartialHalfEdge, PartialObject,
+            PartialSurfaceVertex, PartialVertex,
         },
         services::Services,
         validate::Validate,
@@ -336,9 +336,12 @@ mod tests {
         };
         let invalid = {
             let mut vertices = valid.vertices().clone();
-            let mut vertex = Partial::from(vertices[1].clone());
+            let mut vertex = PartialVertex::from_full(
+                &vertices[1],
+                &mut FullToPartialCache::default(),
+            );
             // Arranging for an equal but not identical curve here.
-            vertex.write().curve = Partial::from_partial(
+            vertex.curve = Partial::from_partial(
                 Partial::from(valid.curve().clone()).read().clone(),
             );
             vertices[1] = vertex.build(&mut services.objects);
@@ -425,8 +428,11 @@ mod tests {
         };
         let invalid = {
             let vertices = valid.vertices().clone().map(|vertex| {
-                let mut vertex = Partial::from(vertex);
-                vertex.write().surface_form.write().surface =
+                let mut vertex = PartialVertex::from_full(
+                    &vertex,
+                    &mut FullToPartialCache::default(),
+                );
+                vertex.surface_form.write().surface =
                     Partial::from(services.objects.surfaces.xz_plane());
 
                 vertex.build(&mut services.objects)
@@ -456,7 +462,10 @@ mod tests {
         };
         let invalid = HalfEdge::new(
             valid.vertices().clone().map(|vertex| {
-                let vertex = Partial::from(vertex).read().clone();
+                let vertex = PartialVertex::from_full(
+                    &vertex,
+                    &mut FullToPartialCache::default(),
+                );
                 let surface = vertex.surface_form.read().surface.clone();
                 PartialVertex {
                     position: Some([0.].into()),
@@ -467,7 +476,6 @@ mod tests {
                     ..vertex
                 }
                 .build(&mut services.objects)
-                .insert(&mut services.objects)
             }),
             valid.global_form().clone(),
         );
@@ -493,8 +501,11 @@ mod tests {
         };
         let invalid = {
             let vertices = valid.vertices().clone().map(|vertex| {
-                let mut vertex = Partial::from(vertex);
-                vertex.write().position = Some(Point::from([2.]));
+                let mut vertex = PartialVertex::from_full(
+                    &vertex,
+                    &mut FullToPartialCache::default(),
+                );
+                vertex.position = Some(Point::from([2.]));
 
                 vertex.build(&mut services.objects)
             });

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -11,10 +11,8 @@ mod surface;
 mod vertex;
 
 pub use self::{
-    cycle::CycleValidationError,
-    edge::HalfEdgeValidationError,
-    face::FaceValidationError,
-    vertex::{SurfaceVertexValidationError, VertexValidationError},
+    cycle::CycleValidationError, edge::HalfEdgeValidationError,
+    face::FaceValidationError, vertex::SurfaceVertexValidationError,
 };
 
 use std::convert::Infallible;
@@ -100,10 +98,6 @@ pub enum ValidationError {
     /// `SurfaceVertex` validation error
     #[error(transparent)]
     SurfaceVertex(#[from] Box<SurfaceVertexValidationError>),
-
-    /// `Vertex` validation error
-    #[error(transparent)]
-    Vertex(#[from] Box<VertexValidationError>),
 }
 
 impl From<Infallible> for ValidationError {

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -32,10 +32,6 @@ impl Validate for GlobalVertex {
     }
 }
 
-/// [`Vertex`] validation failed
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum VertexValidationError {}
-
 /// [`SurfaceVertex`] validation error
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum SurfaceVertexValidationError {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -35,8 +35,7 @@ impl Shape for fj::Sketch {
                     half_edge.curve().write().surface = surface.clone();
 
                     for vertex in &mut half_edge.vertices {
-                        vertex.write().surface_form.write().surface =
-                            surface.clone();
+                        vertex.surface_form.write().surface = surface.clone();
                     }
 
                     half_edge.update_as_circle_from_radius(circle.radius());


### PR DESCRIPTION
From one of the commit messages:

> While `Vertex` instances could, in theory, be shared between different
`HalfEdge`s, this isn't currently done, and I don't think it would
provide any advantage. Therefore, having `Vertex` be a separate object
doesn't make any sense and only makes the object graph more complicated.
>
> This is the first step towards rectifying this and simplifying the
object graph around `HalfEdge`.

I have more ideas for simplifications in that part of the object graph, but at this point it's unclear how directly applicable those are, or whether other foundational cleanups are required first.