### PR TITLE
Remove `position` fields of `SurfaceVertex`/`PartialSurfaceVertex`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -128,9 +128,10 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .into_iter()
         .circular_tuple_windows()
         {
+            let start = edge.read().start_position();
             let end = next.read().start_position();
 
-            edge.write().update_as_line_segment(end);
+            edge.write().update_as_line_segment(start, end);
             edge.write()
                 .infer_global_form(next.read().start_vertex.clone());
         }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -119,7 +119,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         // even if the original edge was a circle, it's still going to be a line
         // when projected into the new surface. For the side edges, because
         // we're sweeping along a straight path.
-        for (mut edge, next) in [
+        for (mut edge, next_half_edge) in [
             edge_bottom.clone(),
             edge_up.clone(),
             edge_top.clone(),
@@ -132,14 +132,14 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
                 .read()
                 .start_position()
                 .expect("Can't infer line segment without surface position");
-            let end = next
+            let end = next_half_edge
                 .read()
                 .start_position()
                 .expect("Can't infer line segment without surface position");
 
             edge.write().update_as_line_segment(start, end);
             edge.write()
-                .infer_global_form(next.read().start_vertex.clone());
+                .infer_global_form(next_half_edge.read().start_vertex.clone());
         }
 
         // Finally, we can make sure that all edges refer to the correct global

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -128,8 +128,14 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .into_iter()
         .circular_tuple_windows()
         {
-            let start = edge.read().start_position();
-            let end = next.read().start_position();
+            let start = edge
+                .read()
+                .start_position()
+                .expect("Can't infer line segment without surface position");
+            let end = next
+                .read()
+                .start_position()
+                .expect("Can't infer line segment without surface position");
 
             edge.write().update_as_line_segment(start, end);
             edge.write()

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -128,8 +128,9 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .into_iter()
         .circular_tuple_windows()
         {
-            edge.write()
-                .update_as_line_segment(next.read().start_position());
+            let end = next.read().start_position();
+
+            edge.write().update_as_line_segment(end);
             edge.write()
                 .infer_global_form(next.read().start_vertex.clone());
         }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -128,7 +128,8 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .into_iter()
         .circular_tuple_windows()
         {
-            edge.write().update_as_line_segment(next.clone());
+            edge.write()
+                .update_as_line_segment(next.read().start_position());
             edge.write()
                 .infer_global_form(next.read().start_vertex.clone());
         }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -119,7 +119,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         // even if the original edge was a circle, it's still going to be a line
         // when projected into the new surface. For the side edges, because
         // we're sweeping along a straight path.
-        for (mut edge, next_half_edge) in [
+        for (mut half_edge, next_half_edge) in [
             edge_bottom.clone(),
             edge_up.clone(),
             edge_top.clone(),
@@ -128,7 +128,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .into_iter()
         .circular_tuple_windows()
         {
-            let start = edge
+            let start = half_edge
                 .read()
                 .start_position()
                 .expect("Can't infer line segment without surface position");
@@ -137,8 +137,9 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
                 .start_position()
                 .expect("Can't infer line segment without surface position");
 
-            edge.write().update_as_line_segment(start, end);
-            edge.write()
+            half_edge.write().update_as_line_segment(start, end);
+            half_edge
+                .write()
                 .infer_global_form(next_half_edge.read().start_vertex.clone());
         }
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -129,6 +129,8 @@ impl Sweep for (Handle<HalfEdge>, &Handle<SurfaceVertex>, &Surface, Color) {
         .circular_tuple_windows()
         {
             edge.write().update_as_line_segment(next.clone());
+            edge.write()
+                .infer_global_form(next.read().start_vertex.clone());
         }
 
         // Finally, we can make sure that all edges refer to the correct global

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -94,23 +94,6 @@ impl Sweep for Handle<Face> {
                 .write()
                 .connect_to_closed_edges(top_edges, &top_surface.geometry());
 
-            for half_edge in &mut top_cycle.write().half_edges {
-                let mut half_edge = half_edge.write();
-
-                let mut start_vertex = half_edge.start_vertex.write();
-                let global_point = start_vertex.global_form.read().position;
-
-                if start_vertex.position.is_none() {
-                    if let Some(global_point) = global_point {
-                        start_vertex.position = Some(
-                            top_surface
-                                .geometry()
-                                .project_global_point(global_point),
-                        );
-                    }
-                }
-            }
-
             for (bottom, top) in original_edges
                 .into_iter()
                 .zip(top_cycle.write().half_edges.iter_mut())

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -14,16 +14,12 @@ impl TransformObject for SurfaceVertex {
         objects: &mut Service<Objects>,
         cache: &mut TransformCache,
     ) -> Self {
-        // Don't need to transform position, as that is defined in surface
-        // coordinates and thus transforming the surface takes care of it.
-        let position = self.position();
-
         let global_form = self
             .global_form()
             .clone()
             .transform_with_cache(transform, objects, cache);
 
-        Self::new(position, global_form)
+        Self::new(global_form)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -196,11 +196,11 @@ mod tests {
         // is not part of the polygon. The higher-level triangulation will
         // filter that out, but it will result in missing triangles.
 
-        let a = [0.1, 0.0];
-        let b = [0.2, 0.9];
-        let c = [0.2, 1.0];
-        let d = [0.1, 0.1];
-        let e = [0.0, 1.0];
+        let a = [1., 0.];
+        let b = [2., 8.];
+        let c = [2., 9.];
+        let d = [1., 1.];
+        let e = [0., 9.];
 
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace {

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -127,7 +127,9 @@ impl CycleBuilder for PartialCycle {
         for (mut half_edge, next) in
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
-            half_edge.write().update_as_line_segment(next.clone());
+            half_edge
+                .write()
+                .update_as_line_segment(next.read().start_position());
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -44,11 +44,6 @@ pub trait CycleBuilder {
         O: ObjectArgument<P>,
         P: Into<Point<2>>;
 
-    /// Update cycle as a polygon
-    ///
-    /// Will update each half-edge in the cycle to be a line segment.
-    fn update_as_polygon(&mut self);
-
     /// Connect the cycles to the provided half-edges
     ///
     /// Assumes that the provided half-edges, once translated into local
@@ -128,16 +123,14 @@ impl CycleBuilder for PartialCycle {
     {
         let half_edges =
             points.map(|point| self.add_half_edge_from_point_to_start(point));
-        self.update_as_polygon();
-        half_edges
-    }
 
-    fn update_as_polygon(&mut self) {
         for (mut half_edge, next) in
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
             half_edge.write().update_as_line_segment(next.clone());
         }
+
+        half_edges
     }
 
     fn connect_to_closed_edges<O>(

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -127,8 +127,10 @@ impl CycleBuilder for PartialCycle {
         for (mut half_edge, next) in
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
+            let start = half_edge.read().start_position();
             let end = next.read().start_position();
-            half_edge.write().update_as_line_segment(end);
+
+            half_edge.write().update_as_line_segment(start, end);
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -128,6 +128,9 @@ impl CycleBuilder for PartialCycle {
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
             half_edge.write().update_as_line_segment(next.clone());
+            half_edge
+                .write()
+                .infer_global_form(next.read().start_vertex.clone());
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -127,9 +127,8 @@ impl CycleBuilder for PartialCycle {
         for (mut half_edge, next) in
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
-            half_edge
-                .write()
-                .update_as_line_segment(next.read().start_position());
+            let end = next.read().start_position();
+            half_edge.write().update_as_line_segment(end);
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -22,19 +22,6 @@ pub trait CycleBuilder {
     /// meaning its front and back vertices are the same.
     fn add_half_edge(&mut self) -> Partial<HalfEdge>;
 
-    /// Add a new half-edge that starts at the provided point
-    ///
-    /// Opens the cycle between the last and first edge, updates the last edge
-    /// to go the provided point, and adds a new half-edge from the provided
-    /// point the the first edge.
-    ///
-    /// If the cycle doesn't have any edges yet, the new edge connects to
-    /// itself, starting and ending at the provided point.
-    fn add_half_edge_from_point_to_start(
-        &mut self,
-        point: impl Into<Point<2>>,
-    ) -> Partial<HalfEdge>;
-
     /// Update cycle as a polygon from the provided points
     fn update_as_polygon_from_points<O, P>(
         &mut self,
@@ -102,15 +89,6 @@ impl CycleBuilder for PartialCycle {
 
         self.half_edges.push(new_half_edge.clone());
         new_half_edge
-    }
-
-    fn add_half_edge_from_point_to_start(
-        &mut self,
-        point: impl Into<Point<2>>,
-    ) -> Partial<HalfEdge> {
-        let mut half_edge = self.add_half_edge();
-        half_edge.write().start_vertex.write().position = Some(point.into());
-        half_edge
     }
 
     fn update_as_polygon_from_points<O, P>(

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -121,16 +121,20 @@ impl CycleBuilder for PartialCycle {
         O: ObjectArgument<P>,
         P: Into<Point<2>>,
     {
-        let half_edges =
-            points.map(|point| self.add_half_edge_from_point_to_start(point));
+        let mut start_positions = Vec::new();
+        let half_edges = points.map(|point| {
+            start_positions.push(point.into());
+            self.add_half_edge()
+        });
 
-        for (mut half_edge, next_half_edge) in
-            self.half_edges.iter().cloned().circular_tuple_windows()
+        for ((start, end), half_edge) in start_positions
+            .into_iter()
+            .circular_tuple_windows()
+            .zip(&mut self.half_edges)
         {
-            let start = half_edge.read().start_position();
-            let end = next_half_edge.read().start_position();
-
-            half_edge.write().update_as_line_segment(start, end);
+            half_edge
+                .write()
+                .update_as_line_segment(Some(start), Some(end));
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -128,9 +128,6 @@ impl CycleBuilder for PartialCycle {
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
             half_edge.write().update_as_line_segment(next.clone());
-            half_edge
-                .write()
-                .infer_global_form(next.read().start_vertex.clone());
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -132,9 +132,7 @@ impl CycleBuilder for PartialCycle {
             .circular_tuple_windows()
             .zip(&mut self.half_edges)
         {
-            half_edge
-                .write()
-                .update_as_line_segment(Some(start), Some(end));
+            half_edge.write().update_as_line_segment(start, end);
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -124,11 +124,11 @@ impl CycleBuilder for PartialCycle {
         let half_edges =
             points.map(|point| self.add_half_edge_from_point_to_start(point));
 
-        for (mut half_edge, next) in
+        for (mut half_edge, next_half_edge) in
             self.half_edges.iter().cloned().circular_tuple_windows()
         {
             let start = half_edge.read().start_position();
-            let end = next.read().start_position();
+            let end = next_half_edge.read().start_position();
 
             half_edge.write().update_as_line_segment(start, end);
         }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -24,7 +24,7 @@ pub trait HalfEdgeBuilder {
     /// # Panics
     ///
     /// Panics if the given angle is not within the range (-2pi, 2pi) radians.
-    fn update_as_arc(&mut self, angle_rad: impl Into<Scalar>, end: Point<2>);
+    fn update_as_arc(&mut self, end: Point<2>, angle_rad: impl Into<Scalar>);
 
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
@@ -91,7 +91,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         path
     }
 
-    fn update_as_arc(&mut self, angle_rad: impl Into<Scalar>, end: Point<2>) {
+    fn update_as_arc(&mut self, end: Point<2>, angle_rad: impl Into<Scalar>) {
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,6 +33,7 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
+        start_position: Option<Point<2>>,
         end_position: Option<Point<2>>,
     ) -> Curve;
 
@@ -138,14 +139,15 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
+        start_position: Option<Point<2>>,
         end_position: Option<Point<2>>,
     ) -> Curve {
+        self.start_vertex.write().position = start_position;
+
         let boundary = self.boundary;
-        let points_surface =
-            [self.start_position(), end_position].map(|position| {
-                position
-                    .expect("Can't infer line segment without surface position")
-            });
+        let points_surface = [start_position, end_position].map(|position| {
+            position.expect("Can't infer line segment without surface position")
+        });
 
         let path = if let [Some(start), Some(end)] = boundary {
             let points = [start, end].zip_ext(points_surface);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -142,8 +142,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     ) -> Curve {
         let boundary = self.boundary;
         let points_surface = [
-            &self.start_position(),
-            &next_half_edge.read().start_position(),
+            self.start_position(),
+            next_half_edge.read().start_position(),
         ]
         .map(|position| {
             position.expect("Can't infer line segment without surface position")

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,8 +33,8 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
-        start_position: Point<2>,
-        end_position: Point<2>,
+        start: Point<2>,
+        end: Point<2>,
     ) -> Curve;
 
     /// Infer the global form of the half-edge
@@ -139,13 +139,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
-        start_position: Point<2>,
-        end_position: Point<2>,
+        start: Point<2>,
+        end: Point<2>,
     ) -> Curve {
-        self.start_vertex.write().position = Some(start_position);
+        self.start_vertex.write().position = Some(start);
 
         let boundary = self.boundary;
-        let points_surface = [start_position, end_position];
+        let points_surface = [start, end];
 
         let path = if let [Some(start), Some(end)] = boundary {
             let points = [start, end].zip_ext(points_surface);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -24,7 +24,12 @@ pub trait HalfEdgeBuilder {
     /// # Panics
     ///
     /// Panics if the given angle is not within the range (-2pi, 2pi) radians.
-    fn update_as_arc(&mut self, end: Point<2>, angle_rad: impl Into<Scalar>);
+    fn update_as_arc(
+        &mut self,
+        start: Point<2>,
+        end: Point<2>,
+        angle_rad: impl Into<Scalar>,
+    );
 
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
@@ -91,16 +96,18 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         path
     }
 
-    fn update_as_arc(&mut self, end: Point<2>, angle_rad: impl Into<Scalar>) {
+    fn update_as_arc(
+        &mut self,
+        start: Point<2>,
+        end: Point<2>,
+        angle_rad: impl Into<Scalar>,
+    ) {
+        self.start_vertex.write().position = Some(start);
+
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
         }
-        let [start, end] = [
-            self.start_position()
-                .expect("Can't infer arc without surface position"),
-            end,
-        ];
 
         let arc = fj_math::Arc::from_endpoints_and_angle(start, end, angle_rad);
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -169,8 +169,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             path
         };
 
-        self.infer_global_form(next_half_edge.read().start_vertex.clone());
-
         path
     }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -82,9 +82,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        self.start_vertex.write().position =
-            Some(path.point_from_path_coords(a_curve));
-
         for (point_boundary, point_curve) in
             self.boundary.each_mut_ext().zip_ext([a_curve, b_curve])
         {
@@ -102,8 +99,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         end: Point<2>,
         angle_rad: impl Into<Scalar>,
     ) {
-        self.start_vertex.write().position = Some(start);
-
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
@@ -116,8 +111,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let [a_curve, b_curve] =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
-        self.start_vertex.write().position =
-            Some(path.point_from_path_coords(a_curve));
 
         for (point_boundary, point_curve) in
             self.boundary.each_mut_ext().zip_ext([a_curve, b_curve])
@@ -131,8 +124,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         start: Point<2>,
         end: Point<2>,
     ) -> Curve {
-        self.start_vertex.write().position = Some(start);
-
         let boundary = self.boundary;
         let points_surface = [start, end];
 
@@ -187,21 +178,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         {
             let position_curve = boundary_point
                 .expect("Can't infer surface position without curve position");
-
-            let position_surface = surface_vertex.read().position;
-
-            // Infer surface position, if not available.
-            let position_surface = match position_surface {
-                Some(position_surface) => position_surface,
-                None => {
-                    let position_surface =
-                        path.point_from_path_coords(position_curve);
-
-                    surface_vertex.write().position = Some(position_surface);
-
-                    position_surface
-                }
-            };
+            let position_surface = path.point_from_path_coords(position_curve);
 
             // Infer global position, if not available.
             let position_global =

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,7 +33,7 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
-        next_half_edge: Partial<HalfEdge>,
+        end_position: Option<Point<2>>,
     ) -> Curve;
 
     /// Infer the global form of the half-edge
@@ -138,16 +138,14 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
-        next_half_edge: Partial<HalfEdge>,
+        end_position: Option<Point<2>>,
     ) -> Curve {
         let boundary = self.boundary;
-        let points_surface = [
-            self.start_position(),
-            next_half_edge.read().start_position(),
-        ]
-        .map(|position| {
-            position.expect("Can't infer line segment without surface position")
-        });
+        let points_surface =
+            [self.start_position(), end_position].map(|position| {
+                position
+                    .expect("Can't infer line segment without surface position")
+            });
 
         let path = if let [Some(start), Some(end)] = boundary {
             let points = [start, end].zip_ext(points_surface);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -133,8 +133,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             surface_vertex.write().position =
                 Some(path.point_from_path_coords(point_curve));
         }
-
-        self.infer_global_form(next_half_edge.read().start_vertex.clone());
     }
 
     fn update_as_line_segment(

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -24,11 +24,7 @@ pub trait HalfEdgeBuilder {
     /// # Panics
     ///
     /// Panics if the given angle is not within the range (-2pi, 2pi) radians.
-    fn update_as_arc(
-        &mut self,
-        angle_rad: impl Into<Scalar>,
-        next_half_edge: Partial<HalfEdge>,
-    );
+    fn update_as_arc(&mut self, angle_rad: impl Into<Scalar>, end: Point<2>);
 
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
@@ -95,11 +91,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         path
     }
 
-    fn update_as_arc(
-        &mut self,
-        angle_rad: impl Into<Scalar>,
-        next_half_edge: Partial<HalfEdge>,
-    ) {
+    fn update_as_arc(&mut self, angle_rad: impl Into<Scalar>, end: Point<2>) {
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
@@ -107,10 +99,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let [start, end] = [
             self.start_position()
                 .expect("Can't infer arc without surface position"),
-            next_half_edge
-                .read()
-                .start_position()
-                .expect("Can't infer arc without surface position"),
+            end,
         ];
 
         let arc = fj_math::Arc::from_endpoints_and_angle(start, end, angle_rad);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -105,12 +105,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
         }
         let [start, end] = [
-            self.start_position(),
-            next_half_edge.read().start_position(),
-        ]
-        .map(|position| {
-            position.expect("Can't infer arc without surface position")
-        });
+            self.start_position()
+                .expect("Can't infer arc without surface position"),
+            next_half_edge
+                .read()
+                .start_position()
+                .expect("Can't infer arc without surface position"),
+        ];
 
         let arc = fj_math::Arc::from_endpoints_and_angle(start, end, angle_rad);
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -105,8 +105,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
         }
         let [start, end] = [
-            &self.start_position(),
-            &next_half_edge.read().start_position(),
+            self.start_position(),
+            next_half_edge.read().start_position(),
         ]
         .map(|position| {
             position.expect("Can't infer arc without surface position")

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -98,7 +98,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn update_as_arc(
         &mut self,
         angle_rad: impl Into<Scalar>,
-        mut next_half_edge: Partial<HalfEdge>,
+        next_half_edge: Partial<HalfEdge>,
     ) {
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
@@ -119,19 +119,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let [a_curve, b_curve] =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
+        self.start_vertex.write().position =
+            Some(path.point_from_path_coords(a_curve));
 
-        for ((point_boundary, surface_vertex), point_curve) in self
-            .boundary
-            .each_mut_ext()
-            .zip_ext([
-                &mut self.start_vertex,
-                &mut next_half_edge.write().start_vertex,
-            ])
-            .zip_ext([a_curve, b_curve])
+        for (point_boundary, point_curve) in
+            self.boundary.each_mut_ext().zip_ext([a_curve, b_curve])
         {
             *point_boundary = Some(point_curve);
-            surface_vertex.write().position =
-                Some(path.point_from_path_coords(point_curve));
         }
     }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,8 +33,8 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
-        start_position: Option<Point<2>>,
-        end_position: Option<Point<2>>,
+        start_position: Point<2>,
+        end_position: Point<2>,
     ) -> Curve;
 
     /// Infer the global form of the half-edge
@@ -139,15 +139,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
-        start_position: Option<Point<2>>,
-        end_position: Option<Point<2>>,
+        start_position: Point<2>,
+        end_position: Point<2>,
     ) -> Curve {
-        self.start_vertex.write().position = start_position;
+        self.start_vertex.write().position = Some(start_position);
 
         let boundary = self.boundary;
-        let points_surface = [start_position, end_position].map(|position| {
-            position.expect("Can't infer line segment without surface position")
-        });
+        let points_surface = [start_position, end_position];
 
         let path = if let [Some(start), Some(end)] = boundary {
             let points = [start, end].zip_ext(points_surface);

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -5,26 +5,13 @@ use crate::storage::Handle;
 /// A vertex, defined in surface (2D) coordinates
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfaceVertex {
-    position: Point<2>,
     global_form: Handle<GlobalVertex>,
 }
 
 impl SurfaceVertex {
     /// Construct a new instance of `SurfaceVertex`
-    pub fn new(
-        position: impl Into<Point<2>>,
-        global_form: Handle<GlobalVertex>,
-    ) -> Self {
-        let position = position.into();
-        Self {
-            position,
-            global_form,
-        }
-    }
-
-    /// Access the position of the vertex on the surface
-    pub fn position(&self) -> Point<2> {
-        self.position
+    pub fn new(global_form: Handle<GlobalVertex>) -> Self {
+        Self { global_form }
     }
 
     /// Access the global form of the vertex

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -25,7 +25,20 @@ pub struct PartialHalfEdge {
 impl PartialHalfEdge {
     /// Compute the surface position where the half-edge starts
     pub fn start_position(&self) -> Option<Point<2>> {
-        self.start_vertex.read().position
+        // Computing the surface position from the curve position is fine.
+        // `HalfEdge` "owns" its start position. There is no competing code that
+        // could compute the surface position from slightly different data.
+
+        let [start, _] = self.boundary;
+        start.and_then(|start| {
+            let curve = self.curve?;
+
+            if let MaybeCurve::Defined(curve) = curve {
+                return Some(curve.point_from_path_coords(start));
+            }
+
+            None
+        })
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -9,9 +9,6 @@ use crate::{
 /// A partial [`SurfaceVertex`]
 #[derive(Clone, Debug, Default)]
 pub struct PartialSurfaceVertex {
-    /// The position of the vertex on the surface
-    pub position: Option<Point<2>>,
-
     /// The global form of the vertex
     pub global_form: Partial<GlobalVertex>,
 }
@@ -24,7 +21,6 @@ impl PartialObject for PartialSurfaceVertex {
         cache: &mut FullToPartialCache,
     ) -> Self {
         Self {
-            position: Some(surface_vertex.position()),
             global_form: Partial::from_full(
                 surface_vertex.global_form().clone(),
                 cache,
@@ -33,12 +29,8 @@ impl PartialObject for PartialSurfaceVertex {
     }
 
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
-        let position = self
-            .position
-            .expect("Can't build `SurfaceVertex` without position");
         let global_form = self.global_form.build(objects);
-
-        SurfaceVertex::new(position, global_form)
+        SurfaceVertex::new(global_form)
     }
 }
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -10,7 +10,3 @@ impl Validate for Cycle {
     ) {
     }
 }
-
-/// [`Cycle`] validation error
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum CycleValidationError {}

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -1,146 +1,16 @@
-use fj_interop::ext::ArrayExt;
-use fj_math::{Point, Scalar};
-use itertools::Itertools;
-
-use crate::{
-    objects::{Cycle, HalfEdge, SurfaceVertex},
-    storage::Handle,
-};
+use crate::objects::Cycle;
 
 use super::{Validate, ValidationConfig, ValidationError};
 
 impl Validate for Cycle {
     fn validate_with_config(
         &self,
-        config: &ValidationConfig,
-        errors: &mut Vec<ValidationError>,
+        _: &ValidationConfig,
+        _: &mut Vec<ValidationError>,
     ) {
-        CycleValidationError::check_half_edge_boundaries(self, config, errors);
     }
 }
 
 /// [`Cycle`] validation error
 #[derive(Clone, Debug, thiserror::Error)]
-pub enum CycleValidationError {
-    /// Mismatch between half-edge boundary and surface vertex position
-    #[error(
-        "Half-edge boundary on curve doesn't match surface vertex position\n\
-        - Position on curve: {position_on_curve:?}\n\
-        - Curve position converted to surface: {curve_position_on_surface:?}\n\
-        - Surface position from vertex: {surface_position_from_vertex:?}\n\
-        - Distance between the positions: {distance}\n\
-        - Surface vertex: {surface_vertex:#?}\n\
-        - Half-edge: {half_edge:#?}"
-    )]
-    HalfEdgeBoundaryMismatch {
-        /// The position on the curve
-        position_on_curve: Point<1>,
-
-        /// The curve position converted into a surface position
-        curve_position_on_surface: Point<2>,
-
-        /// The surface position from the vertex
-        surface_position_from_vertex: Point<2>,
-
-        /// The distance between the positions
-        distance: Scalar,
-
-        /// The surface vertex
-        surface_vertex: Handle<SurfaceVertex>,
-
-        /// The half-edge
-        half_edge: Handle<HalfEdge>,
-    },
-}
-
-impl CycleValidationError {
-    fn check_half_edge_boundaries(
-        cycle: &Cycle,
-        config: &ValidationConfig,
-        errors: &mut Vec<ValidationError>,
-    ) {
-        for (half_edge, next) in
-            cycle.half_edges().circular_tuple_windows::<(_, _)>()
-        {
-            let boundary_and_vertices = half_edge
-                .boundary()
-                .zip_ext([half_edge.start_vertex(), next.start_vertex()]);
-            for (position_on_curve, surface_vertex) in boundary_and_vertices {
-                let curve_position_on_surface =
-                    half_edge.curve().point_from_path_coords(position_on_curve);
-                let surface_position_from_vertex = surface_vertex.position();
-
-                let distance = curve_position_on_surface
-                    .distance_to(&surface_position_from_vertex);
-
-                if distance > config.identical_max_distance {
-                    errors.push(
-                        Self::HalfEdgeBoundaryMismatch {
-                            position_on_curve,
-                            curve_position_on_surface,
-                            surface_position_from_vertex,
-                            distance,
-                            surface_vertex: surface_vertex.clone(),
-                            half_edge: half_edge.clone(),
-                        }
-                        .into(),
-                    );
-                }
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use fj_math::Point;
-
-    use crate::{
-        builder::CycleBuilder,
-        objects::Cycle,
-        partial::{Partial, PartialCycle, PartialObject},
-        services::Services,
-        validate::{CycleValidationError, Validate, ValidationError},
-    };
-
-    #[test]
-    fn vertex_position_mismatch() -> anyhow::Result<()> {
-        let mut services = Services::new();
-
-        let valid = {
-            let surface = services.objects.surfaces.xy_plane();
-
-            let mut cycle = PartialCycle::default();
-            cycle.update_as_polygon_from_points([[0., 0.], [1., 0.], [0., 1.]]);
-            cycle.infer_vertex_positions_if_necessary(&surface.geometry());
-            cycle.build(&mut services.objects)
-        };
-        let invalid = {
-            let mut half_edges = valid
-                .half_edges()
-                .map(|half_edge| Partial::from(half_edge.clone()))
-                .collect::<Vec<_>>();
-
-            // Update a single boundary position so it becomes wrong.
-            if let Some(half_edge) = half_edges.first_mut() {
-                half_edge.write().boundary[0].replace(Point::from([-1.]));
-            }
-
-            let half_edges = half_edges
-                .into_iter()
-                .map(|half_edge| half_edge.build(&mut services.objects));
-
-            Cycle::new(half_edges)
-        };
-
-        valid.validate_and_return_first_error()?;
-        assert!(matches!(
-            invalid.validate_and_return_first_error(),
-            Err(ValidationError::Cycle(
-                CycleValidationError::HalfEdgeBoundaryMismatch { .. }
-            ))
-        ));
-
-        Ok(())
-    }
-}
+pub enum CycleValidationError {}

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -1,7 +1,9 @@
+use fj_interop::ext::ArrayExt;
 use fj_math::{Point, Scalar, Winding};
+use itertools::Itertools;
 
 use crate::{
-    objects::{Face, SurfaceVertex},
+    objects::{Face, HalfEdge},
     storage::Handle,
 };
 
@@ -39,22 +41,22 @@ pub enum FaceValidationError {
         face: Face,
     },
 
-    /// Mismatch between [`SurfaceVertex`] and `GlobalVertex` positions
+    /// Mismatch between edge boundary and `GlobalVertex` positions
     #[error(
-        "`SurfaceVertex` position doesn't match position of its global form\n\
-        - Surface position: {surface_position:?}\n\
-        - Surface position converted to global position: \
-            {surface_position_as_global:?}\n\
+        "`HalfEdge` boundary doesn't match position of `GlobalVertex`\n\
+        - Curve position: {curve_position:?}\n\
+        - Curve position converted to global position: \
+            {curve_position_as_global:?}\n\
         - Global position: {global_position:?}\n\
         - Distance between the positions: {distance}\n\
-        - `SurfaceVertex`: {surface_vertex:#?}"
+        - `HalfEdge`: {half_edge:#?}"
     )]
     VertexPositionMismatch {
         /// The position of the surface vertex
-        surface_position: Point<2>,
+        curve_position: Point<1>,
 
         /// The surface position converted into a global position
-        surface_position_as_global: Point<3>,
+        curve_position_as_global: Point<3>,
 
         /// The position of the global vertex
         global_position: Point<3>,
@@ -62,8 +64,8 @@ pub enum FaceValidationError {
         /// The distance between the positions
         distance: Scalar,
 
-        /// The surface vertex
-        surface_vertex: Handle<SurfaceVertex>,
+        /// The half-edge
+        half_edge: Handle<HalfEdge>,
     },
 }
 
@@ -93,30 +95,37 @@ impl FaceValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         for cycle in face.all_cycles() {
-            for half_edge in cycle.half_edges() {
-                let surface_position_as_global =
-                    face.surface().geometry().point_from_surface_coords(
-                        half_edge.start_vertex().position(),
-                    );
-                let global_position =
-                    half_edge.start_vertex().global_form().position();
+            for (half_edge, next_half_edge) in
+                cycle.half_edges().circular_tuple_windows()
+            {
+                for (curve_position, vertex) in half_edge.boundary().zip_ext([
+                    half_edge.start_vertex(),
+                    next_half_edge.start_vertex(),
+                ]) {
+                    let curve_position_as_surface = half_edge
+                        .curve()
+                        .point_from_path_coords(curve_position);
+                    let curve_position_as_global = face
+                        .surface()
+                        .geometry()
+                        .point_from_surface_coords(curve_position_as_surface);
+                    let global_position = vertex.global_form().position();
 
-                let distance =
-                    surface_position_as_global.distance_to(&global_position);
+                    let distance =
+                        curve_position_as_global.distance_to(&global_position);
 
-                if distance > config.identical_max_distance {
-                    errors.push(
-                        Self::VertexPositionMismatch {
-                            surface_position: half_edge
-                                .start_vertex()
-                                .position(),
-                            surface_position_as_global,
-                            global_position,
-                            distance,
-                            surface_vertex: half_edge.start_vertex().clone(),
-                        }
-                        .into(),
-                    );
+                    if distance > config.identical_max_distance {
+                        errors.push(
+                            Self::VertexPositionMismatch {
+                                curve_position,
+                                curve_position_as_global,
+                                global_position,
+                                distance,
+                                half_edge: half_edge.clone(),
+                            }
+                            .into(),
+                        );
+                    }
                 }
             }
         }

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[test]
-    fn surface_vertex_position_mismatch() -> anyhow::Result<()> {
+    fn vertex_position_mismatch() -> anyhow::Result<()> {
         let mut services = Services::new();
 
         let valid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -140,7 +140,7 @@ mod tests {
         algorithms::reverse::Reverse,
         builder::{CycleBuilder, FaceBuilder, HalfEdgeBuilder},
         insert::Insert,
-        objects::{Cycle, Face, HalfEdge, SurfaceVertex},
+        objects::{Cycle, Face, HalfEdge},
         partial::{Partial, PartialFace, PartialObject},
         services::Services,
         validate::{FaceValidationError, Validate, ValidationError},
@@ -223,15 +223,10 @@ mod tests {
                     .boundary()
                     .map(|point| point + Vector::from([Scalar::PI / 2.]));
 
-                let start_vertex = SurfaceVertex::new(
-                    half_edge.start_vertex().global_form().clone(),
-                )
-                .insert(&mut services.objects);
-
                 HalfEdge::new(
                     half_edge.curve(),
                     boundary,
-                    start_vertex,
+                    half_edge.start_vertex().clone(),
                     half_edge.global_form().clone(),
                 )
                 .insert(&mut services.objects)

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -224,7 +224,6 @@ mod tests {
                     .map(|point| point + Vector::from([Scalar::PI / 2.]));
 
                 let start_vertex = SurfaceVertex::new(
-                    [0., 1.],
                     half_edge.start_vertex().global_form().clone(),
                 )
                 .insert(&mut services.objects);

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -9,10 +9,7 @@ mod solid;
 mod surface;
 mod vertex;
 
-pub use self::{
-    cycle::CycleValidationError, edge::HalfEdgeValidationError,
-    face::FaceValidationError,
-};
+pub use self::{edge::HalfEdgeValidationError, face::FaceValidationError};
 
 use std::convert::Infallible;
 
@@ -83,10 +80,6 @@ impl Default for ValidationConfig {
 /// An error that can occur during a validation
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum ValidationError {
-    /// `Cycle` validation error
-    #[error("`Cycle` validation error:\n{0}")]
-    Cycle(#[from] CycleValidationError),
-
     /// `Face` validation error
     #[error("`Face` validation error:\n{0}")]
     Face(#[from] FaceValidationError),

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -75,9 +75,12 @@ impl Shape for fj::Sketch {
                     {
                         match route {
                             fj::SketchSegmentRoute::Direct => {
-                                let start = half_edge.read().start_position();
-                                let end =
-                                    next_half_edge.read().start_position();
+                                let start =
+                                    half_edge.read().start_position().unwrap();
+                                let end = next_half_edge
+                                    .read()
+                                    .start_position()
+                                    .unwrap();
 
                                 half_edge
                                     .write()

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -75,9 +75,12 @@ impl Shape for fj::Sketch {
                     {
                         match route {
                             fj::SketchSegmentRoute::Direct => {
-                                half_edge
-                                    .write()
-                                    .update_as_line_segment(next_half_edge);
+                                half_edge.write().update_as_line_segment(
+                                    next_half_edge.clone(),
+                                );
+                                half_edge.write().infer_global_form(
+                                    next_half_edge.read().start_vertex.clone(),
+                                );
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -78,9 +78,6 @@ impl Shape for fj::Sketch {
                                 half_edge.write().update_as_line_segment(
                                     next_half_edge.clone(),
                                 );
-                                half_edge.write().infer_global_form(
-                                    next_half_edge.read().start_vertex.clone(),
-                                );
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -76,7 +76,7 @@ impl Shape for fj::Sketch {
                         match route {
                             fj::SketchSegmentRoute::Direct => {
                                 half_edge.write().update_as_line_segment(
-                                    next_half_edge.clone(),
+                                    next_half_edge.read().start_position(),
                                 );
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -86,7 +86,7 @@ impl Shape for fj::Sketch {
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge
                                     .write()
-                                    .update_as_arc(angle.rad(), next_half_edge);
+                                    .update_as_arc(angle.rad(), end);
                             }
                         }
                     }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -84,9 +84,11 @@ impl Shape for fj::Sketch {
                                     .update_as_line_segment(start, end);
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
-                                half_edge
-                                    .write()
-                                    .update_as_arc(end, angle.rad());
+                                half_edge.write().update_as_arc(
+                                    start,
+                                    end,
+                                    angle.rad(),
+                                );
                             }
                         }
                     }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -75,9 +75,9 @@ impl Shape for fj::Sketch {
                     {
                         match route {
                             fj::SketchSegmentRoute::Direct => {
-                                half_edge.write().update_as_line_segment(
-                                    next_half_edge.read().start_position(),
-                                );
+                                let end =
+                                    next_half_edge.read().start_position();
+                                half_edge.write().update_as_line_segment(end);
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -75,9 +75,13 @@ impl Shape for fj::Sketch {
                     {
                         match route {
                             fj::SketchSegmentRoute::Direct => {
+                                let start = half_edge.read().start_position();
                                 let end =
                                     next_half_edge.read().start_position();
-                                half_edge.write().update_as_line_segment(end);
+
+                                half_edge
+                                    .write()
+                                    .update_as_line_segment(start, end);
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -73,15 +73,12 @@ impl Shape for fj::Sketch {
                     for ((mut half_edge, route), (next_half_edge, _)) in
                         half_edges.into_iter().circular_tuple_windows()
                     {
+                        let start = half_edge.read().start_position().unwrap();
+                        let end =
+                            next_half_edge.read().start_position().unwrap();
+
                         match route {
                             fj::SketchSegmentRoute::Direct => {
-                                let start =
-                                    half_edge.read().start_position().unwrap();
-                                let end = next_half_edge
-                                    .read()
-                                    .start_position()
-                                    .unwrap();
-
                                 half_edge
                                     .write()
                                     .update_as_line_segment(start, end);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -86,7 +86,7 @@ impl Shape for fj::Sketch {
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 half_edge
                                     .write()
-                                    .update_as_arc(angle.rad(), end);
+                                    .update_as_arc(end, angle.rad());
                             }
                         }
                     }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -64,19 +64,14 @@ impl Shape for fj::Sketch {
                         .into_iter()
                         .map(|fj::SketchSegment { endpoint, route }| {
                             let endpoint = Point::from(endpoint);
-                            let half_edge = cycle
-                                .add_half_edge_from_point_to_start(endpoint);
-                            (half_edge, route)
+                            let half_edge = cycle.add_half_edge();
+                            (half_edge, endpoint, route)
                         })
                         .collect::<Vec<_>>();
 
-                    for ((mut half_edge, route), (next_half_edge, _)) in
+                    for ((mut half_edge, start, route), (_, end, _)) in
                         half_edges.into_iter().circular_tuple_windows()
                     {
-                        let start = half_edge.read().start_position().unwrap();
-                        let end =
-                            next_half_edge.read().start_position().unwrap();
-
                         match route {
                             fj::SketchSegmentRoute::Direct => {
                                 half_edge


### PR DESCRIPTION
Build on the previous work done in #1635 to also compute the start position of `PartialHalfEdge`, making the `position` fields of `SurfaceVertex`/`PartialSurfaceVertex` completely redundant, allowing them to be removed here.

This is not only a big simplification in itself (230 lines removed, along with lots of opportunities to make mistakes), it also sets `SurfaceVertex`/`PartialSurfaceVertex` up for the ultimate simplification, i.e. complete removal.

Close #1634 