### PR TITLE
Fix rust-analyzer in nix flake

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -25,7 +25,7 @@
           let toolchainToml = (builtins.fromTOML (builtins.readFile ../rust-toolchain.toml)).toolchain; in
           {
             channel = toolchainToml.channel;
-            components = toolchainToml.components ++ [ "rust-analyzer" ];
+            components = toolchainToml.components ++ [ "rust-analyzer" "rust-src" ];
           }
         );
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;


### PR DESCRIPTION
Added "rust-src" component which is necessary for rust-analyzer in nix flake.

PS: Sorry for all the nix PRs, I think this is the last one...