### PR TITLE
Remove `end_vertex` fields of `HalfEdge`/`PartialHalfEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -357,7 +357,7 @@ mod tests {
             half_edge.update_as_circle_from_radius(1.);
             half_edge.infer_vertex_positions_if_necessary(
                 &surface.geometry(),
-                half_edge.end_vertex.clone(),
+                half_edge.start_vertex.clone(),
             );
 
             half_edge

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -25,7 +25,6 @@ impl Reverse for Handle<Cycle> {
                     current.curve(),
                     boundary,
                     next.start_vertex().clone(),
-                    current.start_vertex().clone(),
                     current.global_form().clone(),
                 )
                 .insert(objects)

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -22,16 +22,12 @@ impl TransformObject for HalfEdge {
             .start_vertex()
             .clone()
             .transform_with_cache(transform, objects, cache);
-        let end_vertex = self
-            .end_vertex()
-            .clone()
-            .transform_with_cache(transform, objects, cache);
         let global_form = self
             .global_form()
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(curve, boundary, start_vertex, end_vertex, global_form)
+        Self::new(curve, boundary, start_vertex, global_form)
     }
 }
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -94,8 +94,6 @@ impl CycleBuilder for PartialCycle {
                 new_half_edge.read().start_vertex.clone();
 
             let mut last_half_edge = last_half_edge.write();
-
-            last_half_edge.end_vertex = shared_surface_vertex.clone();
             last_half_edge.infer_global_form(shared_surface_vertex);
         }
 
@@ -104,8 +102,6 @@ impl CycleBuilder for PartialCycle {
                 first_half_edge.read().start_vertex.clone();
 
             let mut new_half_edge = new_half_edge.write();
-
-            new_half_edge.end_vertex = shared_surface_vertex.clone();
             new_half_edge.infer_global_form(shared_surface_vertex);
         }
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -92,17 +92,17 @@ impl CycleBuilder for PartialCycle {
         {
             let shared_surface_vertex =
                 new_half_edge.read().start_vertex.clone();
-
-            let mut last_half_edge = last_half_edge.write();
-            last_half_edge.infer_global_form(shared_surface_vertex);
+            last_half_edge
+                .write()
+                .infer_global_form(shared_surface_vertex);
         }
 
         {
             let shared_surface_vertex =
                 first_half_edge.read().start_vertex.clone();
-
-            let mut new_half_edge = new_half_edge.write();
-            new_half_edge.infer_global_form(shared_surface_vertex);
+            new_half_edge
+                .write()
+                .infer_global_form(shared_surface_vertex);
         }
 
         self.half_edges.push(new_half_edge.clone());

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -152,9 +152,9 @@ impl CycleBuilder for PartialCycle {
     where
         O: ObjectArgument<Partial<HalfEdge>>,
     {
-        edges.map(|other| {
+        edges.map_with_prev(|other, prev| {
             let mut this = self.add_half_edge();
-            this.write().update_from_other_edge(&other, surface);
+            this.write().update_from_other_edge(&other, &prev, surface);
             this
         })
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -311,16 +311,10 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             }
         });
 
-        let other = other.read();
         let other_prev = other_prev.read();
 
-        for (this, other) in [&mut self.start_vertex, &mut self.end_vertex]
-            .iter_mut()
-            .zip([&other_prev.start_vertex, &other.start_vertex])
-        {
-            this.write().global_form.write().position =
-                other.read().global_form.read().position;
-        }
+        self.start_vertex.write().global_form.write().position =
+            other_prev.start_vertex.read().global_form.read().position;
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -82,7 +82,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         self.start_vertex.write().position =
             Some(path.point_from_path_coords(a_curve));
-        self.end_vertex = self.start_vertex.clone();
 
         for (point_boundary, point_curve) in
             self.boundary.each_mut_ext().zip_ext([a_curve, b_curve])

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -311,10 +311,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             }
         });
 
-        let other_prev = other_prev.read();
-
-        self.start_vertex.write().global_form.write().position =
-            other_prev.start_vertex.read().global_form.read().position;
+        self.start_vertex.write().global_form.write().position = other_prev
+            .read()
+            .start_vertex
+            .read()
+            .global_form
+            .read()
+            .position;
     }
 }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -64,6 +64,7 @@ pub trait HalfEdgeBuilder {
     fn update_from_other_edge(
         &mut self,
         other: &Partial<HalfEdge>,
+        other_prev: &Partial<HalfEdge>,
         surface: &SurfaceGeometry,
     );
 }
@@ -233,6 +234,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn update_from_other_edge(
         &mut self,
         other: &Partial<HalfEdge>,
+        other_prev: &Partial<HalfEdge>,
         surface: &SurfaceGeometry,
     ) {
         self.curve = other.read().curve.as_ref().and_then(|path| {
@@ -310,10 +312,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         });
 
         let other = other.read();
+        let other_prev = other_prev.read();
 
         for (this, other) in [&mut self.start_vertex, &mut self.end_vertex]
             .iter_mut()
-            .zip([&other.end_vertex, &other.start_vertex])
+            .zip([&other_prev.start_vertex, &other.start_vertex])
         {
             this.write().global_form.write().position =
                 other.read().global_form.read().position;

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -47,7 +47,6 @@ pub struct HalfEdge {
     curve: Curve,
     boundary: [Point<1>; 2],
     start_vertex: Handle<SurfaceVertex>,
-    end_vertex: Handle<SurfaceVertex>,
     global_form: Handle<GlobalEdge>,
 }
 
@@ -57,14 +56,12 @@ impl HalfEdge {
         curve: Curve,
         boundary: [Point<1>; 2],
         start_vertex: Handle<SurfaceVertex>,
-        end_vertex: Handle<SurfaceVertex>,
         global_form: Handle<GlobalEdge>,
     ) -> Self {
         Self {
             curve,
             boundary,
             start_vertex,
-            end_vertex,
             global_form,
         }
     }
@@ -92,11 +89,6 @@ impl HalfEdge {
     /// Access the vertex from where this half-edge starts
     pub fn start_vertex(&self) -> &Handle<SurfaceVertex> {
         &self.start_vertex
-    }
-
-    /// Access the vertex from where this half-edge ends
-    pub fn end_vertex(&self) -> &Handle<SurfaceVertex> {
-        &self.end_vertex
     }
 
     /// Access the global form of the half-edge

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -18,9 +18,6 @@ pub struct PartialHalfEdge {
     /// The surface vertex where the half-edge starts
     pub start_vertex: Partial<SurfaceVertex>,
 
-    /// The surface vertex where the half-edge ends
-    pub end_vertex: Partial<SurfaceVertex>,
-
     /// The global form of the half-edge
     pub global_form: Partial<GlobalEdge>,
 }
@@ -46,10 +43,6 @@ impl PartialObject for PartialHalfEdge {
                 half_edge.start_vertex().clone(),
                 cache,
             ),
-            end_vertex: Partial::from_full(
-                half_edge.end_vertex().clone(),
-                cache,
-            ),
             global_form: Partial::from_full(
                 half_edge.global_form().clone(),
                 cache,
@@ -70,10 +63,9 @@ impl PartialObject for PartialHalfEdge {
             point.expect("Can't build `HalfEdge` without boundary positions")
         });
         let start_vertex = self.start_vertex.build(objects);
-        let end_vertex = self.end_vertex.build(objects);
         let global_form = self.global_form.build(objects);
 
-        HalfEdge::new(curve, boundary, start_vertex, end_vertex, global_form)
+        HalfEdge::new(curve, boundary, start_vertex, global_form)
     }
 }
 
@@ -99,7 +91,6 @@ impl Default for PartialHalfEdge {
             curve,
             boundary: [None; 2],
             start_vertex,
-            end_vertex,
             global_form,
         }
     }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -175,7 +175,6 @@ mod tests {
                 valid.curve(),
                 valid.boundary(),
                 valid.start_vertex().clone(),
-                valid.end_vertex().clone(),
                 global_form,
             )
         };
@@ -216,7 +215,6 @@ mod tests {
                 valid.curve(),
                 boundary,
                 valid.start_vertex().clone(),
-                valid.end_vertex().clone(),
                 valid.global_form().clone(),
             )
         };

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -201,7 +201,7 @@ mod tests {
 
             let mut half_edge = face.exterior.write().add_half_edge();
             half_edge.write().update_as_circle_from_radius(1.);
-            let next_vertex = half_edge.read().end_vertex.clone();
+            let next_vertex = half_edge.read().start_vertex.clone();
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_vertex,

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -94,31 +94,29 @@ impl FaceValidationError {
     ) {
         for cycle in face.all_cycles() {
             for half_edge in cycle.half_edges() {
-                for surface_vertex in
-                    [half_edge.start_vertex(), half_edge.end_vertex()]
-                {
-                    let surface_position_as_global = face
-                        .surface()
-                        .geometry()
-                        .point_from_surface_coords(surface_vertex.position());
-                    let global_position =
-                        surface_vertex.global_form().position();
+                let surface_position_as_global =
+                    face.surface().geometry().point_from_surface_coords(
+                        half_edge.start_vertex().position(),
+                    );
+                let global_position =
+                    half_edge.start_vertex().global_form().position();
 
-                    let distance = surface_position_as_global
-                        .distance_to(&global_position);
+                let distance =
+                    surface_position_as_global.distance_to(&global_position);
 
-                    if distance > config.identical_max_distance {
-                        errors.push(
-                            Self::VertexPositionMismatch {
-                                surface_position: surface_vertex.position(),
-                                surface_position_as_global,
-                                global_position,
-                                distance,
-                                surface_vertex: surface_vertex.clone(),
-                            }
-                            .into(),
-                        );
-                    }
+                if distance > config.identical_max_distance {
+                    errors.push(
+                        Self::VertexPositionMismatch {
+                            surface_position: half_edge
+                                .start_vertex()
+                                .position(),
+                            surface_position_as_global,
+                            global_position,
+                            distance,
+                            surface_vertex: half_edge.start_vertex().clone(),
+                        }
+                        .into(),
+                    );
                 }
             }
         }

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -219,13 +219,11 @@ mod tests {
                     half_edge.start_vertex().global_form().clone(),
                 )
                 .insert(&mut services.objects);
-                let end_vertex = start_vertex.clone();
 
                 HalfEdge::new(
                     half_edge.curve(),
                     boundary,
                     start_vertex,
-                    end_vertex,
                     half_edge.global_form().clone(),
                 )
                 .insert(&mut services.objects)

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -127,7 +127,6 @@ impl FaceValidationError {
 
 #[cfg(test)]
 mod tests {
-    use fj_interop::ext::ArrayExt;
     use fj_math::{Scalar, Vector};
 
     use crate::{
@@ -217,23 +216,12 @@ mod tests {
                     .boundary()
                     .map(|point| point + Vector::from([Scalar::PI / 2.]));
 
-                let mut surface_vertices =
-                    [half_edge.start_vertex(), half_edge.end_vertex()]
-                        .map(Clone::clone);
-
-                let mut invalid = None;
-                for surface_vertex in surface_vertices.each_mut_ext() {
-                    let invalid = invalid.get_or_insert_with(|| {
-                        SurfaceVertex::new(
-                            [0., 1.],
-                            surface_vertex.global_form().clone(),
-                        )
-                        .insert(&mut services.objects)
-                    });
-                    *surface_vertex = invalid.clone();
-                }
-
-                let [start_vertex, end_vertex] = surface_vertices;
+                let start_vertex = SurfaceVertex::new(
+                    [0., 1.],
+                    half_edge.start_vertex().global_form().clone(),
+                )
+                .insert(&mut services.objects);
+                let end_vertex = start_vertex.clone();
 
                 HalfEdge::new(
                     half_edge.curve(),


### PR DESCRIPTION
Update all code that previously accessed either of those fields and remove them. This is another step towards addressing #1525.