### PR TITLE
Compute `Vertex` position on-demand instead of storing it

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -36,23 +36,23 @@ impl Approx for (&Handle<HalfEdge>, &Surface) {
         .with_source((half_edge.clone(), half_edge.boundary()[0]));
 
         let points = {
-            let approx = match cache.get(half_edge.global_form().clone(), range)
-            {
-                Some(approx) => approx,
-                None => {
-                    let approx = approx_edge(
-                        &half_edge.curve(),
-                        surface,
-                        range,
-                        tolerance,
-                    );
-                    cache.insert_edge(
-                        half_edge.global_form().clone(),
-                        range,
-                        approx,
-                    )
-                }
-            };
+            let approx =
+                match cache.get_edge(half_edge.global_form().clone(), range) {
+                    Some(approx) => approx,
+                    None => {
+                        let approx = approx_edge(
+                            &half_edge.curve(),
+                            surface,
+                            range,
+                            tolerance,
+                        );
+                        cache.insert_edge(
+                            half_edge.global_form().clone(),
+                            range,
+                            approx,
+                        )
+                    }
+                };
 
             approx
                 .points
@@ -195,7 +195,7 @@ impl EdgeCache {
     }
 
     /// Access the approximation for the given [`GlobalEdge`], if available
-    pub fn get(
+    pub fn get_edge(
         &self,
         handle: Handle<GlobalEdge>,
         range: RangeOnPath,

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -46,7 +46,11 @@ impl Approx for (&Handle<HalfEdge>, &Surface) {
                         range,
                         tolerance,
                     );
-                    cache.insert(half_edge.global_form().clone(), range, approx)
+                    cache.insert_edge(
+                        half_edge.global_form().clone(),
+                        range,
+                        approx,
+                    )
                 }
             };
 
@@ -179,7 +183,7 @@ impl EdgeCache {
     }
 
     /// Insert the approximation of a [`GlobalEdge`]
-    pub fn insert(
+    pub fn insert_edge(
         &mut self,
         handle: Handle<GlobalEdge>,
         range: RangeOnPath,

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -212,8 +212,8 @@ impl EdgeCache {
         approx: GlobalEdgeApprox,
     ) -> GlobalEdgeApprox {
         self.edge_approx
-            .insert((handle.id(), range), approx.clone());
-        approx
+            .insert((handle.id(), range), approx.clone())
+            .unwrap_or(approx)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -280,14 +280,9 @@ mod tests {
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[1., 1.], [2., 1.], [1., 2.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[1., 1.], [2., 1.], [1., 2.]],
+                &mut services.objects,
             );
 
             let half_edge = half_edge.read().clone();
@@ -314,14 +309,9 @@ mod tests {
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[1., 1.], [2., 1.], [1., 2.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[1., 1.], [2., 1.], [1., 2.]],
+                &mut services.objects,
             );
 
             let half_edge = half_edge.read().clone();
@@ -351,19 +341,13 @@ mod tests {
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[0., 1.], [1., 1.], [1., 2.]],
-                    &mut services.objects,
-                );
+            let [mut half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[0., 1.], [1., 1.], [1., 2.]],
+                &mut services.objects,
+            );
 
             half_edge.write().boundary[0] = Some(range.boundary[0]);
             half_edge.write().boundary[1] = Some(range.boundary[1]);
-
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
-            );
 
             let half_edge = half_edge.read().clone();
             half_edge
@@ -397,11 +381,6 @@ mod tests {
             let mut half_edge = PartialHalfEdge::new(&mut services.objects);
 
             half_edge.update_as_circle_from_radius(1.);
-            let next_vertex = half_edge.start_vertex.clone();
-            half_edge.infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_vertex,
-            );
 
             half_edge
                 .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -169,7 +169,7 @@ fn approx_edge(
 /// A cache for results of an approximation
 #[derive(Default)]
 pub struct EdgeCache {
-    inner: BTreeMap<(ObjectId, RangeOnPath), GlobalEdgeApprox>,
+    edge_approx: BTreeMap<(ObjectId, RangeOnPath), GlobalEdgeApprox>,
 }
 
 impl EdgeCache {
@@ -185,7 +185,8 @@ impl EdgeCache {
         range: RangeOnPath,
         approx: GlobalEdgeApprox,
     ) -> GlobalEdgeApprox {
-        self.inner.insert((handle.id(), range), approx.clone());
+        self.edge_approx
+            .insert((handle.id(), range), approx.clone());
         approx
     }
 
@@ -195,10 +196,12 @@ impl EdgeCache {
         handle: Handle<GlobalEdge>,
         range: RangeOnPath,
     ) -> Option<GlobalEdgeApprox> {
-        if let Some(approx) = self.inner.get(&(handle.id(), range)) {
+        if let Some(approx) = self.edge_approx.get(&(handle.id(), range)) {
             return Some(approx.clone());
         }
-        if let Some(approx) = self.inner.get(&(handle.id(), range.reverse())) {
+        if let Some(approx) =
+            self.edge_approx.get(&(handle.id(), range.reverse()))
+        {
             // If we have a cache entry for the reverse range, we need to use
             // that too!
             return Some(approx.clone().reverse());

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -184,18 +184,6 @@ impl EdgeCache {
         Self::default()
     }
 
-    /// Insert the approximation of a [`GlobalEdge`]
-    pub fn insert_edge(
-        &mut self,
-        handle: Handle<GlobalEdge>,
-        range: RangeOnPath,
-        approx: GlobalEdgeApprox,
-    ) -> GlobalEdgeApprox {
-        self.edge_approx
-            .insert((handle.id(), range), approx.clone());
-        approx
-    }
-
     /// Access the approximation for the given [`GlobalEdge`], if available
     pub fn get_edge(
         &self,
@@ -214,6 +202,18 @@ impl EdgeCache {
         }
 
         None
+    }
+
+    /// Insert the approximation of a [`GlobalEdge`]
+    pub fn insert_edge(
+        &mut self,
+        handle: Handle<GlobalEdge>,
+        range: RangeOnPath,
+        approx: GlobalEdgeApprox,
+    ) -> GlobalEdgeApprox {
+        self.edge_approx
+            .insert((handle.id(), range), approx.clone());
+        approx
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -29,8 +29,10 @@ impl Approx for (&Handle<HalfEdge>, &Surface) {
         let boundary = half_edge.boundary();
         let range = RangeOnPath { boundary };
 
+        let position_surface = half_edge.start_position();
+
         let first = ApproxPoint::new(
-            half_edge.start_position(),
+            position_surface,
             half_edge.start_vertex().position(),
         )
         .with_source((half_edge.clone(), half_edge.boundary()[0]));

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -72,7 +72,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        builder::{CycleBuilder, HalfEdgeBuilder},
+        builder::CycleBuilder,
         geometry::curve::Curve,
         partial::{PartialCycle, PartialObject},
         services::Services,
@@ -84,19 +84,13 @@ mod tests {
     fn compute_edge_in_front_of_curve_origin() {
         let mut services = Services::new();
 
-        let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[1., -1.], [1., 1.], [0., 1.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[1., -1.], [1., 1.], [0., 1.]],
+                &mut services.objects,
             );
 
             half_edge.build(&mut services.objects)
@@ -116,19 +110,13 @@ mod tests {
     fn compute_edge_behind_curve_origin() {
         let mut services = Services::new();
 
-        let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[-1., -1.], [-1., 1.], [0., 1.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[-1., -1.], [-1., 1.], [0., 1.]],
+                &mut services.objects,
             );
 
             half_edge.build(&mut services.objects)
@@ -148,19 +136,13 @@ mod tests {
     fn compute_edge_parallel_to_curve() {
         let mut services = Services::new();
 
-        let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[-1., -1.], [1., -1.], [1., 1.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.]],
+                &mut services.objects,
             );
 
             half_edge.build(&mut services.objects)
@@ -175,19 +157,13 @@ mod tests {
     fn compute_edge_on_curve() {
         let mut services = Services::new();
 
-        let surface = services.objects.surfaces.xy_plane();
         let curve = Curve::u_axis();
         let half_edge = {
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[-1., 0.], [1., 0.], [1., 1.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[-1., 0.], [1., 0.], [1., 1.]],
+                &mut services.objects,
             );
 
             half_edge.build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -14,7 +14,7 @@ impl Sweep for Handle<Vertex> {
 
     fn sweep_with_cache(
         self,
-        path: impl Into<Vector<3>>,
+        _: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         objects: &mut Service<Objects>,
     ) -> Self::Swept {
@@ -22,9 +22,7 @@ impl Sweep for Handle<Vertex> {
         let b = cache
             .global_vertex
             .entry(self.id())
-            .or_insert_with(|| {
-                Vertex::new(self.position() + path.into()).insert(objects)
-            })
+            .or_insert_with(|| Vertex::new().insert(objects))
             .clone();
 
         let vertices = [a, b];

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -40,7 +40,7 @@ impl TransformObject for GlobalEdge {
     ) -> Self {
         // There's nothing to actually transform here, as `GlobalEdge` holds no
         // data. We still need this implementation though, as a new `GlobalEdge`
-        // must be created to represent the new and transformed edge.
+        // object must be created to represent the new and transformed edge.
         Self::new()
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -10,11 +10,10 @@ use super::{TransformCache, TransformObject};
 impl TransformObject for Vertex {
     fn transform_with_cache(
         self,
-        transform: &Transform,
+        _: &Transform,
         _: &mut Service<Objects>,
         _: &mut TransformCache,
     ) -> Self {
-        let position = transform.transform_point(&self.position());
-        Self::new(position)
+        Self::new()
     }
 }

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -14,6 +14,9 @@ impl TransformObject for Vertex {
         _: &mut Service<Objects>,
         _: &mut TransformCache,
     ) -> Self {
+        // There's nothing to actually transform here, as `Vertex` holds no
+        // data. We still need this implementation though, as a new `Vertex`
+        // object must be created to represent the new and transformed vertex.
         Self::new()
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -110,17 +110,5 @@ impl CycleBuilder for PartialCycle {
         })
     }
 
-    fn infer_vertex_positions_if_necessary(
-        &mut self,
-        surface: &SurfaceGeometry,
-    ) {
-        for (mut half_edge, next_half_edge) in
-            self.half_edges.iter().cloned().circular_tuple_windows()
-        {
-            let next_vertex = next_half_edge.read().start_vertex.clone();
-            half_edge
-                .write()
-                .infer_vertex_positions_if_necessary(surface, next_vertex);
-        }
-    }
+    fn infer_vertex_positions_if_necessary(&mut self, _: &SurfaceGeometry) {}
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -50,12 +50,6 @@ pub trait CycleBuilder {
     ) -> O::SameSize<Partial<HalfEdge>>
     where
         O: ObjectArgument<Partial<HalfEdge>>;
-
-    /// Infer the positions of all vertices, if necessary
-    fn infer_vertex_positions_if_necessary(
-        &mut self,
-        surface: &SurfaceGeometry,
-    );
 }
 
 impl CycleBuilder for PartialCycle {
@@ -109,6 +103,4 @@ impl CycleBuilder for PartialCycle {
             this
         })
     }
-
-    fn infer_vertex_positions_if_necessary(&mut self, _: &SurfaceGeometry) {}
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -249,7 +249,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             }
         });
 
-        self.start_vertex.write().position =
-            other_prev.read().start_vertex.read().position;
+        self.start_vertex = other_prev.read().start_vertex.clone();
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -141,32 +141,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn infer_vertex_positions_if_necessary(
         &mut self,
-        surface: &SurfaceGeometry,
-        next_vertex: Partial<Vertex>,
+        _: &SurfaceGeometry,
+        _: Partial<Vertex>,
     ) {
-        let path = self
-            .curve
-            .expect("Can't infer vertex positions without curve");
-        let MaybeCurve::Defined(path) = path else {
-            panic!("Can't infer vertex positions with undefined path");
-        };
-
-        for (boundary_point, mut vertex) in self
-            .boundary
-            .zip_ext([self.start_vertex.clone(), next_vertex])
-        {
-            let position_curve = boundary_point
-                .expect("Can't infer surface position without curve position");
-            let position_surface = path.point_from_path_coords(position_curve);
-
-            // Infer global position, if not available.
-            let position_global = vertex.read().position;
-            if position_global.is_none() {
-                let position_global =
-                    surface.point_from_surface_coords(position_surface);
-                vertex.write().position = Some(position_global);
-            }
-        }
     }
 
     fn update_from_other_edge(

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -6,7 +6,7 @@ use crate::{
         curve::{Curve, GlobalPath},
         surface::SurfaceGeometry,
     },
-    objects::{HalfEdge, Vertex},
+    objects::HalfEdge,
     partial::{MaybeCurve, Partial, PartialHalfEdge},
 };
 
@@ -37,13 +37,6 @@ pub trait HalfEdgeBuilder {
         start: Point<2>,
         end: Point<2>,
     ) -> Curve;
-
-    /// Infer the vertex positions (surface and global), if not already set
-    fn infer_vertex_positions_if_necessary(
-        &mut self,
-        surface: &SurfaceGeometry,
-        next_vertex: Partial<Vertex>,
-    );
 
     /// Update this edge from another
     ///
@@ -137,13 +130,6 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         };
 
         path
-    }
-
-    fn infer_vertex_positions_if_necessary(
-        &mut self,
-        _: &SurfaceGeometry,
-        _: Partial<Vertex>,
-    ) {
     }
 
     fn update_from_other_edge(

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -46,7 +46,7 @@ use crate::{
 pub struct HalfEdge {
     curve: Curve,
     boundary: [Point<1>; 2],
-    start_vertex: Handle<Vertex>,
+    start_vertex: HandleWrapper<Vertex>,
     global_form: HandleWrapper<GlobalEdge>,
 }
 
@@ -61,7 +61,7 @@ impl HalfEdge {
         Self {
             curve,
             boundary,
-            start_vertex,
+            start_vertex: start_vertex.into(),
             global_form: global_form.into(),
         }
     }

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -1,5 +1,3 @@
-use fj_math::Point;
-
 /// A vertex, defined in global (3D) coordinates
 ///
 /// This struct exists to distinguish between vertices and points at the type
@@ -18,20 +16,12 @@ use fj_math::Point;
 /// [`ValidationConfig`].
 ///
 /// [`ValidationConfig`]: crate::validate::ValidationConfig
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Vertex {
-    position: Point<3>,
-}
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Vertex {}
 
 impl Vertex {
     /// Construct a `Vertex` from a position
-    pub fn new(position: impl Into<Point<3>>) -> Self {
-        let position = position.into();
-        Self { position }
-    }
-
-    /// Access the position of the vertex
-    pub fn position(&self) -> Point<3> {
-        self.position
+    pub fn new() -> Self {
+        Self::default()
     }
 }

--- a/crates/fj-kernel/src/objects/full/vertex.rs
+++ b/crates/fj-kernel/src/objects/full/vertex.rs
@@ -16,7 +16,7 @@
 /// [`ValidationConfig`].
 ///
 /// [`ValidationConfig`]: crate::validate::ValidationConfig
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Hash)]
 pub struct Vertex {}
 
 impl Vertex {

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -1,7 +1,6 @@
 use fj_interop::mesh::Color;
 
 use crate::{
-    builder::CycleBuilder,
     objects::{Cycle, Face, Objects, Surface},
     partial::{FullToPartialCache, Partial, PartialObject},
     services::Service,
@@ -50,17 +49,8 @@ impl PartialObject for PartialFace {
         }
     }
 
-    fn build(mut self, objects: &mut Service<Objects>) -> Self::Full {
+    fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let surface = self.surface.expect("Need `Surface` to build `Face`");
-
-        self.exterior
-            .write()
-            .infer_vertex_positions_if_necessary(&surface.geometry());
-        for interior in &mut self.interiors {
-            interior
-                .write()
-                .infer_vertex_positions_if_necessary(&surface.geometry());
-        }
 
         let exterior = self.exterior.build(objects);
         let interiors =

--- a/crates/fj-kernel/src/partial/objects/vertex.rs
+++ b/crates/fj-kernel/src/partial/objects/vertex.rs
@@ -1,5 +1,3 @@
-use fj_math::Point;
-
 use crate::{
     objects::{Objects, Vertex},
     partial::{FullToPartialCache, PartialObject},
@@ -8,32 +6,20 @@ use crate::{
 
 /// A partial [`Vertex`]
 #[derive(Clone, Debug)]
-pub struct PartialVertex {
-    /// The position of the vertex
-    pub position: Option<Point<3>>,
-}
+pub struct PartialVertex {}
 
 impl PartialObject for PartialVertex {
     type Full = Vertex;
 
     fn new(_: &mut Service<Objects>) -> Self {
-        Self { position: None }
+        Self {}
     }
 
-    fn from_full(
-        global_vertex: &Self::Full,
-        _: &mut FullToPartialCache,
-    ) -> Self {
-        Self {
-            position: Some(global_vertex.position()),
-        }
+    fn from_full(_: &Self::Full, _: &mut FullToPartialCache) -> Self {
+        Self {}
     }
 
     fn build(self, _: &mut Service<Objects>) -> Self::Full {
-        let position = self
-            .position
-            .expect("Can't build `Vertex` without position");
-
-        Vertex::new(position)
+        Vertex::new()
     }
 }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -76,7 +76,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        builder::{CycleBuilder, HalfEdgeBuilder},
+        builder::CycleBuilder,
         objects::HalfEdge,
         partial::{PartialCycle, PartialObject},
         services::Services,
@@ -88,18 +88,11 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let surface = services.objects.surfaces.xy_plane();
-
             let mut cycle = PartialCycle::new(&mut services.objects);
 
-            let [mut half_edge, next_half_edge, _] = cycle
-                .update_as_polygon_from_points(
-                    [[0., 0.], [1., 0.], [1., 1.]],
-                    &mut services.objects,
-                );
-            half_edge.write().infer_vertex_positions_if_necessary(
-                &surface.geometry(),
-                next_half_edge.read().start_vertex.clone(),
+            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
+                [[0., 0.], [1., 0.], [1., 1.]],
+                &mut services.objects,
             );
 
             half_edge.build(&mut services.objects)


### PR DESCRIPTION
Compute `Vertex` positions on-demand in the approximation code, instead of storing it in `Vertex`. This is much simpler than the solution I initially imagined, which included a completely new service for inferring values and caching results. However, I found the solution implemented here to be sufficient for now. In the future, we can extend it as needed.

Close #1586 