### PR TITLE
Prepare `HalfEdgeBuilder` for `HalfEdge`/`PartialHalfEdge` unification

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -377,12 +377,8 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let half_edge = {
-            let half_edge =
-                PartialHalfEdge::make_circle(1., &mut services.objects);
-
-            half_edge.build(&mut services.objects)
-        };
+        let half_edge = PartialHalfEdge::make_circle(1., &mut services.objects)
+            .build(&mut services.objects);
 
         let tolerance = 1.;
         let approx = (&half_edge, surface.deref()).approx(tolerance);

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -378,13 +378,10 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let half_edge = {
-            let mut half_edge = PartialHalfEdge::new(&mut services.objects);
+            let half_edge =
+                PartialHalfEdge::make_circle(1., &mut services.objects);
 
-            half_edge.update_as_circle_from_radius(1.);
-
-            half_edge
-                .build(&mut services.objects)
-                .insert(&mut services.objects)
+            half_edge.build(&mut services.objects)
         };
 
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -1,3 +1,5 @@
+use std::array;
+
 use fj_interop::{ext::ArrayExt, mesh::Color};
 use fj_math::{Point, Scalar, Vector};
 use itertools::Itertools;
@@ -37,10 +39,8 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         );
 
         // Now we're ready to create the edges.
-        let mut edge_bottom = face.exterior.write().add_half_edge(objects);
-        let mut edge_up = face.exterior.write().add_half_edge(objects);
-        let mut edge_top = face.exterior.write().add_half_edge(objects);
-        let mut edge_down = face.exterior.write().add_half_edge(objects);
+        let [mut edge_bottom, mut edge_up, mut edge_top, mut edge_down] =
+            array::from_fn(|_| face.exterior.write().add_half_edge(objects));
 
         // Those edges aren't fully defined yet. We'll do that shortly, but
         // first we have to figure a few things out.

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -5,7 +5,7 @@ use crate::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{Face, GlobalEdge, HalfEdge, Objects, Surface, Vertex},
-    partial::{Partial, PartialFace, PartialObject},
+    partial::{PartialFace, PartialHalfEdge, PartialObject},
     services::Service,
     storage::Handle,
 };
