### PR TITLE
Move reference to `Surface` from `Curve` to `HalfEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -219,7 +219,7 @@ mod tests {
         builder::{CurveBuilder, SurfaceBuilder},
         geometry::path::GlobalPath,
         insert::Insert,
-        partial::{Partial, PartialCurve, PartialObject, PartialSurface},
+        partial::{PartialCurve, PartialObject, PartialSurface},
         services::Services,
     };
 
@@ -231,7 +231,6 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let mut curve = PartialCurve {
-            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
@@ -256,7 +255,6 @@ mod tests {
         .build(&mut services.objects)
         .insert(&mut services.objects);
         let mut curve = PartialCurve {
-            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
@@ -279,7 +277,6 @@ mod tests {
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let mut curve = PartialCurve {
-            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
@@ -312,7 +309,6 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let mut curve = PartialCurve {
-            surface: Partial::from(surface.clone()),
             ..Default::default()
         };
         curve.update_as_circle_from_radius(1.);

--- a/crates/fj-kernel/src/algorithms/approx/curve.rs
+++ b/crates/fj-kernel/src/algorithms/approx/curve.rs
@@ -230,9 +230,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_line_from_points([[1., 1.], [2., 1.]]);
         let curve = curve
             .build(&mut services.objects)
@@ -254,9 +252,7 @@ mod tests {
         )
         .build(&mut services.objects)
         .insert(&mut services.objects);
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_line_from_points([[1., 1.], [1., 2.]]);
         let curve = curve
             .build(&mut services.objects)
@@ -276,9 +272,7 @@ mod tests {
         let surface = PartialSurface::from_axes(path, [0., 0., 1.])
             .build(&mut services.objects)
             .insert(&mut services.objects);
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_line_from_points([[0., 1.], [1., 1.]]);
         let curve = curve
             .build(&mut services.objects)
@@ -308,9 +302,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_circle_from_radius(1.);
         let curve = curve
             .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -5,6 +5,8 @@
 //! approximations are usually used to build cycle approximations, and this way,
 //! the caller doesn't have to call with duplicate vertices.
 
+use std::ops::Deref;
+
 use crate::{objects::HalfEdge, storage::Handle};
 
 use super::{
@@ -30,8 +32,8 @@ impl Approx for &Handle<HalfEdge> {
             self.start_vertex().global_form().position(),
         )
         .with_source((self.clone(), self.boundary()[0]));
-        let curve_approx =
-            (self.curve(), range).approx_with_cache(tolerance, cache);
+        let curve_approx = (self.curve(), self.surface().deref(), range)
+            .approx_with_cache(tolerance, cache);
 
         HalfEdgeApprox {
             first,

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -87,9 +87,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
         let half_edge = {
@@ -117,9 +115,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
         let half_edge = {
@@ -147,9 +143,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
         let half_edge = {
@@ -172,9 +166,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_u_axis();
         let curve = curve.build(&mut services.objects);
         let half_edge = {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -88,7 +88,6 @@ mod tests {
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
-            surface: surface.clone(),
             ..Default::default()
         };
         curve.update_as_u_axis();
@@ -119,7 +118,6 @@ mod tests {
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
-            surface: surface.clone(),
             ..Default::default()
         };
         curve.update_as_u_axis();
@@ -150,7 +148,6 @@ mod tests {
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
-            surface: surface.clone(),
             ..Default::default()
         };
         curve.update_as_u_axis();
@@ -176,7 +173,6 @@ mod tests {
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
         let mut curve = PartialCurve {
-            surface: surface.clone(),
             ..Default::default()
         };
         curve.update_as_u_axis();

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -163,9 +163,7 @@ mod tests {
 
         let surface = Partial::from(services.objects.surfaces.xy_plane());
 
-        let mut curve = PartialCurve {
-            ..Default::default()
-        };
+        let mut curve = PartialCurve::default();
         curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);
         let curve = curve.build(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -164,7 +164,6 @@ mod tests {
         let surface = Partial::from(services.objects.surfaces.xy_plane());
 
         let mut curve = PartialCurve {
-            surface: surface.clone(),
             ..Default::default()
         };
         curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -132,9 +132,8 @@ mod tests {
         let intersection =
             FaceFaceIntersection::compute([&a, &b], &mut services.objects);
 
-        let expected_curves = surfaces.map(|surface| {
+        let expected_curves = surfaces.map(|_| {
             let mut curve = PartialCurve {
-                surface: Partial::from(surface),
                 ..Default::default()
             };
             curve.update_as_line_from_points([[0., 0.], [1., 0.]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -133,9 +133,7 @@ mod tests {
             FaceFaceIntersection::compute([&a, &b], &mut services.objects);
 
         let expected_curves = surfaces.map(|_| {
-            let mut curve = PartialCurve {
-                ..Default::default()
-            };
+            let mut curve = PartialCurve::default();
             curve.update_as_line_from_points([[0., 0.], [1., 0.]]);
             curve
                 .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -57,11 +57,11 @@ impl SurfaceSurfaceIntersection {
 
         let line = Line::from_origin_and_direction(origin, direction);
 
-        let curves = surfaces_and_planes.map(|(surface, plane)| {
+        let curves = surfaces_and_planes.map(|(_, plane)| {
             let path = SurfacePath::Line(plane.project_line(&line));
             let global_form = GlobalCurve.insert(objects);
 
-            Curve::new(surface, path, global_form).insert(objects)
+            Curve::new(path, global_form).insert(objects)
         });
 
         Some(Self {
@@ -92,7 +92,7 @@ mod tests {
         algorithms::transform::TransformObject,
         builder::CurveBuilder,
         insert::Insert,
-        partial::{Partial, PartialCurve, PartialObject},
+        partial::{PartialCurve, PartialObject},
         services::Services,
     };
 
@@ -121,7 +121,6 @@ mod tests {
         );
 
         let mut expected_xy = PartialCurve {
-            surface: Partial::from(xy.clone()),
             ..Default::default()
         };
         expected_xy.update_as_u_axis();
@@ -129,7 +128,6 @@ mod tests {
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let mut expected_xz = PartialCurve {
-            surface: Partial::from(xz.clone()),
             ..Default::default()
         };
         expected_xz.update_as_u_axis();

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -125,6 +125,7 @@ mod tests {
         let expected_xy = expected_xy
             .build(&mut services.objects)
             .insert(&mut services.objects);
+
         let mut expected_xz = PartialCurve::default();
         expected_xz.update_as_u_axis();
         let expected_xz = expected_xz

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -28,10 +28,9 @@ impl SurfaceSurfaceIntersection {
         // coordinates for each surface.
 
         let planes = surfaces.map(|surface| plane_from_surface(&surface));
-        let [a, b] = planes;
 
-        let (a_distance, a_normal) = a.constant_normal_form();
-        let (b_distance, b_normal) = b.constant_normal_form();
+        let [(a_distance, a_normal), (b_distance, b_normal)] =
+            planes.map(|plane| plane.constant_normal_form());
 
         let direction = a_normal.cross(&b_normal);
 

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -120,16 +120,12 @@ mod tests {
             None,
         );
 
-        let mut expected_xy = PartialCurve {
-            ..Default::default()
-        };
+        let mut expected_xy = PartialCurve::default();
         expected_xy.update_as_u_axis();
         let expected_xy = expected_xy
             .build(&mut services.objects)
             .insert(&mut services.objects);
-        let mut expected_xz = PartialCurve {
-            ..Default::default()
-        };
+        let mut expected_xz = PartialCurve::default();
         expected_xz.update_as_u_axis();
         let expected_xz = expected_xz
             .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -27,11 +27,8 @@ impl SurfaceSurfaceIntersection {
         // Adaptations were made to get the intersection curves in local
         // coordinates for each surface.
 
-        let surfaces_and_planes = surfaces.map(|surface| {
-            let plane = plane_from_surface(&surface);
-            (surface, plane)
-        });
-        let [a, b] = surfaces_and_planes.clone().map(|(_, plane)| plane);
+        let planes = surfaces.map(|surface| plane_from_surface(&surface));
+        let [a, b] = planes;
 
         let (a_distance, a_normal) = a.constant_normal_form();
         let (b_distance, b_normal) = b.constant_normal_form();
@@ -57,7 +54,7 @@ impl SurfaceSurfaceIntersection {
 
         let line = Line::from_origin_and_direction(origin, direction);
 
-        let curves = surfaces_and_planes.map(|(_, plane)| {
+        let curves = planes.map(|plane| {
             let path = SurfacePath::Line(plane.project_line(&line));
             let global_form = GlobalCurve.insert(objects);
 

--- a/crates/fj-kernel/src/algorithms/reverse/edge.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/edge.rs
@@ -19,6 +19,7 @@ impl Reverse for Handle<HalfEdge> {
         };
 
         HalfEdge::new(
+            self.surface().clone(),
             self.curve().clone(),
             vertices,
             self.global_form().clone(),

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for Handle<Curve> {
+impl Sweep for (Handle<Curve>, &Surface) {
     type Swept = Handle<Surface>;
 
     fn sweep_with_cache(
@@ -21,9 +21,9 @@ impl Sweep for Handle<Curve> {
         _: &mut SweepCache,
         objects: &mut Service<Objects>,
     ) -> Self::Swept {
-        let curve = self;
+        let (curve, surface) = self;
 
-        match curve.surface().geometry().u {
+        match surface.geometry().u {
             GlobalPath::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
                 // `Surface` is a `GlobalPath`, which we are computing below.
@@ -49,30 +49,22 @@ impl Sweep for Handle<Curve> {
 
         let u = match curve.path() {
             SurfacePath::Circle(circle) => {
-                let center = curve
-                    .surface()
+                let center = surface
                     .geometry()
                     .point_from_surface_coords(circle.center());
-                let a = curve
-                    .surface()
-                    .geometry()
-                    .vector_from_surface_coords(circle.a());
-                let b = curve
-                    .surface()
-                    .geometry()
-                    .vector_from_surface_coords(circle.b());
+                let a =
+                    surface.geometry().vector_from_surface_coords(circle.a());
+                let b =
+                    surface.geometry().vector_from_surface_coords(circle.b());
 
                 let circle = Circle::new(center, a, b);
 
                 GlobalPath::Circle(circle)
             }
             SurfacePath::Line(line) => {
-                let origin = curve
-                    .surface()
-                    .geometry()
-                    .point_from_surface_coords(line.origin());
-                let direction = curve
-                    .surface()
+                let origin =
+                    surface.geometry().point_from_surface_coords(line.origin());
+                let direction = surface
                     .geometry()
                     .vector_from_surface_coords(line.direction());
 

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -21,7 +21,9 @@ impl Sweep for Handle<Curve> {
         _: &mut SweepCache,
         objects: &mut Service<Objects>,
     ) -> Self::Swept {
-        match self.surface().geometry().u {
+        let curve = self;
+
+        match curve.surface().geometry().u {
             GlobalPath::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
                 // `Surface` is a `GlobalPath`, which we are computing below.
@@ -45,17 +47,17 @@ impl Sweep for Handle<Curve> {
             }
         }
 
-        let u = match self.path() {
+        let u = match curve.path() {
             SurfacePath::Circle(circle) => {
-                let center = self
+                let center = curve
                     .surface()
                     .geometry()
                     .point_from_surface_coords(circle.center());
-                let a = self
+                let a = curve
                     .surface()
                     .geometry()
                     .vector_from_surface_coords(circle.a());
-                let b = self
+                let b = curve
                     .surface()
                     .geometry()
                     .vector_from_surface_coords(circle.b());
@@ -65,11 +67,11 @@ impl Sweep for Handle<Curve> {
                 GlobalPath::Circle(circle)
             }
             SurfacePath::Line(line) => {
-                let origin = self
+                let origin = curve
                     .surface()
                     .geometry()
                     .point_from_surface_coords(line.origin());
-                let direction = self
+                let direction = curve
                     .surface()
                     .geometry()
                     .vector_from_surface_coords(line.direction());

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -197,7 +197,7 @@ mod tests {
             };
             let side_up = {
                 let mut side_up = PartialHalfEdge::default();
-                side_up.curve.write().surface = surface.clone();
+                side_up.replace_surface(surface.clone());
 
                 {
                     let [back, front] = side_up
@@ -209,7 +209,6 @@ mod tests {
 
                     let mut front = front.write();
                     front.position = Some([1., 1.].into());
-                    front.surface = surface.clone();
                 }
 
                 side_up.infer_global_form();
@@ -219,7 +218,7 @@ mod tests {
             };
             let top = {
                 let mut top = PartialHalfEdge::default();
-                top.curve.write().surface = surface.clone();
+                top.replace_surface(surface.clone());
 
                 {
                     let [(back, back_surface), (front, front_surface)] =
@@ -231,7 +230,6 @@ mod tests {
                     *front = Some(Point::from([0.]));
                     let mut front_surface = front_surface.write();
                     front_surface.position = Some([0., 1.].into());
-                    front_surface.surface = surface.clone();
                 }
 
                 top.infer_global_form();
@@ -246,7 +244,7 @@ mod tests {
             };
             let side_down = {
                 let mut side_down = PartialHalfEdge::default();
-                side_down.curve.write().surface = surface;
+                side_down.replace_surface(surface);
 
                 let [(back, back_surface), (front, front_surface)] =
                     side_down.vertices.each_mut_ext();

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use fj_interop::{ext::ArrayExt, mesh::Color};
 use fj_math::{Point, Scalar, Vector};
 
@@ -34,7 +36,8 @@ impl Sweep for (Handle<HalfEdge>, Color) {
         // be created by sweeping a curve, so let's sweep the curve of the edge
         // we're sweeping.
         face.exterior.write().surface = Partial::from(
-            edge.curve().clone().sweep_with_cache(path, cache, objects),
+            (edge.curve().clone(), edge.surface().deref())
+                .sweep_with_cache(path, cache, objects),
         );
 
         // Now we're ready to create the edges.

--- a/crates/fj-kernel/src/algorithms/transform/curve.rs
+++ b/crates/fj-kernel/src/algorithms/transform/curve.rs
@@ -18,16 +18,12 @@ impl TransformObject for Curve {
         // coordinates, and thus transforming `surface` takes care of it.
         let path = self.path();
 
-        let surface = self
-            .surface()
-            .clone()
-            .transform_with_cache(transform, objects, cache);
         let global_form = self
             .global_form()
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(surface, path, global_form)
+        Self::new(path, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -15,6 +15,10 @@ impl TransformObject for HalfEdge {
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
+        let surface = self
+            .surface()
+            .clone()
+            .transform_with_cache(transform, objects, cache);
         let curve = self
             .curve()
             .clone()
@@ -32,7 +36,7 @@ impl TransformObject for HalfEdge {
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(curve, boundary, global_form)
+        Self::new(surface, curve, boundary, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -66,8 +66,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         self.surface = surface.clone();
 
-        self.curve.write().surface = surface.clone();
-
         for vertex in &mut self.vertices {
             vertex.1.write().surface = surface.clone();
         }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -64,6 +64,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn replace_surface(&mut self, surface: impl Into<Partial<Surface>>) {
         let surface = surface.into();
 
+        self.surface = surface.clone();
+
         self.curve.write().surface = surface.clone();
 
         for vertex in &mut self.vertices {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -198,7 +198,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         self.curve.write().path =
             other.read().curve.read().path.as_ref().and_then(|path| {
-                match other.read().curve.read().surface.read().geometry {
+                match other.read().surface.read().geometry {
                     Some(surface) => {
                         // We have information about the other edge's surface
                         // available. We need to use that to interpret what the

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -136,14 +136,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         surface: impl Into<Partial<Surface>>,
         points: [impl Into<Point<2>>; 2],
     ) {
-        let surface = surface.into();
-
-        self.curve.write().surface = surface.clone();
+        self.replace_surface(surface.into());
 
         for (vertex, point) in self.vertices.each_mut_ext().zip_ext(points) {
             let mut surface_form = vertex.1.write();
             surface_form.position = Some(point.into());
-            surface_form.surface = surface.clone();
         }
 
         self.update_as_line_segment()

--- a/crates/fj-kernel/src/objects/full/curve.rs
+++ b/crates/fj-kernel/src/objects/full/curve.rs
@@ -1,6 +1,5 @@
 use crate::{
     geometry::path::SurfacePath,
-    objects::Surface,
     storage::{Handle, HandleWrapper},
 };
 
@@ -8,19 +7,16 @@ use crate::{
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Curve {
     path: SurfacePath,
-    surface: Handle<Surface>,
     global_form: HandleWrapper<GlobalCurve>,
 }
 
 impl Curve {
     /// Construct a new instance of `Curve`
     pub fn new(
-        surface: Handle<Surface>,
         path: SurfacePath,
         global_form: impl Into<HandleWrapper<GlobalCurve>>,
     ) -> Self {
         Self {
-            surface,
             path,
             global_form: global_form.into(),
         }
@@ -29,11 +25,6 @@ impl Curve {
     /// Access the path that defines the curve
     pub fn path(&self) -> SurfacePath {
         self.path
-    }
-
-    /// Access the surface that the curve is defined in
-    pub fn surface(&self) -> &Handle<Surface> {
-        &self.surface
     }
 
     /// Access the global form of the curve

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -39,7 +39,7 @@ impl Cycle {
     /// Access the surface that the cycle is in
     pub fn surface(&self) -> &Handle<Surface> {
         if let Some(half_edge) = self.half_edges.first() {
-            return half_edge.curve().surface();
+            return half_edge.surface();
         }
 
         unreachable!(

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -4,13 +4,14 @@ use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
-    objects::{Curve, GlobalCurve, GlobalVertex, SurfaceVertex},
+    objects::{Curve, GlobalCurve, GlobalVertex, Surface, SurfaceVertex},
     storage::{Handle, HandleWrapper},
 };
 
 /// A half-edge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
+    surface: Handle<Surface>,
     curve: Handle<Curve>,
     boundary: [(Point<1>, Handle<SurfaceVertex>); 2],
     global_form: Handle<GlobalEdge>,
@@ -19,15 +20,22 @@ pub struct HalfEdge {
 impl HalfEdge {
     /// Create an instance of `HalfEdge`
     pub fn new(
+        surface: Handle<Surface>,
         curve: Handle<Curve>,
         boundary: [(Point<1>, Handle<SurfaceVertex>); 2],
         global_form: Handle<GlobalEdge>,
     ) -> Self {
         Self {
+            surface,
             curve,
             boundary,
             global_form,
         }
+    }
+
+    /// Access the surface that the half-edge is defined in
+    pub fn surface(&self) -> &Handle<Surface> {
+        &self.surface
     }
 
     /// Access the curve that defines the half-edge's geometry

--- a/crates/fj-kernel/src/partial/objects/curve.rs
+++ b/crates/fj-kernel/src/partial/objects/curve.rs
@@ -2,7 +2,7 @@ use fj_math::Scalar;
 
 use crate::{
     geometry::path::SurfacePath,
-    objects::{Curve, GlobalCurve, Objects, Surface},
+    objects::{Curve, GlobalCurve, Objects},
     partial::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
@@ -12,9 +12,6 @@ use crate::{
 pub struct PartialCurve {
     /// The path that defines the curve
     pub path: Option<MaybeSurfacePath>,
-
-    /// The surface the curve is defined in
-    pub surface: Partial<Surface>,
 
     /// The global form of the curve
     pub global_form: Partial<GlobalCurve>,
@@ -26,7 +23,6 @@ impl PartialObject for PartialCurve {
     fn from_full(curve: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             path: Some(curve.path().into()),
-            surface: Partial::from_full(curve.surface().clone(), cache),
             global_form: Partial::from_full(curve.global_form().clone(), cache),
         }
     }
@@ -40,10 +36,9 @@ impl PartialObject for PartialCurve {
                 )
             }
         };
-        let surface = self.surface.build(objects);
         let global_form = self.global_form.build(objects);
 
-        Curve::new(surface, path, global_form)
+        Curve::new(path, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -6,7 +6,7 @@ use fj_math::Point;
 use crate::{
     objects::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
-        SurfaceVertex,
+        Surface, SurfaceVertex,
     },
     partial::{
         FullToPartialCache, Partial, PartialObject, PartialSurfaceVertex,
@@ -17,6 +17,9 @@ use crate::{
 /// A partial [`HalfEdge`]
 #[derive(Clone, Debug)]
 pub struct PartialHalfEdge {
+    /// The surface that the half-edge is defined in
+    pub surface: Partial<Surface>,
+
     /// The curve that the half-edge is defined in
     pub curve: Partial<Curve>,
 
@@ -35,6 +38,10 @@ impl PartialObject for PartialHalfEdge {
         cache: &mut FullToPartialCache,
     ) -> Self {
         Self {
+            surface: Partial::from_full(
+                half_edge.curve().surface().clone(),
+                cache,
+            ),
             curve: Partial::from_full(half_edge.curve().clone(), cache),
             vertices: half_edge
                 .boundary()
@@ -125,6 +132,7 @@ impl Default for PartialHalfEdge {
         });
 
         Self {
+            surface,
             curve,
             vertices,
             global_form,

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -57,6 +57,7 @@ impl PartialObject for PartialHalfEdge {
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
+        let surface = self.surface.build(objects);
         let curve = self.curve.build(objects);
         let vertices = self.vertices.map(|mut vertex| {
             let position_surface = vertex.1.read().position;
@@ -80,8 +81,7 @@ impl PartialObject for PartialHalfEdge {
             // Infer global position, if not available.
             let position_global = vertex.1.read().global_form.read().position;
             if position_global.is_none() {
-                let position_global = curve
-                    .surface()
+                let position_global = surface
                     .geometry()
                     .point_from_surface_coords(position_surface);
                 vertex.1.write().global_form.write().position =
@@ -96,7 +96,7 @@ impl PartialObject for PartialHalfEdge {
         });
         let global_form = self.global_form.build(objects);
 
-        HalfEdge::new(curve.surface().clone(), curve, vertices, global_form)
+        HalfEdge::new(surface, curve, vertices, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -98,12 +98,12 @@ impl PartialObject for PartialHalfEdge {
 
 impl Default for PartialHalfEdge {
     fn default() -> Self {
+        let surface = Partial::new();
+
         let curve = Partial::<Curve>::new();
         let vertices = array::from_fn(|_| {
-            let surface = Partial::new();
-
             let surface_form = Partial::from_partial(PartialSurfaceVertex {
-                surface,
+                surface: surface.clone(),
                 ..Default::default()
             });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -99,7 +99,7 @@ impl PartialObject for PartialHalfEdge {
         });
         let global_form = self.global_form.build(objects);
 
-        HalfEdge::new(curve, vertices, global_form)
+        HalfEdge::new(curve.surface().clone(), curve, vertices, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -38,10 +38,7 @@ impl PartialObject for PartialHalfEdge {
         cache: &mut FullToPartialCache,
     ) -> Self {
         Self {
-            surface: Partial::from_full(
-                half_edge.curve().surface().clone(),
-                cache,
-            ),
+            surface: Partial::from_full(half_edge.surface().clone(), cache),
             curve: Partial::from_full(half_edge.curve().clone(), cache),
             vertices: half_edge
                 .boundary()

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -80,10 +80,10 @@ impl PartialObject for PartialHalfEdge {
             // Infer global position, if not available.
             let position_global = vertex.1.read().global_form.read().position;
             if position_global.is_none() {
-                let surface = curve.surface().geometry();
-
-                let position_global =
-                    surface.point_from_surface_coords(position_surface);
+                let position_global = curve
+                    .surface()
+                    .geometry()
+                    .point_from_surface_coords(position_surface);
                 vertex.1.write().global_form.write().position =
                     Some(position_global);
             }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -240,7 +240,12 @@ mod tests {
                 .boundary()
                 .zip_ext(valid.surface_vertices().map(Clone::clone));
 
-            HalfEdge::new(valid.curve().clone(), vertices, global_form)
+            HalfEdge::new(
+                valid.surface().clone(),
+                valid.curve().clone(),
+                vertices,
+                global_form,
+            )
         };
 
         valid.validate_and_return_first_error()?;
@@ -282,7 +287,12 @@ mod tests {
                 .boundary()
                 .zip_ext(valid.surface_vertices().map(Clone::clone));
 
-            HalfEdge::new(valid.curve().clone(), vertices, global_form)
+            HalfEdge::new(
+                valid.surface().clone(),
+                valid.curve().clone(),
+                vertices,
+                global_form,
+            )
         };
 
         valid.validate_and_return_first_error()?;
@@ -318,6 +328,7 @@ mod tests {
                 });
 
             HalfEdge::new(
+                valid.surface().clone(),
                 valid.curve().clone(),
                 vertices,
                 valid.global_form().clone(),
@@ -349,6 +360,7 @@ mod tests {
             });
 
             HalfEdge::new(
+                valid.surface().clone(),
                 valid.curve().clone(),
                 vertices,
                 valid.global_form().clone(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -165,10 +165,14 @@ impl HalfEdgeValidationError {
         half_edge: &HalfEdge,
         errors: &mut Vec<ValidationError>,
     ) {
+        let surface = half_edge.surface();
+
         let curve_surface = half_edge.curve().surface();
         let surface_form_surface = half_edge.start_vertex().surface();
 
-        if curve_surface.id() != surface_form_surface.id() {
+        if surface.id() != curve_surface.id()
+            || surface.id() != surface_form_surface.id()
+        {
             errors.push(
                 Box::new(Self::SurfaceMismatch {
                     curve_surface: curve_surface.clone(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -166,16 +166,12 @@ impl HalfEdgeValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         let surface = half_edge.surface();
-
-        let curve_surface = half_edge.curve().surface();
         let surface_form_surface = half_edge.start_vertex().surface();
 
-        if surface.id() != curve_surface.id()
-            || surface.id() != surface_form_surface.id()
-        {
+        if surface.id() != surface_form_surface.id() {
             errors.push(
                 Box::new(Self::SurfaceMismatch {
-                    curve_surface: curve_surface.clone(),
+                    curve_surface: surface.clone(),
                     surface_form_surface: surface_form_surface.clone(),
                 })
                 .into(),

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -31,13 +31,7 @@ impl Shape for fj::Sketch {
                     let surface = Partial::from(surface);
 
                     let mut half_edge = PartialHalfEdge::default();
-
-                    half_edge.curve.write().surface = surface.clone();
-
-                    for vertex in &mut half_edge.vertices {
-                        vertex.1.write().surface = surface.clone();
-                    }
-
+                    half_edge.replace_surface(surface);
                     half_edge.update_as_circle_from_radius(circle.radius());
 
                     Partial::from_partial(half_edge)


### PR DESCRIPTION
This is a first step towards #1588. It doesn't reduce the number of redundant references to `Surface` yet, but by moving the reference from `Curve` to `HalfEdge`, it puts us into a better position to remove the `Surface` references in `SurfaceVertex`, as a next step.