### PR TITLE
Remove unused builder methods

### DIFF
--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -35,19 +35,6 @@ pub trait CycleBuilder {
         point: impl Into<Point<2>>,
     ) -> Partial<HalfEdge>;
 
-    /// Add a new half-edge that starts at the provided point
-    ///
-    /// Opens the cycle between the last and first edge, updates the last edge
-    /// to go the provided point, and adds a new half-edge from the provided
-    /// point the the first edge.
-    ///
-    /// If the cycle doesn't have any edges yet, the new edge connects to
-    /// itself, starting and ending at the provided point.
-    fn add_half_edge_from_global_point_to_start(
-        &mut self,
-        point: impl Into<Point<3>>,
-    ) -> Partial<HalfEdge>;
-
     /// Update cycle as a polygon from the provided points
     fn update_as_polygon_from_points<O, P>(
         &mut self,
@@ -132,21 +119,6 @@ impl CycleBuilder for PartialCycle {
     ) -> Partial<HalfEdge> {
         let mut half_edge = self.add_half_edge();
         half_edge.write().start_vertex.write().position = Some(point.into());
-        half_edge
-    }
-
-    fn add_half_edge_from_global_point_to_start(
-        &mut self,
-        point: impl Into<Point<3>>,
-    ) -> Partial<HalfEdge> {
-        let mut half_edge = self.add_half_edge();
-        half_edge
-            .write()
-            .start_vertex
-            .write()
-            .global_form
-            .write()
-            .position = Some(point.into());
         half_edge
     }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -12,16 +12,6 @@ use crate::{
 
 /// Builder API for [`PartialHalfEdge`]
 pub trait HalfEdgeBuilder {
-    /// Update partial half-edge to represent the u-axis of the surface it is on
-    ///
-    /// Returns the updated path.
-    fn update_as_u_axis(&mut self) -> Curve;
-
-    /// Update partial curve to represent the v-axis of the surface it is on
-    ///
-    /// Returns the updated path.
-    fn update_as_v_axis(&mut self) -> Curve;
-
     /// Update partial half-edge to be a circle, from the given radius
     fn update_as_circle_from_radius(
         &mut self,
@@ -86,18 +76,6 @@ pub trait HalfEdgeBuilder {
 }
 
 impl HalfEdgeBuilder for PartialHalfEdge {
-    fn update_as_u_axis(&mut self) -> Curve {
-        let path = Curve::u_axis();
-        self.curve = Some(path.into());
-        path
-    }
-
-    fn update_as_v_axis(&mut self) -> Curve {
-        let path = Curve::v_axis();
-        self.curve = Some(path.into());
-        path
-    }
-
     fn update_as_circle_from_radius(
         &mut self,
         radius: impl Into<Scalar>,

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,19 +1,12 @@
-use fj_interop::ext::ArrayExt;
-use itertools::Itertools;
-
 use crate::{
-    geometry::curve::Curve,
     objects::Cycle,
-    partial::{MaybeCurve, Partial, PartialFace},
+    partial::{Partial, PartialFace},
 };
 
 /// Builder API for [`PartialFace`]
 pub trait FaceBuilder {
     /// Add an interior cycle
     fn add_interior(&mut self) -> Partial<Cycle>;
-
-    /// Infer any undefined curves in the face
-    fn infer_curves(&mut self);
 }
 
 impl FaceBuilder for PartialFace {
@@ -21,53 +14,5 @@ impl FaceBuilder for PartialFace {
         let cycle = Partial::new();
         self.interiors.push(cycle.clone());
         cycle
-    }
-
-    fn infer_curves(&mut self) {
-        for (mut half_edge, next_half_edge) in self
-            .exterior
-            .read()
-            .half_edges
-            .iter()
-            .cloned()
-            .circular_tuple_windows()
-        {
-            let mut half_edge = half_edge.write();
-
-            let mut curve = half_edge.curve;
-
-            if let Some(path) = &mut curve {
-                match path {
-                    MaybeCurve::Defined(_) => {
-                        // Path is already defined. Nothing to infer.
-                    }
-                    MaybeCurve::UndefinedCircle { .. } => todo!(
-                        "Inferring undefined circles is not supported yet"
-                    ),
-                    MaybeCurve::UndefinedLine => {
-                        let points_surface = [
-                            &half_edge.start_vertex,
-                            &next_half_edge.read().start_vertex,
-                        ]
-                        .map(|vertex| {
-                            vertex.read().position.expect(
-                                "Can't infer curve without surface points",
-                            )
-                        });
-                        let (line, points_curve) =
-                            Curve::line_from_points(points_surface);
-
-                        *path = MaybeCurve::Defined(line);
-                        for (vertex, point) in half_edge
-                            .boundary
-                            .each_mut_ext()
-                            .zip_ext(points_curve)
-                        {
-                            *vertex = Some(point);
-                        }
-                    }
-                }
-            }
-        }
     }
 }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,32 +1,16 @@
-use std::{array, collections::VecDeque};
-
 use fj_interop::ext::ArrayExt;
 use itertools::Itertools;
 
 use crate::{
     geometry::curve::Curve,
-    objects::{Cycle, Surface},
+    objects::Cycle,
     partial::{MaybeCurve, Partial, PartialFace},
 };
-
-use super::SurfaceBuilder;
 
 /// Builder API for [`PartialFace`]
 pub trait FaceBuilder {
     /// Add an interior cycle
     fn add_interior(&mut self) -> Partial<Cycle>;
-
-    /// Update the face's surface as a plane
-    ///
-    /// The plane geometry is inferred from three of the face's vertices. Also
-    /// infers any undefined `SurfaceVertex` positions.
-    ///
-    /// # Panics
-    ///
-    /// Assumes that the face exterior has exactly three vertices to use. Panics
-    /// otherwise. This is a temporary limitation, not a fundamental one. It
-    /// could be overcome with some more work.
-    fn update_surface_as_plane(&mut self) -> Partial<Surface>;
 
     /// Infer any undefined curves in the face
     fn infer_curves(&mut self);
@@ -37,60 +21,6 @@ impl FaceBuilder for PartialFace {
         let cycle = Partial::new();
         self.interiors.push(cycle.clone());
         cycle
-    }
-
-    fn update_surface_as_plane(&mut self) -> Partial<Surface> {
-        let exterior = self.exterior.read();
-        let mut vertices = exterior
-            .half_edges
-            .iter()
-            .map(|half_edge| {
-                let surface_vertex = &half_edge.read().start_vertex;
-                let global_position = surface_vertex
-                    .read()
-                    .global_form
-                    .read()
-                    .position
-                    .expect("Need global position to infer plane");
-
-                (surface_vertex.clone(), global_position)
-            })
-            .collect::<VecDeque<_>>();
-
-        let (significant_vertices, surface) = {
-            let first_three_vertices = array::from_fn(|_| {
-                vertices
-                    .pop_front()
-                    .expect("Expected at least three vertices")
-            });
-
-            let first_three_points_global =
-                first_three_vertices.each_ref_ext().map(|(_, point)| *point);
-
-            let (first_three_points_surface, surface) = self
-                .surface
-                .write()
-                .update_as_plane_from_points(first_three_points_global);
-
-            let first_three_vertices = first_three_vertices
-                .zip_ext(first_three_points_surface)
-                .map(|((vertex, _), point_global)| (vertex, point_global));
-
-            (first_three_vertices, surface)
-        };
-        let rest_of_vertices =
-            vertices.into_iter().map(|(vertex, point_global)| {
-                let point_surface = surface.project_global_point(point_global);
-                (vertex, point_surface)
-            });
-
-        for (mut surface_vertex, point) in
-            significant_vertices.into_iter().chain(rest_of_vertices)
-        {
-            surface_vertex.write().position = Some(point);
-        }
-
-        self.surface.clone()
     }
 
     fn infer_curves(&mut self) {

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -1,21 +1,9 @@
-use crate::{
-    objects::Face,
-    partial::{Partial, PartialShell},
-};
+use crate::partial::PartialShell;
 
 /// Builder API for [`PartialShell`]
 pub trait ShellBuilder {
-    /// Add a face to the shell
-    ///
-    /// The face will not be connected to any other faces that the shell might
-    /// already have.
-    fn add_face(&mut self) -> Partial<Face>;
+    // No methods are currently defined. This trait serves as a placeholder, to
+    // make it clear where to add such methods, once necessary.
 }
 
-impl ShellBuilder for PartialShell {
-    fn add_face(&mut self) -> Partial<Face> {
-        let face = Partial::default();
-        self.faces.push(face.clone());
-        face
-    }
-}
+impl ShellBuilder for PartialShell {}

--- a/crates/fj-kernel/src/builder/sketch.rs
+++ b/crates/fj-kernel/src/builder/sketch.rs
@@ -1,18 +1,9 @@
-use crate::{
-    objects::Face,
-    partial::{Partial, PartialSketch},
-};
+use crate::partial::PartialSketch;
 
 /// Builder API for [`PartialSketch`]
 pub trait SketchBuilder {
-    /// Add a face to the sketch
-    fn add_face(&mut self) -> Partial<Face>;
+    // No methods are currently defined. This trait serves as a placeholder, to
+    // make it clear where to add such methods, once necessary.
 }
 
-impl SketchBuilder for PartialSketch {
-    fn add_face(&mut self) -> Partial<Face> {
-        let face = Partial::default();
-        self.faces.extend([face.clone()]);
-        face
-    }
-}
+impl SketchBuilder for PartialSketch {}

--- a/crates/fj-kernel/src/builder/surface.rs
+++ b/crates/fj-kernel/src/builder/surface.rs
@@ -1,4 +1,4 @@
-use fj_math::{Point, Scalar, Vector};
+use fj_math::Vector;
 
 use crate::{
     geometry::{curve::GlobalPath, surface::SurfaceGeometry},
@@ -9,12 +9,6 @@ use crate::{
 pub trait SurfaceBuilder: Sized {
     /// Build a surface from its two axes
     fn from_axes(u: GlobalPath, v: impl Into<Vector<3>>) -> Self;
-
-    /// Construct a plane from 3 points
-    fn update_as_plane_from_points(
-        &mut self,
-        points: [impl Into<Point<3>>; 3],
-    ) -> ([Point<2>; 3], SurfaceGeometry);
 }
 
 impl SurfaceBuilder for PartialSurface {
@@ -24,24 +18,5 @@ impl SurfaceBuilder for PartialSurface {
         Self {
             geometry: Some(SurfaceGeometry { u, v }),
         }
-    }
-
-    fn update_as_plane_from_points(
-        &mut self,
-        points: [impl Into<Point<3>>; 3],
-    ) -> ([Point<2>; 3], SurfaceGeometry) {
-        let [a, b, c] = points.map(Into::into);
-
-        let (u, u_coords) = GlobalPath::line_from_points([a, b]);
-        let v = c - a;
-
-        let geometry = SurfaceGeometry { u, v };
-        self.geometry = Some(geometry);
-
-        let [a, b] = u_coords.map(|point| point.t);
-        let points = [[a, Scalar::ZERO], [b, Scalar::ZERO], [a, Scalar::ONE]]
-            .map(Point::from);
-
-        (points, geometry)
     }
 }

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,17 +1,17 @@
 use crate::partial::{PartialGlobalVertex, PartialSurfaceVertex};
 
 /// Builder API for [`PartialSurfaceVertex`]
-pub trait SurfaceVertexBuilder {}
-
-impl SurfaceVertexBuilder for PartialSurfaceVertex {
+pub trait SurfaceVertexBuilder {
     // No methods are currently defined. This trait serves as a placeholder, to
     // make it clear where to add such methods, once necessary.
 }
+
+impl SurfaceVertexBuilder for PartialSurfaceVertex {}
 
 /// Builder API for [`PartialGlobalVertex`]
-pub trait GlobalVertexBuilder {}
-
-impl GlobalVertexBuilder for PartialGlobalVertex {
+pub trait GlobalVertexBuilder {
     // No methods are currently defined. This trait serves as a placeholder, to
     // make it clear where to add such methods, once necessary.
 }
+
+impl GlobalVertexBuilder for PartialGlobalVertex {}


### PR DESCRIPTION
Turns out there were quite a few unused methods in the builder API. The less code there is, the less code there is in the way as I continue my cleanup, so I'm happy to remove them.