### PR TITLE
Require `Handle<HalfEdge>` in fewer places

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/approx/cycle.rs
@@ -2,6 +2,8 @@
 //!
 //! See [`CycleApprox`].
 
+use std::ops::Deref;
+
 use fj_math::Segment;
 
 use crate::objects::{Cycle, Surface};
@@ -26,7 +28,7 @@ impl Approx for (&Cycle, &Surface) {
         let half_edges = cycle
             .half_edges()
             .map(|half_edge| {
-                (half_edge, surface).approx_with_cache(tolerance, cache)
+                (half_edge.deref(), surface).approx_with_cache(tolerance, cache)
             })
             .collect();
 

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{path::RangeOnPath, Approx, ApproxPoint, Tolerance};
 
-impl Approx for (&Handle<HalfEdge>, &Surface) {
+impl Approx for (&HalfEdge, &Surface) {
     type Approximation = HalfEdgeApprox;
     type Cache = EdgeCache;
 
@@ -287,7 +287,7 @@ mod tests {
         };
 
         let tolerance = 1.;
-        let approx = (&half_edge, surface.deref()).approx(tolerance);
+        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
 
         assert_eq!(approx.points, Vec::new());
     }
@@ -313,7 +313,7 @@ mod tests {
         };
 
         let tolerance = 1.;
-        let approx = (&half_edge, surface.deref()).approx(tolerance);
+        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
 
         assert_eq!(approx.points, Vec::new());
     }
@@ -338,7 +338,7 @@ mod tests {
         .insert(&mut services.objects);
 
         let tolerance = 1.;
-        let approx = (&half_edge, surface.deref()).approx(tolerance);
+        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
 
         let expected_approx = (path, range)
             .approx(tolerance)
@@ -364,7 +364,7 @@ mod tests {
             .insert(&mut services.objects);
 
         let tolerance = 1.;
-        let approx = (&half_edge, surface.deref()).approx(tolerance);
+        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
 
         let expected_approx =
             (&half_edge.curve(), RangeOnPath::from([[0.], [TAU]]))

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -275,19 +275,12 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let half_edge = {
-            let mut cycle = PartialCycle::new(&mut services.objects);
-
-            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
-                [[1., 1.], [2., 1.], [1., 2.]],
-                &mut services.objects,
-            );
-
-            half_edge
-        };
+        let half_edge =
+            HalfEdgeBuilder::line_segment([[1., 1.], [2., 1.]], None)
+                .build(&mut services.objects);
 
         let tolerance = 1.;
-        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
+        let approx = (&half_edge, surface.deref()).approx(tolerance);
 
         assert_eq!(approx.points, Vec::new());
     }

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -319,11 +319,10 @@ mod tests {
             [[0., 1.], [TAU, 1.]],
             Some(range.boundary),
         )
-        .build(&mut services.objects)
-        .insert(&mut services.objects);
+        .build(&mut services.objects);
 
         let tolerance = 1.;
-        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
+        let approx = (&half_edge, surface.deref()).approx(tolerance);
 
         let expected_approx = (path, range)
             .approx(tolerance)
@@ -344,12 +343,11 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let half_edge = HalfEdgeBuilder::circle(1.)
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
+        let half_edge =
+            HalfEdgeBuilder::circle(1.).build(&mut services.objects);
 
         let tolerance = 1.;
-        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
+        let approx = (&half_edge, surface.deref()).approx(tolerance);
 
         let expected_approx =
             (&half_edge.curve(), RangeOnPath::from([[0.], [TAU]]))

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -43,8 +43,7 @@ impl Approx for (&Handle<HalfEdge>, &Surface) {
             }
         };
 
-        let first = ApproxPoint::new(position_surface, position_global)
-            .with_source((half_edge.clone(), half_edge.boundary()[0]));
+        let first = ApproxPoint::new(position_surface, position_global);
 
         let points = {
             let approx =
@@ -74,7 +73,6 @@ impl Approx for (&Handle<HalfEdge>, &Surface) {
                         .point_from_path_coords(point.local_form);
 
                     ApproxPoint::new(point_surface, point.global_form)
-                        .with_source((half_edge.clone(), point.local_form))
                 })
                 .collect()
         };

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -262,11 +262,10 @@ mod tests {
 
     use crate::{
         algorithms::approx::{path::RangeOnPath, Approx, ApproxPoint},
-        builder::{CycleBuilder, HalfEdgeBuilder},
+        builder::HalfEdgeBuilder,
         geometry::{curve::GlobalPath, surface::SurfaceGeometry},
         insert::Insert,
         objects::Surface,
-        partial::{PartialCycle, PartialObject},
         services::Services,
     };
 
@@ -294,19 +293,12 @@ mod tests {
             v: [0., 0., 1.].into(),
         })
         .insert(&mut services.objects);
