### PR TITLE
Continue cleanup of `HalfEdge`

### DIFF
--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -49,7 +49,7 @@ pub enum CycleValidationError {
         - Curve position converted to surface: {curve_position_on_surface:?}\n\
         - Distance between the positions: {distance}"
     )]
-    VertexPositionMismatch {
+    HalfEdgeBoundaryMismatch {
         /// The position on the curve
         position_on_curve: Point<1>,
 
@@ -105,7 +105,7 @@ impl CycleValidationError {
 
                 if distance > config.identical_max_distance {
                     errors.push(
-                        Self::VertexPositionMismatch {
+                        Self::HalfEdgeBoundaryMismatch {
                             position_on_curve,
                             surface_vertex: surface_vertex.clone(),
                             curve_position_on_surface,

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -1,3 +1,5 @@
+use fj_interop::ext::ArrayExt;
+use fj_math::{Point, Scalar};
 use itertools::Itertools;
 
 use crate::{
@@ -10,10 +12,11 @@ use super::{Validate, ValidationConfig, ValidationError};
 impl Validate for Cycle {
     fn validate_with_config(
         &self,
-        _: &ValidationConfig,
+        config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
         CycleValidationError::check_half_edge_connections(self, errors);
+        CycleValidationError::check_position(self, config, errors);
 
         // We don't need to check that all half-edges are defined in the same
         // surface. We already check that they are connected by identical
@@ -37,6 +40,28 @@ pub enum CycleValidationError {
         /// The back vertex of the next half-edge
         next: Handle<SurfaceVertex>,
     },
+
+    /// Mismatch between position of the vertex and position of its surface form
+    #[error(
+        "Half-edge boundary on curve doesn't match surface vertex position\n\
+        - Position on curve: {position_on_curve:#?}\n\
+        - Surface vertex: {surface_vertex:#?}\n\
+        - Curve position converted to surface: {curve_position_on_surface:?}\n\
+        - Distance between the positions: {distance}"
+    )]
+    VertexPositionMismatch {
+        /// The position on the curve
+        position_on_curve: Point<1>,
+
+        /// The surface vertex
+        surface_vertex: Handle<SurfaceVertex>,
+
+        /// The curve position converted into a surface position
+        curve_position_on_surface: Point<2>,
+
+        /// The distance between the positions
+        distance: Scalar,
+    },
 }
 
 impl CycleValidationError {
@@ -59,10 +84,45 @@ impl CycleValidationError {
             }
         }
     }
+
+    fn check_position(
+        cycle: &Cycle,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
+    ) {
+        for half_edge in cycle.half_edges() {
+            for (position_on_curve, surface_vertex) in
+                half_edge.boundary().zip_ext(half_edge.surface_vertices())
+            {
+                let curve_position_on_surface = half_edge
+                    .curve()
+                    .path()
+                    .point_from_path_coords(position_on_curve);
+                let surface_position = surface_vertex.position();
+
+                let distance =
+                    curve_position_on_surface.distance_to(&surface_position);
+
+                if distance > config.identical_max_distance {
+                    errors.push(
+                        Self::VertexPositionMismatch {
+                            position_on_curve,
+                            surface_vertex: surface_vertex.clone(),
+                            curve_position_on_surface,
+                            distance,
+                        }
+                        .into(),
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use fj_math::Point;
+
     use crate::{
         builder::CycleBuilder,
         objects::Cycle,
@@ -97,6 +157,42 @@ mod tests {
                 let surface_vertex =
                     Partial::from_partial(first_vertex.1.read().clone());
                 first_vertex.1 = surface_vertex;
+            }
+
+            let half_edges = half_edges
+                .into_iter()
+                .map(|half_edge| half_edge.build(&mut services.objects));
+
+            Cycle::new(half_edges)
+        };
+
+        valid.validate_and_return_first_error()?;
+        assert!(invalid.validate_and_return_first_error().is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn vertex_position_mismatch() -> anyhow::Result<()> {
+        let mut services = Services::new();
+
+        let valid = {
+            let mut cycle = PartialCycle {
+                surface: Partial::from(services.objects.surfaces.xy_plane()),
+                ..Default::default()
+            };
+            cycle.update_as_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]]);
+            cycle.build(&mut services.objects)
+        };
+        let invalid = {
+            let mut half_edges = valid
+                .half_edges()
+                .map(|half_edge| Partial::from(half_edge.clone()))
+                .collect::<Vec<_>>();
+
+            // Update a single boundary position so it becomes wrong.
+            if let Some(half_edge) = half_edges.first_mut() {
+                half_edge.write().vertices[0].0.replace(Point::from([-1.]));
             }
 
             let half_edges = half_edges

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -90,10 +90,13 @@ impl CycleValidationError {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        for half_edge in cycle.half_edges() {
-            for (position_on_curve, surface_vertex) in
-                half_edge.boundary().zip_ext(half_edge.surface_vertices())
-            {
+        for (half_edge, next) in
+            cycle.half_edges().circular_tuple_windows::<(_, _)>()
+        {
+            let boundary_and_vertices = half_edge
+                .boundary()
+                .zip_ext([half_edge.start_vertex(), next.start_vertex()]);
+            for (position_on_curve, surface_vertex) in boundary_and_vertices {
                 let curve_position_on_surface = half_edge
                     .curve()
                     .path()

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -16,7 +16,7 @@ impl Validate for Cycle {
         errors: &mut Vec<ValidationError>,
     ) {
         CycleValidationError::check_half_edge_connections(self, errors);
-        CycleValidationError::check_position(self, config, errors);
+        CycleValidationError::check_half_edge_boundaries(self, config, errors);
 
         // We don't need to check that all half-edges are defined in the same
         // surface. We already check that they are connected by identical
@@ -85,7 +85,7 @@ impl CycleValidationError {
         }
     }
 
-    fn check_position(
+    fn check_half_edge_boundaries(
         cycle: &Cycle,
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -41,7 +41,7 @@ pub enum CycleValidationError {
         next: Handle<SurfaceVertex>,
     },
 
-    /// Mismatch between position of the vertex and position of its surface form
+    /// Mismatch between half-edge boundary and surface vertex position
     #[error(
         "Half-edge boundary on curve doesn't match surface vertex position\n\
         - Position on curve: {position_on_curve:#?}\n\

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -68,7 +68,7 @@ pub enum HalfEdgeValidationError {
         /// The [`GlobalVertex`] from the [`HalfEdge`]'s start vertex
         global_vertex_from_half_edge: Handle<GlobalVertex>,
 
-        /// The [`GlobalCurve`] from the [`HalfEdge`]'s global form
+        /// The [`GlobalVertex`] instances from the [`HalfEdge`]'s global form
         global_vertices_from_global_form: [Handle<GlobalVertex>; 2],
 
         /// The half-edge


### PR DESCRIPTION
This is another step towards #1525. It builds on #1535 to further the goal of having `HalfEdge` only reference a single `SurfaceVertex`.