### PR TITLE
Rename `GlobalVertex` to `Vertex`

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use crate::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{Face, GlobalVertex, HalfEdge, Objects, Surface},
+    objects::{Face, HalfEdge, Objects, Surface, Vertex},
     partial::{Partial, PartialFace, PartialObject},
     services::Service,
     storage::Handle,
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for (Handle<HalfEdge>, &Handle<GlobalVertex>, &Surface, Color) {
+impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
     type Swept = (Handle<Face>, Handle<HalfEdge>);
 
     fn sweep_with_cache(

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use fj_math::Vector;
 
 use crate::{
-    objects::{GlobalVertex, Objects},
+    objects::{Objects, Vertex},
     services::Service,
     storage::{Handle, ObjectId},
 };
@@ -46,5 +46,5 @@ pub trait Sweep: Sized {
 #[derive(Default)]
 pub struct SweepCache {
     /// Cache for global vertices
-    pub global_vertex: BTreeMap<ObjectId, Handle<GlobalVertex>>,
+    pub global_vertex: BTreeMap<ObjectId, Handle<Vertex>>,
 }

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -2,14 +2,14 @@ use fj_math::Vector;
 
 use crate::{
     insert::Insert,
-    objects::{GlobalEdge, GlobalVertex, Objects},
+    objects::{GlobalEdge, Objects, Vertex},
     services::Service,
     storage::Handle,
 };
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for Handle<GlobalVertex> {
+impl Sweep for Handle<Vertex> {
     type Swept = (Handle<GlobalEdge>, [Self; 2]);
 
     fn sweep_with_cache(
@@ -23,7 +23,7 @@ impl Sweep for Handle<GlobalVertex> {
             .global_vertex
             .entry(self.id())
             .or_insert_with(|| {
-                GlobalVertex::new(self.position() + path.into()).insert(objects)
+                Vertex::new(self.position() + path.into()).insert(objects)
             })
             .clone();
 

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -1,13 +1,13 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{GlobalVertex, Objects},
+    objects::{Objects, Vertex},
     services::Service,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for GlobalVertex {
+impl TransformObject for Vertex {
     fn transform_with_cache(
         self,
         transform: &Transform,

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -6,7 +6,7 @@ use crate::{
         curve::{Curve, GlobalPath},
         surface::SurfaceGeometry,
     },
-    objects::{GlobalEdge, GlobalVertex, HalfEdge},
+    objects::{GlobalEdge, HalfEdge, Vertex},
     partial::{MaybeCurve, Partial, PartialGlobalEdge, PartialHalfEdge},
 };
 
@@ -44,14 +44,14 @@ pub trait HalfEdgeBuilder {
     /// it.
     fn infer_global_form(
         &mut self,
-        next_vertex: Partial<GlobalVertex>,
+        next_vertex: Partial<Vertex>,
     ) -> Partial<GlobalEdge>;
 
     /// Infer the vertex positions (surface and global), if not already set
     fn infer_vertex_positions_if_necessary(
         &mut self,
         surface: &SurfaceGeometry,
-        next_vertex: Partial<GlobalVertex>,
+        next_vertex: Partial<Vertex>,
     );
 
     /// Update this edge from another
@@ -153,7 +153,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn infer_global_form(
         &mut self,
-        next_vertex: Partial<GlobalVertex>,
+        next_vertex: Partial<Vertex>,
     ) -> Partial<GlobalEdge> {
         self.global_form.write().vertices =
             [&self.start_vertex, &next_vertex].map(|vertex| vertex.clone());
@@ -164,7 +164,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn infer_vertex_positions_if_necessary(
         &mut self,
         surface: &SurfaceGeometry,
-        next_vertex: Partial<GlobalVertex>,
+        next_vertex: Partial<Vertex>,
     ) {
         let path = self
             .curve

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -20,7 +20,7 @@ pub use self::{
     sketch::SketchBuilder,
     solid::SolidBuilder,
     surface::SurfaceBuilder,
-    vertex::GlobalVertexBuilder,
+    vertex::VertexBuilder,
 };
 
 /// Pass objects to a builder method

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,9 +1,9 @@
-use crate::partial::PartialGlobalVertex;
+use crate::partial::PartialVertex;
 
-/// Builder API for [`PartialGlobalVertex`]
+/// Builder API for [`PartialVertex`]
 pub trait GlobalVertexBuilder {
     // No methods are currently defined. This trait serves as a placeholder, to
     // make it clear where to add such methods, once necessary.
 }
 
-impl GlobalVertexBuilder for PartialGlobalVertex {}
+impl GlobalVertexBuilder for PartialVertex {}

--- a/crates/fj-kernel/src/builder/vertex.rs
+++ b/crates/fj-kernel/src/builder/vertex.rs
@@ -1,9 +1,9 @@
 use crate::partial::PartialVertex;
 
 /// Builder API for [`PartialVertex`]
-pub trait GlobalVertexBuilder {
+pub trait VertexBuilder {
     // No methods are currently defined. This trait serves as a placeholder, to
     // make it clear where to add such methods, once necessary.
 }
 
-impl GlobalVertexBuilder for PartialVertex {}
+impl VertexBuilder for PartialVertex {}

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -37,10 +37,10 @@ impl_insert!(
     Cycle, cycles;
     Face, faces;
     GlobalEdge, global_edges;
-    Vertex, vertices;
     HalfEdge, half_edges;
     Shell, shells;
     Sketch, sketches;
     Solid, solids;
     Surface, surfaces;
+    Vertex, vertices;
 );

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -37,7 +37,7 @@ impl_insert!(
     Cycle, cycles;
     Face, faces;
     GlobalEdge, global_edges;
-    Vertex, global_vertices;
+    Vertex, vertices;
     HalfEdge, half_edges;
     Shell, shells;
     Sketch, sketches;

--- a/crates/fj-kernel/src/insert.rs
+++ b/crates/fj-kernel/src/insert.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     objects::{
-        Cycle, Face, GlobalEdge, GlobalVertex, HalfEdge, Objects, Shell,
-        Sketch, Solid, Surface,
+        Cycle, Face, GlobalEdge, HalfEdge, Objects, Shell, Sketch, Solid,
+        Surface, Vertex,
     },
     services::{Service, ServiceObjectsExt},
     storage::Handle,
@@ -37,7 +37,7 @@ impl_insert!(
     Cycle, cycles;
     Face, faces;
     GlobalEdge, global_edges;
-    GlobalVertex, global_vertices;
+    Vertex, global_vertices;
     HalfEdge, half_edges;
     Shell, shells;
     Sketch, sketches;

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -1,6 +1,6 @@
 use fj_math::Point;
 
-use crate::{geometry::curve::Curve, objects::GlobalVertex, storage::Handle};
+use crate::{geometry::curve::Curve, objects::Vertex, storage::Handle};
 
 /// A directed edge, defined in a surface's 2D space
 ///
@@ -42,7 +42,7 @@ use crate::{geometry::curve::Curve, objects::GlobalVertex, storage::Handle};
 pub struct HalfEdge {
     curve: Curve,
     boundary: [Point<1>; 2],
-    start_vertex: Handle<GlobalVertex>,
+    start_vertex: Handle<Vertex>,
     global_form: Handle<GlobalEdge>,
 }
 
@@ -51,7 +51,7 @@ impl HalfEdge {
     pub fn new(
         curve: Curve,
         boundary: [Point<1>; 2],
-        start_vertex: Handle<GlobalVertex>,
+        start_vertex: Handle<Vertex>,
         global_form: Handle<GlobalEdge>,
     ) -> Self {
         Self {
@@ -83,7 +83,7 @@ impl HalfEdge {
     }
 
     /// Access the vertex from where this half-edge starts
-    pub fn start_vertex(&self) -> &Handle<GlobalVertex> {
+    pub fn start_vertex(&self) -> &Handle<Vertex> {
         &self.start_vertex
     }
 
@@ -113,7 +113,7 @@ impl GlobalEdge {
     /// The order of `vertices` is irrelevant. Two `GlobalEdge`s with the same
     /// `curve` and `vertices` will end up being equal, regardless of the order
     /// of `vertices` here.
-    pub fn new(vertices: [Handle<GlobalVertex>; 2]) -> Self {
+    pub fn new(vertices: [Handle<Vertex>; 2]) -> Self {
         let (vertices, _) = VerticesInNormalizedOrder::new(vertices);
 
         Self { vertices }
@@ -137,14 +137,14 @@ impl GlobalEdge {
 /// possible to construct two [`GlobalEdge`] instances that are meant to
 /// represent the same edge, but aren't equal.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct VerticesInNormalizedOrder([Handle<GlobalVertex>; 2]);
+pub struct VerticesInNormalizedOrder([Handle<Vertex>; 2]);
 
 impl VerticesInNormalizedOrder {
     /// Construct a new instance of `VerticesInNormalizedOrder`
     ///
     /// The provided vertices can be in any order. The returned `bool` value
     /// indicates whether the normalization changed the order of the vertices.
-    pub fn new([a, b]: [Handle<GlobalVertex>; 2]) -> (Self, bool) {
+    pub fn new([a, b]: [Handle<Vertex>; 2]) -> (Self, bool) {
         if a < b {
             (Self([a, b]), false)
         } else {
@@ -155,7 +155,7 @@ impl VerticesInNormalizedOrder {
     /// Access the vertices
     ///
     /// The vertices in the returned array will be in normalized order.
-    pub fn access_in_normalized_order(&self) -> [Handle<GlobalVertex>; 2] {
+    pub fn access_in_normalized_order(&self) -> [Handle<Vertex>; 2] {
         self.0.clone()
     }
 }

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -19,12 +19,12 @@ use fj_math::Point;
 ///
 /// [`ValidationConfig`]: crate::validate::ValidationConfig
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct GlobalVertex {
+pub struct Vertex {
     position: Point<3>,
 }
 
-impl GlobalVertex {
-    /// Construct a `GlobalVertex` from a position
+impl Vertex {
+    /// Construct a `Vertex` from a position
     pub fn new(position: impl Into<Point<3>>) -> Self {
         let position = position.into();
         Self { position }

--- a/crates/fj-kernel/src/objects/mod.rs
+++ b/crates/fj-kernel/src/objects/mod.rs
@@ -1,17 +1,17 @@
 //! Objects of a shape
 //!
 //! Objects, in Fornjot parlance, are the elements that make up shapes. An
-//! object can be simple and just contain data (like [`GlobalVertex`], for
-//! example), or they can be quite complex and refer to other objects (which is
-//! actually most of them).
+//! object can be simple and just contain data (like [`Vertex`], for example),
+//! or they can be quite complex and refer to other objects (which is actually
+//! most of them).
 //!
 //! # Object Identity vs Object Equality
 //!
 //! Two objects are *equal*, if they contain the same data. For example, two
-//! instances of [`GlobalVertex`] are equal, if they have the same position.
-//! This doesn't mean those objects are *identical*. They might have been
-//! created by different pieces of code. Or maybe by the same piece of code, but
-//! at different times, maybe even based on different inputs.
+//! instances of [`Vertex`] are equal, if they have the same position. This
+//! doesn't mean those objects are *identical*. They might have been created by
+//! different pieces of code. Or maybe by the same piece of code, but at
+//! different times, maybe even based on different inputs.
 //!
 //! This distinction is relevant, because non-identical objects that are
 //! *supposed* to be equal can end up being equal, if they are created based on
@@ -28,8 +28,8 @@
 //!
 //! If you compute the global coordinates from each of the line-local
 //! coordinates, you'll end up with the same result for sure. If we create two
-//! [`GlobalVertex`] instances from these global coordinates, any validation
-//! code that expects those two instances to be equal, will be happy.
+//! [`Vertex`] instances from these global coordinates, any validation code that
+//! expects those two instances to be equal, will be happy.
 //!
 //! But what if the situation is not so simple? Let's say the curves are circles
 //! instead of lines, and instead of being all neat, they are at some arbitrary
@@ -52,8 +52,8 @@
 //! identity, not equality. That way, this problem can never happen, because we
 //! never expect non-identical objects to be the same.
 //!
-//! For our example, this would mean we compute *one* [`GlobalVertex`] from
-//! *one* of the local coordinates.
+//! For our example, this would mean we compute *one* [`Vertex`] from *one* of
+//! the local coordinates.
 //!
 //! ## How Identity Works
 //!
@@ -86,7 +86,7 @@ pub use self::{
         sketch::Sketch,
         solid::Solid,
         surface::Surface,
-        vertex::GlobalVertex,
+        vertex::Vertex,
     },
     object::{Bare, BehindHandle, Form, Object, WithHandle},
     stores::{Objects, Surfaces},

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -2,8 +2,8 @@ use std::any::Any;
 
 use crate::{
     objects::{
-        Cycle, Face, GlobalEdge, GlobalVertex, HalfEdge, Objects, Shell,
-        Sketch, Solid, Surface,
+        Cycle, Face, GlobalEdge, HalfEdge, Objects, Shell, Sketch, Solid,
+        Surface, Vertex,
     },
     storage::{Handle, ObjectId},
     validate::{Validate, ValidationError},
@@ -111,7 +111,7 @@ object!(
     Cycle, "cycle", cycles;
     Face, "face", faces;
     GlobalEdge, "global edge", global_edges;
-    GlobalVertex, "global vertex", global_vertices;
+    Vertex, "global vertex", global_vertices;
     HalfEdge, "half-edge", half_edges;
     Shell, "shell", shells;
     Sketch, "sketch", sketches;

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -111,7 +111,7 @@ object!(
     Cycle, "cycle", cycles;
     Face, "face", faces;
     GlobalEdge, "global edge", global_edges;
-    Vertex, "global vertex", global_vertices;
+    Vertex, "global vertex", vertices;
     HalfEdge, "half-edge", half_edges;
     Shell, "shell", shells;
     Sketch, "sketch", sketches;

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -111,12 +111,12 @@ object!(
     Cycle, "cycle", cycles;
     Face, "face", faces;
     GlobalEdge, "global edge", global_edges;
-    Vertex, "global vertex", vertices;
     HalfEdge, "half-edge", half_edges;
     Shell, "shell", shells;
     Sketch, "sketch", sketches;
     Solid, "solid", solids;
     Surface, "surface", surfaces;
+    Vertex, "global vertex", vertices;
 );
 
 /// The form that an object can take

--- a/crates/fj-kernel/src/objects/object.rs
+++ b/crates/fj-kernel/src/objects/object.rs
@@ -116,7 +116,7 @@ object!(
     Sketch, "sketch", sketches;
     Solid, "solid", solids;
     Surface, "surface", surfaces;
-    Vertex, "global vertex", vertices;
+    Vertex, "vertex", vertices;
 );
 
 /// The form that an object can take

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -22,7 +22,7 @@ pub struct Objects {
     pub global_edges: Store<GlobalEdge>,
 
     /// Store for [`Vertex`] objects
-    pub global_vertices: Store<Vertex>,
+    pub vertices: Store<Vertex>,
 
     /// Store for [`HalfEdge`]s
     pub half_edges: Store<HalfEdge>,

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -21,9 +21,6 @@ pub struct Objects {
     /// Store for [`GlobalEdge`]s
     pub global_edges: Store<GlobalEdge>,
 
-    /// Store for [`Vertex`] objects
-    pub vertices: Store<Vertex>,
-
     /// Store for [`HalfEdge`]s
     pub half_edges: Store<HalfEdge>,
 
@@ -38,6 +35,9 @@ pub struct Objects {
 
     /// Store for [`Surface`]s
     pub surfaces: Surfaces,
+
+    /// Store for [`Vertex`] objects
+    pub vertices: Store<Vertex>,
 }
 
 impl Objects {

--- a/crates/fj-kernel/src/objects/stores.rs
+++ b/crates/fj-kernel/src/objects/stores.rs
@@ -6,8 +6,7 @@ use crate::{
 };
 
 use super::{
-    Cycle, Face, GlobalEdge, GlobalVertex, HalfEdge, Shell, Sketch, Solid,
-    Surface,
+    Cycle, Face, GlobalEdge, HalfEdge, Shell, Sketch, Solid, Surface, Vertex,
 };
 
 /// The available object stores
@@ -22,8 +21,8 @@ pub struct Objects {
     /// Store for [`GlobalEdge`]s
     pub global_edges: Store<GlobalEdge>,
 
-    /// Store for [`GlobalVertex`] objects
-    pub global_vertices: Store<GlobalVertex>,
+    /// Store for [`Vertex`] objects
+    pub global_vertices: Store<Vertex>,
 
     /// Store for [`HalfEdge`]s
     pub half_edges: Store<HalfEdge>,

--- a/crates/fj-kernel/src/partial/mod.rs
+++ b/crates/fj-kernel/src/partial/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
         sketch::PartialSketch,
         solid::PartialSolid,
         surface::PartialSurface,
-        vertex::PartialGlobalVertex,
+        vertex::PartialVertex,
     },
     traits::{HasPartial, PartialObject},
     wrapper::{FullToPartialCache, Partial},

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{GlobalEdge, GlobalVertex, HalfEdge, Objects},
+    objects::{GlobalEdge, HalfEdge, Objects, Vertex},
     partial::{FullToPartialCache, MaybeCurve, Partial, PartialObject},
     services::Service,
 };
@@ -16,7 +16,7 @@ pub struct PartialHalfEdge {
     pub boundary: [Option<Point<1>>; 2],
 
     /// The surface vertex where the half-edge starts
-    pub start_vertex: Partial<GlobalVertex>,
+    pub start_vertex: Partial<Vertex>,
 
     /// The global form of the half-edge
     pub global_form: Partial<GlobalEdge>,
@@ -105,7 +105,7 @@ impl Default for PartialHalfEdge {
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {
     /// The vertices that bound the edge on the curve
-    pub vertices: [Partial<GlobalVertex>; 2],
+    pub vertices: [Partial<Vertex>; 2],
 }
 
 impl PartialObject for PartialGlobalEdge {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -8,12 +8,12 @@ use crate::{
 
 /// A partial [`Vertex`]
 #[derive(Clone, Debug, Default)]
-pub struct PartialGlobalVertex {
+pub struct PartialVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,
 }
 
-impl PartialObject for PartialGlobalVertex {
+impl PartialObject for PartialVertex {
     type Full = Vertex;
 
     fn from_full(

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -28,7 +28,7 @@ impl PartialObject for PartialGlobalVertex {
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
         let position = self
             .position
-            .expect("Can't build `GlobalVertex` without position");
+            .expect("Can't build `Vertex` without position");
 
         Vertex::new(position)
     }

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -1,12 +1,12 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{GlobalVertex, Objects},
+    objects::{Objects, Vertex},
     partial::{FullToPartialCache, PartialObject},
     services::Service,
 };
 
-/// A partial [`GlobalVertex`]
+/// A partial [`Vertex`]
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalVertex {
     /// The position of the vertex
@@ -14,7 +14,7 @@ pub struct PartialGlobalVertex {
 }
 
 impl PartialObject for PartialGlobalVertex {
-    type Full = GlobalVertex;
+    type Full = Vertex;
 
     fn from_full(
         global_vertex: &Self::Full,
@@ -30,6 +30,6 @@ impl PartialObject for PartialGlobalVertex {
             .position
             .expect("Can't build `GlobalVertex` without position");
 
-        GlobalVertex::new(position)
+        Vertex::new(position)
     }
 }

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -36,7 +36,7 @@ impl_trait!(
     Cycle, PartialCycle;
     Face, PartialFace;
     GlobalEdge, PartialGlobalEdge;
-    Vertex, PartialGlobalVertex;
+    Vertex, PartialVertex;
     HalfEdge, PartialHalfEdge;
     Shell, PartialShell;
     Sketch, PartialSketch;

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -36,7 +36,7 @@ impl_trait!(
     Cycle, PartialCycle;
     Face, PartialFace;
     GlobalEdge, PartialGlobalEdge;
-    GlobalVertex, PartialGlobalVertex;
+    Vertex, PartialGlobalVertex;
     HalfEdge, PartialHalfEdge;
     Shell, PartialShell;
     Sketch, PartialSketch;

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -36,10 +36,10 @@ impl_trait!(
     Cycle, PartialCycle;
     Face, PartialFace;
     GlobalEdge, PartialGlobalEdge;
-    Vertex, PartialVertex;
     HalfEdge, PartialHalfEdge;
     Shell, PartialShell;
     Sketch, PartialSketch;
     Solid, PartialSolid;
     Surface, PartialSurface;
+    Vertex, PartialVertex;
 );

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -33,13 +33,13 @@ pub enum HalfEdgeValidationError {
     /// [`HalfEdge`]'s [`Vertex`] objects do not match
     #[error(
         "`HalfEdge` vertices don't match vertices of `HalfEdge`'s global form\n\
-        - Start vertex: {global_vertex_from_half_edge:#?}\n\
+        - Start vertex: {vertex_from_half_edge:#?}\n\
         - Vertices from `GlobalEdge`: {global_vertices_from_global_form:#?}\n\
         - `HalfEdge`: {half_edge:#?}"
     )]
     VertexMismatch {
         /// The [`Vertex`] from the [`HalfEdge`]'s start vertex
-        global_vertex_from_half_edge: Handle<Vertex>,
+        vertex_from_half_edge: Handle<Vertex>,
 
         /// The [`Vertex`] instances from the [`HalfEdge`]'s global form
         global_vertices_from_global_form: [Handle<Vertex>; 2],
@@ -75,7 +75,7 @@ impl HalfEdgeValidationError {
         half_edge: &HalfEdge,
         errors: &mut Vec<ValidationError>,
     ) {
-        let global_vertex_from_half_edge = half_edge.start_vertex().clone();
+        let vertex_from_half_edge = half_edge.start_vertex().clone();
         let global_vertices_from_global_form = half_edge
             .global_form()
             .vertices()
@@ -84,13 +84,13 @@ impl HalfEdgeValidationError {
         let matching_global_vertex = global_vertices_from_global_form
             .iter()
             .find(|global_vertex| {
-                global_vertex.id() == global_vertex_from_half_edge.id()
+                global_vertex.id() == vertex_from_half_edge.id()
             });
 
         if matching_global_vertex.is_none() {
             errors.push(
                 Self::VertexMismatch {
-                    global_vertex_from_half_edge,
+                    vertex_from_half_edge,
                     global_vertices_from_global_form,
                     half_edge: half_edge.clone(),
                 }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -81,12 +81,12 @@ impl HalfEdgeValidationError {
             .vertices()
             .access_in_normalized_order();
 
-        let matching_global_vertex =
+        let matching_vertex =
             vertices_from_global_form.iter().find(|global_vertex| {
                 global_vertex.id() == vertex_from_half_edge.id()
             });
 
-        if matching_global_vertex.is_none() {
+        if matching_vertex.is_none() {
             errors.push(
                 Self::VertexMismatch {
                     vertex_from_half_edge,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -34,7 +34,7 @@ pub enum HalfEdgeValidationError {
     #[error(
         "`HalfEdge` vertices don't match vertices of `HalfEdge`'s global form\n\
         - Start vertex: {vertex_from_half_edge:#?}\n\
-        - Vertices from `GlobalEdge`: {global_vertices_from_global_form:#?}\n\
+        - Vertices from `GlobalEdge`: {vertices_from_global_form:#?}\n\
         - `HalfEdge`: {half_edge:#?}"
     )]
     VertexMismatch {
@@ -42,7 +42,7 @@ pub enum HalfEdgeValidationError {
         vertex_from_half_edge: Handle<Vertex>,
 
         /// The [`Vertex`] instances from the [`HalfEdge`]'s global form
-        global_vertices_from_global_form: [Handle<Vertex>; 2],
+        vertices_from_global_form: [Handle<Vertex>; 2],
 
         /// The half-edge
         half_edge: HalfEdge,
@@ -76,14 +76,13 @@ impl HalfEdgeValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         let vertex_from_half_edge = half_edge.start_vertex().clone();
-        let global_vertices_from_global_form = half_edge
+        let vertices_from_global_form = half_edge
             .global_form()
             .vertices()
             .access_in_normalized_order();
 
-        let matching_global_vertex = global_vertices_from_global_form
-            .iter()
-            .find(|global_vertex| {
+        let matching_global_vertex =
+            vertices_from_global_form.iter().find(|global_vertex| {
                 global_vertex.id() == vertex_from_half_edge.id()
             });
 
@@ -91,7 +90,7 @@ impl HalfEdgeValidationError {
             errors.push(
                 Self::VertexMismatch {
                     vertex_from_half_edge,
-                    global_vertices_from_global_form,
+                    vertices_from_global_form,
                     half_edge: half_edge.clone(),
                 }
                 .into(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -1,7 +1,7 @@
 use fj_math::{Point, Scalar};
 
 use crate::{
-    objects::{GlobalEdge, GlobalVertex, HalfEdge},
+    objects::{GlobalEdge, HalfEdge, Vertex},
     storage::Handle,
 };
 
@@ -30,7 +30,7 @@ impl Validate for GlobalEdge {
 /// [`HalfEdge`] validation failed
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum HalfEdgeValidationError {
-    /// [`HalfEdge`]'s [`GlobalVertex`] objects do not match
+    /// [`HalfEdge`]'s [`Vertex`] objects do not match
     #[error(
         "Global forms of `HalfEdge` vertices do not match vertices of \n\
         `HalfEdge`'s global form\n\
@@ -40,11 +40,11 @@ pub enum HalfEdgeValidationError {
         - `HalfEdge`: {half_edge:#?}"
     )]
     GlobalVertexMismatch {
-        /// The [`GlobalVertex`] from the [`HalfEdge`]'s start vertex
-        global_vertex_from_half_edge: Handle<GlobalVertex>,
+        /// The [`Vertex`] from the [`HalfEdge`]'s start vertex
+        global_vertex_from_half_edge: Handle<Vertex>,
 
-        /// The [`GlobalVertex`] instances from the [`HalfEdge`]'s global form
-        global_vertices_from_global_form: [Handle<GlobalVertex>; 2],
+        /// The [`Vertex`] instances from the [`HalfEdge`]'s global form
+        global_vertices_from_global_form: [Handle<Vertex>; 2],
 
         /// The half-edge
         half_edge: HalfEdge,

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -32,11 +32,9 @@ impl Validate for GlobalEdge {
 pub enum HalfEdgeValidationError {
     /// [`HalfEdge`]'s [`Vertex`] objects do not match
     #[error(
-        "Global forms of `HalfEdge` vertices do not match vertices of \n\
-        `HalfEdge`'s global form\n\
-        - `GlobalVertex` from start vertex: {global_vertex_from_half_edge:#?}\n\
-        - `GlobalVertex` objects from `GlobalEdge`: \
-            {global_vertices_from_global_form:#?}\n\
+        "`HalfEdge` vertices don't match vertices of `HalfEdge`'s global form\n\
+        - Start vertex: {global_vertex_from_half_edge:#?}\n\
+        - Vertices from `GlobalEdge`: {global_vertices_from_global_form:#?}\n\
         - `HalfEdge`: {half_edge:#?}"
     )]
     GlobalVertexMismatch {

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -37,7 +37,7 @@ pub enum HalfEdgeValidationError {
         - Vertices from `GlobalEdge`: {global_vertices_from_global_form:#?}\n\
         - `HalfEdge`: {half_edge:#?}"
     )]
-    GlobalVertexMismatch {
+    VertexMismatch {
         /// The [`Vertex`] from the [`HalfEdge`]'s start vertex
         global_vertex_from_half_edge: Handle<Vertex>,
 
@@ -89,7 +89,7 @@ impl HalfEdgeValidationError {
 
         if matching_global_vertex.is_none() {
             errors.push(
-                Self::GlobalVertexMismatch {
+                Self::VertexMismatch {
                     global_vertex_from_half_edge,
                     global_vertices_from_global_form,
                     half_edge: half_edge.clone(),
@@ -180,7 +180,7 @@ mod tests {
         assert!(matches!(
             invalid.validate_and_return_first_error(),
             Err(ValidationError::HalfEdge(
-                HalfEdgeValidationError::GlobalVertexMismatch { .. }
+                HalfEdgeValidationError::VertexMismatch { .. }
             ))
         ));
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -134,7 +134,7 @@ mod tests {
     };
 
     #[test]
-    fn half_edge_global_vertex_mismatch() -> anyhow::Result<()> {
+    fn vertex_mismatch() -> anyhow::Result<()> {
         let mut services = Services::new();
 
         let valid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -43,7 +43,7 @@ pub enum FaceValidationError {
 
     /// Mismatch between edge boundary and `Vertex` positions
     #[error(
-        "`HalfEdge` boundary doesn't match position of `GlobalVertex`\n\
+        "`HalfEdge` boundary doesn't match position of `Vertex`\n\
         - Curve position: {curve_position:?}\n\
         - Curve position converted to global position: \
             {curve_position_as_global:?}\n\

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -41,7 +41,7 @@ pub enum FaceValidationError {
         face: Face,
     },
 
-    /// Mismatch between edge boundary and `GlobalVertex` positions
+    /// Mismatch between edge boundary and `Vertex` positions
     #[error(
         "`HalfEdge` boundary doesn't match position of `GlobalVertex`\n\
         - Curve position: {curve_position:?}\n\

--- a/crates/fj-kernel/src/validate/vertex.rs
+++ b/crates/fj-kernel/src/validate/vertex.rs
@@ -1,8 +1,8 @@
-use crate::objects::GlobalVertex;
+use crate::objects::Vertex;
 
 use super::{Validate, ValidationConfig, ValidationError};
 
-impl Validate for GlobalVertex {
+impl Validate for Vertex {
     fn validate_with_config(
         &self,
         _: &ValidationConfig,


### PR DESCRIPTION
With the recent cleanups, which features the removal of `Vertex` and `SurfaceVertex`, the shorter name has become available for the last remaining vertex struct to take.

Close #1525 