### PR TITLE
Compute position of `HalfEdge`s start vertex

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -30,7 +30,7 @@ impl Approx for (&Handle<HalfEdge>, &Surface) {
         let range = RangeOnPath { boundary };
 
         let first = ApproxPoint::new(
-            half_edge.start_vertex().position(),
+            half_edge.start_position(),
             half_edge.start_vertex().global_form().position(),
         )
         .with_source((half_edge.clone(), half_edge.boundary()[0]));

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -318,10 +318,7 @@ mod tests {
         let edge = face
             .exterior()
             .half_edges()
-            .find(|edge| {
-                let vertex = edge.start_vertex();
-                vertex.position() == Point::from([0., 0.])
-            })
+            .find(|edge| edge.start_position() == Point::from([0., 0.]))
             .unwrap();
         assert_eq!(
             intersection,

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -349,10 +349,10 @@ mod tests {
         let vertex = face
             .exterior()
             .half_edges()
-            .map(|half_edge| half_edge.start_vertex().clone())
-            .find(|surface_vertex| {
-                surface_vertex.position() == Point::from([1., 0.])
+            .find(|half_edge| {
+                half_edge.start_vertex().position() == Point::from([1., 0.])
             })
+            .map(|half_edge| half_edge.start_vertex().clone())
             .unwrap();
         assert_eq!(
             intersection,

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -350,7 +350,7 @@ mod tests {
             .exterior()
             .half_edges()
             .find(|half_edge| {
-                half_edge.start_vertex().position() == Point::from([1., 0.])
+                half_edge.start_position() == Point::from([1., 0.])
             })
             .map(|half_edge| half_edge.start_vertex().clone())
             .unwrap();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -288,10 +288,10 @@ mod tests {
         let vertex = face
             .exterior()
             .half_edges()
-            .map(|half_edge| half_edge.start_vertex().clone())
-            .find(|surface_vertex| {
-                surface_vertex.position() == Point::from([-1., -1.])
+            .find(|half_edge| {
+                half_edge.start_vertex().position() == Point::from([-1., -1.])
             })
+            .map(|half_edge| half_edge.start_vertex().clone())
             .unwrap();
         assert_eq!(
             (&ray, &face).intersect(),

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -289,7 +289,7 @@ mod tests {
             .exterior()
             .half_edges()
             .find(|half_edge| {
-                half_edge.start_vertex().position() == Point::from([-1., -1.])
+                half_edge.start_position() == Point::from([-1., -1.])
             })
             .map(|half_edge| half_edge.start_vertex().clone())
             .unwrap();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -256,10 +256,7 @@ mod tests {
         let edge = face
             .exterior()
             .half_edges()
-            .find(|edge| {
-                let vertex = edge.start_vertex();
-                vertex.position() == Point::from([-1., 1.])
-            })
+            .find(|edge| edge.start_position() == Point::from([-1., 1.]))
             .unwrap();
         assert_eq!(
             (&ray, &face).intersect(),

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -77,8 +77,7 @@ impl Cycle {
         let mut sum = Scalar::ZERO;
 
         for [a, b] in self.half_edges.as_slice().array_windows_ext() {
-            let [a, b] =
-                [a, b].map(|half_edge| half_edge.start_vertex().position());
+            let [a, b] = [a, b].map(|half_edge| half_edge.start_position());
 
             sum += (b.u - a.u) * (b.v + a.v);
         }

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -81,7 +81,12 @@ impl HalfEdge {
 
     /// Compute the surface position where the half-edge starts
     pub fn start_position(&self) -> Point<2> {
-        self.start_vertex.position()
+        // Computing the surface position from the curve position is fine.
+        // `HalfEdge` "owns" its start position. There is no competing code that
+        // could compute the surface position from slightly different data.
+
+        let [start, _] = self.boundary;
+        self.curve.point_from_path_coords(start)
     }
 
     /// Access the vertex from where this half-edge starts

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -80,7 +80,7 @@ impl HalfEdge {
     }
 
     /// Compute the surface position where the half-edge starts
-    pub fn start_surface_position(&self) -> Point<2> {
+    pub fn start_position(&self) -> Point<2> {
         self.start_vertex.position()
     }
 

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -79,6 +79,11 @@ impl HalfEdge {
         self.boundary
     }
 
+    /// Compute the surface position where the half-edge starts
+    pub fn start_surface_position(&self) -> Point<2> {
+        self.start_vertex.position()
+    }
+
     /// Access the vertex from where this half-edge starts
     pub fn start_vertex(&self) -> &Handle<SurfaceVertex> {
         &self.start_vertex


### PR DESCRIPTION
Add `HalfEdge::start_position`, which computes the position of the `HalfEdge`'s start vertex. Update most code to use that method instead, instead of `SurfaceVertex::position`. This is preparation for eventually removing `SurfaceVertex::position`, and then `SurfaceVertex` as a whole.

Most of the remaining uses of the `SurfaceVertex::position` are fairly trivial and can be removed when the `position` field is removed. The only tricky case is `PartialSurfaceVertex`, which still needs `SurfaceVertex::position` to be around, while it itself stores a surface position. Addressing this will be subject to follow-up pull requests.

This is a step towards addressing #1634.