### PR TITLE
Shell and Solid validation

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -37,8 +37,8 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                 [
                     Some(edge.global_form().clone()),
                     Some(edge_up),
-                    Some(edge_down),
                     None,
+                    Some(edge_down),
                 ],
             )
         };

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use fj_math::Vector;
 
 use crate::{
-    objects::{Objects, Vertex},
+    objects::{GlobalEdge, Objects, Vertex},
     services::Service,
     storage::{Handle, ObjectId},
 };
@@ -47,4 +47,6 @@ pub trait Sweep: Sized {
 pub struct SweepCache {
     /// Cache for global vertices
     pub global_vertex: BTreeMap<ObjectId, Handle<Vertex>>,
+    /// Cache for global edges
+    pub global_edge: BTreeMap<ObjectId, Handle<GlobalEdge>>,
 }

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -26,7 +26,11 @@ impl Sweep for Handle<Vertex> {
             .clone();
 
         let vertices = [a, b];
-        let global_edge = GlobalEdge::new().insert(objects);
+        let global_edge = cache
+            .global_edge
+            .entry(self.id())
+            .or_insert_with(|| GlobalEdge::new().insert(objects))
+            .clone();
 
         // The vertices of the returned `GlobalEdge` are in normalized order,
         // which means the order can't be relied upon by the caller. Return the

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -44,9 +44,10 @@ impl CycleBuilder {
         let half_edges = edges
             .into_iter()
             .circular_tuple_windows()
-            .map(|((prev, _, _), (_, curve, boundary))| {
+            .map(|((prev, _, _), (half_edge, curve, boundary))| {
                 HalfEdgeBuilder::new(curve, boundary)
                     .with_start_vertex(prev.start_vertex().clone())
+                    .with_global_form(half_edge.global_form().clone())
             })
             .collect();
 

--- a/crates/fj-kernel/src/objects/full/face.rs
+++ b/crates/fj-kernel/src/objects/full/face.rs
@@ -75,7 +75,7 @@ impl Face {
         self.interiors.iter()
     }
 
-    /// Access all cycles of the face
+    /// Access all cycles of the face (both exterior and interior)
     pub fn all_cycles(&self) -> impl Iterator<Item = &Handle<Cycle>> + '_ {
         [self.exterior()].into_iter().chain(self.interiors())
     }

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -42,6 +42,7 @@ pub enum CycleValidationError {
         /// The half-edge
         half_edges: Box<(HalfEdge, HalfEdge)>,
     },
+    /// [`Cycle`]'s should have at least one `HalfEdge`
     #[error("Expected at least one `HalfEdge`\n")]
     NotEnoughHalfEdges,
 }

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -94,6 +94,7 @@ impl CycleValidationError {
 mod tests {
 
     use crate::{
+        assert_contains_err,
         builder::{CycleBuilder, HalfEdgeBuilder},
         objects::Cycle,
         services::Services,
@@ -120,21 +121,19 @@ mod tests {
                 .add_half_edge(second)
                 .build(&mut services.objects)
         };
-        assert!(matches!(
-            disconnected.validate_and_return_first_error(),
-            Err(ValidationError::Cycle(
+
+        assert_contains_err!(
+            disconnected,
+            ValidationError::Cycle(
                 CycleValidationError::HalfEdgesDisconnected { .. }
-            ))
-        ));
+            )
+        );
 
         let empty = Cycle::new([]);
-        assert!(matches!(
-            empty.validate_and_return_first_error(),
-            Err(ValidationError::Cycle(
-                CycleValidationError::NotEnoughHalfEdges
-            ))
-        ));
-
+        assert_contains_err!(
+            empty,
+            ValidationError::Cycle(CycleValidationError::NotEnoughHalfEdges)
+        );
         Ok(())
     }
 }

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -76,6 +76,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
+        assert_contains_err,
         builder::HalfEdgeBuilder,
         objects::HalfEdge,
         services::Services,
@@ -100,12 +101,12 @@ mod tests {
         };
 
         valid.validate_and_return_first_error()?;
-        assert!(matches!(
-            invalid.validate_and_return_first_error(),
-            Err(ValidationError::HalfEdge(
+        assert_contains_err!(
+            invalid,
+            ValidationError::HalfEdge(
                 HalfEdgeValidationError::VerticesAreCoincident { .. }
-            ))
-        ));
+            )
+        );
 
         Ok(())
     }

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -72,6 +72,7 @@ impl FaceValidationError {
 mod tests {
     use crate::{
         algorithms::reverse::Reverse,
+        assert_contains_err,
         builder::{CycleBuilder, FaceBuilder},
         objects::Face,
         services::Services,
@@ -110,12 +111,12 @@ mod tests {
         };
 
         valid.validate_and_return_first_error()?;
-        assert!(matches!(
-            invalid.validate_and_return_first_error(),
-            Err(ValidationError::Face(
+        assert_contains_err!(
+            invalid,
+            ValidationError::Face(
                 FaceValidationError::InvalidInteriorWinding { .. }
-            ))
-        ));
+            )
+        );
 
         Ok(())
     }

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -9,7 +9,7 @@ mod solid;
 mod surface;
 mod vertex;
 
-use self::cycle::CycleValidationError;
+use self::{cycle::CycleValidationError, shell::ShellValidationError};
 pub use self::{edge::HalfEdgeValidationError, face::FaceValidationError};
 
 use std::convert::Infallible;
@@ -92,6 +92,10 @@ pub enum ValidationError {
     /// `Cycle` validation error
     #[error("`Cycle` validation error:\n{0}")]
     Cycle(#[from] CycleValidationError),
+
+    /// `Shell` validation error
+    #[error("`Shell` validation error:\n{0}")]
+    Shell(#[from] ShellValidationError),
 }
 
 impl From<Infallible> for ValidationError {

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -75,11 +75,6 @@ pub struct ValidationConfig {
     /// that distance is less than the one defined in this field, can not be
     /// considered identical.
     pub identical_max_distance: Scalar,
-
-    /// How often to sample edges when checking if they coincide. This
-    /// represents the number of points we check on each Edge.
-    /// The higher this is the more precise our validation is, and the slower it is.
-    pub sample_count: usize,
 }
 
 impl Default for ValidationConfig {
@@ -92,9 +87,6 @@ impl Default for ValidationConfig {
             // false positives due to floating-point accuracy issues), we can
             // adjust it.
             identical_max_distance: Scalar::from_f64(5e-14),
-
-            // This value is completely arbitrary, but seems good enough for now.
-            sample_count: 16,
         }
     }
 }

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -16,6 +16,19 @@ use std::convert::Infallible;
 
 use fj_math::Scalar;
 
+/// Assert that some object has a validation error which matches a specifc pattern.
+/// This is preferred to matching on [`Validate::validate_and_return_first_error`], since usually we don't care about the order.
+#[macro_export]
+macro_rules! assert_contains_err {
+    ($o:tt,$p:pat) => {
+        assert!({
+            let mut errors = Vec::new();
+            $o.validate(&mut errors);
+            errors.iter().find(|e| matches!(e, $p)).is_some()
+        })
+    };
+}
+
 /// Validate an object
 ///
 /// This trait is used automatically when inserting an object into a store.

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -24,7 +24,7 @@ macro_rules! assert_contains_err {
         assert!({
             let mut errors = Vec::new();
             $o.validate(&mut errors);
-            errors.iter().find(|e| matches!(e, $p)).is_some()
+            errors.iter().any(|e| matches!(e, $p))
         })
     };
 }

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -9,8 +9,11 @@ mod solid;
 mod surface;
 mod vertex;
 
-use self::{cycle::CycleValidationError, shell::ShellValidationError};
-pub use self::{edge::HalfEdgeValidationError, face::FaceValidationError};
+pub use self::{
+    cycle::CycleValidationError, edge::HalfEdgeValidationError,
+    face::FaceValidationError, shell::ShellValidationError,
+    solid::SolidValidationError,
+};
 
 use std::convert::Infallible;
 
@@ -109,6 +112,10 @@ pub enum ValidationError {
     /// `Shell` validation error
     #[error("`Shell` validation error:\n{0}")]
     Shell(#[from] ShellValidationError),
+
+    /// `Solid` validation error
+    #[error("`Solid` validation error:\n{0}")]
+    Solid(#[from] SolidValidationError),
 }
 
 impl From<Infallible> for ValidationError {

--- a/crates/fj-kernel/src/validate/mod.rs
+++ b/crates/fj-kernel/src/validate/mod.rs
@@ -62,6 +62,11 @@ pub struct ValidationConfig {
     /// that distance is less than the one defined in this field, can not be
     /// considered identical.
     pub identical_max_distance: Scalar,
+
+    /// How often to sample edges when checking if they coincide. This
+    /// represents the number of points we check on each Edge.
+    /// The higher this is the more precise our validation is, and the slower it is.
+    pub sample_count: usize,
 }
 
 impl Default for ValidationConfig {
@@ -74,6 +79,9 @@ impl Default for ValidationConfig {
             // false positives due to floating-point accuracy issues), we can
             // adjust it.
             identical_max_distance: Scalar::from_f64(5e-14),
+
+            // This value is completely arbitrary, but seems good enough for now.
+            sample_count: 16,
         }
     }
 }

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -1,12 +1,50 @@
-use crate::objects::Shell;
+use std::collections::HashMap;
+
+use crate::{objects::Shell, storage::ObjectId};
 
 use super::{Validate, ValidationConfig, ValidationError};
 
 impl Validate for Shell {
     fn validate_with_config(
         &self,
-        _: &ValidationConfig,
-        _: &mut Vec<ValidationError>,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
     ) {
+        ShellValidationError::validate_watertight(self, config, errors);
+    }
+}
+
+/// [`Shell`] validation failed
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ShellValidationError {
+    /// [`Shell`] contains global_edges not referred to by two half_edges
+    #[error("Shell is not watertight")]
+    NotWaterTight,
+}
+
+impl ShellValidationError {
+    fn validate_watertight(
+        shell: &Shell,
+        _: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
+    ) {
+        let faces = shell.faces();
+        let mut half_edge_to_faces: HashMap<ObjectId, usize> = HashMap::new();
+        for face in faces {
+            let cycles =
+                face.interiors().chain(std::iter::once(face.exterior()));
+            for cycle in cycles {
+                for half_edge in cycle.half_edges() {
+                    let id = half_edge.global_form().id();
+                    let entry = half_edge_to_faces.entry(id);
+                    *entry.or_insert(0) += 1;
+                }
+            }
+        }
+
+        // Each global edge should have exactly two half edges that are part of the shell
+        if half_edge_to_faces.iter().find(|(_, c)| **c != 2).is_some() {
+            errors.push(Self::NotWaterTight.into())
+        }
     }
 }

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -34,7 +34,7 @@ pub enum ShellValidationError {
         Edge 2: {1:#?}
         "
     )]
-    CoincidentEdgesNotIdentical(HalfEdge, HalfEdge),
+    CoincidentEdgesNotIdentical(Handle<HalfEdge>, Handle<HalfEdge>),
 }
 
 /// Check whether to [`HalfEdge`]s are coincident. Along with the edges you
@@ -106,8 +106,8 @@ impl ShellValidationError {
                 {
                     errors.push(
                         Self::CoincidentEdgesNotIdentical(
-                            edge.0.clone_object(),
-                            other_edge.0.clone_object(),
+                            edge.0.clone(),
+                            other_edge.0.clone(),
                         )
                         .into(),
                     )
@@ -134,7 +134,7 @@ impl ShellValidationError {
         }
 
         // Each global edge should have exactly two half edges that are part of the shell
-        if half_edge_to_faces.iter().find(|(_, c)| **c != 2).is_some() {
+        if half_edge_to_faces.iter().any(|(_, c)| *c != 2) {
             errors.push(Self::NotWatertight.into())
         }
     }

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -189,7 +189,6 @@ mod tests {
     fn coincident_not_identical() -> anyhow::Result<()> {
         let mut services = Services::new();
         let invalid = {
-            // Shell with single face is not watertight
             let face1 = FaceBuilder::new(services.objects.surfaces.xy_plane())
                 .with_exterior(CycleBuilder::polygon([
                     [0., 0.],

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -63,8 +63,12 @@ fn are_coincident(
         .distance_to(&sample(0.0, (&edge2, surface2)))
         > config.identical_max_distance;
 
-    for i in 0..config.sample_count {
-        let percent = i as f64 * (1.0 / config.sample_count as f64);
+    // Three samples (start, middle, end), are enough to detect weather lines
+    // and circles match. If we were to add more complicated curves, this might
+    // need to change.
+    let sample_count = 3;
+    for i in 0..sample_count {
+        let percent = i as f64 * (1.0 / sample_count as f64);
         let sample1 = sample(percent, (&edge1, surface1));
         let sample2 = sample(
             if flip { 1.0 - percent } else { percent },

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -1,6 +1,12 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, iter::repeat};
 
-use crate::{objects::Shell, storage::ObjectId};
+use fj_math::Point;
+
+use crate::{
+    geometry::surface::SurfaceGeometry,
+    objects::{HalfEdge, Shell},
+    storage::{Handle, ObjectId},
+};
 
 use super::{Validate, ValidationConfig, ValidationError};
 
@@ -11,6 +17,7 @@ impl Validate for Shell {
         errors: &mut Vec<ValidationError>,
     ) {
         ShellValidationError::validate_watertight(self, config, errors);
+        ShellValidationError::validate_coincident(self, config, errors);
     }
 }
 
@@ -20,9 +27,95 @@ pub enum ShellValidationError {
     /// [`Shell`] contains global_edges not referred to by two half_edges
     #[error("Shell is not watertight")]
     NotWaterTight,
+    /// [`Shell`] contains half_edges that are coincident, but refer to different global_edges
+    #[error(
+        "Shell contains HalfEdges which are coinciendent but refer to different GlobalEdges\n
+        Edge 1: {0:#?}
+        Edge 2: {1:#?}
+        "
+    )]
+    CoincidentEdgesNotIdentical(HalfEdge, HalfEdge),
+}
+
+/// Check whether to [`HalfEdge`]s are coincident. Along with the edges you
+/// provide the surface that they are on, so that we can check their positions
+/// in 3D space.
+/// We check whether they are coincident by comparing a configurable amount
+/// of points, and seeing whether they are further than the maximum distance for
+/// identical objects, see [`ValidationConfig`]
+fn are_coincident(
+    config: &ValidationConfig,
+    (edge1, surface1): (Handle<HalfEdge>, SurfaceGeometry),
+    (edge2, surface2): (Handle<HalfEdge>, SurfaceGeometry),
+) -> bool {
+    fn sample(
+        percent: f64,
+        (edge, surface): (&Handle<HalfEdge>, SurfaceGeometry),
+    ) -> Point<3> {
+        let boundary = edge.boundary();
+        let path_coords = boundary[0] + (boundary[1] - boundary[0]) * percent;
+        let surface_coords = edge.curve().point_from_path_coords(path_coords);
+        surface.point_from_surface_coords(surface_coords)
+    }
+
+    // Check whether start positions do not match. If they don't treat second edge as flipped
+    let flip = sample(0.0, (&edge1, surface1))
+        .distance_to(&sample(0.0, (&edge2, surface2)))
+        > config.identical_max_distance;
+
+    for i in 0..config.sample_count {
+        let percent = i as f64 * (1.0 / config.sample_count as f64);
+        let sample1 = sample(percent, (&edge1, surface1));
+        let sample2 = sample(
+            if flip { 1.0 - percent } else { percent },
+            (&edge2, surface2),
+        );
+        if sample1.distance_to(&sample2) > config.identical_max_distance {
+            // If corresponding points are further than the max distance than these HalfEdges are not coincident
+            return false;
+        }
+    }
+
+    true
 }
 
 impl ShellValidationError {
+    fn validate_coincident(
+        shell: &Shell,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
+    ) {
+        let faces: Vec<(Handle<HalfEdge>, SurfaceGeometry)> = shell
+            .faces()
+            .into_iter()
+            .flat_map(|face| {
+                face.all_cycles()
+                    .flat_map(|cycle| cycle.half_edges().cloned())
+                    .zip(repeat(face.surface().geometry()))
+            })
+            .collect();
+
+        // This is O(N) which isn't great, but we can't use a HashMap since we need to deal with float inaccuracies.
+        #[allow(unreachable_code)]
+        for edge in &faces {
+            for other_edge in &faces {
+                let identical = edge.0.global_form().id()
+                    == other_edge.0.global_form().id();
+                if are_coincident(config, edge.clone(), other_edge.clone())
+                    && !identical
+                {
+                    errors.push(
+                        Self::CoincidentEdgesNotIdentical(
+                            edge.0.clone_object(),
+                            other_edge.0.clone_object(),
+                        )
+                        .into(),
+                    )
+                }
+            }
+        }
+    }
+
     fn validate_watertight(
         shell: &Shell,
         _: &ValidationConfig,
@@ -31,9 +124,7 @@ impl ShellValidationError {
         let faces = shell.faces();
         let mut half_edge_to_faces: HashMap<ObjectId, usize> = HashMap::new();
         for face in faces {
-            let cycles =
-                face.interiors().chain(std::iter::once(face.exterior()));
-            for cycle in cycles {
+            for cycle in face.all_cycles() {
                 for half_edge in cycle.half_edges() {
                     let id = half_edge.global_form().id();
                     let entry = half_edge_to_faces.entry(id);

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -142,6 +142,7 @@ impl ShellValidationError {
 
 #[cfg(test)]
 mod tests {
+    use crate::assert_contains_err;
     use crate::insert::Insert;
 
     use crate::validate::shell::ShellValidationError;
@@ -180,23 +181,12 @@ mod tests {
             Shell::new([face1, face2])
         };
 
-        assert!({
-            let mut errors = Vec::new();
-            invalid.validate(&mut errors);
-            errors
-                .iter()
-                .find(|e| {
-                    matches!(
-                        e,
-                        ValidationError::Shell(
-                            ShellValidationError::CoincidentEdgesNotIdentical(
-                                ..
-                            )
-                        )
-                    )
-                })
-                .is_some()
-        });
+        assert_contains_err!(
+            invalid,
+            ValidationError::Shell(
+                ShellValidationError::CoincidentEdgesNotIdentical(..)
+            )
+        );
 
         Ok(())
     }
@@ -218,21 +208,10 @@ mod tests {
             Shell::new([face])
         };
 
-        assert!({
-            let mut errors = Vec::new();
-            invalid.validate(&mut errors);
-            errors
-                .iter()
-                .find(|e| {
-                    matches!(
-                        e,
-                        ValidationError::Shell(
-                            ShellValidationError::NotWatertight
-                        )
-                    )
-                })
-                .is_some()
-        });
+        assert_contains_err!(
+            invalid,
+            ValidationError::Shell(ShellValidationError::NotWatertight)
+        );
 
         Ok(())
     }

--- a/crates/fj-kernel/src/validate/solid.rs
+++ b/crates/fj-kernel/src/validate/solid.rs
@@ -1,12 +1,99 @@
-use crate::objects::Solid;
+use std::iter::repeat;
+
+use crate::{
+    objects::{Solid, Vertex},
+    storage::Handle,
+};
+use fj_math::Point;
 
 use super::{Validate, ValidationConfig, ValidationError};
 
 impl Validate for Solid {
     fn validate_with_config(
         &self,
-        _: &ValidationConfig,
-        _: &mut Vec<ValidationError>,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
     ) {
+        SolidValidationError::check_vertices(self, config, errors)
+    }
+}
+
+/// [`Solid`] validation failed
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum SolidValidationError {
+    /// [`Solid`] contains vertices that are coincident, but not identical
+    #[error(
+        "Solid contains Vertices that are coinciendent but not identical\n
+        Vertex 1: {:#?} {:#?}
+        Vertex 2: {:#?} {:#?}
+        ", .0[0].0, .0[0].1,.0[1].0,.0[1].1
+    )]
+    DistinctVertsCoincide([(Handle<Vertex>, Point<3>); 2]),
+
+    /// [`Solid`] contains vertices that are identical, but do not coincide
+    #[error(
+        "Solid contains Vertices that are identical but do not coincide\n
+        Vertex 1: {:#?} {:#?}
+        Vertex 2: {:#?} {:#?}
+        ", .0[0].0, .0[0].1,.0[1].0,.0[1].1
+    )]
+    IdenticalVertsNotCoincident([(Handle<Vertex>, Point<3>); 2]),
+}
+
+impl SolidValidationError {
+    fn check_vertices(
+        solid: &Solid,
+        config: &ValidationConfig,
+        errors: &mut Vec<ValidationError>,
+    ) {
+        let vertices: Vec<(Point<3>, Handle<Vertex>)> = solid
+            .shells()
+            .flat_map(|s| s.faces())
+            .flat_map(|face| {
+                face.all_cycles()
+                    .flat_map(|cycle| cycle.half_edges().cloned())
+                    .zip(repeat(face.surface().geometry()))
+            })
+            .map(|(h, s)| {
+                (
+                    s.point_from_surface_coords(h.start_position()),
+                    h.start_vertex().clone(),
+                )
+            })
+            .collect();
+
+        // This is O(N^2) which isn't great, but we can't use a HashMap since we
+        // need to deal with float inaccuracies. Maybe we could use some smarter
+        // data-structure like an octree.
+        for a in &vertices {
+            for b in &vertices {
+                match a.1.id() == b.1.id() {
+                    true => {
+                        if a.0.distance_to(&b.0) > config.identical_max_distance
+                        {
+                            errors.push(
+                                Self::IdenticalVertsNotCoincident([
+                                    (a.1.clone(), a.0),
+                                    (b.1.clone(), b.0),
+                                ])
+                                .into(),
+                            )
+                        }
+                    }
+                    false => {
+                        if a.0.distance_to(&b.0) < config.distinct_min_distance
+                        {
+                            errors.push(
+                                Self::DistinctVertsCoincide([
+                                    (a.1.clone(), a.0),
+                                    (b.1.clone(), b.0),
+                                ])
+                                .into(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Attempt to validate `Shell`'s by making sure that each half-edge in a shell refers to a global-edge that is referred to by another half-edge in that same shell. My logic says that each edge in a shell should be a part of exactly two faces but I may be wrong.

This validation check currently fails with `cargo run --package export- validator`, but I'm not sure if this is a bug in my validation checks, or whether I exposed a bug in existing code.

For example looking at the cuboid example, many global edges are referred to by only one half_edge, which seems wrong to me...

edit by @hannobraun:
Close #1594