### PR TITLE
Unify `GlobalEdge` and `PartialGlobalEdge`

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -246,7 +246,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(
@@ -281,7 +281,7 @@ mod tests {
         .build(&mut services.objects)
         .insert(&mut services.objects);
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(
@@ -316,7 +316,7 @@ mod tests {
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(
@@ -361,7 +361,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::new();
+            let mut half_edge = PartialHalfEdge::new(&mut services.objects);
 
             half_edge.update_as_circle_from_radius(1.);
             let next_vertex = half_edge.start_vertex.clone();

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -352,7 +352,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::default();
+            let mut half_edge = PartialHalfEdge::new();
 
             half_edge.update_as_circle_from_radius(1.);
             let next_vertex = half_edge.start_vertex.clone();

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -246,7 +246,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([[1., 1.], [2., 1.], [1., 2.]]);
@@ -278,7 +278,7 @@ mod tests {
         .build(&mut services.objects)
         .insert(&mut services.objects);
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([[1., 1.], [2., 1.], [1., 2.]]);
@@ -310,7 +310,7 @@ mod tests {
             .build(&mut services.objects)
             .insert(&mut services.objects);
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([[0., 1.], [1., 1.], [1., 2.]]);

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -249,7 +249,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([[1., 1.], [2., 1.], [1., 2.]]);
+                .update_as_polygon_from_points(
+                    [[1., 1.], [2., 1.], [1., 2.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),
@@ -281,7 +284,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([[1., 1.], [2., 1.], [1., 2.]]);
+                .update_as_polygon_from_points(
+                    [[1., 1.], [2., 1.], [1., 2.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),
@@ -313,7 +319,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([[0., 1.], [1., 1.], [1., 2.]]);
+                .update_as_polygon_from_points(
+                    [[0., 1.], [1., 1.], [1., 2.]],
+                    &mut services.objects,
+                );
 
             half_edge.write().boundary[0] = Some(range.boundary[0]);
             half_edge.write().boundary[1] = Some(range.boundary[1]);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -90,7 +90,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([[1., -1.], [1., 1.], [0., 1.]]);
+                .update_as_polygon_from_points(
+                    [[1., -1.], [1., 1.], [0., 1.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),
@@ -119,11 +122,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([
-                    [-1., -1.],
-                    [-1., 1.],
-                    [0., 1.],
-                ]);
+                .update_as_polygon_from_points(
+                    [[-1., -1.], [-1., 1.], [0., 1.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),
@@ -152,11 +154,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([
-                    [-1., -1.],
-                    [1., -1.],
-                    [1., 1.],
-                ]);
+                .update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),
@@ -180,7 +181,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([[-1., 0.], [1., 0.], [1., 1.]]);
+                .update_as_polygon_from_points(
+                    [[-1., 0.], [1., 0.], [1., 1.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -74,7 +74,7 @@ mod tests {
     use crate::{
         builder::{CycleBuilder, HalfEdgeBuilder},
         geometry::curve::Curve,
-        partial::PartialCycle,
+        partial::{PartialCycle, PartialObject},
         services::Services,
     };
 
@@ -87,7 +87,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([[1., -1.], [1., 1.], [0., 1.]]);
@@ -116,7 +116,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([
@@ -149,7 +149,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([
@@ -177,7 +177,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([[-1., 0.], [1., 0.], [1., 1.]]);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -87,7 +87,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(
@@ -119,7 +119,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(
@@ -151,7 +151,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(
@@ -178,7 +178,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -185,10 +185,10 @@ mod tests {
             face.surface = Partial::from(services.objects.surfaces.xy_plane());
             face.exterior
                 .write()
-                .update_as_polygon_from_points(exterior);
+                .update_as_polygon_from_points(exterior, &mut services.objects);
             face.add_interior(&mut services.objects)
                 .write()
-                .update_as_polygon_from_points(interior);
+                .update_as_polygon_from_points(interior, &mut services.objects);
 
             face.build(&mut services.objects)
         };

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -182,7 +182,7 @@ mod tests {
         let face = {
             let mut face = PartialFace {
                 surface: Partial::from(services.objects.surfaces.xy_plane()),
-                ..Default::default()
+                ..PartialFace::new()
             };
             face.exterior
                 .write()

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -180,7 +180,7 @@ mod tests {
         ];
 
         let face = {
-            let mut face = PartialFace::new();
+            let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Partial::from(services.objects.surfaces.xy_plane());
             face.exterior

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -186,7 +186,7 @@ mod tests {
             face.exterior
                 .write()
                 .update_as_polygon_from_points(exterior);
-            face.add_interior()
+            face.add_interior(&mut services.objects)
                 .write()
                 .update_as_polygon_from_points(interior);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -180,10 +180,9 @@ mod tests {
         ];
 
         let face = {
-            let mut face = PartialFace {
-                surface: Partial::from(services.objects.surfaces.xy_plane()),
-                ..PartialFace::new()
-            };
+            let mut face = PartialFace::new();
+
+            face.surface = Partial::from(services.objects.surfaces.xy_plane());
             face.exterior
                 .write()
                 .update_as_polygon_from_points(exterior);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -89,7 +89,9 @@ mod tests {
             let mut face = PartialFace::new();
 
             face.surface = Partial::from(surface);
-            face.exterior.write().update_as_polygon_from_points(points);
+            face.exterior
+                .write()
+                .update_as_polygon_from_points(points, &mut services.objects);
 
             face.build(&mut services.objects)
         });
@@ -118,7 +120,9 @@ mod tests {
             let mut face = PartialFace::new();
 
             face.surface = Partial::from(surface);
-            face.exterior.write().update_as_polygon_from_points(points);
+            face.exterior
+                .write()
+                .update_as_polygon_from_points(points, &mut services.objects);
 
             face.build(&mut services.objects)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -88,7 +88,7 @@ mod tests {
         .map(|surface| {
             let mut face = PartialFace {
                 surface: Partial::from(surface),
-                ..Default::default()
+                ..PartialFace::new()
             };
             face.exterior.write().update_as_polygon_from_points(points);
 
@@ -118,7 +118,7 @@ mod tests {
         let [a, b] = surfaces.clone().map(|surface| {
             let mut face = PartialFace {
                 surface: Partial::from(surface),
-                ..Default::default()
+                ..PartialFace::new()
             };
             face.exterior.write().update_as_polygon_from_points(points);
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -86,7 +86,7 @@ mod tests {
             services.objects.surfaces.xz_plane(),
         ]
         .map(|surface| {
-            let mut face = PartialFace::new();
+            let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Partial::from(surface);
             face.exterior
@@ -117,7 +117,7 @@ mod tests {
             services.objects.surfaces.xz_plane(),
         ];
         let [a, b] = surfaces.clone().map(|surface| {
-            let mut face = PartialFace::new();
+            let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Partial::from(surface);
             face.exterior

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -86,10 +86,9 @@ mod tests {
             services.objects.surfaces.xz_plane(),
         ]
         .map(|surface| {
-            let mut face = PartialFace {
-                surface: Partial::from(surface),
-                ..PartialFace::new()
-            };
+            let mut face = PartialFace::new();
+
+            face.surface = Partial::from(surface);
             face.exterior.write().update_as_polygon_from_points(points);
 
             face.build(&mut services.objects)
@@ -116,10 +115,9 @@ mod tests {
             services.objects.surfaces.xz_plane(),
         ];
         let [a, b] = surfaces.clone().map(|surface| {
-            let mut face = PartialFace {
-                surface: Partial::from(surface),
-                ..PartialFace::new()
-            };
+            let mut face = PartialFace::new();
+
+            face.surface = Partial::from(surface);
             face.exterior.write().update_as_polygon_from_points(points);
 
             face.build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -148,10 +148,9 @@ mod tests {
     fn point_is_outside_face() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [1., 1.],
@@ -170,10 +169,9 @@ mod tests {
     fn ray_hits_vertex_while_passing_outside() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [2., 1.],
@@ -195,10 +193,9 @@ mod tests {
     fn ray_hits_vertex_at_cycle_seam() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [4., 2.],
             [0., 4.],
@@ -220,10 +217,9 @@ mod tests {
     fn ray_hits_vertex_while_staying_inside() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [2., 1.],
@@ -246,10 +242,9 @@ mod tests {
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [2., 1.],
@@ -272,10 +267,9 @@ mod tests {
     fn ray_hits_parallel_edge_and_does_not_leave_face_there() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [2., 1.],
@@ -299,10 +293,9 @@ mod tests {
     fn point_is_coincident_with_edge() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [2., 0.],
@@ -330,10 +323,9 @@ mod tests {
     fn point_is_coincident_with_vertex() {
         let mut services = Services::new();
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
             [1., 0.],

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -150,7 +150,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
@@ -172,7 +172,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
@@ -197,7 +197,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [4., 2.],
@@ -222,7 +222,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
@@ -248,7 +248,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
@@ -274,7 +274,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
@@ -301,7 +301,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],
@@ -332,7 +332,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [0., 0.],

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -151,11 +151,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [1., 1.],
-            [0., 2.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [1., 1.], [0., 2.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -172,11 +171,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [2., 1.],
-            [0., 2.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [2., 1.], [0., 2.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -196,11 +194,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [4., 2.],
-            [0., 4.],
-            [0., 0.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[4., 2.], [0., 4.], [0., 0.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -220,12 +217,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [2., 1.],
-            [3., 0.],
-            [3., 4.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -245,12 +240,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [2., 1.],
-            [3., 1.],
-            [0., 2.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -270,13 +263,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [2., 1.],
-            [3., 1.],
-            [4., 0.],
-            [4., 5.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -296,11 +286,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [2., 0.],
-            [0., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [2., 0.], [0., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -326,11 +315,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [0., 0.],
-            [1., 0.],
-            [0., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[0., 0.], [1., 0.], [0., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -148,7 +148,7 @@ mod tests {
     fn point_is_outside_face() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -168,7 +168,7 @@ mod tests {
     fn ray_hits_vertex_while_passing_outside() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -191,7 +191,7 @@ mod tests {
     fn ray_hits_vertex_at_cycle_seam() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -214,7 +214,7 @@ mod tests {
     fn ray_hits_vertex_while_staying_inside() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -237,7 +237,7 @@ mod tests {
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -260,7 +260,7 @@ mod tests {
     fn ray_hits_parallel_edge_and_does_not_leave_face_there() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -283,7 +283,7 @@ mod tests {
     fn point_is_coincident_with_edge() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -312,7 +312,7 @@ mod tests {
     fn point_is_coincident_with_vertex() {
         let mut services = Services::new();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -165,7 +165,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
@@ -189,7 +189,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
@@ -216,7 +216,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
@@ -240,7 +240,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
@@ -272,7 +272,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
@@ -307,7 +307,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
@@ -333,7 +333,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -163,10 +163,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],
@@ -187,10 +186,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],
@@ -214,10 +212,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],
@@ -238,10 +235,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],
@@ -270,10 +266,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.yz_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],
@@ -305,10 +300,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],
@@ -331,10 +325,9 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points([
             [-1., -1.],
             [1., -1.],

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -163,7 +163,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -184,7 +184,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -208,7 +208,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -229,7 +229,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -258,7 +258,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -290,7 +290,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(
@@ -313,7 +313,7 @@ mod tests {
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior.write().update_as_polygon_from_points(

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -166,12 +166,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -189,12 +187,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -215,12 +211,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -238,12 +232,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -269,12 +261,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -303,12 +293,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -328,12 +316,10 @@ mod tests {
         let mut face = PartialFace::new();
 
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points([
-            [-1., -1.],
-            [1., -1.],
-            [1., 1.],
-            [-1., 1.],
-        ]);
+        face.exterior.write().update_as_polygon_from_points(
+            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -28,7 +28,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         // The result of sweeping an edge is a face. Let's create that.
         let mut face = PartialFace {
             color: Some(color),
-            ..Default::default()
+            ..PartialFace::new()
         };
 
         // A face (and everything in it) is defined on a surface. A surface can

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -127,7 +127,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         [edge_bottom.write(), edge_up.write(), edge_down.write()]
             .zip_ext(global_edges)
             .map(|(mut half_edge, global_edge)| {
-                half_edge.global_form = Partial::from(global_edge);
+                half_edge.global_form = global_edge;
             });
 
         // And we're done creating the face! All that's left to do is build our

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -26,10 +26,8 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         let path = path.into();
 
         // The result of sweeping an edge is a face. Let's create that.
-        let mut face = PartialFace {
-            color: Some(color),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+        face.color = Some(color);
 
         // A face (and everything in it) is defined on a surface. A surface can
         // be created by sweeping a curve, so let's sweep the curve of the edge

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -26,7 +26,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         let path = path.into();
 
         // The result of sweeping an edge is a face. Let's create that.
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(objects);
         face.color = Some(color);
 
         // A face (and everything in it) is defined on a surface. A surface can

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -40,10 +40,10 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         }
 
         // Now we're ready to create the edges.
-        let mut edge_bottom = face.exterior.write().add_half_edge();
-        let mut edge_up = face.exterior.write().add_half_edge();
-        let mut edge_top = face.exterior.write().add_half_edge();
-        let mut edge_down = face.exterior.write().add_half_edge();
+        let mut edge_bottom = face.exterior.write().add_half_edge(objects);
+        let mut edge_up = face.exterior.write().add_half_edge(objects);
+        let mut edge_top = face.exterior.write().add_half_edge(objects);
+        let mut edge_down = face.exterior.write().add_half_edge(objects);
 
         // Those edges aren't fully defined yet. We'll do that shortly, but
         // first we have to figure a few things out.

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -89,9 +89,11 @@ impl Sweep for Handle<Face> {
                 top_edges.push(Partial::from(top_edge));
             }
 
-            top_cycle
-                .write()
-                .connect_to_closed_edges(top_edges, &top_surface.geometry());
+            top_cycle.write().connect_to_closed_edges(
+                top_edges,
+                &top_surface.geometry(),
+                objects,
+            );
 
             for (bottom, top) in original_edges
                 .into_iter()

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -57,7 +57,7 @@ impl Sweep for Handle<Face> {
         let top_surface =
             bottom_face.surface().clone().translate(path, objects);
 
-        let mut top_face = PartialFace::new();
+        let mut top_face = PartialFace::new(objects);
         top_face.surface = Partial::from(top_surface.clone());
         top_face.color = Some(self.color());
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -59,7 +59,7 @@ impl Sweep for Handle<Face> {
         let mut top_face = PartialFace {
             surface: Partial::from(top_surface.clone()),
             color: Some(self.color()),
-            ..PartialFace::default()
+            ..PartialFace::new()
         };
 
         for (i, cycle) in bottom_face.all_cycles().cloned().enumerate() {

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -67,7 +67,7 @@ impl Sweep for Handle<Face> {
             let mut top_cycle = if i == 0 {
                 top_face.exterior.clone()
             } else {
-                top_face.add_interior()
+                top_face.add_interior(objects)
             };
 
             let mut original_edges = Vec::new();

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -56,11 +56,10 @@ impl Sweep for Handle<Face> {
 
         let top_surface =
             bottom_face.surface().clone().translate(path, objects);
-        let mut top_face = PartialFace {
-            surface: Partial::from(top_surface.clone()),
-            color: Some(self.color()),
-            ..PartialFace::new()
-        };
+
+        let mut top_face = PartialFace::new();
+        top_face.surface = Partial::from(top_surface.clone());
+        top_face.color = Some(self.color());
 
         for (i, cycle) in bottom_face.all_cycles().cloned().enumerate() {
             let cycle = cycle.reverse(objects);

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -96,10 +96,8 @@ mod tests {
         let c = [2., 2.];
         let d = [0., 1.];
 
-        let mut face = PartialFace {
-            surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..PartialFace::new()
-        };
+        let mut face = PartialFace::new();
+        face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior
             .write()
             .update_as_polygon_from_points([a, b, c, d]);
@@ -137,10 +135,9 @@ mod tests {
         let h = [3., 1.];
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut face = PartialFace {
-            surface: Partial::from(surface.clone()),
-            ..PartialFace::new()
-        };
+
+        let mut face = PartialFace::new();
+        face.surface = Partial::from(surface.clone());
         face.exterior
             .write()
             .update_as_polygon_from_points([a, b, c, d]);
@@ -203,10 +200,9 @@ mod tests {
         let e = [0., 9.];
 
         let surface = services.objects.surfaces.xy_plane();
-        let mut face = PartialFace {
-            surface: Partial::from(surface.clone()),
-            ..PartialFace::new()
-        };
+
+        let mut face = PartialFace::new();
+        face.surface = Partial::from(surface.clone());
         face.exterior
             .write()
             .update_as_polygon_from_points([a, b, c, d, e]);

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -98,7 +98,7 @@ mod tests {
 
         let mut face = PartialFace {
             surface: Partial::from(services.objects.surfaces.xy_plane()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior
             .write()
@@ -139,7 +139,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace {
             surface: Partial::from(surface.clone()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior
             .write()
@@ -205,7 +205,7 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
         let mut face = PartialFace {
             surface: Partial::from(surface.clone()),
-            ..Default::default()
+            ..PartialFace::new()
         };
         face.exterior
             .write()

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior
             .write()
-            .update_as_polygon_from_points([a, b, c, d]);
+            .update_as_polygon_from_points([a, b, c, d], &mut services.objects);
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -140,10 +140,10 @@ mod tests {
         face.surface = Partial::from(surface.clone());
         face.exterior
             .write()
-            .update_as_polygon_from_points([a, b, c, d]);
+            .update_as_polygon_from_points([a, b, c, d], &mut services.objects);
         face.add_interior(&mut services.objects)
             .write()
-            .update_as_polygon_from_points([e, f, g, h]);
+            .update_as_polygon_from_points([e, f, g, h], &mut services.objects);
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -203,9 +203,10 @@ mod tests {
 
         let mut face = PartialFace::new();
         face.surface = Partial::from(surface.clone());
-        face.exterior
-            .write()
-            .update_as_polygon_from_points([a, b, c, d, e]);
+        face.exterior.write().update_as_polygon_from_points(
+            [a, b, c, d, e],
+            &mut services.objects,
+        );
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -141,7 +141,7 @@ mod tests {
         face.exterior
             .write()
             .update_as_polygon_from_points([a, b, c, d]);
-        face.add_interior()
+        face.add_interior(&mut services.objects)
             .write()
             .update_as_polygon_from_points([e, f, g, h]);
         let face = face

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -96,7 +96,7 @@ mod tests {
         let c = [2., 2.];
         let d = [0., 1.];
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
         face.surface = Partial::from(services.objects.surfaces.xy_plane());
         face.exterior
             .write()
@@ -136,7 +136,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
         face.surface = Partial::from(surface.clone());
         face.exterior
             .write()
@@ -201,7 +201,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xy_plane();
 
-        let mut face = PartialFace::new();
+        let mut face = PartialFace::new(&mut services.objects);
         face.surface = Partial::from(surface.clone());
         face.exterior.write().update_as_polygon_from_points(
             [a, b, c, d, e],

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -3,8 +3,9 @@ use itertools::Itertools;
 
 use crate::{
     geometry::surface::SurfaceGeometry,
-    objects::HalfEdge,
+    objects::{HalfEdge, Objects},
     partial::{Partial, PartialCycle},
+    services::Service,
 };
 
 use super::{HalfEdgeBuilder, ObjectArgument};
@@ -26,6 +27,7 @@ pub trait CycleBuilder {
     fn update_as_polygon_from_points<O, P>(
         &mut self,
         points: O,
+        objects: &mut Service<Objects>,
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<P>,
@@ -62,6 +64,7 @@ impl CycleBuilder for PartialCycle {
     fn update_as_polygon_from_points<O, P>(
         &mut self,
         points: O,
+        _: &mut Service<Objects>,
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<P>,

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -21,7 +21,10 @@ pub trait CycleBuilder {
     ///
     /// If this is the first half-edge being added, it is connected to itself,
     /// meaning its front and back vertices are the same.
-    fn add_half_edge(&mut self) -> Partial<HalfEdge>;
+    fn add_half_edge(
+        &mut self,
+        objects: &mut Service<Objects>,
+    ) -> Partial<HalfEdge>;
 
     /// Update cycle as a polygon from the provided points
     fn update_as_polygon_from_points<O, P>(
@@ -56,7 +59,7 @@ pub trait CycleBuilder {
 }
 
 impl CycleBuilder for PartialCycle {
-    fn add_half_edge(&mut self) -> Partial<HalfEdge> {
+    fn add_half_edge(&mut self, _: &mut Service<Objects>) -> Partial<HalfEdge> {
         let half_edge = Partial::new();
         self.half_edges.push(half_edge.clone());
         half_edge
@@ -65,7 +68,7 @@ impl CycleBuilder for PartialCycle {
     fn update_as_polygon_from_points<O, P>(
         &mut self,
         points: O,
-        _: &mut Service<Objects>,
+        objects: &mut Service<Objects>,
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<P>,
@@ -74,7 +77,7 @@ impl CycleBuilder for PartialCycle {
         let mut start_positions = Vec::new();
         let half_edges = points.map(|point| {
             start_positions.push(point.into());
-            self.add_half_edge()
+            self.add_half_edge(objects)
         });
 
         for ((start, end), half_edge) in start_positions
@@ -92,13 +95,13 @@ impl CycleBuilder for PartialCycle {
         &mut self,
         edges: O,
         surface: &SurfaceGeometry,
-        _: &mut Service<Objects>,
+        objects: &mut Service<Objects>,
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<Partial<HalfEdge>>,
     {
         edges.map_with_prev(|other, prev| {
-            let mut this = self.add_half_edge();
+            let mut this = self.add_half_edge(objects);
             this.write().update_from_other_edge(&other, &prev, surface);
             this
         })

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -43,6 +43,7 @@ pub trait CycleBuilder {
         &mut self,
         edges: O,
         surface: &SurfaceGeometry,
+        objects: &mut Service<Objects>,
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<Partial<HalfEdge>>;
@@ -91,6 +92,7 @@ impl CycleBuilder for PartialCycle {
         &mut self,
         edges: O,
         surface: &SurfaceGeometry,
+        _: &mut Service<Objects>,
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<Partial<HalfEdge>>,

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -59,8 +59,11 @@ pub trait CycleBuilder {
 }
 
 impl CycleBuilder for PartialCycle {
-    fn add_half_edge(&mut self, _: &mut Service<Objects>) -> Partial<HalfEdge> {
-        let half_edge = Partial::new();
+    fn add_half_edge(
+        &mut self,
+        objects: &mut Service<Objects>,
+    ) -> Partial<HalfEdge> {
+        let half_edge = Partial::new(objects);
         self.half_edges.push(half_edge.clone());
         half_edge
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -7,7 +7,7 @@ use crate::{
         surface::SurfaceGeometry,
     },
     objects::{HalfEdge, Vertex},
-    partial::{MaybeCurve, Partial, PartialGlobalEdge, PartialHalfEdge},
+    partial::{MaybeCurve, Partial, PartialHalfEdge},
 };
 
 /// Builder API for [`PartialHalfEdge`]
@@ -253,11 +253,3 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             other_prev.read().start_vertex.read().position;
     }
 }
-
-/// Builder API for [`PartialGlobalEdge`]
-pub trait GlobalEdgeBuilder {
-    // No methods are currently defined. This trait serves as a placeholder, to
-    // make it clear where to add such methods, once necessary.
-}
-
-impl GlobalEdgeBuilder for PartialGlobalEdge {}

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -14,8 +14,11 @@ pub trait FaceBuilder {
 }
 
 impl FaceBuilder for PartialFace {
-    fn add_interior(&mut self, _: &mut Service<Objects>) -> Partial<Cycle> {
-        let cycle = Partial::new();
+    fn add_interior(
+        &mut self,
+        objects: &mut Service<Objects>,
+    ) -> Partial<Cycle> {
+        let cycle = Partial::new(objects);
         self.interiors.push(cycle.clone());
         cycle
     }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,16 +1,20 @@
 use crate::{
-    objects::Cycle,
+    objects::{Cycle, Objects},
     partial::{Partial, PartialFace},
+    services::Service,
 };
 
 /// Builder API for [`PartialFace`]
 pub trait FaceBuilder {
     /// Add an interior cycle
-    fn add_interior(&mut self) -> Partial<Cycle>;
+    fn add_interior(
+        &mut self,
+        objects: &mut Service<Objects>,
+    ) -> Partial<Cycle>;
 }
 
 impl FaceBuilder for PartialFace {
-    fn add_interior(&mut self) -> Partial<Cycle> {
+    fn add_interior(&mut self, _: &mut Service<Objects>) -> Partial<Cycle> {
         let cycle = Partial::new();
         self.interiors.push(cycle.clone());
         cycle

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -13,14 +13,9 @@ mod vertex;
 use std::array;
 
 pub use self::{
-    cycle::CycleBuilder,
-    edge::{GlobalEdgeBuilder, HalfEdgeBuilder},
-    face::FaceBuilder,
-    shell::ShellBuilder,
-    sketch::SketchBuilder,
-    solid::SolidBuilder,
-    surface::SurfaceBuilder,
-    vertex::VertexBuilder,
+    cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder,
+    shell::ShellBuilder, sketch::SketchBuilder, solid::SolidBuilder,
+    surface::SurfaceBuilder, vertex::VertexBuilder,
 };
 
 /// Pass objects to a builder method

--- a/crates/fj-kernel/src/partial/mod.rs
+++ b/crates/fj-kernel/src/partial/mod.rs
@@ -16,15 +16,9 @@ mod wrapper;
 
 pub use self::{
     objects::{
-        curve::MaybeCurve,
-        cycle::PartialCycle,
-        edge::{PartialGlobalEdge, PartialHalfEdge},
-        face::PartialFace,
-        shell::PartialShell,
-        sketch::PartialSketch,
-        solid::PartialSolid,
-        surface::PartialSurface,
-        vertex::PartialVertex,
+        curve::MaybeCurve, cycle::PartialCycle, edge::PartialHalfEdge,
+        face::PartialFace, shell::PartialShell, sketch::PartialSketch,
+        solid::PartialSolid, surface::PartialSurface, vertex::PartialVertex,
     },
     traits::{HasPartial, PartialObject},
     wrapper::{FullToPartialCache, Partial},

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -15,7 +15,9 @@ impl PartialObject for PartialCycle {
     type Full = Cycle;
 
     fn new() -> Self {
-        Self::default()
+        Self {
+            half_edges: Vec::new(),
+        }
     }
 
     fn from_full(cycle: &Self::Full, cache: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Cycle`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialCycle {
     /// The half-edges that make up the cycle
     pub half_edges: Vec<Partial<HalfEdge>>,

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -14,6 +14,10 @@ pub struct PartialCycle {
 impl PartialObject for PartialCycle {
     type Full = Cycle;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(cycle: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             half_edges: cycle

--- a/crates/fj-kernel/src/partial/objects/cycle.rs
+++ b/crates/fj-kernel/src/partial/objects/cycle.rs
@@ -14,7 +14,7 @@ pub struct PartialCycle {
 impl PartialObject for PartialCycle {
     type Full = Cycle;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self {
             half_edges: Vec::new(),
         }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -84,9 +84,8 @@ impl PartialObject for PartialHalfEdge {
             point.expect("Can't build `HalfEdge` without boundary positions")
         });
         let start_vertex = self.start_vertex.build(objects);
-        let global_form = self.global_form;
 
-        HalfEdge::new(curve, boundary, start_vertex, global_form)
+        HalfEdge::new(curve, boundary, start_vertex, self.global_form)
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -1,9 +1,11 @@
 use fj_math::Point;
 
 use crate::{
+    insert::Insert,
     objects::{GlobalEdge, HalfEdge, Objects, Vertex},
     partial::{FullToPartialCache, MaybeCurve, Partial, PartialObject},
     services::Service,
+    storage::Handle,
 };
 
 /// A partial [`HalfEdge`]
@@ -19,7 +21,7 @@ pub struct PartialHalfEdge {
     pub start_vertex: Partial<Vertex>,
 
     /// The global form of the half-edge
-    pub global_form: Partial<GlobalEdge>,
+    pub global_form: Handle<GlobalEdge>,
 }
 
 impl PartialHalfEdge {
@@ -48,7 +50,7 @@ impl PartialObject for PartialHalfEdge {
     fn new(objects: &mut Service<Objects>) -> Self {
         let curve = None;
         let start_vertex = Partial::new(objects);
-        let global_form = Partial::new(objects);
+        let global_form = GlobalEdge::new().insert(objects);
 
         Self {
             curve,
@@ -69,10 +71,7 @@ impl PartialObject for PartialHalfEdge {
                 half_edge.start_vertex().clone(),
                 cache,
             ),
-            global_form: Partial::from_full(
-                half_edge.global_form().clone(),
-                cache,
-            ),
+            global_form: half_edge.global_form().clone(),
         }
     }
 
@@ -89,7 +88,7 @@ impl PartialObject for PartialHalfEdge {
             point.expect("Can't build `HalfEdge` without boundary positions")
         });
         let start_vertex = self.start_vertex.build(objects);
-        let global_form = self.global_form.build(objects);
+        let global_form = self.global_form;
 
         HalfEdge::new(curve, boundary, start_vertex, global_form)
     }

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -88,23 +88,3 @@ impl PartialObject for PartialHalfEdge {
         HalfEdge::new(curve, boundary, start_vertex, self.global_form)
     }
 }
-
-/// A partial [`GlobalEdge`]
-#[derive(Clone, Debug)]
-pub struct PartialGlobalEdge {}
-
-impl PartialObject for PartialGlobalEdge {
-    type Full = GlobalEdge;
-
-    fn new(_: &mut Service<Objects>) -> Self {
-        Self {}
-    }
-
-    fn from_full(_: &Self::Full, _: &mut FullToPartialCache) -> Self {
-        Self {}
-    }
-
-    fn build(self, _: &mut Service<Objects>) -> Self::Full {
-        GlobalEdge::new()
-    }
-}

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -45,10 +45,10 @@ impl PartialHalfEdge {
 impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
 
-    fn new() -> Self {
+    fn new(objects: &mut Service<Objects>) -> Self {
         let curve = None;
-        let start_vertex = Partial::new();
-        let global_form = Partial::new();
+        let start_vertex = Partial::new(objects);
+        let global_form = Partial::new(objects);
 
         Self {
             curve,
@@ -102,7 +102,7 @@ pub struct PartialGlobalEdge {}
 impl PartialObject for PartialGlobalEdge {
     type Full = GlobalEdge;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self {}
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -96,7 +96,7 @@ impl PartialObject for PartialHalfEdge {
 }
 
 /// A partial [`GlobalEdge`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialGlobalEdge {}
 
 impl PartialObject for PartialGlobalEdge {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -46,7 +46,16 @@ impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
 
     fn new() -> Self {
-        Self::default()
+        let curve = None;
+        let start_vertex = Partial::default();
+        let global_form = Partial::default();
+
+        Self {
+            curve,
+            boundary: [None; 2],
+            start_vertex,
+            global_form,
+        }
     }
 
     fn from_full(
@@ -88,16 +97,7 @@ impl PartialObject for PartialHalfEdge {
 
 impl Default for PartialHalfEdge {
     fn default() -> Self {
-        let curve = None;
-        let start_vertex = Partial::default();
-        let global_form = Partial::default();
-
-        Self {
-            curve,
-            boundary: [None; 2],
-            start_vertex,
-            global_form,
-        }
+        Self::new()
     }
 }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -48,15 +48,11 @@ impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
 
     fn new(objects: &mut Service<Objects>) -> Self {
-        let curve = None;
-        let start_vertex = Partial::new(objects);
-        let global_form = GlobalEdge::new().insert(objects);
-
         Self {
-            curve,
+            curve: None,
             boundary: [None; 2],
-            start_vertex,
-            global_form,
+            start_vertex: Partial::new(objects),
+            global_form: GlobalEdge::new().insert(objects),
         }
     }
 

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -103,7 +103,7 @@ impl PartialObject for PartialGlobalEdge {
     type Full = GlobalEdge;
 
     fn new() -> Self {
-        Self::default()
+        Self {}
     }
 
     fn from_full(_: &Self::Full, _: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -95,12 +95,6 @@ impl PartialObject for PartialHalfEdge {
     }
 }
 
-impl Default for PartialHalfEdge {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// A partial [`GlobalEdge`]
 #[derive(Clone, Debug, Default)]
 pub struct PartialGlobalEdge {}

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -45,6 +45,10 @@ impl PartialHalfEdge {
 impl PartialObject for PartialHalfEdge {
     type Full = HalfEdge;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(
         half_edge: &Self::Full,
         cache: &mut FullToPartialCache,
@@ -103,6 +107,10 @@ pub struct PartialGlobalEdge {}
 
 impl PartialObject for PartialGlobalEdge {
     type Full = GlobalEdge;
+
+    fn new() -> Self {
+        Self::default()
+    }
 
     fn from_full(_: &Self::Full, _: &mut FullToPartialCache) -> Self {
         Self {}

--- a/crates/fj-kernel/src/partial/objects/edge.rs
+++ b/crates/fj-kernel/src/partial/objects/edge.rs
@@ -47,8 +47,8 @@ impl PartialObject for PartialHalfEdge {
 
     fn new() -> Self {
         let curve = None;
-        let start_vertex = Partial::default();
-        let global_form = Partial::default();
+        let start_vertex = Partial::new();
+        let global_form = Partial::new();
 
         Self {
             curve,

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -28,6 +28,10 @@ pub struct PartialFace {
 impl PartialObject for PartialFace {
     type Full = Face;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(face: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             surface: Partial::from_full(face.surface().clone(), cache),

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -28,10 +28,10 @@ pub struct PartialFace {
 impl PartialObject for PartialFace {
     type Full = Face;
 
-    fn new() -> Self {
+    fn new(objects: &mut Service<Objects>) -> Self {
         Self {
-            surface: Partial::new(),
-            exterior: Partial::new(),
+            surface: Partial::new(objects),
+            exterior: Partial::new(objects),
             interiors: Vec::new(),
             color: None,
         }

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// A partial [`Face`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialFace {
     /// The surface that the face is defined in
     pub surface: Partial<Surface>,

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -29,7 +29,12 @@ impl PartialObject for PartialFace {
     type Full = Face;
 
     fn new() -> Self {
-        Self::default()
+        Self {
+            surface: Partial::new(),
+            exterior: Partial::new(),
+            interiors: Vec::new(),
+            color: None,
+        }
     }
 
     fn from_full(face: &Self::Full, cache: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Shell`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialShell {
     /// The faces that make up the shell
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -14,6 +14,10 @@ pub struct PartialShell {
 impl PartialObject for PartialShell {
     type Full = Shell;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(shell: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             faces: shell

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -15,7 +15,7 @@ impl PartialObject for PartialShell {
     type Full = Shell;
 
     fn new() -> Self {
-        Self::default()
+        Self { faces: Vec::new() }
     }
 
     fn from_full(shell: &Self::Full, cache: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/shell.rs
+++ b/crates/fj-kernel/src/partial/objects/shell.rs
@@ -14,7 +14,7 @@ pub struct PartialShell {
 impl PartialObject for PartialShell {
     type Full = Shell;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self { faces: Vec::new() }
     }
 

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Sketch`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSketch {
     /// The faces that make up the sketch
     pub faces: Vec<Partial<Face>>,

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -14,7 +14,7 @@ pub struct PartialSketch {
 impl PartialObject for PartialSketch {
     type Full = Sketch;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self { faces: Vec::new() }
     }
 

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -14,6 +14,10 @@ pub struct PartialSketch {
 impl PartialObject for PartialSketch {
     type Full = Sketch;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(sketch: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             faces: sketch

--- a/crates/fj-kernel/src/partial/objects/sketch.rs
+++ b/crates/fj-kernel/src/partial/objects/sketch.rs
@@ -15,7 +15,7 @@ impl PartialObject for PartialSketch {
     type Full = Sketch;
 
     fn new() -> Self {
-        Self::default()
+        Self { faces: Vec::new() }
     }
 
     fn from_full(sketch: &Self::Full, cache: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 /// A partial [`Solid`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSolid {
     /// The shells that make up the solid
     pub shells: Vec<Partial<Shell>>,

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -14,7 +14,7 @@ pub struct PartialSolid {
 impl PartialObject for PartialSolid {
     type Full = Solid;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self { shells: Vec::new() }
     }
 

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -14,6 +14,10 @@ pub struct PartialSolid {
 impl PartialObject for PartialSolid {
     type Full = Solid;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(solid: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             shells: solid

--- a/crates/fj-kernel/src/partial/objects/solid.rs
+++ b/crates/fj-kernel/src/partial/objects/solid.rs
@@ -15,7 +15,7 @@ impl PartialObject for PartialSolid {
     type Full = Solid;
 
     fn new() -> Self {
-        Self::default()
+        Self { shells: Vec::new() }
     }
 
     fn from_full(solid: &Self::Full, cache: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -15,7 +15,7 @@ pub struct PartialSurface {
 impl PartialObject for PartialSurface {
     type Full = Surface;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self { geometry: None }
     }
 

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 /// A partial [`Surface`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialSurface {
     /// The surface's geometry
     pub geometry: Option<SurfaceGeometry>,

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -15,6 +15,10 @@ pub struct PartialSurface {
 impl PartialObject for PartialSurface {
     type Full = Surface;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(surface: &Self::Full, _: &mut FullToPartialCache) -> Self {
         Self {
             geometry: Some(surface.geometry()),

--- a/crates/fj-kernel/src/partial/objects/surface.rs
+++ b/crates/fj-kernel/src/partial/objects/surface.rs
@@ -16,7 +16,7 @@ impl PartialObject for PartialSurface {
     type Full = Surface;
 
     fn new() -> Self {
-        Self::default()
+        Self { geometry: None }
     }
 
     fn from_full(surface: &Self::Full, _: &mut FullToPartialCache) -> Self {

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -17,7 +17,7 @@ impl PartialObject for PartialVertex {
     type Full = Vertex;
 
     fn new() -> Self {
-        Self::default()
+        Self { position: None }
     }
 
     fn from_full(

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -16,6 +16,10 @@ pub struct PartialVertex {
 impl PartialObject for PartialVertex {
     type Full = Vertex;
 
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn from_full(
         global_vertex: &Self::Full,
         _: &mut FullToPartialCache,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A partial [`Vertex`]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartialVertex {
     /// The position of the vertex
     pub position: Option<Point<3>>,

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -16,7 +16,7 @@ pub struct PartialVertex {
 impl PartialObject for PartialVertex {
     type Full = Vertex;
 
-    fn new() -> Self {
+    fn new(_: &mut Service<Objects>) -> Self {
         Self { position: None }
     }
 

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -11,7 +11,7 @@ pub trait HasPartial {
 }
 
 /// Implemented for partial objects
-pub trait PartialObject: Clone + Debug + Default {
+pub trait PartialObject: Clone + Debug {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
 

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -15,6 +15,9 @@ pub trait PartialObject: Clone + Debug + Default {
     /// The type representing the full object
     type Full: HasPartial<Partial = Self>;
 
+    /// Construct a default partial object
+    fn new() -> Self;
+
     /// Construct a partial object from a full one
     fn from_full(full: &Self::Full, cache: &mut FullToPartialCache) -> Self;
 

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -38,7 +38,6 @@ macro_rules! impl_trait {
 impl_trait!(
     Cycle, PartialCycle;
     Face, PartialFace;
-    GlobalEdge, PartialGlobalEdge;
     HalfEdge, PartialHalfEdge;
     Shell, PartialShell;
     Sketch, PartialSketch;

--- a/crates/fj-kernel/src/partial/traits.rs
+++ b/crates/fj-kernel/src/partial/traits.rs
@@ -16,7 +16,7 @@ pub trait PartialObject: Clone + Debug {
     type Full: HasPartial<Partial = Self>;
 
     /// Construct a default partial object
-    fn new() -> Self;
+    fn new(objects: &mut Service<Objects>) -> Self;
 
     /// Construct a partial object from a full one
     fn from_full(full: &Self::Full, cache: &mut FullToPartialCache) -> Self;

--- a/crates/fj-kernel/src/partial/wrapper.rs
+++ b/crates/fj-kernel/src/partial/wrapper.rs
@@ -30,8 +30,8 @@ pub struct Partial<T: HasPartial> {
 impl<T: HasPartial + 'static> Partial<T> {
     /// Construct a `Partial` with a default inner partial object
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self::from_partial(T::Partial::new())
+    pub fn new(objects: &mut Service<Objects>) -> Self {
+        Self::from_partial(T::Partial::new(objects))
     }
 
     /// Construct a `Partial` from a partial object

--- a/crates/fj-kernel/src/partial/wrapper.rs
+++ b/crates/fj-kernel/src/partial/wrapper.rs
@@ -30,7 +30,7 @@ pub struct Partial<T: HasPartial> {
 impl<T: HasPartial + 'static> Partial<T> {
     /// Construct a `Partial` with a default inner partial object
     pub fn new() -> Self {
-        Self::from_partial(T::Partial::default())
+        Self::from_partial(T::Partial::new())
     }
 
     /// Construct a `Partial` from a partial object

--- a/crates/fj-kernel/src/partial/wrapper.rs
+++ b/crates/fj-kernel/src/partial/wrapper.rs
@@ -29,7 +29,6 @@ pub struct Partial<T: HasPartial> {
 
 impl<T: HasPartial + 'static> Partial<T> {
     /// Construct a `Partial` with a default inner partial object
-    #[allow(clippy::new_without_default)]
     pub fn new(objects: &mut Service<Objects>) -> Self {
         Self::from_partial(T::Partial::new(objects))
     }

--- a/crates/fj-kernel/src/partial/wrapper.rs
+++ b/crates/fj-kernel/src/partial/wrapper.rs
@@ -29,6 +29,7 @@ pub struct Partial<T: HasPartial> {
 
 impl<T: HasPartial + 'static> Partial<T> {
     /// Construct a `Partial` with a default inner partial object
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self::from_partial(T::Partial::new())
     }
@@ -139,12 +140,6 @@ impl<T: HasPartial> Clone for Partial<T> {
         Self {
             inner: self.inner.clone(),
         }
-    }
-}
-
-impl<T: HasPartial + 'static> Default for Partial<T> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -93,7 +93,10 @@ mod tests {
             let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points([[0., 0.], [1., 0.], [1., 1.]]);
+                .update_as_polygon_from_points(
+                    [[0., 0.], [1., 0.], [1., 1.]],
+                    &mut services.objects,
+                );
             half_edge.write().infer_vertex_positions_if_necessary(
                 &surface.geometry(),
                 next_half_edge.read().start_vertex.clone(),

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -78,7 +78,7 @@ mod tests {
     use crate::{
         builder::{CycleBuilder, HalfEdgeBuilder},
         objects::HalfEdge,
-        partial::PartialCycle,
+        partial::{PartialCycle, PartialObject},
         services::Services,
         validate::{HalfEdgeValidationError, Validate, ValidationError},
     };
@@ -90,7 +90,7 @@ mod tests {
         let valid = {
             let surface = services.objects.surfaces.xy_plane();
 
-            let mut cycle = PartialCycle::default();
+            let mut cycle = PartialCycle::new();
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points([[0., 0.], [1., 0.], [1., 1.]]);

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -90,7 +90,7 @@ mod tests {
         let valid = {
             let surface = services.objects.surfaces.xy_plane();
 
-            let mut cycle = PartialCycle::new();
+            let mut cycle = PartialCycle::new(&mut services.objects);
 
             let [mut half_edge, next_half_edge, _] = cycle
                 .update_as_polygon_from_points(

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -153,7 +153,7 @@ mod tests {
         let valid = {
             let mut face = PartialFace {
                 surface: Partial::from(services.objects.surfaces.xy_plane()),
-                ..Default::default()
+                ..PartialFace::new()
             };
             face.exterior.write().update_as_polygon_from_points([
                 [0., 0.],
@@ -202,7 +202,7 @@ mod tests {
 
             let mut face = PartialFace {
                 surface: Partial::from(surface.clone()),
-                ..Default::default()
+                ..PartialFace::new()
             };
 
             let mut half_edge = face.exterior.write().add_half_edge();

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -151,7 +151,7 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let mut face = PartialFace::new();
+            let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Partial::from(services.objects.surfaces.xy_plane());
             face.exterior.write().update_as_polygon_from_points(
@@ -199,7 +199,7 @@ mod tests {
         let valid = {
             let surface = services.objects.surfaces.xy_plane();
 
-            let mut face = PartialFace::new();
+            let mut face = PartialFace::new(&mut services.objects);
             face.surface = Partial::from(surface.clone());
 
             let mut half_edge =

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -154,14 +154,16 @@ mod tests {
             let mut face = PartialFace::new();
 
             face.surface = Partial::from(services.objects.surfaces.xy_plane());
-            face.exterior.write().update_as_polygon_from_points([
-                [0., 0.],
-                [3., 0.],
-                [0., 3.],
-            ]);
+            face.exterior.write().update_as_polygon_from_points(
+                [[0., 0.], [3., 0.], [0., 3.]],
+                &mut services.objects,
+            );
             face.add_interior(&mut services.objects)
                 .write()
-                .update_as_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]]);
+                .update_as_polygon_from_points(
+                    [[1., 1.], [1., 2.], [2., 1.]],
+                    &mut services.objects,
+                );
             face.build(&mut services.objects)
         };
         let invalid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -202,7 +202,8 @@ mod tests {
             let mut face = PartialFace::new();
             face.surface = Partial::from(surface.clone());
 
-            let mut half_edge = face.exterior.write().add_half_edge();
+            let mut half_edge =
+                face.exterior.write().add_half_edge(&mut services.objects);
             half_edge.write().update_as_circle_from_radius(1.);
             let next_vertex = half_edge.read().start_vertex.clone();
             half_edge.write().infer_vertex_positions_if_necessary(

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -159,11 +159,9 @@ mod tests {
                 [3., 0.],
                 [0., 3.],
             ]);
-            face.add_interior().write().update_as_polygon_from_points([
-                [1., 1.],
-                [1., 2.],
-                [2., 1.],
-            ]);
+            face.add_interior(&mut services.objects)
+                .write()
+                .update_as_polygon_from_points([[1., 1.], [1., 2.], [2., 1.]]);
             face.build(&mut services.objects)
         };
         let invalid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -151,10 +151,9 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let mut face = PartialFace {
-                surface: Partial::from(services.objects.surfaces.xy_plane()),
-                ..PartialFace::new()
-            };
+            let mut face = PartialFace::new();
+
+            face.surface = Partial::from(services.objects.surfaces.xy_plane());
             face.exterior.write().update_as_polygon_from_points([
                 [0., 0.],
                 [3., 0.],
@@ -200,10 +199,8 @@ mod tests {
         let valid = {
             let surface = services.objects.surfaces.xy_plane();
 
-            let mut face = PartialFace {
-                surface: Partial::from(surface.clone()),
-                ..PartialFace::new()
-            };
+            let mut face = PartialFace::new();
+            face.surface = Partial::from(surface.clone());
 
             let mut half_edge = face.exterior.write().add_half_edge();
             half_edge.write().update_as_circle_from_radius(1.);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -37,7 +37,7 @@ impl Shape for fj::Sketch {
                     Partial::from_partial(half_edge)
                 };
                 let exterior = {
-                    let mut cycle = PartialCycle::default();
+                    let mut cycle = PartialCycle::new();
                     cycle.half_edges.push(half_edge);
                     Partial::from_partial(cycle)
                 };
@@ -57,7 +57,7 @@ impl Shape for fj::Sketch {
                 );
 
                 let exterior = {
-                    let mut cycle = PartialCycle::default();
+                    let mut cycle = PartialCycle::new();
 
                     let half_edges = poly_chain
                         .to_segments()

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -64,7 +64,7 @@ impl Shape for fj::Sketch {
                         .into_iter()
                         .map(|fj::SketchSegment { endpoint, route }| {
                             let endpoint = Point::from(endpoint);
-                            let half_edge = cycle.add_half_edge();
+                            let half_edge = cycle.add_half_edge(objects);
                             (half_edge, endpoint, route)
                         })
                         .collect::<Vec<_>>();

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -31,18 +31,18 @@ impl Shape for fj::Sketch {
                 let surface = Partial::from(surface);
 
                 let half_edge = {
-                    let mut half_edge = PartialHalfEdge::new();
+                    let mut half_edge = PartialHalfEdge::new(objects);
                     half_edge.update_as_circle_from_radius(circle.radius());
 
                     Partial::from_partial(half_edge)
                 };
                 let exterior = {
-                    let mut cycle = PartialCycle::new();
+                    let mut cycle = PartialCycle::new(objects);
                     cycle.half_edges.push(half_edge);
                     Partial::from_partial(cycle)
                 };
 
-                let mut face = PartialFace::new();
+                let mut face = PartialFace::new(objects);
                 face.surface = surface;
                 face.exterior = exterior;
                 face.color = Some(Color(self.color()));
@@ -57,7 +57,7 @@ impl Shape for fj::Sketch {
                 );
 
                 let exterior = {
-                    let mut cycle = PartialCycle::new();
+                    let mut cycle = PartialCycle::new(objects);
 
                     let half_edges = poly_chain
                         .to_segments()
@@ -91,7 +91,7 @@ impl Shape for fj::Sketch {
                     Partial::from_partial(cycle)
                 };
 
-                let mut face = PartialFace::new();
+                let mut face = PartialFace::new(objects);
                 face.surface = Partial::from(surface);
                 face.exterior = exterior;
                 face.color = Some(Color(self.color()));

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -31,7 +31,7 @@ impl Shape for fj::Sketch {
                 let surface = Partial::from(surface);
 
                 let half_edge = {
-                    let mut half_edge = PartialHalfEdge::default();
+                    let mut half_edge = PartialHalfEdge::new();
                     half_edge.update_as_circle_from_radius(circle.radius());
 
                     Partial::from_partial(half_edge)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -42,12 +42,12 @@ impl Shape for fj::Sketch {
                     Partial::from_partial(cycle)
                 };
 
-                PartialFace {
-                    surface,
-                    exterior,
-                    color: Some(Color(self.color())),
-                    ..PartialFace::new()
-                }
+                let mut face = PartialFace::new();
+                face.surface = surface;
+                face.exterior = exterior;
+                face.color = Some(Color(self.color()));
+
+                face
             }
             fj::Chain::PolyChain(poly_chain) => {
                 let segments = poly_chain.to_segments();
@@ -91,12 +91,12 @@ impl Shape for fj::Sketch {
                     Partial::from_partial(cycle)
                 };
 
-                PartialFace {
-                    surface: Partial::from(surface),
-                    exterior,
-                    color: Some(Color(self.color())),
-                    ..PartialFace::new()
-                }
+                let mut face = PartialFace::new();
+                face.surface = Partial::from(surface);
+                face.exterior = exterior;
+                face.color = Some(Color(self.color()));
+
+                face
             }
         };
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -46,7 +46,7 @@ impl Shape for fj::Sketch {
                     surface,
                     exterior,
                     color: Some(Color(self.color())),
-                    ..Default::default()
+                    ..PartialFace::new()
                 }
             }
             fj::Chain::PolyChain(poly_chain) => {
@@ -95,7 +95,7 @@ impl Shape for fj::Sketch {
                     surface: Partial::from(surface),
                     exterior,
                     color: Some(Color(self.color())),
-                    ..Default::default()
+                    ..PartialFace::new()
                 }
             }
         };


### PR DESCRIPTION
Or, to be more precise, just remove `PartialGlobalEdge`, since `GlobalEdge` didn't require any changes to make this happen. This did require a lot of changes to the partial object infrastructure though. Those weren't specific to `GlobalEdge`/`PartialGlobalEdge` though, and should help with any future full/partial object unification.

This is a first step towards achieving #1570.