### PR TITLE
Fix wrong link

### DIFF
--- a/tools/automator/README.md
+++ b/tools/automator/README.md
@@ -16,4 +16,4 @@ To learn how to use it, run the following command:
 automator --help
 ```
 
-Please also refer to the [release procedure](../../RELEASES.md), which is the main use case for `automator`, as of this writing.
+Please also refer to the [release procedure](../../release-procedure.md), which is the main use case for `automator`, as of this writing.


### PR DESCRIPTION
The previous link should have been changed, resulting in 404 links in `README.md` under the **automation** directory