### PR TITLE
Fix nix flake

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -31,7 +31,7 @@
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
         version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).workspace.package.version;
         # Only keeps assets in crates/ (currently shaders and fonts)
-        assetsFilter = path: _type: (builtins.match ".*(:?wgsl|ttf)$" path) != null;
+        assetsFilter = path: _type: (builtins.match ".*(:?wgsl|ttf|png|obj|fj.toml|mtl)$" path) != null;
         filter = path: type: (assetsFilter path type) || (craneLib.filterCargoSources path type);
         buildInputs = with pkgs; [
           pkg-config

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -77,7 +77,7 @@
           inherit buildInputs;
           nativeBuildInputs = [ rustToolchain ];
 
-          LD_LIBRARY_PATH = "${nixpkgs.lib.makeLibraryPath [ pkgs.vulkan-loader ]}";
+          LD_LIBRARY_PATH = "${nixpkgs.lib.makeLibraryPath [ pkgs.vulkan-loader pkgs.stdenv.cc.cc.lib pkgs.lib3mf]}";
         };
       });
 }


### PR DESCRIPTION
Make `nix run` work, and make `export-validator` work within `nix develop`.
Resolves the issues I had in #1688