### PR TITLE
Improve projections into plane

### DIFF
--- a/crates/fj-math/src/plane.rs
+++ b/crates/fj-math/src/plane.rs
@@ -84,16 +84,7 @@ impl Plane {
 
     /// Project a line into the plane
     pub fn project_line(&self, line: &Line<3>) -> Line<2> {
-        let line_origin_relative_to_plane = line.origin() - self.origin();
-        let line_origin_in_plane = Point {
-            coords: Vector::from([
-                self.u()
-                    .scalar_projection_onto(&line_origin_relative_to_plane),
-                self.v()
-                    .scalar_projection_onto(&line_origin_relative_to_plane),
-            ]),
-        };
-
+        let line_origin_in_plane = self.project_point(line.origin());
         let line_direction_in_plane = self.project_vector(line.direction());
 
         Line::from_origin_and_direction(

--- a/crates/fj-math/src/plane.rs
+++ b/crates/fj-math/src/plane.rs
@@ -65,6 +65,13 @@ impl Plane {
         self.normal().dot(vector) == Scalar::ZERO
     }
 
+    /// Project a point into the plane
+    pub fn project_point(&self, point: impl Into<Point<3>>) -> Point<2> {
+        let origin_to_point = point.into() - self.origin();
+        let coords = self.project_vector(origin_to_point);
+        Point { coords }
+    }
+
     /// Project a vector into the plane
     pub fn project_vector(&self, vector: impl Into<Vector<3>>) -> Vector<2> {
         let vector = vector.into();
@@ -98,7 +105,16 @@ impl Plane {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Plane, Vector};
+    use crate::{Plane, Point, Vector};
+
+    #[test]
+    fn project_point() {
+        let plane =
+            Plane::from_parametric([1., 1., 1.], [1., 0., 0.], [0., 1., 0.]);
+
+        assert_eq!(plane.project_point([2., 1., 2.]), Point::from([1., 0.]));
+        assert_eq!(plane.project_point([1., 2., 2.]), Point::from([0., 1.]));
+    }
 
     #[test]
     fn project_vector() {

--- a/crates/fj-math/src/plane.rs
+++ b/crates/fj-math/src/plane.rs
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn project_vector() {
         let plane =
-            Plane::from_parametric([0., 0., 0.], [1., 0., 0.], [0., 1., 0.]);
+            Plane::from_parametric([1., 1., 1.], [1., 0., 0.], [0., 1., 0.]);
 
         assert_eq!(plane.project_vector([1., 0., 1.]), Vector::from([1., 0.]));
         assert_eq!(plane.project_vector([0., 1., 1.]), Vector::from([0., 1.]));


### PR DESCRIPTION
Fix `Plane::project_vector` for non-orthogonal coordinate systems, add `Plane::project_point`, and make other minor improvements.