-        let half_edge = {
-            let mut cycle = PartialCycle::new(&mut services.objects);
-
-            let [half_edge, _, _] = cycle.update_as_polygon_from_points(
-                [[1., 1.], [2., 1.], [1., 2.]],
-                &mut services.objects,
-            );
-
-            half_edge
-        };
+        let half_edge =
+            HalfEdgeBuilder::line_segment([[1., 1.], [2., 1.]], None)
+                .build(&mut services.objects);
 
         let tolerance = 1.;
-        let approx = (half_edge.deref(), surface.deref()).approx(tolerance);
+        let approx = (&half_edge, surface.deref()).approx(tolerance);
 
         assert_eq!(approx.points, Vec::new());
     }

--- a/crates/fj-kernel/src/algorithms/approx/face.rs
+++ b/crates/fj-kernel/src/algorithms/approx/face.rs
@@ -47,10 +47,8 @@ impl Approx for &FaceSet {
                         panic!(
                             "Invalid approximation: \
                             Distinct points are too close \
-                            (a: {:?}, b: {:?}, distance: {distance})\n\
-                            source of `a`: {:#?}\n\
-                            source of `b`: {:#?}\n",
-                            a.global_form, b.global_form, a.source, b.source
+                            (a: {:?}, b: {:?}, distance: {distance})",
+                            a.global_form, b.global_form,
                         );
                     }
                 }

--- a/crates/fj-kernel/src/algorithms/approx/mod.rs
+++ b/crates/fj-kernel/src/algorithms/approx/mod.rs
@@ -10,16 +10,12 @@ pub mod solid;
 pub mod tolerance;
 
 use std::{
-    any::Any,
     cmp::Ordering,
     fmt::Debug,
     hash::{Hash, Hasher},
-    rc::Rc,
 };
 
 use fj_math::Point;
-
-use crate::{objects::HalfEdge, storage::Handle};
 
 pub use self::tolerance::{InvalidTolerance, Tolerance};
 
@@ -59,9 +55,6 @@ pub struct ApproxPoint<const D: usize> {
 
     /// The global form of the points
     pub global_form: Point<3>,
-
-    /// The optional source of the point
-    pub source: Option<Rc<dyn Source>>,
 }
 
 impl<const D: usize> ApproxPoint<D> {
@@ -70,15 +63,6 @@ impl<const D: usize> ApproxPoint<D> {
         Self {
             local_form,
             global_form,
-            source: None,
-        }
-    }
-
-    /// Attach a source to the point
-    pub fn with_source(self, source: impl Source) -> Self {
-        Self {
-            source: Some(Rc::new(source)),
-            ..self
         }
     }
 }
@@ -114,8 +98,3 @@ impl<const D: usize> PartialOrd for ApproxPoint<D> {
         Some(self.cmp(other))
     }
 }
-
-/// The source of an [`ApproxPoint`]
-pub trait Source: Any + Debug {}
-
-impl Source for (Handle<HalfEdge>, Point<1>) {}

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -104,9 +104,7 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
                     builder.build(objects).insert(objects)
                 };
 
