### PR TITLE
Add `PartialHalfEdge::start_position`

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -72,9 +72,9 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        builder::HalfEdgeBuilder,
+        builder::{CycleBuilder, HalfEdgeBuilder},
         geometry::curve::Curve,
-        partial::{PartialHalfEdge, PartialObject},
+        partial::PartialCycle,
         services::Services,
     };
 
@@ -87,14 +87,13 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [[1., -1.], [1., 1.]],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] = cycle
+                .update_as_polygon_from_points([[1., -1.], [1., 1.], [0., 1.]]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)
@@ -117,14 +116,17 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [[-1., -1.], [-1., 1.]],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] = cycle
+                .update_as_polygon_from_points([
+                    [-1., -1.],
+                    [-1., 1.],
+                    [0., 1.],
+                ]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)
@@ -147,14 +149,17 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [[-1., -1.], [1., -1.]],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] = cycle
+                .update_as_polygon_from_points([
+                    [-1., -1.],
+                    [1., -1.],
+                    [1., 1.],
+                ]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)
@@ -172,14 +177,13 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [[-1., 0.], [1., 0.]],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] = cycle
+                .update_as_polygon_from_points([[-1., 0.], [1., 0.], [1., 1.]]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -128,8 +128,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .into_iter()
         .circular_tuple_windows()
         {
-            edge.write()
-                .update_as_line_segment(next.read().start_vertex.clone());
+            edge.write().update_as_line_segment(next.clone());
         }
 
         // Finally, we can make sure that all edges refer to the correct global

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -140,9 +140,7 @@ impl CycleBuilder for PartialCycle {
         for (mut half_edge, next) in
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
-            half_edge
-                .write()
-                .update_as_line_segment(next.read().start_vertex.clone());
+            half_edge.write().update_as_line_segment(next.clone());
         }
     }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -30,13 +30,6 @@ pub trait HalfEdgeBuilder {
         next_half_edge: Partial<HalfEdge>,
     );
 
-    /// Update partial half-edge to be a line segment, from the given points
-    fn update_as_line_segment_from_points(
-        &mut self,
-        points: [impl Into<Point<2>>; 2],
-        next_vertex: Partial<SurfaceVertex>,
-    ) -> Curve;
-
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
@@ -141,21 +134,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         }
 
         self.infer_global_form(next_half_edge.read().start_vertex.clone());
-    }
-
-    fn update_as_line_segment_from_points(
-        &mut self,
-        points: [impl Into<Point<2>>; 2],
-        mut next_vertex: Partial<SurfaceVertex>,
-    ) -> Curve {
-        for (vertex, point) in
-            [&mut self.start_vertex, &mut next_vertex].zip_ext(points)
-        {
-            let mut surface_form = vertex.write();
-            surface_form.position = Some(point.into());
-        }
-
-        self.update_as_line_segment(next_vertex)
     }
 
     fn update_as_line_segment(

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,7 +33,7 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
-        next_vertex: Partial<SurfaceVertex>,
+        next_half_edge: Partial<HalfEdge>,
     ) -> Curve;
 
     /// Infer the global form of the half-edge