@@ -88,14 +88,15 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
             .zip_ext(global_vertices)
             .zip_ext(global_edges)
             .map(|((((boundary, start), end), global_vertex), global_edge)| {
-                let mut half_edge = Partial::<HalfEdge>::new(objects);
+                let mut half_edge = PartialHalfEdge::make_line_segment(
+                    [start, end],
+                    Some(boundary),
+                    objects,
+                );
 
                 half_edge.write().start_vertex = global_vertex;
                 half_edge.write().global_form = global_edge
                     .unwrap_or_else(|| GlobalEdge::new().insert(objects));
-                half_edge
-                    .write()
-                    .update_as_line_segment([start, end], Some(boundary));
 
                 face.exterior.write().add_half_edge(half_edge.clone());
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -8,7 +8,7 @@ use crate::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{Face, HalfEdge, Objects, Surface, Vertex},
-    partial::{PartialFace, PartialObject},
+    partial::{Partial, PartialFace, PartialObject},
     services::Service,
     storage::Handle,
 };
@@ -40,7 +40,11 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
 
         // Now we're ready to create the edges.
         let [mut edge_bottom, mut edge_up, mut edge_top, mut edge_down] =
-            array::from_fn(|_| face.exterior.write().add_half_edge(objects));
+            array::from_fn(|_| {
+                let edge = Partial::new(objects);
+                face.exterior.write().add_half_edge(edge.clone());
+                edge
+            });
 
         // Those edges aren't fully defined yet. We'll do that shortly, but
         // first we have to figure a few things out.

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -40,14 +40,14 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         // the global vertices and edges.
         let (global_vertices, global_edges) = {
             let [a, b] = [edge.start_vertex(), next_vertex].map(Clone::clone);
-            let (edge_right, [_, c]) =
+            let (edge_up, [_, c]) =
                 b.clone().sweep_with_cache(path, cache, objects);
-            let (edge_left, [_, d]) =
+            let (edge_down, [_, d]) =
                 a.clone().sweep_with_cache(path, cache, objects);
 
             (
                 [a, b, c, d],
-                [edge.global_form().clone(), edge_right, edge_left],
+                [edge.global_form().clone(), edge_up, edge_down],
             )
         };
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -91,10 +91,10 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
                 let mut half_edge = PartialHalfEdge::make_line_segment(
                     [start, end],
                     Some(boundary),
+                    Some(start_vertex),
                     objects,
                 );
 
-                half_edge.write().start_vertex = start_vertex;
                 half_edge.write().global_form = global_edge
                     .unwrap_or_else(|| GlobalEdge::new().insert(objects));
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -37,7 +37,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
 
         // Next, we need to define the boundaries of the face. Let's start with
         // the global vertices and edges.
-        let (global_vertices, global_edges) = {
+        let (vertices, global_edges) = {
             let [a, b] = [edge.start_vertex(), next_vertex].map(Clone::clone);
             let (edge_up, [_, c]) =
                 b.clone().sweep_with_cache(path, cache, objects);
@@ -85,7 +85,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         let [_edge_bottom, _edge_up, edge_top, _edge_down] = boundaries
             .zip_ext(surface_points)
             .zip_ext(surface_points_next)
-            .zip_ext(global_vertices)
+            .zip_ext(vertices)
             .zip_ext(global_edges)
             .map(|((((boundary, start), end), start_vertex), global_edge)| {
                 let mut half_edge = PartialHalfEdge::make_line_segment(

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -87,9 +87,6 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
                         *a = Some(b);
                     }
 
-                    // Writing to the start vertices is enough. Neighboring
-                    // half-edges share surface vertices, so writing the start
-                    // vertex of each half-edge writes to all vertices.
                     half_edge.write().start_vertex = global_vertex;
 
                     face.exterior.write().add_half_edge(half_edge.clone());

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -77,9 +77,9 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
         // Now we're ready to create the edges.
         let [mut edge_bottom, mut edge_up, mut edge_top, mut edge_down] =
             array::from_fn(|_| {
-                let edge = Partial::new(objects);
-                face.exterior.write().add_half_edge(edge.clone());
-                edge
+                let half_edge = Partial::new(objects);
+                face.exterior.write().add_half_edge(half_edge.clone());
+                half_edge
             });
 
         // Armed with all of that, we can set the edge's vertices.

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -99,7 +99,11 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
                 half_edge.write().start_vertex = global_vertex;
                 half_edge.write().global_form = global_edge
                     .unwrap_or_else(|| GlobalEdge::new().insert(objects));
-                half_edge.write().update_as_line_segment(start, end);
+                half_edge.write().update_as_line_segment(
+                    start,
+                    end,
+                    Some(boundary),
+                );
 
                 face.exterior.write().add_half_edge(half_edge.clone());
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -90,12 +90,6 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
             .map(|((((boundary, start), end), global_vertex), global_edge)| {
                 let mut half_edge = Partial::<HalfEdge>::new(objects);
 
-                for (a, b) in
-                    half_edge.write().boundary.each_mut_ext().zip_ext(boundary)
-                {
-                    *a = Some(b);
-                }
-
                 half_edge.write().start_vertex = global_vertex;
                 half_edge.write().global_form = global_edge
                     .unwrap_or_else(|| GlobalEdge::new().insert(objects));

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -87,14 +87,14 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
             .zip_ext(surface_points_next)
             .zip_ext(global_vertices)
             .zip_ext(global_edges)
-            .map(|((((boundary, start), end), global_vertex), global_edge)| {
+            .map(|((((boundary, start), end), start_vertex), global_edge)| {
                 let mut half_edge = PartialHalfEdge::make_line_segment(
                     [start, end],
                     Some(boundary),
                     objects,
                 );
 
-                half_edge.write().start_vertex = global_vertex;
+                half_edge.write().start_vertex = start_vertex;
                 half_edge.write().global_form = global_edge
                     .unwrap_or_else(|| GlobalEdge::new().insert(objects));
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -93,11 +93,9 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
                 half_edge.write().start_vertex = global_vertex;
                 half_edge.write().global_form = global_edge
                     .unwrap_or_else(|| GlobalEdge::new().insert(objects));
-                half_edge.write().update_as_line_segment(
-                    start,
-                    end,
-                    Some(boundary),
-                );
+                half_edge
+                    .write()
+                    .update_as_line_segment([start, end], Some(boundary));
 
                 face.exterior.write().add_half_edge(half_edge.clone());
 

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -38,18 +38,8 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
             (edge.curve(), surface).sweep_with_cache(path, cache, objects),
         );
 
-        // Now we're ready to create the edges.
-        let [mut edge_bottom, mut edge_up, mut edge_top, mut edge_down] =
-            array::from_fn(|_| {
-                let edge = Partial::new(objects);
-                face.exterior.write().add_half_edge(edge.clone());
-                edge
-            });
-
-        // Those edges aren't fully defined yet. We'll do that shortly, but
-        // first we have to figure a few things out.
-        //
-        // Let's start with the global vertices and edges.
+        // Next, we need to define the boundaries of the face. Let's start with
+        // the global vertices and edges.
         let (global_vertices, global_edges) = {
             let [a, b] = [edge.start_vertex(), next_vertex].map(Clone::clone);
             let (edge_right, [_, c]) =
@@ -63,7 +53,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
             )
         };
 
-        // Next, let's figure out the surface coordinates of the edge vertices.
+        // Let's figure out the surface coordinates of the edge vertices.
         let surface_points = {
             let [a, b] = edge.boundary();
 
@@ -83,6 +73,14 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
 
             [[a, b], [c, d], [b, a], [d, c]]
         };
+
+        // Now we're ready to create the edges.
+        let [mut edge_bottom, mut edge_up, mut edge_top, mut edge_down] =
+            array::from_fn(|_| {
+                let edge = Partial::new(objects);
+                face.exterior.write().add_half_edge(edge.clone());
+                edge
+            });
 
         // Armed with all of that, we can set the edge's vertices.
         [

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -4,7 +4,7 @@ use fj_math::{Point, Scalar, Vector};
 use crate::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{Face, GlobalEdge, HalfEdge, Objects, Surface, Vertex},
+    objects::{Face, HalfEdge, Objects, Surface, Vertex},
     partial::{PartialFace, PartialHalfEdge, PartialObject},
     services::Service,
     storage::Handle,
@@ -88,15 +88,13 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
             .zip_ext(vertices)
             .zip_ext(global_edges)
             .map(|((((boundary, start), end), start_vertex), global_edge)| {
-                let mut half_edge = PartialHalfEdge::make_line_segment(
+                let half_edge = PartialHalfEdge::make_line_segment(
                     [start, end],
                     Some(boundary),
                     Some(start_vertex),
+                    global_edge,
                     objects,
                 );
-
-                half_edge.write().global_form = global_edge
-                    .unwrap_or_else(|| GlobalEdge::new().insert(objects));
 
                 face.exterior.write().add_half_edge(half_edge.clone());
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -65,6 +65,7 @@ impl CycleBuilder for PartialCycle {
                 [start, end],
                 None,
                 None,
+                None,
                 objects,
             );
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -61,8 +61,12 @@ impl CycleBuilder for PartialCycle {
         P: Clone + Into<Point<2>>,
     {
         points.map_with_next(|start, end| {
-            let half_edge =
-                PartialHalfEdge::make_line_segment([start, end], None, objects);
+            let half_edge = PartialHalfEdge::make_line_segment(
+                [start, end],
+                None,
+                None,
+                objects,
+            );
 
             self.add_half_edge(half_edge.clone());
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -76,7 +76,7 @@ impl CycleBuilder for PartialCycle {
             .circular_tuple_windows()
             .zip(&mut self.half_edges)
         {
-            half_edge.write().update_as_line_segment(start, end, None);
+            half_edge.write().update_as_line_segment([start, end], None);
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -20,10 +20,7 @@ pub trait CycleBuilder {
     ///
     /// If this is the first half-edge being added, it is connected to itself,
     /// meaning its front and back vertices are the same.
-    fn add_half_edge(
-        &mut self,
-        half_edge: Partial<HalfEdge>,
-    ) -> Partial<HalfEdge>;
+    fn add_half_edge(&mut self, half_edge: Partial<HalfEdge>);
 
     /// Update cycle as a polygon from the provided points
     fn update_as_polygon_from_points<O, P>(
@@ -51,12 +48,8 @@ pub trait CycleBuilder {
 }
 
 impl CycleBuilder for PartialCycle {
-    fn add_half_edge(
-        &mut self,
-        half_edge: Partial<HalfEdge>,
-    ) -> Partial<HalfEdge> {
-        self.half_edges.push(half_edge.clone());
-        half_edge
+    fn add_half_edge(&mut self, half_edge: Partial<HalfEdge>) {
+        self.half_edges.push(half_edge);
     }
 
     fn update_as_polygon_from_points<O, P>(

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{HalfEdge, Objects},
-    partial::{Partial, PartialCycle},
+    partial::{Partial, PartialCycle, PartialHalfEdge},
     services::Service,
 };
 
@@ -61,8 +61,8 @@ impl CycleBuilder for PartialCycle {
         P: Clone + Into<Point<2>>,
     {
         points.map_with_next(|start, end| {
-            let mut half_edge = Partial::<HalfEdge>::new(objects);
-            half_edge.write().update_as_line_segment([start, end], None);
+            let half_edge =
+                PartialHalfEdge::make_line_segment([start, end], None, objects);
 
             self.add_half_edge(half_edge.clone());
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -22,7 +22,7 @@ pub trait CycleBuilder {
     /// meaning its front and back vertices are the same.
     fn add_half_edge(
         &mut self,
-        objects: &mut Service<Objects>,
+        half_edge: Partial<HalfEdge>,
     ) -> Partial<HalfEdge>;
 
     /// Update cycle as a polygon from the provided points
@@ -53,9 +53,8 @@ pub trait CycleBuilder {
 impl CycleBuilder for PartialCycle {
     fn add_half_edge(
         &mut self,
-        objects: &mut Service<Objects>,
+        half_edge: Partial<HalfEdge>,
     ) -> Partial<HalfEdge> {
-        let half_edge = Partial::new(objects);
         self.half_edges.push(half_edge.clone());
         half_edge
     }
@@ -72,7 +71,11 @@ impl CycleBuilder for PartialCycle {
         let mut start_positions = Vec::new();
         let half_edges = points.map(|point| {
             start_positions.push(point.into());
-            self.add_half_edge(objects)
+
+            let half_edge = Partial::new(objects);
+            self.add_half_edge(half_edge.clone());
+
+            half_edge
         });
 
         for ((start, end), half_edge) in start_positions
@@ -95,8 +98,11 @@ impl CycleBuilder for PartialCycle {
         O: ObjectArgument<Partial<HalfEdge>>,
     {
         edges.map_with_prev(|_, prev| {
-            let mut edge = self.add_half_edge(objects);
+            let mut edge: Partial<HalfEdge> = Partial::new(objects);
             edge.write().start_vertex = prev.read().start_vertex.clone();
+
+            self.add_half_edge(edge.clone());
+
             edge
         })
     }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -76,7 +76,7 @@ impl CycleBuilder for PartialCycle {
             .circular_tuple_windows()
             .zip(&mut self.half_edges)
         {
-            half_edge.write().update_as_line_segment(start, end);
+            half_edge.write().update_as_line_segment(start, end, None);
         }
 
         half_edges

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -40,11 +40,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let curve = Curve::circle_from_radius(radius);
         self.curve = Some(curve);
 
-        let [a_curve, b_curve] =
+        let points_curve =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
         for (point_boundary, point_curve) in
-            self.boundary.each_mut_ext().zip_ext([a_curve, b_curve])
+            self.boundary.each_mut_ext().zip_ext(points_curve)
         {
             *point_boundary = Some(point_curve);
         }
@@ -69,11 +69,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             Curve::circle_from_center_and_radius(arc.center, arc.radius);
         self.curve = Some(curve);
 
-        let [a_curve, b_curve] =
+        let points_curve =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
         for (point_boundary, point_curve) in
-            self.boundary.each_mut_ext().zip_ext([a_curve, b_curve])
+            self.boundary.each_mut_ext().zip_ext(points_curve)
         {
             *point_boundary = Some(point_curve);
         }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -19,8 +19,8 @@ pub trait HalfEdgeBuilder {
     /// Panics if the given angle is not within the range (-2pi, 2pi) radians.
     fn update_as_arc(
         &mut self,
-        start: Point<2>,
-        end: Point<2>,
+        start: impl Into<Point<2>>,
+        end: impl Into<Point<2>>,
         angle_rad: impl Into<Scalar>,
     );
 
@@ -54,8 +54,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_arc(
         &mut self,
-        start: Point<2>,
-        end: Point<2>,
+        start: impl Into<Point<2>>,
+        end: impl Into<Point<2>>,
         angle_rad: impl Into<Scalar>,
     ) {
         let angle_rad = angle_rad.into();

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -44,12 +44,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge> {
         let curve = Curve::circle_from_radius(radius);
-        let points_curve =
+        let boundary =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
         Partial::from_partial(PartialHalfEdge {
             curve: Some(curve),
-            boundary: points_curve.map(Some),
+            boundary: boundary.map(Some),
             start_vertex: Vertex::new().insert(objects),
             global_form: GlobalEdge::new().insert(objects),
         })

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -88,6 +88,10 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         end: Point<2>,
         boundary: Option<[Point<1>; 2]>,
     ) -> Curve {
+        if let Some(boundary) = boundary {
+            self.boundary = boundary.map(Some);
+        }
+
         let points_surface = [start, end];
 
         let path = if let Some([start, end]) = boundary {

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -38,6 +38,15 @@ pub trait HalfEdgeBuilder {
         global_form: Option<Handle<GlobalEdge>>,
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge>;
+
+    /// Create a half-edge
+    fn make_half_edge(
+        curve: Curve,
+        boundary: [Point<1>; 2],
+        start_vertex: Option<Handle<Vertex>>,
+        global_form: Option<Handle<GlobalEdge>>,
+        objects: &mut Service<Objects>,
+    ) -> Partial<HalfEdge>;
 }
 
 impl HalfEdgeBuilder for PartialHalfEdge {
@@ -49,12 +58,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let boundary =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        Partial::from_partial(PartialHalfEdge {
-            curve: Some(curve),
-            boundary: boundary.map(Some),
-            start_vertex: Vertex::new().insert(objects),
-            global_form: GlobalEdge::new().insert(objects),
-        })
+        Self::make_half_edge(curve, boundary, None, None, objects)
     }
 
     fn make_arc(
@@ -75,12 +79,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let boundary =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
-        Partial::from_partial(PartialHalfEdge {
-            curve: Some(curve),
-            boundary: boundary.map(Some),
-            start_vertex: Vertex::new().insert(objects),
-            global_form: GlobalEdge::new().insert(objects),
-        })
+        Self::make_half_edge(curve, boundary, None, None, objects)
     }
 
     fn make_line_segment(
@@ -95,16 +94,30 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let curve = Curve::line_from_points_with_coords(
             boundary.zip_ext(points_surface),
         );
-        let start_vertex =
-            start_vertex.unwrap_or_else(|| Vertex::new().insert(objects));
-        let global_form =
-            global_form.unwrap_or_else(|| GlobalEdge::new().insert(objects));
 
+        Self::make_half_edge(
+            curve,
+            boundary,
+            start_vertex,
+            global_form,
+            objects,
+        )
+    }
+
+    fn make_half_edge(
+        curve: Curve,
+        boundary: [Point<1>; 2],
+        start_vertex: Option<Handle<Vertex>>,
+        global_form: Option<Handle<GlobalEdge>>,
+        objects: &mut Service<Objects>,
+    ) -> Partial<HalfEdge> {
         Partial::from_partial(PartialHalfEdge {
             curve: Some(curve),
             boundary: boundary.map(Some),
-            start_vertex,
-            global_form,
+            start_vertex: start_vertex
+                .unwrap_or_else(|| Vertex::new().insert(objects)),
+            global_form: global_form
+                .unwrap_or_else(|| GlobalEdge::new().insert(objects)),
         })
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -88,10 +88,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     ) -> Partial<HalfEdge> {
         let boundary =
             boundary.unwrap_or_else(|| [[0.], [1.]].map(Point::from));
-
-        let points = boundary.zip_ext(points_surface);
-
-        let curve = Curve::line_from_points_with_coords(points);
+        let curve = Curve::line_from_points_with_coords(
+            boundary.zip_ext(points_surface),
+        );
 
         Partial::from_partial(PartialHalfEdge {
             curve: Some(curve),

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -36,6 +36,7 @@ pub trait HalfEdgeBuilder {
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
         start_vertex: Option<Handle<Vertex>>,
+        global_form: Option<Handle<GlobalEdge>>,
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge>;
 }
@@ -87,6 +88,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
         start_vertex: Option<Handle<Vertex>>,
+        global_form: Option<Handle<GlobalEdge>>,
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge> {
         let boundary =
@@ -96,12 +98,14 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         );
         let start_vertex =
             start_vertex.unwrap_or_else(|| Vertex::new().insert(objects));
+        let global_form =
+            global_form.unwrap_or_else(|| GlobalEdge::new().insert(objects));
 
         Partial::from_partial(PartialHalfEdge {
             curve: Some(curve),
             boundary: boundary.map(Some),
             start_vertex,
-            global_form: GlobalEdge::new().insert(objects),
+            global_form,
         })
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -1,5 +1,5 @@
 use fj_interop::ext::ArrayExt;
-use fj_math::{Point, Scalar};
+use fj_math::{Arc, Point, Scalar};
 
 use crate::{
     geometry::curve::Curve,
@@ -66,7 +66,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
         }
 
-        let arc = fj_math::Arc::from_endpoints_and_angle(start, end, angle_rad);
+        let arc = Arc::from_endpoints_and_angle(start, end, angle_rad);
 
         let curve =
             Curve::circle_from_center_and_radius(arc.center, arc.radius);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -12,14 +12,13 @@ use crate::{
 
 /// Builder API for [`PartialHalfEdge`]
 pub trait HalfEdgeBuilder {
-    /// Update partial half-edge to be a circle, from the given radius
+    /// Create a circle
     fn make_circle(
         radius: impl Into<Scalar>,
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge>;
 
-    /// Update partial half-edge to be an arc, spanning the given angle in
-    /// radians
+    /// Create an arc
     ///
     /// # Panics
     ///
@@ -31,7 +30,7 @@ pub trait HalfEdgeBuilder {
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge>;
 
-    /// Update partial half-edge to be a line segment
+    /// Create a line segment
     fn make_line_segment(
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -7,6 +7,7 @@ use crate::{
     objects::{GlobalEdge, HalfEdge, Objects, Vertex},
     partial::{Partial, PartialHalfEdge},
     services::Service,
+    storage::Handle,
 };
 
 /// Builder API for [`PartialHalfEdge`]
@@ -34,6 +35,7 @@ pub trait HalfEdgeBuilder {
     fn make_line_segment(
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
+        start_vertex: Option<Handle<Vertex>>,
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge>;
 }
@@ -84,6 +86,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
     fn make_line_segment(
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
+        start_vertex: Option<Handle<Vertex>>,
         objects: &mut Service<Objects>,
     ) -> Partial<HalfEdge> {
         let boundary =
@@ -91,11 +94,13 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         let curve = Curve::line_from_points_with_coords(
             boundary.zip_ext(points_surface),
         );
+        let start_vertex =
+            start_vertex.unwrap_or_else(|| Vertex::new().insert(objects));
 
         Partial::from_partial(PartialHalfEdge {
             curve: Some(curve),
             boundary: boundary.map(Some),
-            start_vertex: Vertex::new().insert(objects),
+            start_vertex,
             global_form: GlobalEdge::new().insert(objects),
         })
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,8 +33,7 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
-        start: Point<2>,
-        end: Point<2>,
+        points_surface: [Point<2>; 2],
         boundary: Option<[Point<1>; 2]>,
     ) -> Curve;
 }
@@ -84,15 +83,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
-        start: Point<2>,
-        end: Point<2>,
+        points_surface: [Point<2>; 2],
         boundary: Option<[Point<1>; 2]>,
     ) -> Curve {
         if let Some(boundary) = boundary {
             self.boundary = boundary.map(Some);
         }
-
-        let points_surface = [start, end];
 
         let path = if let Some([start, end]) = boundary {
             let points = [start, end].zip_ext(points_surface);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -86,29 +86,15 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         points_surface: [Point<2>; 2],
         boundary: Option<[Point<1>; 2]>,
     ) -> Curve {
-        if let Some(boundary) = boundary {
-            self.boundary = boundary.map(Some);
-        }
+        let boundary =
+            boundary.unwrap_or_else(|| [[0.], [1.]].map(Point::from));
 
-        let path = if let Some(boundary) = boundary {
-            let points = boundary.zip_ext(points_surface);
+        self.boundary = boundary.map(Some);
 
-            let path = Curve::line_from_points_with_coords(points);
-            self.curve = Some(path);
+        let points = boundary.zip_ext(points_surface);
 
-            path
-        } else {
-            let (path, _) = Curve::line_from_points(points_surface);
-            self.curve = Some(path);
-
-            for (vertex, position) in
-                self.boundary.each_mut_ext().zip_ext([0., 1.])
-            {
-                *vertex = Some([position].into());
-            }
-
-            path
-        };
+        let path = Curve::line_from_points_with_coords(points);
+        self.curve = Some(path);
 
         path
     }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -33,7 +33,7 @@ pub trait HalfEdgeBuilder {
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
         &mut self,
-        points_surface: [Point<2>; 2],
+        points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
     ) -> Curve;
 }
@@ -83,7 +83,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
     fn update_as_line_segment(
         &mut self,
-        points_surface: [Point<2>; 2],
+        points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
     ) -> Curve {
         let boundary =

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -37,8 +37,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         &mut self,
         radius: impl Into<Scalar>,
     ) -> Curve {
-        let path = Curve::circle_from_radius(radius);
-        self.curve = Some(path);
+        let curve = Curve::circle_from_radius(radius);
+        self.curve = Some(curve);
 
         let [a_curve, b_curve] =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
@@ -49,7 +49,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             *point_boundary = Some(point_curve);
         }
 
-        path
+        curve
     }
 
     fn update_as_arc(
@@ -65,8 +65,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let arc = fj_math::Arc::from_endpoints_and_angle(start, end, angle_rad);
 
-        let path = Curve::circle_from_center_and_radius(arc.center, arc.radius);
-        self.curve = Some(path);
+        let curve =
+            Curve::circle_from_center_and_radius(arc.center, arc.radius);
+        self.curve = Some(curve);
 
         let [a_curve, b_curve] =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -90,8 +90,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
             self.boundary = boundary.map(Some);
         }
 
-        let path = if let Some([start, end]) = boundary {
-            let points = [start, end].zip_ext(points_surface);
+        let path = if let Some(boundary) = boundary {
+            let points = boundary.zip_ext(points_surface);
 
             let path = Curve::line_from_points_with_coords(points);
             self.curve = Some(path);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -35,6 +35,7 @@ pub trait HalfEdgeBuilder {
         &mut self,
         start: Point<2>,
         end: Point<2>,
+        boundary: Option<[Point<1>; 2]>,
     ) -> Curve;
 }
 
@@ -85,10 +86,11 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         &mut self,
         start: Point<2>,
         end: Point<2>,
+        boundary: Option<[Point<1>; 2]>,
     ) -> Curve {
         let points_surface = [start, end];
 
-        let path = if let [Some(start), Some(end)] = self.boundary {
+        let path = if let Some([start, end]) = boundary {
             let points = [start, end].zip_ext(points_surface);
 
             let path = Curve::line_from_points_with_coords(points);

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -93,9 +93,9 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let points = boundary.zip_ext(points_surface);
 
-        let path = Curve::line_from_points_with_coords(points);
-        self.curve = Some(path);
+        let curve = Curve::line_from_points_with_coords(points);
+        self.curve = Some(curve);
 
-        path
+        curve
     }
 }

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -22,7 +22,7 @@ pub trait HalfEdgeBuilder {
         start: impl Into<Point<2>>,
         end: impl Into<Point<2>>,
         angle_rad: impl Into<Scalar>,
-    );
+    ) -> Curve;
 
     /// Update partial half-edge to be a line segment
     fn update_as_line_segment(
@@ -57,7 +57,7 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         start: impl Into<Point<2>>,
         end: impl Into<Point<2>>,
         angle_rad: impl Into<Scalar>,
-    ) {
+    ) -> Curve {
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
@@ -77,6 +77,8 @@ impl HalfEdgeBuilder for PartialHalfEdge {
         {
             *point_boundary = Some(point_curve);
         }
+
+        curve
     }
 
     fn update_as_line_segment(

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -70,12 +70,12 @@ impl HalfEdgeBuilder for PartialHalfEdge {
 
         let curve =
             Curve::circle_from_center_and_radius(arc.center, arc.radius);
-        let points_curve =
+        let boundary =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
         Partial::from_partial(PartialHalfEdge {
             curve: Some(curve),
-            boundary: points_curve.map(Some),
+            boundary: boundary.map(Some),
             start_vertex: Vertex::new().insert(objects),
             global_form: GlobalEdge::new().insert(objects),
         })

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -89,8 +89,7 @@ impl<T> ObjectArgument<T> for Vec<T> {
         prev.rotate_right(1);
 
         let mut ret = Vec::new();
-        for (i, item) in self.into_iter().enumerate() {
-            let prev = prev[i].clone();
+        for (item, prev) in self.into_iter().zip(prev) {
             ret.push(f(item, prev));
         }
 

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -133,9 +133,8 @@ macro_rules! impl_object_argument_for_arrays {
                     F: FnMut(T, T) -> R,
                     T: Clone,
                 {
-                    let prev: [_; $len] = array::from_fn(|i| {
-                        self[(i + self.len() - 1) % self.len()].clone()
-                    });
+                    let mut prev = self.clone();
+                    prev.rotate_right(1);
 
                     let mut i = 0;
                     self.map(|item| {

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -85,10 +85,8 @@ impl<T> ObjectArgument<T> for Vec<T> {
         F: FnMut(T, T) -> R,
         T: Clone,
     {
-        let mut prev = Vec::new();
-        for i in 0..self.len() {
-            prev.push(self[(i + self.len() - 1) % self.len()].clone());
-        }
+        let mut prev = self.clone();
+        prev.rotate_right(1);
 
         let mut ret = Vec::new();
         for (i, item) in self.into_iter().enumerate() {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -73,14 +73,12 @@ impl Shape for fj::Sketch {
                                 half_edge
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
-                                let mut half_edge: Partial<HalfEdge> =
-                                    Partial::new(objects);
-                                half_edge.write().update_as_arc(
+                                PartialHalfEdge::make_arc(
                                     start,
                                     end,
                                     angle.rad(),
-                                );
-                                half_edge
+                                    objects,
+                                )
                             }
                         };
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -68,6 +68,7 @@ impl Shape for fj::Sketch {
                                 PartialHalfEdge::make_line_segment(
                                     [start, end],
                                     None,
+                                    None,
                                     objects,
                                 )
                             }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -69,6 +69,7 @@ impl Shape for fj::Sketch {
                                     [start, end],
                                     None,
                                     None,
+                                    None,
                                     objects,
                                 )
                             }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -69,7 +69,7 @@ impl Shape for fj::Sketch {
                                     Partial::new(objects);
                                 half_edge
                                     .write()
-                                    .update_as_line_segment(start, end, None);
+                                    .update_as_line_segment([start, end], None);
                                 half_edge
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -4,7 +4,7 @@ use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{HalfEdge, Objects, Sketch},
+    objects::{Objects, Sketch},
     partial::{
         Partial, PartialCycle, PartialFace, PartialHalfEdge, PartialObject,
         PartialSketch,
@@ -65,12 +65,11 @@ impl Shape for fj::Sketch {
                     for ((start, route), (end, _)) in segments {
                         let half_edge = match route {
                             fj::SketchSegmentRoute::Direct => {
-                                let mut half_edge: Partial<HalfEdge> =
-                                    Partial::new(objects);
-                                half_edge
-                                    .write()
-                                    .update_as_line_segment([start, end], None);
-                                half_edge
+                                PartialHalfEdge::make_line_segment(
+                                    [start, end],
+                                    None,
+                                    objects,
+                                )
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
                                 PartialHalfEdge::make_arc(

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -4,7 +4,7 @@ use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{Objects, Sketch},
+    objects::{HalfEdge, Objects, Sketch},
     partial::{
         Partial, PartialCycle, PartialFace, PartialHalfEdge, PartialObject,
         PartialSketch,
@@ -63,23 +63,28 @@ impl Shape for fj::Sketch {
                         .circular_tuple_windows();
 
                     for ((start, route), (end, _)) in segments {
-                        let mut half_edge = Partial::new(objects);
-                        cycle.add_half_edge(half_edge.clone());
-
-                        match route {
+                        let half_edge = match route {
                             fj::SketchSegmentRoute::Direct => {
+                                let mut half_edge: Partial<HalfEdge> =
+                                    Partial::new(objects);
                                 half_edge
                                     .write()
                                     .update_as_line_segment(start, end);
+                                half_edge
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
+                                let mut half_edge: Partial<HalfEdge> =
+                                    Partial::new(objects);
                                 half_edge.write().update_as_arc(
                                     start,
                                     end,
                                     angle.rad(),
                                 );
+                                half_edge
                             }
-                        }
+                        };
+
+                        cycle.add_half_edge(half_edge);
                     }
 
                     Partial::from_partial(cycle)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -28,12 +28,8 @@ impl Shape for fj::Sketch {
 
         let face = match self.chain() {
             fj::Chain::Circle(circle) => {
-                let half_edge = {
-                    let mut half_edge = PartialHalfEdge::new(objects);
-                    half_edge.update_as_circle_from_radius(circle.radius());
-
-                    Partial::from_partial(half_edge)
-                };
+                let half_edge =
+                    PartialHalfEdge::make_circle(circle.radius(), objects);
                 let exterior = {
                     let mut cycle = PartialCycle::new(objects);
                     cycle.half_edges.push(half_edge);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -57,19 +57,18 @@ impl Shape for fj::Sketch {
                 let exterior = {
                     let mut cycle = PartialCycle::new(objects);
 
-                    let half_edges = poly_chain
+                    let segments = poly_chain
                         .to_segments()
                         .into_iter()
                         .map(|fj::SketchSegment { endpoint, route }| {
                             let endpoint = Point::from(endpoint);
-                            let half_edge = cycle.add_half_edge(objects);
-                            (half_edge, endpoint, route)
+                            (endpoint, route)
                         })
-                        .collect::<Vec<_>>();
+                        .circular_tuple_windows();
 
-                    for ((mut half_edge, start, route), (_, end, _)) in
-                        half_edges.into_iter().circular_tuple_windows()
-                    {
+                    for ((start, route), (end, _)) in segments {
+                        let mut half_edge = cycle.add_half_edge(objects);
+
                         match route {
                             fj::SketchSegmentRoute::Direct => {
                                 half_edge

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -69,7 +69,7 @@ impl Shape for fj::Sketch {
                                     Partial::new(objects);
                                 half_edge
                                     .write()
-                                    .update_as_line_segment(start, end);
+                                    .update_as_line_segment(start, end, None);
                                 half_edge
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -128,11 +128,11 @@ impl Shape for fj::Sketch {
                                 segment.endpoint,
                                 fj_math::Scalar::from_f64(angle.rad()),
                             );
-                            for circle_minmax_angle in
+                            for circle_min_max_angle in
                                 [0., PI / 2., PI, 3. * PI / 2.]
                             {
                                 let mm_angle = fj_math::Scalar::from_f64(
-                                    circle_minmax_angle,
+                                    circle_min_max_angle,
                                 );
                                 if arc.start_angle < mm_angle
                                     && mm_angle < arc.end_angle
@@ -141,9 +141,11 @@ impl Shape for fj::Sketch {
                                         arc.center
                                             + [
                                                 arc.radius
-                                                    * circle_minmax_angle.cos(),
+                                                    * circle_min_max_angle
+                                                        .cos(),
                                                 arc.radius
-                                                    * circle_minmax_angle.sin(),
+                                                    * circle_min_max_angle
+                                                        .sin(),
                                             ],
                                     );
                                 }

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -67,7 +67,8 @@ impl Shape for fj::Sketch {
                         .circular_tuple_windows();
 
                     for ((start, route), (end, _)) in segments {
-                        let mut half_edge = cycle.add_half_edge(objects);
+                        let mut half_edge = Partial::new(objects);
+                        cycle.add_half_edge(half_edge.clone());
 
                         match route {
                             fj::SketchSegmentRoute::Direct => {


### PR DESCRIPTION
Once `HalfEdge` and `PartialHalfEdge` are unified, which should result in something that looks almost, if not exactly, like `HalfEdge` does now, the unified `HalfEdge` will no longer be mutable. This pull request prepares `HalfEdgeBuilder` for that future, by redesigning it in a way that doesn't require its caller to mutate the `PartialHalfEdge`s it produces.

This is another big step towards addressing #1570.