-                face.exterior.write().add_half_edge(half_edge.clone());
-
-                half_edge
+                face.exterior.write().add_half_edge(half_edge)
             });
 
         // And we're done creating the face! All that's left to do is build our

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
+impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Color) {
     type Swept = (Handle<Face>, Handle<HalfEdge>);
 
     fn sweep_with_cache(

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -101,10 +101,10 @@ impl Sweep for (Handle<HalfEdge>, &Handle<Vertex>, &Surface, Color) {
                         builder
                     };
 
-                    builder.build(objects).insert(objects)
+                    builder.build(objects)
                 };
 
-                face.exterior.write().add_half_edge(half_edge)
+                face.exterior.write().add_half_edge(half_edge, objects)
             });
 
         // And we're done creating the face! All that's left to do is build our

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -68,7 +68,7 @@ impl Sweep for Handle<Face> {
                 cycle.half_edges().cloned().circular_tuple_windows()
             {
                 let (face, top_edge) = (
-                    half_edge.clone(),
+                    half_edge.deref(),
                     next.start_vertex(),
                     self.surface().deref(),
                     self.color(),

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -75,9 +75,7 @@ impl CycleBuilder for PartialCycle {
                 .build(objects)
                 .insert(objects);
 
-            self.add_half_edge(half_edge.clone());
-
-            half_edge
+            self.add_half_edge(half_edge)
         })
     }
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -93,9 +93,7 @@ impl CycleBuilder for PartialCycle {
                 .build(objects)
                 .insert(objects);
 
-            self.add_half_edge(half_edge.clone());
-
-            half_edge
+            self.add_half_edge(half_edge)
         })
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -24,7 +24,8 @@ pub trait CycleBuilder {
     /// meaning its front and back vertices are the same.
     fn add_half_edge(
         &mut self,
-        half_edge: Handle<HalfEdge>,
+        half_edge: HalfEdge,
+        objects: &mut Service<Objects>,
     ) -> Handle<HalfEdge>;
 
     /// Update cycle as a polygon from the provided points
@@ -55,8 +56,10 @@ pub trait CycleBuilder {
 impl CycleBuilder for PartialCycle {
     fn add_half_edge(
         &mut self,
-        half_edge: Handle<HalfEdge>,
+        half_edge: HalfEdge,
+        objects: &mut Service<Objects>,
     ) -> Handle<HalfEdge> {
+        let half_edge = half_edge.insert(objects);
         self.half_edges.push(half_edge.clone());
         half_edge
     }
@@ -72,10 +75,9 @@ impl CycleBuilder for PartialCycle {
     {
         points.map_with_next(|start, end| {
             let half_edge = HalfEdgeBuilder::line_segment([start, end], None)
-                .build(objects)
-                .insert(objects);
+                .build(objects);
 
-            self.add_half_edge(half_edge)
+            self.add_half_edge(half_edge, objects)
         })
     }
 
@@ -90,10 +92,9 @@ impl CycleBuilder for PartialCycle {
         edges.map_with_prev(|(_, curve, boundary), (prev, _, _)| {
             let half_edge = HalfEdgeBuilder::new(curve, boundary)
                 .with_start_vertex(prev.start_vertex().clone())
-                .build(objects)
-                .insert(objects);
+                .build(objects);
 
-            self.add_half_edge(half_edge)
+            self.add_half_edge(half_edge, objects)
         })
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -22,7 +22,10 @@ pub trait CycleBuilder {
     ///
     /// If this is the first half-edge being added, it is connected to itself,
     /// meaning its front and back vertices are the same.
-    fn add_half_edge(&mut self, half_edge: Handle<HalfEdge>);
+    fn add_half_edge(
+        &mut self,
+        half_edge: Handle<HalfEdge>,
+    ) -> Handle<HalfEdge>;
 
     /// Update cycle as a polygon from the provided points
     fn update_as_polygon_from_points<O, P>(
@@ -50,8 +53,12 @@ pub trait CycleBuilder {
 }
 
 impl CycleBuilder for PartialCycle {
-    fn add_half_edge(&mut self, half_edge: Handle<HalfEdge>) {
-        self.half_edges.push(half_edge);
+    fn add_half_edge(
+        &mut self,
+        half_edge: Handle<HalfEdge>,
+    ) -> Handle<HalfEdge> {
+        self.half_edges.push(half_edge.clone());
+        half_edge
     }
 
     fn update_as_polygon_from_points<O, P>(

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -75,9 +75,8 @@ impl Shape for fj::Sketch {
                             }
                         };
 
-                        let half_edge =
-                            half_edge.build(objects).insert(objects);
-                        cycle.add_half_edge(half_edge);
+                        let half_edge = half_edge.build(objects);
+                        cycle.add_half_edge(half_edge, objects);
                     }
 
                     Partial::from_partial(cycle)


### PR DESCRIPTION
Go through a few places in the code and make sure they accept a bare `HalfEdge` where possible.