### PR TITLE
Minimize scope of `unsafe` block

### DIFF
--- a/tools/export-validator/src/main.rs
+++ b/tools/export-validator/src/main.rs
@@ -33,11 +33,8 @@ fn main() -> anyhow::Result<()> {
 
         // Presumably we're using the library in the way it's intended, so this
         // might be sound?
-        unsafe {
-            validate_model(export_file_path_str).with_context(|| {
-                format!("Could not validate model `{model}`")
-            })?;
-        }
+        unsafe { validate_model(export_file_path_str) }
+            .with_context(|| format!("Could not validate model `{model}`"))?;
     }
 
     Ok(())


### PR DESCRIPTION
This is a small fix to `export-validator` which I made while working on something else.