### PR TITLE
Use `Handle<Cycle>` instead of `Partial<Cycle>` for `PartialFace exterior

### DIFF
--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -152,6 +152,7 @@ mod tests {
     use crate::{
         builder::{CycleBuilder, FaceBuilder},
         geometry::curve::Curve,
+        insert::Insert,
         partial::{PartialFace, PartialObject},
         services::Services,
     };
@@ -184,12 +185,12 @@ mod tests {
 
             face.surface = Some(services.objects.surfaces.xy_plane());
             {
-                let exterior = face.exterior.read().clone();
+                let exterior = face.exterior.clone_object();
                 let (exterior, _) = exterior.update_as_polygon_from_points(
                     exterior_points,
                     &mut services.objects,
                 );
-                *face.exterior.write() = exterior;
+                face.exterior = exterior.insert(&mut services.objects);
             }
             {
                 let mut interior = face.add_interior(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -183,16 +183,23 @@ mod tests {
             let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Some(services.objects.surfaces.xy_plane());
-            face.exterior.write().update_as_polygon_from_points(
-                exterior_points,
-                &mut services.objects,
-            );
-            face.add_interior(&mut services.objects)
-                .write()
-                .update_as_polygon_from_points(
-                    interior_points,
+            {
+                let exterior = face.exterior.read().clone();
+                let (exterior, _) = exterior.update_as_polygon_from_points(
+                    exterior_points,
                     &mut services.objects,
                 );
+                *face.exterior.write() = exterior;
+            }
+            {
+                let mut interior = face.add_interior(&mut services.objects);
+                let (updated, _) =
+                    interior.read().clone().update_as_polygon_from_points(
+                        interior_points,
+                        &mut services.objects,
+                    );
+                *interior.write() = updated;
+            }
 
             face.build(&mut services.objects)
         };

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -165,14 +165,14 @@ mod tests {
         let (curve, _) = Curve::line_from_points([[-3., 0.], [-2., 0.]]);
 
         #[rustfmt::skip]
-        let exterior = [
+        let exterior_points = [
             [-2., -2.],
             [ 2., -2.],
             [ 2.,  2.],
             [-2.,  2.],
         ];
         #[rustfmt::skip]
-        let interior = [
+        let interior_points = [
             [-1., -1.],
             [-1.,  1.],
             [ 1.,  1.],
@@ -183,12 +183,16 @@ mod tests {
             let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Some(services.objects.surfaces.xy_plane());
-            face.exterior
-                .write()
-                .update_as_polygon_from_points(exterior, &mut services.objects);
+            face.exterior.write().update_as_polygon_from_points(
+                exterior_points,
+                &mut services.objects,
+            );
             face.add_interior(&mut services.objects)
                 .write()
-                .update_as_polygon_from_points(interior, &mut services.objects);
+                .update_as_polygon_from_points(
+                    interior_points,
+                    &mut services.objects,
+                );
 
             face.build(&mut services.objects)
         };

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -185,11 +185,11 @@ mod tests {
 
             face.surface = Some(services.objects.surfaces.xy_plane());
             {
-                let exterior = face.exterior.clone_object();
-                let (exterior, _) = exterior.update_as_polygon_from_points(
-                    exterior_points,
-                    &mut services.objects,
-                );
+                let (exterior, _) =
+                    face.exterior.clone_object().update_as_polygon_from_points(
+                        exterior_points,
+                        &mut services.objects,
+                    );
                 face.exterior = exterior.insert(&mut services.objects);
             }
             {

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -91,11 +91,11 @@ mod tests {
 
             face.surface = Some(surface);
             {
-                let exterior = face.exterior.clone_object();
-                let (exterior, _) = exterior.update_as_polygon_from_points(
-                    points,
-                    &mut services.objects,
-                );
+                let (exterior, _) =
+                    face.exterior.clone_object().update_as_polygon_from_points(
+                        points,
+                        &mut services.objects,
+                    );
                 face.exterior = exterior.insert(&mut services.objects);
             }
 
@@ -127,11 +127,11 @@ mod tests {
 
             face.surface = Some(surface);
             {
-                let exterior = face.exterior.clone_object();
-                let (exterior, _) = exterior.update_as_polygon_from_points(
-                    points,
-                    &mut services.objects,
-                );
+                let (exterior, _) =
+                    face.exterior.clone_object().update_as_polygon_from_points(
+                        points,
+                        &mut services.objects,
+                    );
                 face.exterior = exterior.insert(&mut services.objects);
             }
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -64,6 +64,7 @@ mod tests {
         algorithms::intersect::CurveFaceIntersection,
         builder::CycleBuilder,
         geometry::curve::Curve,
+        insert::Insert,
         partial::{PartialFace, PartialObject},
         services::Services,
     };
@@ -90,12 +91,12 @@ mod tests {
 
             face.surface = Some(surface);
             {
-                let exterior = face.exterior.read().clone();
+                let exterior = face.exterior.clone_object();
                 let (exterior, _) = exterior.update_as_polygon_from_points(
                     points,
                     &mut services.objects,
                 );
-                *face.exterior.write() = exterior;
+                face.exterior = exterior.insert(&mut services.objects);
             }
 
             face.build(&mut services.objects)
@@ -126,12 +127,12 @@ mod tests {
 
             face.surface = Some(surface);
             {
-                let exterior = face.exterior.read().clone();
+                let exterior = face.exterior.clone_object();
                 let (exterior, _) = exterior.update_as_polygon_from_points(
                     points,
                     &mut services.objects,
                 );
-                *face.exterior.write() = exterior;
+                face.exterior = exterior.insert(&mut services.objects);
             }
 
             face.build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -89,9 +89,14 @@ mod tests {
             let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Some(surface);
-            face.exterior
-                .write()
-                .update_as_polygon_from_points(points, &mut services.objects);
+            {
+                let exterior = face.exterior.read().clone();
+                let (exterior, _) = exterior.update_as_polygon_from_points(
+                    points,
+                    &mut services.objects,
+                );
+                *face.exterior.write() = exterior;
+            }
 
             face.build(&mut services.objects)
         });
@@ -120,9 +125,14 @@ mod tests {
             let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Some(surface);
-            face.exterior
-                .write()
-                .update_as_polygon_from_points(points, &mut services.objects);
+            {
+                let exterior = face.exterior.read().clone();
+                let (exterior, _) = exterior.update_as_polygon_from_points(
+                    points,
+                    &mut services.objects,
+                );
+                *face.exterior.write() = exterior;
+            }
 
             face.build(&mut services.objects)
         });

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -152,12 +152,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [1., 1.], [0., 2.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -176,12 +176,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [2., 1.], [0., 2.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -203,12 +203,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[4., 2.], [0., 4.], [0., 0.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -230,12 +230,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -257,12 +257,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -284,12 +284,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -311,12 +311,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [2., 0.], [0., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -344,12 +344,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[0., 0.], [1., 0.], [0., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -152,11 +152,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [1., 1.], [0., 2.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [1., 1.], [0., 2.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -176,11 +176,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [2., 1.], [0., 2.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [2., 1.], [0., 2.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -203,11 +203,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[4., 2.], [0., 4.], [0., 0.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[4., 2.], [0., 4.], [0., 0.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -230,11 +230,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -257,11 +257,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -284,11 +284,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -311,11 +311,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [2., 0.], [0., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [2., 0.], [0., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -344,11 +344,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[0., 0.], [1., 0.], [0., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[0., 0.], [1., 0.], [0., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -151,10 +151,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [1., 1.], [0., 2.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [1., 1.], [0., 2.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -171,10 +175,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [2., 1.], [0., 2.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [2., 1.], [0., 2.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -194,10 +202,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[4., 2.], [0., 4.], [0., 0.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[4., 2.], [0., 4.], [0., 0.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -217,10 +229,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -240,10 +256,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -263,10 +283,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -286,10 +310,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [2., 0.], [0., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [2., 0.], [0., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -315,10 +343,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[0., 0.], [1., 0.], [0., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[0., 0.], [1., 0.], [0., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -166,10 +166,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -187,10 +191,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -211,10 +219,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -232,10 +244,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -261,10 +277,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.yz_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)
@@ -293,10 +313,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -316,10 +340,14 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
 
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior.write().update_as_polygon_from_points(
-            [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -167,12 +167,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -192,12 +192,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -220,12 +220,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -245,12 +245,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -278,12 +278,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -314,12 +314,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -341,12 +341,12 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -167,11 +167,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -192,11 +192,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -220,11 +220,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -245,11 +245,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -278,11 +278,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.yz_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -314,11 +314,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -341,11 +341,11 @@ mod tests {
 
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -104,7 +104,14 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Color) {
                     builder.build(objects)
                 };
 
-                face.exterior.write().add_half_edge(half_edge, objects)
+                let (exterior, half_edge) = face
+                    .exterior
+                    .read()
+                    .clone()
+                    .add_half_edge(half_edge, objects);
+                *face.exterior.write() = exterior;
+
+                half_edge
             });
 
         // And we're done creating the face! All that's left to do is build our

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -81,7 +81,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Color) {
             [[a, b], [c, d], [b, a], [d, c]]
         };
 
-        let mut exterior = Some(face.exterior.read().clone());
+        let mut exterior = Some(face.exterior.clone_object());
 
         // Armed with all of that, we're ready to create the edges.
         let [_edge_bottom, _edge_up, edge_top, _edge_down] = boundaries
@@ -113,7 +113,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Color) {
                 half_edge
             });
 
-        *face.exterior.write() = exterior.unwrap();
+        face.exterior = exterior.unwrap().insert(objects);
 
         // And we're done creating the face! All that's left to do is build our
         // return values.

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -104,12 +104,12 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Color) {
                     builder.build(objects)
                 };
 
-                let (exterior, half_edge) = face
+                let (updated, half_edge) = face
                     .exterior
                     .read()
                     .clone()
                     .add_half_edge(half_edge, objects);
-                *face.exterior.write() = exterior;
+                *face.exterior.write() = updated;
 
                 half_edge
             });

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -89,7 +89,13 @@ impl Sweep for Handle<Face> {
             } else {
                 top_face.add_interior(objects)
             };
-            top_cycle.write().connect_to_edges(top_edges, objects);
+            {
+                let (updated, _) = top_cycle
+                    .read()
+                    .clone()
+                    .connect_to_edges(top_edges, objects);
+                *top_cycle.write() = updated;
+            }
         }
 
         let top_face = top_face.build(objects).insert(objects);

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -90,7 +90,7 @@ impl Sweep for Handle<Face> {
                 PartialCycle::new(objects).connect_to_edges(top_edges, objects);
 
             if i == 0 {
-                *top_face.exterior.write() = top_cycle;
+                top_face.exterior = top_cycle.build(objects).insert(objects);
             } else {
                 let mut interior = top_face.add_interior(objects);
                 *interior.write() = top_cycle;

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -99,11 +99,11 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [a, b, c, d],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [a, b, c, d],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
@@ -144,11 +144,11 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(surface.clone());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [a, b, c, d],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [a, b, c, d],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         {
@@ -220,11 +220,11 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(surface.clone());
         {
-            let exterior = face.exterior.clone_object();
-            let (exterior, _) = exterior.update_as_polygon_from_points(
-                [a, b, c, d, e],
-                &mut services.objects,
-            );
+            let (exterior, _) =
+                face.exterior.clone_object().update_as_polygon_from_points(
+                    [a, b, c, d, e],
+                    &mut services.objects,
+                );
             face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -99,12 +99,12 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(services.objects.surfaces.xy_plane());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [a, b, c, d],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)
@@ -144,12 +144,12 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(surface.clone());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [a, b, c, d],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         {
             let mut interior = face.add_interior(&mut services.objects);
@@ -220,12 +220,12 @@ mod tests {
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(surface.clone());
         {
-            let exterior = face.exterior.read().clone();
+            let exterior = face.exterior.clone_object();
             let (exterior, _) = exterior.update_as_polygon_from_points(
                 [a, b, c, d, e],
                 &mut services.objects,
             );
-            *face.exterior.write() = exterior;
+            face.exterior = exterior.insert(&mut services.objects);
         }
         let face = face
             .build(&mut services.objects)

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -98,9 +98,14 @@ mod tests {
 
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(services.objects.surfaces.xy_plane());
-        face.exterior
-            .write()
-            .update_as_polygon_from_points([a, b, c, d], &mut services.objects);
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [a, b, c, d],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -138,12 +143,23 @@ mod tests {
 
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(surface.clone());
-        face.exterior
-            .write()
-            .update_as_polygon_from_points([a, b, c, d], &mut services.objects);
-        face.add_interior(&mut services.objects)
-            .write()
-            .update_as_polygon_from_points([e, f, g, h], &mut services.objects);
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [a, b, c, d],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
+        {
+            let mut interior = face.add_interior(&mut services.objects);
+            let (updated, _) =
+                interior.read().clone().update_as_polygon_from_points(
+                    [e, f, g, h],
+                    &mut services.objects,
+                );
+            *interior.write() = updated;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);
@@ -203,10 +219,14 @@ mod tests {
 
         let mut face = PartialFace::new(&mut services.objects);
         face.surface = Some(surface.clone());
-        face.exterior.write().update_as_polygon_from_points(
-            [a, b, c, d, e],
-            &mut services.objects,
-        );
+        {
+            let exterior = face.exterior.read().clone();
+            let (exterior, _) = exterior.update_as_polygon_from_points(
+                [a, b, c, d, e],
+                &mut services.objects,
+            );
+            *face.exterior.write() = exterior;
+        }
         let face = face
             .build(&mut services.objects)
             .insert(&mut services.objects);

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -3,7 +3,7 @@ use fj_math::Point;
 use crate::{
     geometry::curve::Curve,
     insert::Insert,
-    objects::{HalfEdge, Objects},
+    objects::{Cycle, HalfEdge, Objects},
     partial::PartialCycle,
     services::Service,
     storage::Handle,
@@ -51,6 +51,66 @@ pub trait CycleBuilder: Sized {
     ) -> (Self, O::SameSize<Handle<HalfEdge>>)
     where
         O: ObjectArgument<(Handle<HalfEdge>, Curve, [Point<1>; 2])>;
+}
+
+impl CycleBuilder for Cycle {
+    fn add_half_edge(
+        self,
+        half_edge: HalfEdge,
+        objects: &mut Service<Objects>,
+    ) -> (Self, Handle<HalfEdge>) {
+        let half_edge = half_edge.insert(objects);
+        let cycle =
+            Cycle::new(self.half_edges().cloned().chain([half_edge.clone()]));
+        (cycle, half_edge)
+    }
+
+    fn update_as_polygon_from_points<O, P>(
+        mut self,
+        points: O,
+        objects: &mut Service<Objects>,
+    ) -> (Self, O::SameSize<Handle<HalfEdge>>)
+    where
+        O: ObjectArgument<P>,
+        P: Clone + Into<Point<2>>,
+    {
+        let half_edges = points.map_with_next(|start, end| {
+            let half_edge = HalfEdgeBuilder::line_segment([start, end], None)
+                .build(objects);
+
+            let (cycle, half_edge) =
+                self.clone().add_half_edge(half_edge, objects);
+            self = cycle;
+
+            half_edge
+        });
+
+        (self, half_edges)
+    }
+
+    fn connect_to_edges<O>(
+        mut self,
+        edges: O,
+        objects: &mut Service<Objects>,
+    ) -> (Self, O::SameSize<Handle<HalfEdge>>)
+    where
+        O: ObjectArgument<(Handle<HalfEdge>, Curve, [Point<1>; 2])>,
+    {
+        let edges =
+            edges.map_with_prev(|(_, curve, boundary), (prev, _, _)| {
+                let half_edge = HalfEdgeBuilder::new(curve, boundary)
+                    .with_start_vertex(prev.start_vertex().clone())
+                    .build(objects);
+
+                let (cycle, half_edge) =
+                    self.clone().add_half_edge(half_edge, objects);
+                self = cycle;
+
+                half_edge
+            });
+
+        (self, edges)
+    }
 }
 
 impl CycleBuilder for PartialCycle {

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -13,10 +13,6 @@ pub struct Cycle {
 
 impl Cycle {
     /// Create an instance of `Cycle`
-    ///
-    /// # Panics
-    ///
-    /// Panics, if `half_edges` does not yield at least one half-edge.
     pub fn new(half_edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
 

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -20,15 +20,6 @@ impl Cycle {
     pub fn new(half_edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
 
-        // This is not a validation check, and thus not part of the validation
-        // infrastructure. The property being checked here is inherent to the
-        // validity of a `Cycle`, as methods of `Cycle` might assume that there
-        // is at least one edge.
-        assert!(
-            !half_edges.is_empty(),
-            "Cycle must contain at least one half-edge"
-        );
-
         Self { half_edges }
     }
 

--- a/crates/fj-kernel/src/objects/full/cycle.rs
+++ b/crates/fj-kernel/src/objects/full/cycle.rs
@@ -15,7 +15,6 @@ impl Cycle {
     /// Create an instance of `Cycle`
     pub fn new(half_edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
         let half_edges = half_edges.into_iter().collect::<Vec<_>>();
-
         Self { half_edges }
     }
 

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -53,11 +53,10 @@ impl PartialObject for PartialFace {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let surface = self.surface.expect("Need `Surface` to build `Face`");
 
-        let exterior = self.exterior;
         let interiors =
             self.interiors.into_iter().map(|cycle| cycle.build(objects));
         let color = self.color.unwrap_or_default();
 
-        Face::new(surface, exterior, interiors, color)
+        Face::new(surface, self.exterior, interiors, color)
     }
 }

--- a/crates/fj-kernel/src/partial/objects/face.rs
+++ b/crates/fj-kernel/src/partial/objects/face.rs
@@ -1,6 +1,7 @@
 use fj_interop::mesh::Color;
 
 use crate::{
+    insert::Insert,
     objects::{Cycle, Face, Objects, Surface},
     partial::{FullToPartialCache, Partial, PartialObject},
     services::Service,
@@ -14,7 +15,7 @@ pub struct PartialFace {
     pub surface: Option<Handle<Surface>>,
 
     /// The cycle that bounds the face on the outside
-    pub exterior: Partial<Cycle>,
+    pub exterior: Handle<Cycle>,
 
     /// The cycles that bound the face on the inside
     ///
@@ -31,7 +32,7 @@ impl PartialObject for PartialFace {
     fn new(objects: &mut Service<Objects>) -> Self {
         Self {
             surface: None,
-            exterior: Partial::new(objects),
+            exterior: Cycle::new([]).insert(objects),
             interiors: Vec::new(),
             color: None,
         }
@@ -40,7 +41,7 @@ impl PartialObject for PartialFace {
     fn from_full(face: &Self::Full, cache: &mut FullToPartialCache) -> Self {
         Self {
             surface: Some(face.surface().clone()),
-            exterior: Partial::from_full(face.exterior().clone(), cache),
+            exterior: face.exterior().clone(),
             interiors: face
                 .interiors()
                 .map(|cycle| Partial::from_full(cycle.clone(), cache))
@@ -52,7 +53,7 @@ impl PartialObject for PartialFace {
     fn build(self, objects: &mut Service<Objects>) -> Self::Full {
         let surface = self.surface.expect("Need `Surface` to build `Face`");
 
-        let exterior = self.exterior.build(objects);
+        let exterior = self.exterior;
         let interiors =
             self.interiors.into_iter().map(|cycle| cycle.build(objects));
         let color = self.color.unwrap_or_default();

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -73,6 +73,7 @@ mod tests {
     use crate::{
         algorithms::reverse::Reverse,
         builder::{CycleBuilder, FaceBuilder},
+        insert::Insert,
         objects::Face,
         partial::{PartialFace, PartialObject},
         services::Services,
@@ -88,12 +89,12 @@ mod tests {
 
             face.surface = Some(services.objects.surfaces.xy_plane());
             {
-                let exterior = face.exterior.read().clone();
+                let exterior = face.exterior.clone_object();
                 let (exterior, _) = exterior.update_as_polygon_from_points(
                     [[0., 0.], [3., 0.], [0., 3.]],
                     &mut services.objects,
                 );
-                *face.exterior.write() = exterior;
+                face.exterior = exterior.insert(&mut services.objects);
             }
             {
                 let mut interior = face.add_interior(&mut services.objects);

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -89,11 +89,11 @@ mod tests {
 
             face.surface = Some(services.objects.surfaces.xy_plane());
             {
-                let exterior = face.exterior.clone_object();
-                let (exterior, _) = exterior.update_as_polygon_from_points(
-                    [[0., 0.], [3., 0.], [0., 3.]],
-                    &mut services.objects,
-                );
+                let (exterior, _) =
+                    face.exterior.clone_object().update_as_polygon_from_points(
+                        [[0., 0.], [3., 0.], [0., 3.]],
+                        &mut services.objects,
+                    );
                 face.exterior = exterior.insert(&mut services.objects);
             }
             {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -76,16 +76,23 @@ mod tests {
             let mut face = PartialFace::new(&mut services.objects);
 
             face.surface = Some(services.objects.surfaces.xy_plane());
-            face.exterior.write().update_as_polygon_from_points(
-                [[0., 0.], [3., 0.], [0., 3.]],
-                &mut services.objects,
-            );
-            face.add_interior(&mut services.objects)
-                .write()
-                .update_as_polygon_from_points(
-                    [[1., 1.], [1., 2.], [2., 1.]],
+            {
+                let exterior = face.exterior.read().clone();
+                let (exterior, _) = exterior.update_as_polygon_from_points(
+                    [[0., 0.], [3., 0.], [0., 3.]],
                     &mut services.objects,
                 );
+                *face.exterior.write() = exterior;
+            }
+            {
+                let mut interior = face.add_interior(&mut services.objects);
+                let (updated, _) =
+                    interior.read().clone().update_as_polygon_from_points(
+                        [[1., 1.], [1., 2.], [2., 1.]],
+                        &mut services.objects,
+                    );
+                *interior.write() = updated;
+            }
             face.build(&mut services.objects)
         };
         let invalid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -38,9 +38,20 @@ pub enum FaceValidationError {
 
 impl FaceValidationError {
     fn check_interior_winding(face: &Face, errors: &mut Vec<ValidationError>) {
+        if face.exterior().half_edges().count() == 0 {
+            // Can't determine winding, if the cycle has no half-edges. Sounds
+            // like a job for a different validation check.
+            return;
+        }
+
         let exterior_winding = face.exterior().winding();
 
         for interior in face.interiors() {
+            if interior.half_edges().count() == 0 {
+                // Can't determine winding, if the cycle has no half-edges.
+                // Sounds like a job for a different validation check.
+                continue;
+            }
             let interior_winding = interior.winding();
 
             if exterior_winding == interior_winding {

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -83,7 +83,7 @@ impl Shape for fj::Difference2d {
 
             let face = PartialFace {
                 surface: Some(surface.clone()),
-                exterior: Partial::from(exterior),
+                exterior,
                 interiors,
                 color: Some(Color(self.color())),
             };

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -76,7 +76,7 @@ impl Shape for fj::Sketch {
                         };
 
                         let half_edge = half_edge.build(objects);
-                        cycle.add_half_edge(half_edge, objects);
+                        cycle = cycle.add_half_edge(half_edge, objects).0;
                     }
 
                     Partial::from_partial(cycle)

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -32,7 +32,7 @@ impl Shape for fj::Sketch {
 
                 let mut face = PartialFace::new(objects);
                 face.surface = Some(surface);
-                face.exterior = Partial::from(exterior);
+                face.exterior = exterior;
                 face.color = Some(Color(self.color()));
 
                 face
@@ -73,7 +73,7 @@ impl Shape for fj::Sketch {
                         cycle = cycle.add_half_edge(half_edge, objects).0;
                     }
 
-                    Partial::from(cycle.insert(objects))
+                    cycle.insert(objects)
                 };
 
                 let mut face = PartialFace::new(objects);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -4,7 +4,7 @@ use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
-    objects::{Objects, Sketch},
+    objects::{Cycle, Objects, Sketch},
     partial::{
         Partial, PartialCycle, PartialFace, PartialObject, PartialSketch,
     },
@@ -30,15 +30,11 @@ impl Shape for fj::Sketch {
                 let half_edge = HalfEdgeBuilder::circle(circle.radius())
                     .build(objects)
                     .insert(objects);
-                let exterior = {
-                    let mut cycle = PartialCycle::new(objects);
-                    cycle.half_edges.push(half_edge);
-                    Partial::from_partial(cycle)
-                };
+                let exterior = Cycle::new([half_edge]).insert(objects);
 
                 let mut face = PartialFace::new(objects);
                 face.surface = Some(surface);
-                face.exterior = exterior;
+                face.exterior = Partial::from(exterior);
                 face.color = Some(Color(self.color()));
 
                 face

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -5,9 +5,7 @@ use fj_kernel::{
     builder::{CycleBuilder, HalfEdgeBuilder},
     insert::Insert,
     objects::{Cycle, Objects, Sketch},
-    partial::{
-        Partial, PartialCycle, PartialFace, PartialObject, PartialSketch,
-    },
+    partial::{Partial, PartialFace, PartialObject, PartialSketch},
     services::Service,
 };
 use fj_math::{Aabb, Point};
@@ -47,7 +45,7 @@ impl Shape for fj::Sketch {
                 );
 
                 let exterior = {
-                    let mut cycle = PartialCycle::new(objects);
+                    let mut cycle = Cycle::new([]);
 
                     let segments = poly_chain
                         .to_segments()
@@ -75,7 +73,7 @@ impl Shape for fj::Sketch {
                         cycle = cycle.add_half_edge(half_edge, objects).0;
                     }
 
-                    Partial::from_partial(cycle)
+                    Partial::from(cycle.insert(objects))
                 };
 
                 let mut face = PartialFace::new(objects);


### PR DESCRIPTION
This is one less place where `PartialCycle` is used and thus one more step towards removing `PartialCycle` in favor of `Cycle`. This is another step towards addressing #1570.