### PR TITLE
Add more debug information to approximation

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -5,7 +5,7 @@
 //! approximations are usually used to build cycle approximations, and this way,
 //! the caller doesn't have to call with duplicate vertices.
 
-use crate::objects::HalfEdge;
+use crate::{objects::HalfEdge, storage::Handle};
 
 use super::{
     curve::{CurveApprox, CurveCache},
@@ -13,7 +13,7 @@ use super::{
     Approx, ApproxPoint, Tolerance,
 };
 
-impl Approx for &HalfEdge {
+impl Approx for &Handle<HalfEdge> {
     type Approximation = HalfEdgeApprox;
     type Cache = CurveCache;
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -28,7 +28,8 @@ impl Approx for &Handle<HalfEdge> {
         let first = ApproxPoint::new(
             self.start_vertex().position(),
             self.start_vertex().global_form().position(),
-        );
+        )
+        .with_source((self.clone(), self.boundary()[0]));
         let curve_approx =
             (self.curve(), range).approx_with_cache(tolerance, cache);
 

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -39,15 +39,14 @@ impl Approx for &FaceSet {
             let approx: &FaceApprox = approx;
 
             for point in &approx.points() {
-                for p in &all_points {
+                for b in &all_points {
                     let distance =
-                        (p.global_form - point.global_form).magnitude();
+                        (b.global_form - point.global_form).magnitude();
 
-                    if p.global_form != point.global_form
+                    if b.global_form != point.global_form
                         && distance < min_distance
                     {
                         let a = point;
-                        let b = p;
 
                         panic!(
                             "Invalid approximation: \

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -38,16 +38,12 @@ impl Approx for &FaceSet {
         for approx in &approx {
             let approx: &FaceApprox = approx;
 
-            for point in &approx.points() {
+            for a in &approx.points() {
                 for b in &all_points {
-                    let distance =
-                        (b.global_form - point.global_form).magnitude();
+                    let distance = (b.global_form - a.global_form).magnitude();
 
-                    if b.global_form != point.global_form
-                        && distance < min_distance
+                    if b.global_form != a.global_form && distance < min_distance
                     {
-                        let a = point;
-
                         panic!(
                             "Invalid approximation: \
                             Distinct points are too close \
@@ -59,7 +55,7 @@ impl Approx for &FaceSet {
                     }
                 }
 
-                all_points.insert(point.clone());
+                all_points.insert(a.clone());
             }
         }
 

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -46,8 +46,8 @@ impl Approx for &FaceSet {
                     if p.global_form != point.global_form
                         && distance < min_distance
                     {
-                        let a = p;
-                        let b = point;
+                        let a = point;
+                        let b = p;
 
                         panic!(
                             "Invalid approximation: \

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -20,7 +20,10 @@ use std::{
 
 use fj_math::Point;
 
-use crate::{objects::Curve, storage::Handle};
+use crate::{
+    objects::{Curve, HalfEdge},
+    storage::Handle,
+};
 
 pub use self::tolerance::{InvalidTolerance, Tolerance};
 
@@ -120,3 +123,4 @@ impl<const D: usize> PartialOrd for ApproxPoint<D> {
 pub trait Source: Any + Debug {}
 
 impl Source for (Handle<Curve>, Point<1>) {}
+impl Source for (Handle<HalfEdge>, Point<1>) {}


### PR DESCRIPTION
 From one of the commit messages:
> Record the source of approximation points that come from the start vertex of a `HalfEdge`.

This can help with making sense of approximation validation failures.