### PR TITLE
Remove reference to `Surface` from `SurfaceVertex`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -196,8 +196,10 @@ mod tests {
                 half_edge
             };
             let side_up = {
-                let mut side_up = PartialHalfEdge::default();
-                side_up.replace_surface(surface.clone());
+                let mut side_up = PartialHalfEdge {
+                    surface: surface.clone(),
+                    ..Default::default()
+                };
 
                 {
                     let [back, front] = side_up
@@ -217,8 +219,10 @@ mod tests {
                 side_up
             };
             let top = {
-                let mut top = PartialHalfEdge::default();
-                top.replace_surface(surface.clone());
+                let mut top = PartialHalfEdge {
+                    surface: surface.clone(),
+                    ..Default::default()
+                };
 
                 {
                     let [(back, back_surface), (front, front_surface)] =
@@ -243,8 +247,10 @@ mod tests {
                 .clone()
             };
             let side_down = {
-                let mut side_down = PartialHalfEdge::default();
-                side_down.replace_surface(surface);
+                let mut side_down = PartialHalfEdge {
+                    surface,
+                    ..Default::default()
+                };
 
                 let [(back, back_surface), (front, front_surface)] =
                     side_down.vertices.each_mut_ext();

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -18,16 +18,12 @@ impl TransformObject for SurfaceVertex {
         // coordinates and thus transforming the surface takes care of it.
         let position = self.position();
 
-        let surface = self
-            .surface()
-            .clone()
-            .transform_with_cache(transform, objects, cache);
         let global_form = self
             .global_form()
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(position, surface, global_form)
+        Self::new(position, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -149,7 +149,7 @@ impl CycleBuilder for PartialCycle {
 
             let [_, vertex] = &mut new_half_edge.vertices;
             vertex.1 = shared_surface_vertex;
-            new_half_edge.replace_surface(self.surface.clone());
+            new_half_edge.surface = self.surface.clone();
             new_half_edge.infer_global_form();
         }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -64,11 +64,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn replace_surface(&mut self, surface: impl Into<Partial<Surface>>) {
         let surface = surface.into();
 
-        self.surface = surface.clone();
-
-        for vertex in &mut self.vertices {
-            vertex.1.write().surface = surface.clone();
-        }
+        self.surface = surface;
     }
 
     fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>) {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -11,16 +11,6 @@ use super::CurveBuilder;
 
 /// Builder API for [`PartialHalfEdge`]
 pub trait HalfEdgeBuilder {
-    /// Completely replace the surface in this half-edge's object graph
-    ///
-    /// Please note that this operation will write to both vertices that the
-    /// half-edge references. If any of them were created from full objects,
-    /// this will break the connection to those, meaning that building the
-    /// partial objects won't result in those full objects again. This will be
-    /// the case, even if those full objects already referenced the provided
-    /// surface.
-    fn replace_surface(&mut self, surface: impl Into<Partial<Surface>>);
-
     /// Update partial half-edge to be a circle, from the given radius
     fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>);
 
@@ -61,12 +51,6 @@ pub trait HalfEdgeBuilder {
 }
 
 impl HalfEdgeBuilder for PartialHalfEdge {
-    fn replace_surface(&mut self, surface: impl Into<Partial<Surface>>) {
-        let surface = surface.into();
-
-        self.surface = surface;
-    }
-
     fn update_as_circle_from_radius(&mut self, radius: impl Into<Scalar>) {
         let path = self.curve.write().update_as_circle_from_radius(radius);
 
@@ -130,7 +114,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         surface: impl Into<Partial<Surface>>,
         points: [impl Into<Point<2>>; 2],
     ) {
-        self.replace_surface(surface.into());
+        self.surface = surface.into();
 
         for (vertex, point) in self.vertices.each_mut_ext().zip_ext(points) {
             let mut surface_form = vertex.1.write();

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,33 +1,11 @@
-use fj_math::Point;
-
 use crate::partial::{PartialGlobalVertex, PartialSurfaceVertex};
 
 /// Builder API for [`PartialSurfaceVertex`]
-pub trait SurfaceVertexBuilder {
-    /// Infer the position of the surface vertex' global form
-    ///
-    /// Updates the global vertex referenced by this surface vertex with the
-    /// inferred position, and also returns the position.
-    fn infer_global_position(&mut self) -> Point<3>;
-}
+pub trait SurfaceVertexBuilder {}
 
 impl SurfaceVertexBuilder for PartialSurfaceVertex {
-    fn infer_global_position(&mut self) -> Point<3> {
-        let position_surface = self
-            .position
-            .expect("Can't infer global position without surface position");
-        let surface = self
-            .surface
-            .read()
-            .geometry
-            .expect("Can't infer global position without surface geometry");
-
-        let position_global =
-            surface.point_from_surface_coords(position_surface);
-        self.global_form.write().position = Some(position_global);
-
-        position_global
-    }
+    // No methods are currently defined. This trait serves as a placeholder, to
+    // make it clear where to add such methods, once necessary.
 }
 
 /// Builder API for [`PartialGlobalVertex`]

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -1,12 +1,11 @@
 use fj_math::Point;
 
-use crate::{objects::Surface, storage::Handle};
+use crate::storage::Handle;
 
 /// A vertex, defined in surface (2D) coordinates
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfaceVertex {
     position: Point<2>,
-    surface: Handle<Surface>,
     global_form: Handle<GlobalVertex>,
 }
 
@@ -14,13 +13,11 @@ impl SurfaceVertex {
     /// Construct a new instance of `SurfaceVertex`
     pub fn new(
         position: impl Into<Point<2>>,
-        surface: Handle<Surface>,
         global_form: Handle<GlobalVertex>,
     ) -> Self {
         let position = position.into();
         Self {
             position,
-            surface,
             global_form,
         }
     }
@@ -28,11 +25,6 @@ impl SurfaceVertex {
     /// Access the position of the vertex on the surface
     pub fn position(&self) -> Point<2> {
         self.position
-    }
-
-    /// Access the surface that the vertex is defined in
-    pub fn surface(&self) -> &Handle<Surface> {
-        &self.surface
     }
 
     /// Access the global form of the vertex

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -107,7 +107,6 @@ impl Default for PartialHalfEdge {
         let curve = Partial::<Curve>::new();
         let vertices = array::from_fn(|_| {
             let surface_form = Partial::from_partial(PartialSurfaceVertex {
-                surface: surface.clone(),
                 ..Default::default()
             });
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -8,9 +8,7 @@ use crate::{
         Curve, GlobalCurve, GlobalEdge, GlobalVertex, HalfEdge, Objects,
         Surface, SurfaceVertex,
     },
-    partial::{
-        FullToPartialCache, Partial, PartialObject, PartialSurfaceVertex,
-    },
+    partial::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
 
@@ -106,10 +104,7 @@ impl Default for PartialHalfEdge {
 
         let curve = Partial::<Curve>::new();
         let vertices = array::from_fn(|_| {
-            let surface_form = Partial::from_partial(PartialSurfaceVertex {
-                ..Default::default()
-            });
-
+            let surface_form = Partial::default();
             (None, surface_form)
         });
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{GlobalVertex, Objects, Surface, SurfaceVertex},
+    objects::{GlobalVertex, Objects, SurfaceVertex},
     partial::{FullToPartialCache, Partial, PartialObject},
     services::Service,
 };
@@ -11,9 +11,6 @@ use crate::{
 pub struct PartialSurfaceVertex {
     /// The position of the vertex on the surface
     pub position: Option<Point<2>>,
-
-    /// The surface that the vertex is defined in
-    pub surface: Partial<Surface>,
 
     /// The global form of the vertex
     pub global_form: Partial<GlobalVertex>,
@@ -28,10 +25,6 @@ impl PartialObject for PartialSurfaceVertex {
     ) -> Self {
         Self {
             position: Some(surface_vertex.position()),
-            surface: Partial::from_full(
-                surface_vertex.surface().clone(),
-                cache,
-            ),
             global_form: Partial::from_full(
                 surface_vertex.global_form().clone(),
                 cache,
@@ -43,10 +36,9 @@ impl PartialObject for PartialSurfaceVertex {
         let position = self
             .position
             .expect("Can't build `SurfaceVertex` without position");
-        let surface = self.surface.build(objects);
         let global_form = self.global_form.build(objects);
 
-        SurfaceVertex::new(position, surface, global_form)
+        SurfaceVertex::new(position, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -133,7 +133,7 @@ pub enum HalfEdgeValidationError {
         distance: Scalar,
 
         /// The surface vertex
-        surface_vertex: SurfaceVertex,
+        surface_vertex: Handle<SurfaceVertex>,
     },
 }
 
@@ -248,7 +248,7 @@ impl HalfEdgeValidationError {
                         surface_position_as_global,
                         global_position,
                         distance,
-                        surface_vertex: surface_vertex.clone_object(),
+                        surface_vertex: surface_vertex.clone(),
                     })
                     .into(),
                 );

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -109,7 +109,7 @@ pub enum HalfEdgeValidationError {
         half_edge: HalfEdge,
     },
 
-    /// Mismatch between position and position of global form
+    /// Mismatch between [`SurfaceVertex`] and [`GlobalVertex`] positions
     #[error(
         "`SurfaceVertex` position doesn't match position of its global form\n\
         - Surface position: {surface_position:?}\n\

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -20,10 +20,6 @@ impl Validate for HalfEdge {
         HalfEdgeValidationError::check_surface_identity(self, errors);
         HalfEdgeValidationError::check_vertex_coincidence(self, config, errors);
         HalfEdgeValidationError::check_vertex_positions(self, config, errors);
-
-        // We don't need to check anything about surfaces here. We already check
-        // curves, which makes sure the vertices are consistent with each other,
-        // and the validation of those vertices checks the surfaces.
     }
 }
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -119,7 +119,7 @@ pub enum HalfEdgeValidationError {
         - Distance between the positions: {distance}\n\
         - `SurfaceVertex`: {surface_vertex:#?}"
     )]
-    PositionMismatch {
+    VertexSurfacePositionMismatch {
         /// The position of the surface vertex
         surface_position: Point<2>,
 
@@ -243,7 +243,7 @@ impl HalfEdgeValidationError {
 
             if distance > config.identical_max_distance {
                 errors.push(
-                    Box::new(Self::PositionMismatch {
+                    Box::new(Self::VertexSurfacePositionMismatch {
                         surface_position: surface_vertex.position(),
                         surface_position_as_global,
                         global_position,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -232,7 +232,7 @@ impl HalfEdgeValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         for surface_vertex in half_edge.surface_vertices() {
-            let surface_position_as_global = surface_vertex
+            let surface_position_as_global = half_edge
                 .surface()
                 .geometry()
                 .point_from_surface_coords(surface_vertex.position());

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -16,7 +16,7 @@ impl Validate for HalfEdge {
         HalfEdgeValidationError::check_global_curve_identity(self, errors);
         HalfEdgeValidationError::check_global_vertex_identity(self, errors);
         HalfEdgeValidationError::check_surface_identity(self, errors);
-        HalfEdgeValidationError::check_vertex_positions(self, config, errors);
+        HalfEdgeValidationError::check_vertex_coincidence(self, config, errors);
 
         // We don't need to check anything about surfaces here. We already check
         // curves, which makes sure the vertices are consistent with each other,
@@ -179,7 +179,7 @@ impl HalfEdgeValidationError {
         }
     }
 
-    fn check_vertex_positions(
+    fn check_vertex_coincidence(
         half_edge: &HalfEdge,
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -12,7 +12,7 @@ mod vertex;
 
 pub use self::{
     cycle::CycleValidationError, edge::HalfEdgeValidationError,
-    face::FaceValidationError, vertex::SurfaceVertexValidationError,
+    face::FaceValidationError,
 };
 
 use std::convert::Infallible;
@@ -94,10 +94,6 @@ pub enum ValidationError {
     /// `HalfEdge` validation error
     #[error("`HalfEdge` validation error:\n{0}")]
     HalfEdge(#[from] Box<HalfEdgeValidationError>),
-
-    /// `SurfaceVertex` validation error
-    #[error("`SurfaceVertex` validation error:\n{0}")]
-    SurfaceVertex(#[from] Box<SurfaceVertexValidationError>),
 }
 
 impl From<Infallible> for ValidationError {

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -19,7 +19,3 @@ impl Validate for GlobalVertex {
     ) {
     }
 }
-
-/// [`SurfaceVertex`] validation error
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum SurfaceVertexValidationError {}

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -1,5 +1,3 @@
-use fj_math::{Point, Scalar};
-
 use crate::objects::{GlobalVertex, SurfaceVertex};
 
 use super::{Validate, ValidationConfig, ValidationError};
@@ -7,10 +5,9 @@ use super::{Validate, ValidationConfig, ValidationError};
 impl Validate for SurfaceVertex {
     fn validate_with_config(
         &self,
-        config: &ValidationConfig,
-        errors: &mut Vec<ValidationError>,
+        _: &ValidationConfig,
+        _: &mut Vec<ValidationError>,
     ) {
-        SurfaceVertexValidationError::check_position(self, config, errors);
     }
 }
 
@@ -25,99 +22,4 @@ impl Validate for GlobalVertex {
 
 /// [`SurfaceVertex`] validation error
 #[derive(Clone, Debug, thiserror::Error)]
-pub enum SurfaceVertexValidationError {
-    /// Mismatch between position and position of global form
-    #[error(
-        "`SurfaceVertex` position doesn't match position of its global form\n\
-        - Surface position: {surface_position:?}\n\
-        - Surface position converted to global position: \
-            {surface_position_as_global:?}\n\
-        - Global position: {global_position:?}\n\
-        - Distance between the positions: {distance}\n\
-        - `SurfaceVertex`: {surface_vertex:#?}"
-    )]
-    PositionMismatch {
-        /// The position of the surface vertex
-        surface_position: Point<2>,
-
-        /// The surface position converted into a global position
-        surface_position_as_global: Point<3>,
-
-        /// The position of the global vertex
-        global_position: Point<3>,
-
-        /// The distance between the positions
-        distance: Scalar,
-
-        /// The surface vertex
-        surface_vertex: SurfaceVertex,
-    },
-}
-
-impl SurfaceVertexValidationError {
-    fn check_position(
-        surface_vertex: &SurfaceVertex,
-        config: &ValidationConfig,
-        errors: &mut Vec<ValidationError>,
-    ) {
-        let surface_position_as_global = surface_vertex
-            .surface()
-            .geometry()
-            .point_from_surface_coords(surface_vertex.position());
-        let global_position = surface_vertex.global_form().position();
-
-        let distance = surface_position_as_global.distance_to(&global_position);
-
-        if distance > config.identical_max_distance {
-            errors.push(
-                Box::new(Self::PositionMismatch {
-                    surface_position: surface_vertex.position(),
-                    surface_position_as_global,
-                    global_position,
-                    distance,
-                    surface_vertex: surface_vertex.clone(),
-                })
-                .into(),
-            );
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use fj_math::Point;
-
-    use crate::{
-        insert::Insert,
-        objects::{GlobalVertex, SurfaceVertex},
-        partial::{
-            Partial, PartialGlobalVertex, PartialObject, PartialSurfaceVertex,
-        },
-        services::Services,
-        validate::Validate,
-    };
-
-    #[test]
-    fn surface_vertex_position_mismatch() -> anyhow::Result<()> {
-        let mut services = Services::new();
-
-        let valid = PartialSurfaceVertex {
-            position: Some([0., 0.].into()),
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            global_form: Partial::from_partial(PartialGlobalVertex {
-                position: Some(Point::from([0., 0., 0.])),
-            }),
-        }
-        .build(&mut services.objects);
-        let invalid = SurfaceVertex::new(
-            valid.position(),
-            valid.surface().clone(),
-            GlobalVertex::new([1., 0., 0.]).insert(&mut services.objects),
-        );
-
-        valid.validate_and_return_first_error()?;
-        assert!(invalid.validate_and_return_first_error().is_err());
-
-        Ok(())
-    }
-}
+pub enum SurfaceVertexValidationError {}

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -30,8 +30,10 @@ impl Shape for fj::Sketch {
                 let half_edge = {
                     let surface = Partial::from(surface);
 
-                    let mut half_edge = PartialHalfEdge::default();
-                    half_edge.replace_surface(surface);
+                    let mut half_edge = PartialHalfEdge {
+                        surface,
+                        ..Default::default()
+                    };
                     half_edge.update_as_circle_from_radius(circle.radius());
 
                     Partial::from_partial(half_edge)


### PR DESCRIPTION
This reduces the level of redundancy in the object graph with regards to `Surface`. This is another step towards #1588.