### PR TITLE
Lift limitation when inferring surface as plane

### DIFF
--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -182,7 +182,7 @@ impl CycleBuilder for PartialCycle {
     ) -> [Partial<HalfEdge>; 3] {
         let points_global = points_global.map(Into::into);
 
-        let points_surface = self
+        let (points_surface, _) = self
             .surface
             .write()
             .update_as_plane_from_points(points_global);

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -110,8 +110,8 @@ impl FaceBuilder for PartialFace {
     fn update_surface_as_plane(&mut self) -> Partial<Surface> {
         let mut exterior = self.exterior.write();
         let mut vertices = exterior.half_edges.iter().map(|half_edge| {
-            let [vertex, _] = &half_edge.read().vertices;
-            vertex.1.clone()
+            let [(_, surface_vertex), _] = &half_edge.read().vertices;
+            surface_vertex.clone()
         });
 
         let vertices = {

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -129,7 +129,7 @@ impl FaceBuilder for PartialFace {
             array
         };
 
-        let points_surface = {
+        let (points_surface, _) = {
             let points_global = vertices.each_ref_ext().map(|vertex| {
                 vertex
                     .read()

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -135,13 +135,13 @@ impl FaceBuilder for PartialFace {
         };
 
         let (points_surface, _) = {
-            let points_global =
+            let first_three_points_global =
                 first_three_vertices.each_ref_ext().map(|(_, point)| *point);
 
             exterior
                 .surface
                 .write()
-                .update_as_plane_from_points(points_global)
+                .update_as_plane_from_points(first_three_points_global)
         };
 
         for ((mut surface_vertex, _), point) in

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -128,7 +128,7 @@ impl FaceBuilder for PartialFace {
 
             array
         };
-        let points = vertices.each_ref_ext().map(|vertex| {
+        let points_global = vertices.each_ref_ext().map(|vertex| {
             vertex
                 .read()
                 .global_form
@@ -137,8 +137,10 @@ impl FaceBuilder for PartialFace {
                 .expect("Need global position to infer plane")
         });
 
-        let points_surface =
-            exterior.surface.write().update_as_plane_from_points(points);
+        let points_surface = exterior
+            .surface
+            .write()
+            .update_as_plane_from_points(points_global);
 
         for (mut surface_vertex, point) in vertices.zip_ext(points_surface) {
             surface_vertex.write().position = Some(point);

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -12,7 +12,7 @@ use super::{CycleBuilder, HalfEdgeBuilder, ObjectArgument, SurfaceBuilder};
 
 /// Builder API for [`PartialFace`]
 pub trait FaceBuilder {
-    /// Connect the face to another face at the provided half-edges
+    /// Connect the face to other faces at the provided half-edges
     ///
     /// Assumes that the provided half-edges, once translated into local
     /// equivalents of this face, will not form a cycle.
@@ -26,7 +26,7 @@ pub trait FaceBuilder {
     where
         O: ObjectArgument<Partial<HalfEdge>>;
 
-    /// Connect the face to another face at the provided half-edges
+    /// Connect the face to other faces at the provided half-edges
     ///
     /// Assumes that the provided half-edges, once translated into local
     /// equivalents of this face, form a cycle.

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{array, collections::VecDeque};
 
 use fj_interop::ext::ArrayExt;
 
@@ -122,11 +122,9 @@ impl FaceBuilder for PartialFace {
         });
 
         let vertices = {
-            let array = [
-                vertices.next().expect("Expected exactly three vertices"),
-                vertices.next().expect("Expected exactly three vertices"),
-                vertices.next().expect("Expected exactly three vertices"),
-            ];
+            let array = array::from_fn(|_| {
+                vertices.next().expect("Expected exactly three vertices")
+            });
 
             assert!(
                 vertices.next().is_none(),

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -139,10 +139,12 @@ impl FaceBuilder for PartialFace {
                 .write()
                 .update_as_plane_from_points(first_three_points_global);
 
-            first_three_vertices.zip_ext(first_three_points_surface)
+            first_three_vertices
+                .zip_ext(first_three_points_surface)
+                .map(|((vertex, _), point_global)| (vertex, point_global))
         };
 
-        for ((mut surface_vertex, _), point) in first_three_vertices {
+        for (mut surface_vertex, point) in first_three_vertices {
             surface_vertex.write().position = Some(point);
         }
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -131,22 +131,18 @@ impl FaceBuilder for PartialFace {
                 "Expected exactly three vertices"
             );
 
-            first_three_vertices
-        };
-
-        let (points_surface, _) = {
             let first_three_points_global =
                 first_three_vertices.each_ref_ext().map(|(_, point)| *point);
 
-            exterior
+            let (first_three_points_surface, _) = exterior
                 .surface
                 .write()
-                .update_as_plane_from_points(first_three_points_global)
+                .update_as_plane_from_points(first_three_points_global);
+
+            first_three_vertices.zip_ext(first_three_points_surface)
         };
 
-        for ((mut surface_vertex, _), point) in
-            first_three_vertices.zip_ext(points_surface)
-        {
+        for ((mut surface_vertex, _), point) in first_three_vertices {
             surface_vertex.write().position = Some(point);
         }
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -122,7 +122,7 @@ impl FaceBuilder for PartialFace {
         });
 
         let first_three_vertices = {
-            let array = array::from_fn(|_| {
+            let first_three_vertices = array::from_fn(|_| {
                 vertices.next().expect("Expected exactly three vertices")
             });
 
@@ -131,7 +131,7 @@ impl FaceBuilder for PartialFace {
                 "Expected exactly three vertices"
             );
 
-            array
+            first_three_vertices
         };
 
         let (points_surface, _) = {

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -128,19 +128,22 @@ impl FaceBuilder for PartialFace {
 
             array
         };
-        let points_global = vertices.each_ref_ext().map(|vertex| {
-            vertex
-                .read()
-                .global_form
-                .read()
-                .position
-                .expect("Need global position to infer plane")
-        });
 
-        let points_surface = exterior
-            .surface
-            .write()
-            .update_as_plane_from_points(points_global);
+        let points_surface = {
+            let points_global = vertices.each_ref_ext().map(|vertex| {
+                vertex
+                    .read()
+                    .global_form
+                    .read()
+                    .position
+                    .expect("Need global position to infer plane")
+            });
+
+            exterior
+                .surface
+                .write()
+                .update_as_plane_from_points(points_global)
+        };
 
         for (mut surface_vertex, point) in vertices.zip_ext(points_surface) {
             surface_vertex.write().position = Some(point);

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -121,7 +121,7 @@ impl FaceBuilder for PartialFace {
             (surface_vertex.clone(), global_position)
         });
 
-        let vertices = {
+        let first_three_vertices = {
             let array = array::from_fn(|_| {
                 vertices.next().expect("Expected exactly three vertices")
             });
@@ -136,7 +136,7 @@ impl FaceBuilder for PartialFace {
 
         let (points_surface, _) = {
             let points_global =
-                vertices.each_ref_ext().map(|(_, point)| *point);
+                first_three_vertices.each_ref_ext().map(|(_, point)| *point);
 
             exterior
                 .surface
@@ -144,7 +144,8 @@ impl FaceBuilder for PartialFace {
                 .update_as_plane_from_points(points_global)
         };
 
-        for ((mut surface_vertex, _), point) in vertices.zip_ext(points_surface)
+        for ((mut surface_vertex, _), point) in
+            first_three_vertices.zip_ext(points_surface)
         {
             surface_vertex.write().position = Some(point);
         }

--- a/crates/fj-kernel/src/builder/surface.rs
+++ b/crates/fj-kernel/src/builder/surface.rs
@@ -14,7 +14,7 @@ pub trait SurfaceBuilder: Sized {
     fn update_as_plane_from_points(
         &mut self,
         points: [impl Into<Point<3>>; 3],
-    ) -> [Point<2>; 3];
+    ) -> ([Point<2>; 3], SurfaceGeometry);
 }
 
 impl SurfaceBuilder for PartialSurface {
@@ -29,16 +29,19 @@ impl SurfaceBuilder for PartialSurface {
     fn update_as_plane_from_points(
         &mut self,
         points: [impl Into<Point<3>>; 3],
-    ) -> [Point<2>; 3] {
+    ) -> ([Point<2>; 3], SurfaceGeometry) {
         let [a, b, c] = points.map(Into::into);
 
         let (u, u_coords) = GlobalPath::line_from_points([a, b]);
         let v = c - a;
 
-        self.geometry = Some(SurfaceGeometry { u, v });
+        let geometry = SurfaceGeometry { u, v };
+        self.geometry = Some(geometry);
 
         let [a, b] = u_coords.map(|point| point.t);
-        [[a, Scalar::ZERO], [b, Scalar::ZERO], [a, Scalar::ONE]]
-            .map(Point::from)
+        let points = [[a, Scalar::ZERO], [b, Scalar::ZERO], [a, Scalar::ONE]]
+            .map(Point::from);
+
+        (points, geometry)
     }
 }

--- a/crates/fj-kernel/src/geometry/surface.rs
+++ b/crates/fj-kernel/src/geometry/surface.rs
@@ -1,6 +1,6 @@
 //! The geometry that defines a surface
 
-use fj_math::{Line, Point, Transform, Vector};
+use fj_math::{Line, Plane, Point, Transform, Vector};
 
 use super::path::GlobalPath;
 
@@ -37,6 +37,17 @@ impl SurfaceGeometry {
 
     fn path_to_line(&self) -> Line<3> {
         Line::from_origin_and_direction(self.u.origin(), self.v)
+    }
+
+    /// Project the global point into the surface
+    pub fn project_global_point(&self, point: impl Into<Point<3>>) -> Point<2> {
+        let GlobalPath::Line(line) = self.u else {
+            todo!("Projecting point into non-plane surface is not supported")
+        };
+
+        let plane =
+            Plane::from_parametric(line.origin(), line.direction(), self.v);
+        plane.project_point(point)
     }
 
     /// Transform the surface geometry


### PR DESCRIPTION
Previously, `FaceBuilder::update_surface_as_plane` expected the surface exterior to contain exactly 3 vertices. Now it can handle more vertices. It uses the first three to infer the plane and projects the rest of them into the inferred surface. This can lead to validation failures later on, if the vertices don't all fit into a plane.

I'm currently working on rewriting parts of the sweep code to advance #1525, and this is a building block required to do that.