### PR TITLE
Simplify intersection code that uses or produces curves

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -72,8 +72,9 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        builder::{CurveBuilder, HalfEdgeBuilder},
-        partial::{PartialCurve, PartialHalfEdge, PartialObject},
+        builder::HalfEdgeBuilder,
+        geometry::path::SurfacePath,
+        partial::{PartialHalfEdge, PartialObject},
         services::Services,
     };
 
@@ -84,9 +85,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut curve = PartialCurve::default();
-        curve.update_as_u_axis();
-        let curve = curve.build(&mut services.objects);
+        let curve = SurfacePath::u_axis();
         let half_edge = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points([[1., -1.], [1., 1.]]);
@@ -95,8 +94,7 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection =
-            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert_eq!(
             intersection,
@@ -111,9 +109,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut curve = PartialCurve::default();
-        curve.update_as_u_axis();
-        let curve = curve.build(&mut services.objects);
+        let curve = SurfacePath::u_axis();
         let half_edge = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge
@@ -123,8 +119,7 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection =
-            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert_eq!(
             intersection,
@@ -139,9 +134,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut curve = PartialCurve::default();
-        curve.update_as_u_axis();
-        let curve = curve.build(&mut services.objects);
+        let curve = SurfacePath::u_axis();
         let half_edge = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge
@@ -151,8 +144,7 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection =
-            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert!(intersection.is_none());
     }
@@ -162,9 +154,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut curve = PartialCurve::default();
-        curve.update_as_u_axis();
-        let curve = curve.build(&mut services.objects);
+        let curve = SurfacePath::u_axis();
         let half_edge = {
             let mut half_edge = PartialHalfEdge::default();
             half_edge.update_as_line_segment_from_points([[-1., 0.], [1., 0.]]);
@@ -173,8 +163,7 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection =
-            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
+        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
         assert_eq!(
             intersection,

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::LineSegmentIntersection;
 
-/// The intersection between a [`Curve`] and a [`HalfEdge`]
+/// The intersection between a curve and a [`HalfEdge`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CurveEdgeIntersection {
     /// The curve and edge intersect at a point
@@ -29,7 +29,7 @@ impl CurveEdgeIntersection {
     /// # Panics
     ///
     /// Currently, only intersections between lines and line segments can be
-    /// computed. Panics, if a different type of [`Curve`] or [`HalfEdge`] is
+    /// computed. Panics, if a different type of curve or [`HalfEdge`] is
     /// passed.
     pub fn compute(curve: &Curve, half_edge: &HalfEdge) -> Option<Self> {
         let curve_as_line = match curve.path() {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -1,9 +1,6 @@
 use fj_math::{Point, Segment};
 
-use crate::{
-    geometry::path::SurfacePath,
-    objects::{Curve, HalfEdge},
-};
+use crate::{geometry::path::SurfacePath, objects::HalfEdge};
 
 use super::LineSegmentIntersection;
 
@@ -31,8 +28,8 @@ impl CurveEdgeIntersection {
     /// Currently, only intersections between lines and line segments can be
     /// computed. Panics, if a different type of curve or [`HalfEdge`] is
     /// passed.
-    pub fn compute(curve: &Curve, half_edge: &HalfEdge) -> Option<Self> {
-        let curve_as_line = match curve.path() {
+    pub fn compute(curve: &SurfacePath, half_edge: &HalfEdge) -> Option<Self> {
+        let curve_as_line = match curve {
             SurfacePath::Line(line) => line,
             _ => todo!("Curve-edge intersection only supports lines"),
         };
@@ -53,7 +50,7 @@ impl CurveEdgeIntersection {
         };
 
         let intersection =
-            LineSegmentIntersection::compute(&curve_as_line, &edge_as_segment)?;
+            LineSegmentIntersection::compute(curve_as_line, &edge_as_segment)?;
 
         let intersection = match intersection {
             LineSegmentIntersection::Point { point_on_line } => Self::Point {
@@ -98,7 +95,8 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
+        let intersection =
+            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
 
         assert_eq!(
             intersection,
@@ -125,7 +123,8 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
+        let intersection =
+            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
 
         assert_eq!(
             intersection,
@@ -152,7 +151,8 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
+        let intersection =
+            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
 
         assert!(intersection.is_none());
     }
@@ -173,7 +173,8 @@ mod tests {
             half_edge.build(&mut services.objects)
         };
 
-        let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
+        let intersection =
+            CurveEdgeIntersection::compute(&curve.path(), &half_edge);
 
         assert_eq!(
             intersection,

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -27,7 +27,7 @@ impl CurveFaceIntersection {
         Self { intervals }
     }
 
-    /// Compute the intersections between a [`Curve`] and a [`Face`]
+    /// Compute the intersection
     pub fn compute(curve: &Curve, face: &Face) -> Self {
         let half_edges = face.all_cycles().flat_map(|cycle| cycle.half_edges());
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -34,7 +34,8 @@ impl CurveFaceIntersection {
         let mut intersections = Vec::new();
 
         for half_edge in half_edges {
-            let intersection = CurveEdgeIntersection::compute(curve, half_edge);
+            let intersection =
+                CurveEdgeIntersection::compute(&curve.path(), half_edge);
 
             if let Some(intersection) = intersection {
                 match intersection {

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -3,7 +3,7 @@ use std::vec;
 use fj_interop::ext::SliceExt;
 use fj_math::Point;
 
-use crate::objects::{Curve, Face};
+use crate::{geometry::path::SurfacePath, objects::Face};
 
 use super::CurveEdgeIntersection;
 
@@ -28,14 +28,13 @@ impl CurveFaceIntersection {
     }
 
     /// Compute the intersection
-    pub fn compute(curve: &Curve, face: &Face) -> Self {
+    pub fn compute(curve: &SurfacePath, face: &Face) -> Self {
         let half_edges = face.all_cycles().flat_map(|cycle| cycle.half_edges());
 
         let mut intersections = Vec::new();
 
         for half_edge in half_edges {
-            let intersection =
-                CurveEdgeIntersection::compute(&curve.path(), half_edge);
+            let intersection = CurveEdgeIntersection::compute(curve, half_edge);
 
             if let Some(intersection) = intersection {
                 match intersection {
@@ -198,7 +197,10 @@ mod tests {
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);
-        assert_eq!(CurveFaceIntersection::compute(&curve, &face), expected);
+        assert_eq!(
+            CurveFaceIntersection::compute(&curve.path(), &face),
+            expected
+        );
     }
 
     #[test]

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -150,8 +150,9 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{CurveBuilder, CycleBuilder, FaceBuilder},
-        partial::{Partial, PartialCurve, PartialFace, PartialObject},
+        builder::{CycleBuilder, FaceBuilder},
+        geometry::path::SurfacePath,
+        partial::{Partial, PartialFace, PartialObject},
         services::Services,
     };
 
@@ -161,9 +162,7 @@ mod tests {
     fn compute() {
         let mut services = Services::new();
 
-        let mut curve = PartialCurve::default();
-        curve.update_as_line_from_points([[-3., 0.], [-2., 0.]]);
-        let curve = curve.build(&mut services.objects);
+        let (curve, _) = SurfacePath::line_from_points([[-3., 0.], [-2., 0.]]);
 
         #[rustfmt::skip]
         let exterior = [
@@ -197,10 +196,7 @@ mod tests {
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);
-        assert_eq!(
-            CurveFaceIntersection::compute(&curve.path(), &face),
-            expected
-        );
+        assert_eq!(CurveFaceIntersection::compute(&curve, &face), expected);
     }
 
     #[test]

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -7,7 +7,7 @@ use crate::objects::{Curve, Face};
 
 use super::CurveEdgeIntersection;
 
-/// The intersections between a [`Curve`] and a [`Face`], in curve coordinates
+/// The intersections between a curve and a [`Face`], in curve coordinates
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct CurveFaceIntersection {
     /// The intervals where the curve and face intersect, in curve coordinates

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -30,12 +30,12 @@ impl FaceFaceIntersection {
     /// Compute the intersections between two faces
     pub fn compute(
         faces: [&Face; 2],
-        objects: &mut Service<Objects>,
+        _: &mut Service<Objects>,
     ) -> Option<Self> {
         let surfaces = faces.map(|face| face.surface().clone());
 
         let intersection_curves =
-            match SurfaceSurfaceIntersection::compute(surfaces, objects) {
+            match SurfaceSurfaceIntersection::compute(surfaces) {
                 Some(intersection) => intersection.intersection_curves,
                 None => return None,
             };

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -1,11 +1,7 @@
 use fj_interop::ext::ArrayExt;
 use iter_fixed::IntoIteratorFixed;
 
-use crate::{
-    geometry::path::SurfacePath,
-    objects::{Face, Objects},
-    services::Service,
-};
+use crate::{geometry::path::SurfacePath, objects::Face};
 
 use super::{CurveFaceIntersection, SurfaceSurfaceIntersection};
 
@@ -28,10 +24,7 @@ pub struct FaceFaceIntersection {
 
 impl FaceFaceIntersection {
     /// Compute the intersections between two faces
-    pub fn compute(
-        faces: [&Face; 2],
-        _: &mut Service<Objects>,
-    ) -> Option<Self> {
+    pub fn compute(faces: [&Face; 2]) -> Option<Self> {
         let surfaces = faces.map(|face| face.surface().clone());
 
         let intersection_curves =
@@ -102,8 +95,7 @@ mod tests {
             face.build(&mut services.objects)
         });
 
-        let intersection =
-            FaceFaceIntersection::compute([&a, &b], &mut services.objects);
+        let intersection = FaceFaceIntersection::compute([&a, &b]);
 
         assert!(intersection.is_none());
     }
@@ -133,8 +125,7 @@ mod tests {
             face.build(&mut services.objects)
         });
 
-        let intersection =
-            FaceFaceIntersection::compute([&a, &b], &mut services.objects);
+        let intersection = FaceFaceIntersection::compute([&a, &b]);
 
         let expected_curves = surfaces.map(|_| {
             let (path, _) = SurfacePath::line_from_points([[0., 0.], [1., 0.]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -36,9 +36,7 @@ impl FaceFaceIntersection {
 
         let intersection_curves =
             match SurfaceSurfaceIntersection::compute(surfaces, objects) {
-                Some(intersection) => {
-                    intersection.intersection_curves.map(|curve| curve.path())
-                }
+                Some(intersection) => intersection.intersection_curves,
                 None => return None,
             };
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -44,7 +44,9 @@ impl FaceFaceIntersection {
             .each_ref_ext()
             .into_iter_fixed()
             .zip(faces)
-            .map(|(curve, face)| CurveFaceIntersection::compute(curve, face))
+            .map(|(curve, face)| {
+                CurveFaceIntersection::compute(&curve.path(), face)
+            })
             .collect::<[_; 2]>();
 
         let intersection_intervals = {

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -2,8 +2,7 @@ use fj_math::{Line, Plane, Point, Scalar};
 
 use crate::{
     geometry::path::{GlobalPath, SurfacePath},
-    objects::{Objects, Surface},
-    services::Service,
+    objects::Surface,
     storage::Handle,
 };
 
@@ -16,10 +15,7 @@ pub struct SurfaceSurfaceIntersection {
 
 impl SurfaceSurfaceIntersection {
     /// Compute the intersection between two surfaces
-    pub fn compute(
-        surfaces: [Handle<Surface>; 2],
-        _: &mut Service<Objects>,
-    ) -> Option<Self> {
+    pub fn compute(surfaces: [Handle<Surface>; 2]) -> Option<Self> {
         // Algorithm from Real-Time Collision Detection by Christer Ericson. See
         // section 5.4.4, Intersection of Two Planes.
         //
@@ -95,16 +91,13 @@ mod tests {
 
         // Coincident and parallel planes don't have an intersection curve.
         assert_eq!(
-            SurfaceSurfaceIntersection::compute(
-                [
-                    xy.clone(),
-                    xy.clone().transform(
-                        &Transform::translation([0., 0., 1.],),
-                        &mut services.objects
-                    )
-                ],
-                &mut services.objects
-            ),
+            SurfaceSurfaceIntersection::compute([
+                xy.clone(),
+                xy.clone().transform(
+                    &Transform::translation([0., 0., 1.],),
+                    &mut services.objects
+                )
+            ],),
             None,
         );
 
@@ -112,10 +105,7 @@ mod tests {
         let expected_xz = SurfacePath::u_axis();
 
         assert_eq!(
-            SurfaceSurfaceIntersection::compute(
-                [xy, xz],
-                &mut services.objects
-            ),
+            SurfaceSurfaceIntersection::compute([xy, xz],),
             Some(SurfaceSurfaceIntersection {
                 intersection_curves: [expected_xy, expected_xz],
             })

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -50,10 +50,9 @@ pub trait CurveBuilder {
 
 impl CurveBuilder for PartialCurve {
     fn update_as_u_axis(&mut self) -> SurfacePath {
-        let a = Point::origin();
-        let b = a + Vector::unit_u();
-
-        self.update_as_line_from_points([a, b])
+        let path = SurfacePath::u_axis();
+        self.path = Some(path.into());
+        path
     }
 
     fn update_as_v_axis(&mut self) -> SurfacePath {

--- a/crates/fj-kernel/src/builder/curve.rs
+++ b/crates/fj-kernel/src/builder/curve.rs
@@ -1,4 +1,4 @@
-use fj_math::{Point, Scalar, Vector};
+use fj_math::{Point, Scalar};
 
 use crate::{geometry::path::SurfacePath, partial::PartialCurve};
 
@@ -56,10 +56,9 @@ impl CurveBuilder for PartialCurve {
     }
 
     fn update_as_v_axis(&mut self) -> SurfacePath {
-        let a = Point::origin();
-        let b = a + Vector::unit_v();
-
-        self.update_as_line_from_points([a, b])
+        let path = SurfacePath::v_axis();
+        self.path = Some(path.into());
+        path
     }
 
     fn update_as_circle_from_radius(

--- a/crates/fj-kernel/src/geometry/path.rs
+++ b/crates/fj-kernel/src/geometry/path.rs
@@ -52,6 +52,15 @@ impl SurfacePath {
         self_
     }
 
+    /// Build a line that represents the v-axis of the surface its on
+    pub fn v_axis() -> Self {
+        let a = Point::origin();
+        let b = a + Vector::unit_v();
+
+        let (self_, _) = Self::line_from_points([a, b]);
+        self_
+    }
+
     /// Construct a line from two points
     ///
     /// Also returns the coordinates of the points on the path.

--- a/crates/fj-kernel/src/geometry/path.rs
+++ b/crates/fj-kernel/src/geometry/path.rs
@@ -43,6 +43,15 @@ impl SurfacePath {
         Self::Circle(Circle::from_center_and_radius(center, radius))
     }
 
+    /// Build a line that represents the u-axis of the surface its on
+    pub fn u_axis() -> Self {
+        let a = Point::origin();
+        let b = a + Vector::unit_u();
+
+        let (self_, _) = Self::line_from_points([a, b]);
+        self_
+    }
+
     /// Construct a line from two points
     ///
     /// Also returns the coordinates of the points on the path.


### PR DESCRIPTION
Simplify all such code by using `SurfacePath` instead of `Curve` this simplifies both use (slightly) and construction (significantly) of intersection curves.

I haven't renamed any of those intersection tests, as it's very likely that `SurfacePath` will be renamed to `Curve` soon anyway (see https://github.com/hannobraun/Fornjot/issues/1605).