### PR TITLE
Reuse cached curve approximation, if range is reversed

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -192,6 +192,14 @@ pub struct GlobalCurveApprox {
     pub points: Vec<ApproxPoint<1>>,
 }
 
+impl GlobalCurveApprox {
+    /// Reverse the order of the approximation
+    pub fn reverse(mut self) -> Self {
+        self.points.reverse();
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::f64::consts::TAU;

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -181,7 +181,16 @@ impl CurveCache {
         handle: Handle<GlobalCurve>,
         range: RangeOnPath,
     ) -> Option<GlobalCurveApprox> {
-        self.inner.get(&(handle.id(), range)).cloned()
+        if let Some(approx) = self.inner.get(&(handle.id(), range)) {
+            return Some(approx.clone());
+        }
+        if let Some(approx) = self.inner.get(&(handle.id(), range.reverse())) {
+            // If we have a cache entry for the reverse range, we need to use
+            // that too!
+            return Some(approx.clone().reverse());
+        }
+
+        None
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/path.rs
+++ b/crates/fj-kernel/src/algorithms/approx/path.rs
@@ -83,6 +83,14 @@ pub struct RangeOnPath {
     pub boundary: [Point<1>; 2],
 }
 
+impl RangeOnPath {
+    /// Reverse the direction of the range
+    pub fn reverse(self) -> Self {
+        let [a, b] = self.boundary;
+        Self { boundary: [b, a] }
+    }
+}
+
 impl<T> From<[T; 2]> for RangeOnPath
 where
     T: Into<Point<1>>,


### PR DESCRIPTION
From the message of the main commit:
> By not doing that, coincident `Curve`s that share the same `GlobalCurve` but whose coordinate systems are pointed in opposite directions, will not share their approximation. This can lead to vertices in the approximation that *should* be identical to not actually be coincident.

This is another building block that is required for the rewrite of parts of the sweep code that I'm doing for #1525.