@@ -138,15 +138,17 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
-        next_vertex: Partial<SurfaceVertex>,
+        next_half_edge: Partial<HalfEdge>,
     ) -> Curve {
         let boundary = self.boundary;
-        let points_surface = [&self.start_vertex, &next_vertex].map(|vertex| {
-            vertex
-                .read()
-                .position
-                .expect("Can't infer line segment without surface position")
-        });
+        let points_surface =
+            [&self.start_vertex, &next_half_edge.read().start_vertex].map(
+                |vertex| {
+                    vertex.read().position.expect(
+                        "Can't infer line segment without surface position",
+                    )
+                },
+            );
 
         let path = if let [Some(start), Some(end)] = boundary {
             let points = [start, end].zip_ext(points_surface);
@@ -168,7 +170,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             path
         };
 
-        self.infer_global_form(next_vertex);
+        self.infer_global_form(next_half_edge.read().start_vertex.clone());
 
         path
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -141,14 +141,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         next_half_edge: Partial<HalfEdge>,
     ) -> Curve {
         let boundary = self.boundary;
-        let points_surface =
-            [&self.start_vertex, &next_half_edge.read().start_vertex].map(
-                |vertex| {
-                    vertex.read().position.expect(
-                        "Can't infer line segment without surface position",
-                    )
-                },
-            );
+        let points_surface = [
+            &self.start_position(),
+            &next_half_edge.read().start_position(),
+        ]
+        .map(|position| {
+            position.expect("Can't infer line segment without surface position")
+        });
 
         let path = if let [Some(start), Some(end)] = boundary {
             let points = [start, end].zip_ext(points_surface);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -110,15 +110,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
         }
-        let [start, end] =
-            [&self.start_vertex, &next_half_edge.read().start_vertex].map(
-                |vertex| {
-                    vertex
-                        .read()
-                        .position
-                        .expect("Can't infer arc without surface position")
-                },
-            );
+        let [start, end] = [
+            &self.start_position(),
+            &next_half_edge.read().start_position(),
+        ]
+        .map(|position| {
+            position.expect("Can't infer arc without surface position")
+        });
 
         let arc = fj_math::Arc::from_endpoints_and_angle(start, end, angle_rad);
 

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -177,8 +177,8 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::{
-        builder::HalfEdgeBuilder,
-        partial::{PartialHalfEdge, PartialObject},
+        builder::{CycleBuilder, HalfEdgeBuilder},
+        partial::PartialCycle,
         services::Services,
     };
 
@@ -190,29 +190,28 @@ mod tests {
 
         let a = [0., 0.];
         let b = [1., 0.];
+        let c = [0., 1.];
 
         let a_to_b = {
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [a, b],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] =
+                cycle.update_as_polygon_from_points([a, b, c]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)
         };
         let b_to_a = {
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [b, a],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] =
+                cycle.update_as_polygon_from_points([b, a, c]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -25,6 +25,13 @@ pub struct PartialHalfEdge {
     pub global_form: Partial<GlobalEdge>,
 }
 
+impl PartialHalfEdge {
+    /// Compute the surface position where the half-edge starts
+    pub fn start_position(&self) -> Option<Point<2>> {
+        self.start_vertex.read().position
+    }
+}
+
 impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -143,9 +143,9 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        builder::HalfEdgeBuilder,
+        builder::{CycleBuilder, HalfEdgeBuilder},
         objects::HalfEdge,
-        partial::{Partial, PartialHalfEdge, PartialObject},
+        partial::{Partial, PartialCycle},
         services::Services,
         validate::Validate,
     };
@@ -157,14 +157,13 @@ mod tests {
         let valid = {
             let surface = services.objects.surfaces.xy_plane();
 
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [[0., 0.], [1., 0.]],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] = cycle
+                .update_as_polygon_from_points([[0., 0.], [1., 0.], [1., 1.]]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)
@@ -208,14 +207,13 @@ mod tests {
         let valid = {
             let surface = services.objects.surfaces.xy_plane();
 
-            let mut half_edge = PartialHalfEdge::default();
-            half_edge.update_as_line_segment_from_points(
-                [[0., 0.], [1., 0.]],
-                half_edge.end_vertex.clone(),
-            );
-            half_edge.infer_vertex_positions_if_necessary(
+            let mut cycle = PartialCycle::default();
+
+            let [mut half_edge, next_half_edge, _] = cycle
+                .update_as_polygon_from_points([[0., 0.], [1., 0.], [1., 1.]]);
+            half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                next_half_edge.read().start_vertex.clone(),
             );
 
             half_edge.build(&mut services.objects)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -85,7 +85,7 @@ impl Shape for fj::Sketch {
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge
                                     .write()
-                                    .update_as_arc(angle.rad(), next_vertex);
+                                    .update_as_arc(angle.rad(), next_half_edge);
                             }
                         }
                     }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -73,14 +73,11 @@ impl Shape for fj::Sketch {
                     for ((mut half_edge, route), (next_half_edge, _)) in
                         half_edges.into_iter().circular_tuple_windows()
                     {
-                        let next_vertex =
-                            next_half_edge.read().start_vertex.clone();
-
                         match route {
                             fj::SketchSegmentRoute::Direct => {
                                 half_edge
                                     .write()
-                                    .update_as_line_segment(next_vertex);
+                                    .update_as_line_segment(next_half_edge);
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge


### PR DESCRIPTION
Add `PartialHalfEdge::start_position` and update some code to use this method instead of `PartialHalfEdge`'s `start_vertex` field. The goal is to eventually compute the position using the curve, so `PartialSurfaceVertex`'s `position` field can be removed. So far, this isn't possible, as lots of code relies on the surface position being set during object construction. I'm currently thinking about how to address this.

This is another step towards addressing #1634 