### PR TITLE
Move `Curve` reference from `Vertex` to `HalfEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -14,6 +14,11 @@ impl Reverse for Handle<HalfEdge> {
             [b, a]
         };
 
-        HalfEdge::new(vertices, self.global_form().clone()).insert(objects)
+        HalfEdge::new(
+            self.curve().clone(),
+            vertices,
+            self.global_form().clone(),
+        )
+        .insert(objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -84,7 +84,8 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     })
             };
 
-            HalfEdge::new(vertices, edge.global_form().clone()).insert(objects)
+            HalfEdge::new(curve, vertices, edge.global_form().clone())
+                .insert(objects)
         };
 
         let side_edges = bottom_edge.vertices().clone().map(|vertex| {
@@ -139,7 +140,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                     Vertex::new(vertex.position(), curve.clone(), surface_form)
                 });
 
-            HalfEdge::new(vertices, global).insert(objects)
+            HalfEdge::new(curve, vertices, global).insert(objects)
         };
 
         let cycle = {

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -230,7 +230,7 @@ mod tests {
             };
             let side_up = {
                 let mut side_up = PartialHalfEdge::default();
-                side_up.curve().write().surface = surface.clone();
+                side_up.curve.write().surface = surface.clone();
 
                 {
                     let [back, front] = &mut side_up.vertices;
@@ -249,7 +249,7 @@ mod tests {
             };
             let top = {
                 let mut top = PartialHalfEdge::default();
-                top.curve().write().surface = surface.clone();
+                top.curve.write().surface = surface.clone();
 
                 {
                     let [back, front] = &mut top.vertices;
@@ -275,7 +275,7 @@ mod tests {
             };
             let side_down = {
                 let mut side_down = PartialHalfEdge::default();
-                side_down.curve().write().surface = surface;
+                side_down.curve.write().surface = surface;
 
                 let [back, front] = &mut side_down.vertices;
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -76,11 +76,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                         )
                         .insert(objects);
 
-                        Vertex::new(
-                            vertex.position(),
-                            curve.clone(),
-                            surface_vertex,
-                        )
+                        Vertex::new(vertex.position(), surface_vertex)
                     })
             };
 
@@ -137,7 +133,7 @@ impl Sweep for (Handle<HalfEdge>, Color) {
                 .zip(surface_vertices)
                 .collect::<[_; 2]>()
                 .map(|(vertex, surface_form)| {
-                    Vertex::new(vertex.position(), curve.clone(), surface_form)
+                    Vertex::new(vertex.position(), surface_form)
                 });
 
             HalfEdge::new(curve, vertices, global).insert(objects)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -153,6 +153,7 @@ impl Sweep for Handle<GlobalVertex> {
 
 #[cfg(test)]
 mod tests {
+    use fj_math::Point;
     use pretty_assertions::assert_eq;
 
     use crate::{
@@ -160,8 +161,8 @@ mod tests {
         builder::{CurveBuilder, HalfEdgeBuilder},
         insert::Insert,
         partial::{
-            Partial, PartialCurve, PartialHalfEdge, PartialObject,
-            PartialSurfaceVertex, PartialVertex,
+            Partial, PartialCurve, PartialGlobalVertex, PartialHalfEdge,
+            PartialObject, PartialSurfaceVertex, PartialVertex,
         },
         services::Services,
     };
@@ -183,8 +184,11 @@ mod tests {
             position: Some([0.].into()),
             curve: Partial::from(curve),
             surface_form: Partial::from_partial(PartialSurfaceVertex {
+                position: Some(Point::from([0., 0.])),
                 surface: Partial::from(surface.clone()),
-                ..Default::default()
+                global_form: Partial::from_partial(PartialGlobalVertex {
+                    position: Some(Point::from([0., 0., 0.])),
+                }),
             }),
         }
         .build(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -116,7 +116,7 @@ impl Sweep for (Vertex, Handle<Surface>) {
 
         // And finally, creating the output `Edge` is just a matter of
         // assembling the pieces we've already created.
-        HalfEdge::new(vertices, edge_global).insert(objects)
+        HalfEdge::new(curve, vertices, edge_global).insert(objects)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -107,11 +107,7 @@ impl Sweep for (Vertex, Handle<Surface>) {
 
         // And now the vertices. Again, nothing wild here.
         let vertices = vertices_surface.map(|surface_form| {
-            Vertex::new(
-                [surface_form.position().v],
-                curve.clone(),
-                surface_form,
-            )
+            Vertex::new([surface_form.position().v], surface_form)
         });
 
         // And finally, creating the output `Edge` is just a matter of
@@ -177,12 +173,8 @@ mod tests {
             ..Default::default()
         };
         curve.update_as_u_axis();
-        let curve = curve
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
         let vertex = PartialVertex {
             position: Some([0.].into()),
-            curve: Partial::from(curve),
             surface_form: Partial::from_partial(PartialSurfaceVertex {
                 position: Some(Point::from([0., 0.])),
                 surface: Partial::from(surface.clone()),

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -14,6 +14,10 @@ impl TransformObject for HalfEdge {
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
+        let curve = self
+            .curve()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
         let vertices = self.vertices().clone().map(|vertex| {
             vertex.transform_with_cache(transform, objects, cache)
         });
@@ -22,7 +26,7 @@ impl TransformObject for HalfEdge {
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(vertices, global_form)
+        Self::new(curve, vertices, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -18,16 +18,12 @@ impl TransformObject for Vertex {
         // coordinates and thus transforming the curve takes care of it.
         let position = self.position();
 
-        let curve = self
-            .curve()
-            .clone()
-            .transform_with_cache(transform, objects, cache);
         let surface_form = self
             .surface_form()
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(position, curve, surface_form)
+        Self::new(position, surface_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -64,8 +64,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     }
 
     fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>) {
-        let mut curve = self.curve();
-        let path = curve.write().update_as_circle_from_radius(radius);
+        let path = self.curve.write().update_as_circle_from_radius(radius);
 
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
@@ -107,8 +106,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             angle_rad,
         );
 
-        let mut curve = self.curve();
-        let path = curve
+        let path = self
+            .curve
             .write()
             .update_as_circle_from_center_and_radius(arc.center, arc.radius);
 
@@ -157,7 +156,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
                 .expect("Can't infer line segment without surface position")
         });
 
-        self.curve()
+        self.curve
             .write()
             .update_as_line_from_points(points_surface);
 
@@ -170,8 +169,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     }
 
     fn infer_global_form(&mut self) -> Partial<GlobalEdge> {
-        self.global_form.write().curve =
-            self.curve().read().global_form.clone();
+        self.global_form.write().curve = self.curve.read().global_form.clone();
         self.global_form.write().vertices = self
             .vertices
             .each_ref_ext()
@@ -181,13 +179,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     }
 
     fn update_from_other_edge(&mut self, other: &Partial<HalfEdge>) {
-        let global_curve = other.read().curve().read().global_form.clone();
-        self.curve().write().global_form = global_curve.clone();
+        let global_curve = other.read().curve.read().global_form.clone();
+        self.curve.write().global_form = global_curve.clone();
         self.global_form.write().curve = global_curve;
 
-        self.curve().write().path = other
+        self.curve.write().path = other
             .read()
-            .curve()
+            .curve
             .read()
             .path
             .as_ref()

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -141,8 +141,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         self.curve.write().surface = surface.clone();
 
         for (vertex, point) in self.vertices.each_mut_ext().zip_ext(points) {
-            vertex.curve.write().surface = surface.clone();
-
             let mut surface_form = vertex.surface_form.write();
             surface_form.position = Some(point.into());
             surface_form.surface = surface.clone();

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -58,6 +58,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn replace_surface(&mut self, surface: impl Into<Partial<Surface>>) {
         let surface = surface.into();
 
+        self.curve.write().surface = surface.clone();
+
         for vertex in &mut self.vertices {
             vertex.replace_surface(surface.clone());
         }
@@ -135,6 +137,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         points: [impl Into<Point<2>>; 2],
     ) {
         let surface = surface.into();
+
+        self.curve.write().surface = surface.clone();
 
         for (vertex, point) in self.vertices.each_mut_ext().zip_ext(points) {
             vertex.curve.write().surface = surface.clone();

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -151,7 +151,7 @@ impl FaceBuilder for PartialFace {
         for half_edge in &mut self.exterior.write().half_edges {
             let mut half_edge = half_edge.write();
 
-            let mut curve = half_edge.curve();
+            let mut curve = half_edge.curve.clone();
             let mut curve = curve.write();
 
             if let Some(path) = &mut curve.path {

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -23,8 +23,6 @@ pub trait VertexBuilder {
 impl VertexBuilder for PartialVertex {
     fn replace_surface(&mut self, surface: impl Into<Partial<Surface>>) {
         let surface = surface.into();
-
-        self.curve.write().surface = surface.clone();
         self.surface_form.write().surface = surface;
     }
 }

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -29,8 +29,7 @@ impl HalfEdge {
 
     /// Access the curve that defines the half-edge's geometry
     pub fn curve(&self) -> &Handle<Curve> {
-        let [vertex, _] = self.vertices();
-        vertex.curve()
+        &self.curve
     }
 
     /// Access the vertices that bound the half-edge on the curve

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -8,14 +8,20 @@ use crate::{
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
+    curve: Handle<Curve>,
     vertices: [Vertex; 2],
     global_form: Handle<GlobalEdge>,
 }
 
 impl HalfEdge {
     /// Create an instance of `HalfEdge`
-    pub fn new(vertices: [Vertex; 2], global_form: Handle<GlobalEdge>) -> Self {
+    pub fn new(
+        curve: Handle<Curve>,
+        vertices: [Vertex; 2],
+        global_form: Handle<GlobalEdge>,
+    ) -> Self {
         Self {
+            curve,
             vertices,
             global_form,
         }

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -1,9 +1,6 @@
 use fj_math::Point;
 
-use crate::{
-    objects::{Curve, Surface},
-    storage::Handle,
-};
+use crate::{objects::Surface, storage::Handle};
 
 /// A vertex
 ///
@@ -15,7 +12,6 @@ use crate::{
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Vertex {
     position: Point<1>,
-    curve: Handle<Curve>,
     surface_form: Handle<SurfaceVertex>,
 }
 
@@ -23,14 +19,12 @@ impl Vertex {
     /// Construct an instance of `Vertex`
     pub fn new(
         position: impl Into<Point<1>>,
-        curve: Handle<Curve>,
         surface_form: Handle<SurfaceVertex>,
     ) -> Self {
         let position = position.into();
 
         Self {
             position,
-            curve,
             surface_form,
         }
     }
@@ -38,11 +32,6 @@ impl Vertex {
     /// Access the position of the vertex on the curve
     pub fn position(&self) -> Point<1> {
         self.position
-    }
-
-    /// Access the curve that the vertex is defined in
-    pub fn curve(&self) -> &Handle<Curve> {
-        &self.curve
     }
 
     /// Access the surface form of this vertex

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -24,12 +24,6 @@ pub struct PartialHalfEdge {
 }
 
 impl PartialHalfEdge {
-    /// Access the curve the partial edge is defined on
-    pub fn curve(&self) -> Partial<Curve> {
-        let [vertex, _] = &self.vertices;
-        vertex.curve.clone()
-    }
-
     /// Access a reference to the half-edge's back vertex
     pub fn back(&self) -> &PartialVertex {
         let [back, _] = &self.vertices;
@@ -76,7 +70,7 @@ impl PartialObject for PartialHalfEdge {
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
-        let curve = self.curve().build(objects);
+        let curve = self.curve.build(objects);
         let vertices = self.vertices.map(|vertex| vertex.build(objects));
         let global_form = self.global_form.build(objects);
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -72,10 +72,11 @@ impl PartialObject for PartialHalfEdge {
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let curve = self.curve().build(objects);
         let vertices = self.vertices.map(|vertex| vertex.build(objects));
         let global_form = self.global_form.build(objects);
 
-        HalfEdge::new(vertices, global_form)
+        HalfEdge::new(curve, vertices, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -13,6 +13,9 @@ use crate::{
 /// A partial [`HalfEdge`]
 #[derive(Clone, Debug)]
 pub struct PartialHalfEdge {
+    /// The curve that the half-edge is defined in
+    pub curve: Partial<Curve>,
+
     /// The vertices that bound the half-edge on the curve
     pub vertices: [PartialVertex; 2],
 
@@ -60,6 +63,7 @@ impl PartialObject for PartialHalfEdge {
         cache: &mut FullToPartialCache,
     ) -> Self {
         Self {
+            curve: Partial::from_full(half_edge.curve().clone(), cache),
             vertices: half_edge
                 .vertices()
                 .clone()
@@ -102,6 +106,7 @@ impl Default for PartialHalfEdge {
         });
 
         Self {
+            curve,
             vertices,
             global_form,
         }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -114,10 +114,7 @@ impl PartialObject for PartialHalfEdge {
 impl Default for PartialHalfEdge {
     fn default() -> Self {
         let curve = Partial::<Curve>::new();
-        let vertices = array::from_fn(|_| PartialVertex {
-            curve: curve.clone(),
-            ..Default::default()
-        });
+        let vertices = array::from_fn(|_| PartialVertex::default());
 
         let global_curve = curve.read().global_form.clone();
         let global_vertices =

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -1,7 +1,6 @@
 use fj_math::Point;
 
 use crate::{
-    builder::SurfaceVertexBuilder,
     objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
     partial::{FullToPartialCache, Partial, PartialCurve, PartialObject},
     services::Service,
@@ -34,18 +33,11 @@ impl PartialObject for PartialVertex {
         }
     }
 
-    fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let position = self
             .position
             .expect("Can't build `Vertex` without position");
         let curve = self.curve.build(objects);
-
-        // Infer surface position, if not available.
-        if self.surface_form.read().position.is_none() {
-            self.surface_form.write().position =
-                Some(curve.path().point_from_path_coords(position));
-        }
-
         let surface_form = self.surface_form.build(objects);
 
         Vertex::new(position, curve, surface_form)
@@ -106,11 +98,7 @@ impl PartialObject for PartialSurfaceVertex {
         }
     }
 
-    fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
-        if self.global_form.read().position.is_none() {
-            self.infer_global_position();
-        }
-
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let position = self
             .position
             .expect("Can't build `SurfaceVertex` without position");

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -1,8 +1,8 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Curve, GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
-    partial::{FullToPartialCache, Partial, PartialCurve, PartialObject},
+    objects::{GlobalVertex, Objects, Surface, SurfaceVertex, Vertex},
+    partial::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -11,9 +11,6 @@ use crate::{
 pub struct PartialVertex {
     /// The position of the vertex on the curve
     pub position: Option<Point<1>>,
-
-    /// The curve that the vertex is defined in
-    pub curve: Partial<Curve>,
 
     /// The surface form of the vertex
     pub surface_form: Partial<SurfaceVertex>,
@@ -25,7 +22,6 @@ impl PartialObject for PartialVertex {
     fn from_full(vertex: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             position: Some(vertex.position()),
-            curve: Partial::from_full(vertex.curve().clone(), cache),
             surface_form: Partial::from_full(
                 vertex.surface_form().clone(),
                 cache,
@@ -37,10 +33,9 @@ impl PartialObject for PartialVertex {
         let position = self
             .position
             .expect("Can't build `Vertex` without position");
-        let curve = self.curve.build(objects);
         let surface_form = self.surface_form.build(objects);
 
-        Vertex::new(position, curve, surface_form)
+        Vertex::new(position, surface_form)
     }
 }
 
@@ -48,10 +43,6 @@ impl Default for PartialVertex {
     fn default() -> Self {
         let surface = Partial::new();
 
-        let curve = Partial::from_partial(PartialCurve {
-            surface: surface.clone(),
-            ..Default::default()
-        });
         let surface_form = Partial::from_partial(PartialSurfaceVertex {
             surface,
             ..Default::default()
@@ -59,7 +50,6 @@ impl Default for PartialVertex {
 
         Self {
             position: None,
-            curve,
             surface_form,
         }
     }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -282,7 +282,7 @@ impl HalfEdgeValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         for vertex in half_edge.vertices() {
-            let curve_position_on_surface = vertex
+            let curve_position_on_surface = half_edge
                 .curve()
                 .path()
                 .point_from_path_coords(vertex.position());

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -346,7 +346,11 @@ mod tests {
             );
             vertices[1] = vertex.build(&mut services.objects);
 
-            HalfEdge::new(vertices, valid.global_form().clone())
+            HalfEdge::new(
+                valid.curve().clone(),
+                vertices,
+                valid.global_form().clone(),
+            )
         };
 
         valid.validate_and_return_first_error()?;
@@ -368,12 +372,13 @@ mod tests {
 
             half_edge.build(&mut services.objects)
         };
-        let invalid = HalfEdge::new(valid.vertices().clone(), {
-            let mut tmp = Partial::from(valid.global_form().clone());
-            tmp.write().curve =
-                Partial::from(GlobalCurve.insert(&mut services.objects));
-            tmp.build(&mut services.objects)
-        });
+        let invalid =
+            HalfEdge::new(valid.curve().clone(), valid.vertices().clone(), {
+                let mut tmp = Partial::from(valid.global_form().clone());
+                tmp.write().curve =
+                    Partial::from(GlobalCurve.insert(&mut services.objects));
+                tmp.build(&mut services.objects)
+            });
 
         valid.validate_and_return_first_error()?;
         assert!(invalid.validate_and_return_first_error().is_err());
@@ -394,18 +399,21 @@ mod tests {
 
             half_edge.build(&mut services.objects)
         };
-        let invalid = HalfEdge::new(valid.vertices().clone(), {
-            let mut tmp = Partial::from(valid.global_form().clone());
-            tmp.write().vertices = valid
-                .global_form()
-                .vertices()
-                .access_in_normalized_order()
-                // Creating equal but not identical vertices here.
-                .map(|vertex| {
-                    Partial::from_partial(Partial::from(vertex).read().clone())
-                });
-            tmp.build(&mut services.objects)
-        });
+        let invalid =
+            HalfEdge::new(valid.curve().clone(), valid.vertices().clone(), {
+                let mut tmp = Partial::from(valid.global_form().clone());
+                tmp.write().vertices = valid
+                    .global_form()
+                    .vertices()
+                    .access_in_normalized_order()
+                    // Creating equal but not identical vertices here.
+                    .map(|vertex| {
+                        Partial::from_partial(
+                            Partial::from(vertex).read().clone(),
+                        )
+                    });
+                tmp.build(&mut services.objects)
+            });
 
         valid.validate_and_return_first_error()?;
         assert!(invalid.validate_and_return_first_error().is_err());
@@ -438,7 +446,11 @@ mod tests {
                 vertex.build(&mut services.objects)
             });
 
-            HalfEdge::new(vertices, valid.global_form().clone())
+            HalfEdge::new(
+                valid.curve().clone(),
+                vertices,
+                valid.global_form().clone(),
+            )
         };
 
         valid.validate_and_return_first_error()?;
@@ -461,6 +473,7 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
         let invalid = HalfEdge::new(
+            valid.curve().clone(),
             valid.vertices().clone().map(|vertex| {
                 let vertex = PartialVertex::from_full(
                     &vertex,
@@ -510,7 +523,11 @@ mod tests {
                 vertex.build(&mut services.objects)
             });
 
-            HalfEdge::new(vertices, valid.global_form().clone())
+            HalfEdge::new(
+                valid.curve().clone(),
+                vertices,
+                valid.global_form().clone(),
+            )
         };
 
         valid.validate_and_return_first_error()?;

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -88,10 +88,14 @@ impl SurfaceVertexValidationError {
 
 #[cfg(test)]
 mod tests {
+    use fj_math::Point;
+
     use crate::{
         insert::Insert,
         objects::{GlobalVertex, SurfaceVertex},
-        partial::{Partial, PartialObject, PartialSurfaceVertex},
+        partial::{
+            Partial, PartialGlobalVertex, PartialObject, PartialSurfaceVertex,
+        },
         services::Services,
         validate::Validate,
     };
@@ -103,7 +107,9 @@ mod tests {
         let valid = PartialSurfaceVertex {
             position: Some([0., 0.].into()),
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            global_form: Partial::from_partial(PartialGlobalVertex {
+                position: Some(Point::from([0., 0., 0.])),
+            }),
         }
         .build(&mut services.objects);
         let invalid = SurfaceVertex::new(

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -32,7 +32,7 @@ impl Shape for fj::Sketch {
 
                     let mut half_edge = PartialHalfEdge::default();
 
-                    half_edge.curve().write().surface = surface.clone();
+                    half_edge.curve.write().surface = surface.clone();
 
                     for vertex in &mut half_edge.vertices {
                         vertex.surface_form.write().surface = surface.clone();


### PR DESCRIPTION
Build on #1521 to further simplify the object graph.

This is another step towards making the object graph simpler. This hasn't changed from the previous pull request. Quoting myself:

> I have more ideas for simplifications in that part of the object graph, but at this point it's unclear how directly applicable those are, or whether other foundational cleanups are required first.