### PR TITLE
Respect existing boundary when updating `HalfEdge` as line segment

### DIFF
--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -38,6 +38,14 @@ pub trait CurveBuilder {
         &mut self,
         points: [impl Into<Point<2>>; 2],
     ) -> SurfacePath;
+
+    /// Update partial curve to be a line, from provided points and line coords
+    ///
+    /// Returns the updated path.
+    fn update_as_line_from_points_with_line_coords(
+        &mut self,
+        points: [(impl Into<Point<1>>, impl Into<Point<2>>); 2],
+    ) -> SurfacePath;
 }
 
 impl CurveBuilder for PartialCurve {
@@ -79,6 +87,15 @@ impl CurveBuilder for PartialCurve {
         points: [impl Into<Point<2>>; 2],
     ) -> SurfacePath {
         let (path, _) = SurfacePath::line_from_points(points);
+        self.path = Some(path.into());
+        path
+    }
+
+    fn update_as_line_from_points_with_line_coords(
+        &mut self,
+        points: [(impl Into<Point<1>>, impl Into<Point<2>>); 2],
+    ) -> SurfacePath {
+        let path = SurfacePath::from_points_with_line_coords(points);
         self.path = Some(path.into());
         path
     }

--- a/crates/fj-kernel/src/geometry/path.rs
+++ b/crates/fj-kernel/src/geometry/path.rs
@@ -58,6 +58,13 @@ impl SurfacePath {
         (Self::Line(line), coords)
     }
 
+    /// Create a line from two points that include line coordinates
+    pub fn from_points_with_line_coords(
+        points: [(impl Into<Point<1>>, impl Into<Point<2>>); 2],
+    ) -> Self {
+        Self::Line(Line::from_points_with_line_coords(points))
+    }
+
     /// Convert a point on the path into surface coordinates
     pub fn point_from_path_coords(
         &self,

--- a/crates/fj-math/src/line.rs
+++ b/crates/fj-math/src/line.rs
@@ -182,6 +182,30 @@ mod tests {
     use super::Line;
 
     #[test]
+    fn from_points_with_line_coords() {
+        let line = Line::from_points_with_line_coords([
+            ([0.], [0., 0.]),
+            ([1.], [1., 0.]),
+        ]);
+        assert_eq!(line.origin(), Point::from([0., 0.]));
+        assert_eq!(line.direction(), Vector::from([1., 0.]));
+
+        let line = Line::from_points_with_line_coords([
+            ([1.], [0., 1.]),
+            ([0.], [1., 1.]),
+        ]);
+        assert_eq!(line.origin(), Point::from([1., 1.]));
+        assert_eq!(line.direction(), Vector::from([-1., 0.]));
+
+        let line = Line::from_points_with_line_coords([
+            ([-1.], [0., 2.]),
+            ([0.], [1., 2.]),
+        ]);
+        assert_eq!(line.origin(), Point::from([1., 2.]));
+        assert_eq!(line.direction(), Vector::from([1., 0.]));
+    }
+
+    #[test]
     fn is_coincident_with() {
         let (line, _) = Line::from_points([[0., 0.], [1., 0.]]);
 


### PR DESCRIPTION
From one of the commit messages:
> Previously, `HalfEdgeBuilder::update_as_line_segment` would always update the boundary after inferring a line segment. With this change, it respects the existing boundary, changing its inferrence of the line segment accordingly.

The previous behavior caused some trouble for me, as I'm working towards #1525.