### PR TITLE
Add Cycle validation

### DIFF
--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -86,6 +86,16 @@ impl HalfEdge {
         self.curve.point_from_path_coords(start)
     }
 
+    /// Compute the surface position where the half-edge ends
+    pub fn end_position(&self) -> Point<2> {
+        // Computing the surface position from the curve position is fine.
+        // `HalfEdge` "owns" its end position. There is no competing code that
+        // could compute the surface position from slightly different data.
+
+        let [_, end] = self.boundary;
+        self.curve.point_from_path_coords(end)
+    }
+
     /// Access the vertex from where this half-edge starts
     pub fn start_vertex(&self) -> &Handle<Vertex> {
         &self.start_vertex

--- a/crates/fj-kernel/src/objects/full/edge.rs
+++ b/crates/fj-kernel/src/objects/full/edge.rs
@@ -86,16 +86,6 @@ impl HalfEdge {
         self.curve.point_from_path_coords(start)
     }
 
-    /// Compute the surface position where the half-edge ends
-    pub fn end_position(&self) -> Point<2> {
-        // Computing the surface position from the curve position is fine.
-        // `HalfEdge` "owns" its end position. There is no competing code that
-        // could compute the surface position from slightly different data.
-
-        let [_, end] = self.boundary;
-        self.curve.point_from_path_coords(end)
-    }
-
     /// Access the vertex from where this half-edge starts
     pub fn start_vertex(&self) -> &Handle<Vertex> {
         &self.start_vertex

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -55,7 +55,6 @@ impl CycleValidationError {
         // If there are no half edges
         if cycle.half_edges().next().is_none() {
             errors.push(Self::NotEnoughHalfEdges.into());
-            return;
         }
     }
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -39,7 +39,7 @@ pub enum CycleValidationError {
         distance: Scalar,
 
         /// The half-edge
-        half_edges: (HalfEdge, HalfEdge),
+        half_edges: Box<(HalfEdge, HalfEdge)>,
     },
     #[error("Expected at least one `HalfEdge`\n")]
     NotEnoughHalfEdges,
@@ -67,10 +67,10 @@ impl CycleValidationError {
                         end_of_first,
                         start_of_second,
                         distance,
-                        half_edges: (
+                        half_edges: Box::new((
                             first.clone_object(),
                             second.clone_object(),
-                        ),
+                        )),
                     }
                     .into(),
                 );
@@ -81,16 +81,12 @@ impl CycleValidationError {
 
 #[cfg(test)]
 mod tests {
-    use fj_math::Point;
 
     use crate::{
         builder::{CycleBuilder, HalfEdgeBuilder},
-        objects::{Cycle, HalfEdge},
+        objects::Cycle,
         services::Services,
-        validate::{
-            cycle::CycleValidationError, HalfEdgeValidationError, Validate,
-            ValidationError,
-        },
+        validate::{cycle::CycleValidationError, Validate, ValidationError},
     };
 
     #[test]

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -51,8 +51,8 @@ impl CycleValidationError {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        // If there are less than two half edges
-        if cycle.half_edges().nth(1).is_none() {
+        // If there are no half edges
+        if cycle.half_edges().next().is_none() {
             errors.push(Self::NotEnoughHalfEdges.into());
             return;
         }

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -1,12 +1,129 @@
 use crate::objects::Cycle;
+use crate::objects::HalfEdge;
+use fj_math::Point;
+use fj_math::Scalar;
+use itertools::Itertools;
 
 use super::{Validate, ValidationConfig, ValidationError};
 
 impl Validate for Cycle {
     fn validate_with_config(
         &self,
-        _: &ValidationConfig,
-        _: &mut Vec<ValidationError>,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
     ) {
+        CycleValidationError::check_half_edges_disconnected(
+            self, config, errors,
+        )
+    }
+}
+
+/// [`Cycle`] validation failed
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum CycleValidationError {
+    /// [`Cycle`]'s half-edges are not connected
+    #[error(
+        "Adjacent `HalfEdge`s are distinct\n\
+        - End position of first `HalfEdge`: {end_of_first:?}\n\
+        - Start position of second `HalfEdge`: {start_of_second:?}\n\
+        - `HalfEdge`s: {half_edges:#?}"
+    )]
+    HalfEdgesDisconnected {
+        /// The end position of the first [`HalfEdge`]
+        end_of_first: Point<2>,
+
+        /// The start position of the second [`HalfEdge`]
+        start_of_second: Point<2>,
+
+        /// The distance between the two vertices
+        distance: Scalar,
+
+        /// The half-edge
+        half_edges: (HalfEdge, HalfEdge),
+    },
+    #[error("Expected at least one `HalfEdge`\n")]
+    NotEnoughHalfEdges,
+}
+
+impl CycleValidationError {
+    fn check_half_edges_disconnected(
+        cycle: &Cycle,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
+    ) {
+        for (first, second) in cycle
+            .half_edges()
+            .chain(std::iter::once(cycle.half_edges().next().unwrap()))
+            .tuple_windows()
+        {
+            let end_of_first = first.end_position();
+            let start_of_second = second.start_position();
+
+            let distance = (end_of_first - start_of_second).magnitude();
+
+            if distance > config.identical_max_distance {
+                errors.push(
+                    Self::HalfEdgesDisconnected {
+                        end_of_first,
+                        start_of_second,
+                        distance,
+                        half_edges: (
+                            first.clone_object(),
+                            second.clone_object(),
+                        ),
+                    }
+                    .into(),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fj_math::Point;
+
+    use crate::{
+        builder::{CycleBuilder, HalfEdgeBuilder},
+        objects::{Cycle, HalfEdge},
+        services::Services,
+        validate::{
+            cycle::CycleValidationError, HalfEdgeValidationError, Validate,
+            ValidationError,
+        },
+    };
+
+    #[test]
+    fn half_edges_connected() -> anyhow::Result<()> {
+        let mut services = Services::new();
+
+        let valid = Cycle::new([])
+            .update_as_polygon_from_points(
+                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+                &mut services.objects,
+            )
+            .0;
+
+        valid.validate_and_return_first_error()?;
+
+        let first = HalfEdgeBuilder::line_segment([[0., 0.], [1., 0.]], None)
+            .build(&mut services.objects);
+        let second = HalfEdgeBuilder::line_segment([[0., 0.], [1., 0.]], None)
+            .build(&mut services.objects);
+
+        let invalid = Cycle::new([])
+            .add_half_edge(first, &mut services.objects)
+            .0
+            .add_half_edge(second, &mut services.objects)
+            .0;
+
+        assert!(matches!(
+            invalid.validate_and_return_first_error(),
+            Err(ValidationError::Cycle(
+                CycleValidationError::HalfEdgesDisconnected { .. }
+            ))
+        ));
+
+        Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -51,8 +51,15 @@ impl CycleValidationError {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
+        // If there are less than two half edges
+        if cycle.half_edges().nth(1).is_none() {
+            errors.push(Self::NotEnoughHalfEdges.into());
+            return;
+        }
         for (first, second) in cycle
             .half_edges()
+            // Chain the first half_edge so that we make sure that the last connects to the first.
+            // This unwrap will never fail because we checked before that there are enough half_edges.
             .chain(std::iter::once(cycle.half_edges().next().unwrap()))
             .tuple_windows()
         {

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -9,6 +9,7 @@ mod solid;
 mod surface;
 mod vertex;
 
+use self::cycle::CycleValidationError;
 pub use self::{edge::HalfEdgeValidationError, face::FaceValidationError};
 
 use std::convert::Infallible;
@@ -87,6 +88,10 @@ pub enum ValidationError {
     /// `HalfEdge` validation error
     #[error("`HalfEdge` validation error:\n{0}")]
     HalfEdge(#[from] HalfEdgeValidationError),
+
+    /// `Cycle` validation error
+    #[error("`Cycle` validation error:\n{0}")]
+    Cycle(#[from] CycleValidationError),
 }
 
 impl From<Infallible> for ValidationError {


### PR DESCRIPTION
Add basic checks to ensure that `Cycle`s contain at least 2 half-edges, and that all half-edges are connected to each-other.