### PR TITLE
Add `HalfEdge::start_vertex`, start using it

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -25,7 +25,7 @@ impl Approx for &HalfEdge {
         let boundary = self.boundary();
         let range = RangeOnPath { boundary };
 
-        let [first, _] = self.surface_vertices();
+        let first = self.start_vertex();
         let first =
             ApproxPoint::new(first.position(), first.global_form().position());
         let curve_approx =

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -25,9 +25,10 @@ impl Approx for &HalfEdge {
         let boundary = self.boundary();
         let range = RangeOnPath { boundary };
 
-        let first = self.start_vertex();
-        let first =
-            ApproxPoint::new(first.position(), first.global_form().position());
+        let first = ApproxPoint::new(
+            self.start_vertex().position(),
+            self.start_vertex().global_form().position(),
+        );
         let curve_approx =
             (self.curve(), range).approx_with_cache(tolerance, cache);
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -311,9 +311,8 @@ mod tests {
             .exterior()
             .half_edges()
             .find(|edge| {
-                let [a, b] = edge.surface_vertices();
-                a.position() == Point::from([0., 0.])
-                    && b.position() == Point::from([2., 0.])
+                let [vertex, _] = edge.surface_vertices();
+                vertex.position() == Point::from([0., 0.])
             })
             .unwrap();
         assert_eq!(

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -1,6 +1,5 @@
 //! Intersection between faces and points in 2D
 
-use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
@@ -49,17 +48,15 @@ impl Intersect for (&Handle<Face>, &Point<2>) {
                         ));
                     }
                     (Some(RaySegmentIntersection::RayStartsOnOnFirstVertex), _) => {
-                        let [vertex, _] = half_edge.boundary().zip_ext(
-                            half_edge.surface_vertices().map(Clone::clone)
-                        );
+                        let [vertex, _] =
+                            half_edge.surface_vertices().map(Clone::clone);
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
                     }
                     (Some(RaySegmentIntersection::RayStartsOnSecondVertex), _) => {
-                        let [_, vertex] = half_edge.boundary().zip_ext(
-                            half_edge.surface_vertices().map(Clone::clone)
-                        );
+                        let [_, vertex] =
+                            half_edge.surface_vertices().map(Clone::clone);
                         return Some(
                             FacePointIntersection::PointIsOnVertex(vertex)
                         );
@@ -130,12 +127,11 @@ pub enum FacePointIntersection {
     PointIsOnEdge(Handle<HalfEdge>),
 
     /// The point is coincident with a vertex
-    PointIsOnVertex((Point<1>, Handle<SurfaceVertex>)),
+    PointIsOnVertex(Handle<SurfaceVertex>),
 }
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::ext::ArrayExt;
     use fj_math::Point;
     use pretty_assertions::assert_eq;
 
@@ -349,11 +345,9 @@ mod tests {
             .exterior()
             .half_edges()
             .flat_map(|half_edge| {
-                half_edge
-                    .boundary()
-                    .zip_ext(half_edge.surface_vertices().map(Clone::clone))
+                half_edge.surface_vertices().map(Clone::clone)
             })
-            .find(|(_, surface_vertex)| {
+            .find(|surface_vertex| {
                 surface_vertex.position() == Point::from([1., 0.])
             })
             .unwrap();

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -311,7 +311,7 @@ mod tests {
             .exterior()
             .half_edges()
             .find(|edge| {
-                let [vertex, _] = edge.surface_vertices();
+                let vertex = edge.start_vertex();
                 vertex.position() == Point::from([0., 0.])
             })
             .unwrap();
@@ -343,9 +343,7 @@ mod tests {
         let vertex = face
             .exterior()
             .half_edges()
-            .flat_map(|half_edge| {
-                half_edge.surface_vertices().map(Clone::clone)
-            })
+            .map(|half_edge| half_edge.start_vertex().clone())
             .find(|surface_vertex| {
                 surface_vertex.position() == Point::from([1., 0.])
             })

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -253,7 +253,7 @@ mod tests {
             .exterior()
             .half_edges()
             .find(|edge| {
-                let [vertex, _] = edge.surface_vertices();
+                let vertex = edge.start_vertex();
                 vertex.position() == Point::from([-1., 1.])
             })
             .unwrap();
@@ -286,9 +286,7 @@ mod tests {
         let vertex = face
             .exterior()
             .half_edges()
-            .flat_map(|half_edge| {
-                half_edge.surface_vertices().map(Clone::clone)
-            })
+            .map(|half_edge| half_edge.start_vertex().clone())
             .find(|surface_vertex| {
                 surface_vertex.position() == Point::from([-1., -1.])
             })

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -114,7 +114,7 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Handle<Face>) {
             FacePointIntersection::PointIsOnEdge(edge) => {
                 RayFaceIntersection::RayHitsEdge(edge)
             }
-            FacePointIntersection::PointIsOnVertex((_, vertex)) => {
+            FacePointIntersection::PointIsOnVertex(vertex) => {
                 RayFaceIntersection::RayHitsVertex(vertex)
             }
         };

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -114,7 +114,7 @@ impl Intersect for (&HorizontalRayToTheRight<3>, &Handle<Face>) {
             FacePointIntersection::PointIsOnEdge(edge) => {
                 RayFaceIntersection::RayHitsEdge(edge)
             }
-            FacePointIntersection::PointIsOnVertex(vertex) => {
+            FacePointIntersection::PointIsOnVertex((_, vertex)) => {
                 RayFaceIntersection::RayHitsVertex(vertex)
             }
         };
@@ -136,12 +136,11 @@ pub enum RayFaceIntersection {
     RayHitsEdge(Handle<HalfEdge>),
 
     /// The ray hits a vertex
-    RayHitsVertex((Point<1>, Handle<SurfaceVertex>)),
+    RayHitsVertex(Handle<SurfaceVertex>),
 }
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::ext::ArrayExt;
     use fj_math::Point;
 
     use crate::{
@@ -289,11 +288,9 @@ mod tests {
             .exterior()
             .half_edges()
             .flat_map(|half_edge| {
-                half_edge
-                    .boundary()
-                    .zip_ext(half_edge.surface_vertices().map(Clone::clone))
+                half_edge.surface_vertices().map(Clone::clone)
             })
-            .find(|(_, surface_vertex)| {
+            .find(|surface_vertex| {
                 surface_vertex.position() == Point::from([-1., -1.])
             })
             .unwrap();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -253,9 +253,8 @@ mod tests {
             .exterior()
             .half_edges()
             .find(|edge| {
-                let [a, b] = edge.surface_vertices();
-                a.position() == Point::from([-1., 1.])
-                    && b.position() == Point::from([-1., -1.])
+                let [vertex, _] = edge.surface_vertices();
+                vertex.position() == Point::from([-1., 1.])
             })
             .unwrap();
         assert_eq!(

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -93,7 +93,7 @@ impl Cycle {
 
         for [a, b] in self.half_edges.as_slice().array_windows_ext() {
             let [a, b] = [a, b].map(|half_edge| {
-                let [surface_vertex, _] = half_edge.surface_vertices();
+                let surface_vertex = half_edge.start_vertex();
                 surface_vertex.position()
             });
 

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -92,10 +92,8 @@ impl Cycle {
         let mut sum = Scalar::ZERO;
 
         for [a, b] in self.half_edges.as_slice().array_windows_ext() {
-            let [a, b] = [a, b].map(|half_edge| {
-                let surface_vertex = half_edge.start_vertex();
-                surface_vertex.position()
-            });
+            let [a, b] =
+                [a, b].map(|half_edge| half_edge.start_vertex().position());
 
             sum += (b.u - a.u) * (b.v + a.v);
         }

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -40,6 +40,13 @@ impl HalfEdge {
         self.boundary.each_ref_ext().map(|&(point, _)| point)
     }
 
+    /// Access the vertex from where this half-edge starts
+    pub fn start_vertex(&self) -> &Handle<SurfaceVertex> {
+        let [vertex, _] =
+            self.boundary.each_ref_ext().map(|(_, vertex)| vertex);
+        vertex
+    }
+
     /// Access the surface vertices that bound the half-edge
     pub fn surface_vertices(&self) -> [&Handle<SurfaceVertex>; 2] {
         self.boundary


### PR DESCRIPTION
This is another step towards #1525. Specifically, it's a partial step towards the next open item in that issue, only referencing a single `SurfaceVertex` per `HalfEdge`.