### PR TITLE
Expand `Shell` validation tests

### DIFF
--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -24,8 +24,11 @@ impl CycleBuilder {
     }
 
     /// Add a half-edge to the cycle
-    pub fn add_half_edge(mut self, half_edge: HalfEdgeBuilder) -> Self {
-        self.half_edges.push(half_edge);
+    pub fn add_half_edges(
+        mut self,
+        half_edges: impl IntoIterator<Item = HalfEdgeBuilder>,
+    ) -> Self {
+        self.half_edges.extend(half_edges);
         self
     }
 

--- a/crates/fj-kernel/src/builder/edge.rs
+++ b/crates/fj-kernel/src/builder/edge.rs
@@ -4,7 +4,7 @@ use fj_math::{Arc, Point, Scalar};
 use crate::{
     geometry::curve::Curve,
     insert::Insert,
-    objects::{GlobalEdge, HalfEdge, Objects, Vertex},
+    objects::{GlobalEdge, HalfEdge, Objects, Surface, Vertex},
     services::Service,
     storage::Handle,
 };
@@ -74,6 +74,17 @@ impl HalfEdgeBuilder {
         );
 
         Self::new(curve, boundary)
+    }
+
+    /// Create a line segment from global points
+    pub fn line_segment_from_global_points(
+        points_global: [impl Into<Point<3>>; 2],
+        surface: &Surface,
+        boundary: Option<[Point<1>; 2]>,
+    ) -> Self {
+        let points_surface = points_global
+            .map(|point| surface.geometry().project_global_point(point));
+        Self::line_segment(points_surface, boundary)
     }
 
     /// Build the half-edge with a specific start vertex

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,13 +1,14 @@
 use fj_interop::mesh::Color;
+use fj_math::Point;
 
 use crate::{
     insert::Insert,
-    objects::{Face, Objects, Surface},
+    objects::{Cycle, Face, GlobalEdge, Objects, Surface},
     services::Service,
     storage::Handle,
 };
 
-use super::CycleBuilder;
+use super::{CycleBuilder, HalfEdgeBuilder, SurfaceBuilder};
 
 /// Builder API for [`Face`]
 pub struct FaceBuilder {
@@ -25,6 +26,37 @@ impl FaceBuilder {
             interiors: Vec::new(),
             color: None,
         }
+    }
+
+    /// Create a triangle
+    pub fn triangle(
+        points: [impl Into<Point<3>>; 3],
+        objects: &mut Service<Objects>,
+    ) -> (Handle<Face>, [Handle<GlobalEdge>; 3]) {
+        let [a, b, c] = points.map(Into::into);
+
+        let surface =
+            SurfaceBuilder::plane_from_points([a, b, c]).insert(objects);
+        let (exterior, global_edges) = {
+            let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
+                HalfEdgeBuilder::line_segment_from_global_points(
+                    points, &surface, None,
+                )
+                .build(objects)
+                .insert(objects)
+            });
+
+            let cycle = Cycle::new(half_edges.clone()).insert(objects);
+
+            let global_edges =
+                half_edges.map(|half_edge| half_edge.global_form().clone());
+
+            (cycle, global_edges)
+        };
+
+        let face = Face::new(surface, exterior, [], None).insert(objects);
+
+        (face, global_edges)
     }
 
     /// Replace the face's exterior cycle

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -4,5 +4,9 @@
 mod cycle;
 mod edge;
 mod face;
+mod surface;
 
-pub use self::{cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder};
+pub use self::{
+    cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder,
+    surface::SurfaceBuilder,
+};

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -4,9 +4,10 @@
 mod cycle;
 mod edge;
 mod face;
+mod shell;
 mod surface;
 
 pub use self::{
     cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder,
-    surface::SurfaceBuilder,
+    shell::ShellBuilder, surface::SurfaceBuilder,
 };

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -1,0 +1,131 @@
+use fj_math::Point;
+
+use crate::{
+    insert::Insert,
+    objects::{Cycle, Face, Objects, Shell},
+    services::Service,
+};
+
+use super::{HalfEdgeBuilder, SurfaceBuilder};
+
+/// Builder API for [`Shell`]
+pub struct ShellBuilder {}
+
+impl ShellBuilder {
+    /// Create a tetrahedron from the provided points
+    pub fn tetrahedron(
+        points: [impl Into<Point<3>>; 4],
+        objects: &mut Service<Objects>,
+    ) -> Shell {
+        let [a, b, c, d] = points.map(Into::into);
+
+        let (bottom, [ab, bc, ca]) = {
+            let surface =
+                SurfaceBuilder::plane_from_points([a, b, c]).insert(objects);
+            let (exterior, global_edges) = {
+                let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
+                    HalfEdgeBuilder::line_segment_from_global_points(
+                        points, &surface, None,
+                    )
+                    .build(objects)
+                    .insert(objects)
+                });
+
+                let cycle = Cycle::new(half_edges.clone()).insert(objects);
+
+                let global_edges =
+                    half_edges.map(|half_edge| half_edge.global_form().clone());
+
+                (cycle, global_edges)
+            };
+
+            let face = Face::new(surface, exterior, [], None).insert(objects);
+
+            (face, global_edges)
+        };
+        let (front, [_, bd, da]) = {
+            let surface =
+                SurfaceBuilder::plane_from_points([a, b, d]).insert(objects);
+            let (exterior, global_edges) = {
+                let half_edges =
+                    [([a, b], Some(ab)), ([b, d], None), ([d, a], None)].map(
+                        |(points, global_form)| {
+                            let mut builder =
+                            HalfEdgeBuilder::line_segment_from_global_points(
+                                points, &surface, None,
+                            );
+
+                            if let Some(global_form) = global_form {
+                                builder = builder.with_global_form(global_form);
+                            }
+
+                            builder.build(objects).insert(objects)
+                        },
+                    );
+
+                let cycle = Cycle::new(half_edges.clone()).insert(objects);
+
+                let global_edges = half_edges
+                    .map(|half_edges| half_edges.global_form().clone());
+
+                (cycle, global_edges)
+            };
+
+            let face = Face::new(surface, exterior, [], None).insert(objects);
+
+            (face, global_edges)
+        };
+        let (left, [_, _, dc]) = {
+            let surface =
+                SurfaceBuilder::plane_from_points([c, a, d]).insert(objects);
+            let (exterior, global_edges) = {
+                let half_edges =
+                    [([c, a], Some(ca)), ([a, d], Some(da)), ([d, c], None)]
+                        .map(|(points, global_form)| {
+                            let mut builder =
+                            HalfEdgeBuilder::line_segment_from_global_points(
+                                points, &surface, None,
+                            );
+
+                            if let Some(global_form) = global_form {
+                                builder = builder.with_global_form(global_form);
+                            }
+
+                            builder.build(objects).insert(objects)
+                        });
+
+                let cycle = Cycle::new(half_edges.clone()).insert(objects);
+
+                let global_edges =
+                    half_edges.map(|half_edge| half_edge.global_form().clone());
+
+                (cycle, global_edges)
+            };
+
+            let face = Face::new(surface, exterior, [], None).insert(objects);
+
+            (face, global_edges)
+        };
+        let back_right = {
+            let surface =
+                SurfaceBuilder::plane_from_points([b, c, d]).insert(objects);
+            let exterior = {
+                let half_edges = [([b, c], bc), ([c, d], dc), ([d, b], bd)]
+                    .map(|(points, global_form)| {
+                        HalfEdgeBuilder::line_segment_from_global_points(
+                            points, &surface, None,
+                        )
+                        .with_global_form(global_form)
+                        .build(objects)
+                        .insert(objects)
+                    });
+
+                Cycle::new(half_edges).insert(objects)
+            };
+
+            Face::new(surface, exterior, [], None).insert(objects)
+        };
+
+        Shell::new([bottom, front, left, back_right])
+    }
+}

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -19,7 +19,8 @@ impl ShellBuilder {
     ) -> Shell {
         let [a, b, c, d] = points.map(Into::into);
 
-        let (bottom, [ab, bc, ca]) = FaceBuilder::triangle([a, b, c], objects);
+        let (bottom, [ab, bc, ca]) =
+            FaceBuilder::triangle([a, b, c], [None, None, None], objects);
         let (front, [_, bd, da]) = {
             let surface =
                 SurfaceBuilder::plane_from_points([a, b, d]).insert(objects);

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -18,21 +18,21 @@ impl ShellBuilder {
     ) -> Shell {
         let [a, b, c, d] = points.map(Into::into);
 
-        let (bottom, [ab, bc, ca]) =
+        let (base, [ab, bc, ca]) =
             FaceBuilder::triangle([a, b, c], [None, None, None], objects);
-        let (front, [_, bd, da]) =
+        let (side_a, [_, bd, da]) =
             FaceBuilder::triangle([a, b, d], [Some(ab), None, None], objects);
-        let (left, [_, _, dc]) = FaceBuilder::triangle(
+        let (side_b, [_, _, dc]) = FaceBuilder::triangle(
             [c, a, d],
             [Some(ca), Some(da), None],
             objects,
         );
-        let (back_right, _) = FaceBuilder::triangle(
+        let (side_c, _) = FaceBuilder::triangle(
             [b, c, d],
             [Some(bc), Some(dc), Some(bd)],
             objects,
         );
 
-        Shell::new([bottom, front, left, back_right])
+        Shell::new([base, side_a, side_b, side_c])
     }
 }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -1,12 +1,11 @@
 use fj_math::Point;
 
 use crate::{
-    insert::Insert,
-    objects::{Cycle, Face, Objects, Shell},
+    objects::{Objects, Shell},
     services::Service,
 };
 
-use super::{FaceBuilder, HalfEdgeBuilder, SurfaceBuilder};
+use super::FaceBuilder;
 
 /// Builder API for [`Shell`]
 pub struct ShellBuilder {}
@@ -21,88 +20,18 @@ impl ShellBuilder {
 
         let (bottom, [ab, bc, ca]) =
             FaceBuilder::triangle([a, b, c], [None, None, None], objects);
-        let (front, [_, bd, da]) = {
-            let surface =
-                SurfaceBuilder::plane_from_points([a, b, d]).insert(objects);
-            let (exterior, global_edges) = {
-                let half_edges =
-                    [([a, b], Some(ab)), ([b, d], None), ([d, a], None)].map(
-                        |(points, global_form)| {
-                            let mut builder =
-                            HalfEdgeBuilder::line_segment_from_global_points(
-                                points, &surface, None,
-                            );
-
-                            if let Some(global_form) = global_form {
-                                builder = builder.with_global_form(global_form);
-                            }
-
-                            builder.build(objects).insert(objects)
-                        },
-                    );
-
-                let cycle = Cycle::new(half_edges.clone()).insert(objects);
-
-                let global_edges = half_edges
-                    .map(|half_edges| half_edges.global_form().clone());
-
-                (cycle, global_edges)
-            };
-
-            let face = Face::new(surface, exterior, [], None).insert(objects);
-
-            (face, global_edges)
-        };
-        let (left, [_, _, dc]) = {
-            let surface =
-                SurfaceBuilder::plane_from_points([c, a, d]).insert(objects);
-            let (exterior, global_edges) = {
-                let half_edges =
-                    [([c, a], Some(ca)), ([a, d], Some(da)), ([d, c], None)]
-                        .map(|(points, global_form)| {
-                            let mut builder =
-                            HalfEdgeBuilder::line_segment_from_global_points(
-                                points, &surface, None,
-                            );
-
-                            if let Some(global_form) = global_form {
-                                builder = builder.with_global_form(global_form);
-                            }
-
-                            builder.build(objects).insert(objects)
-                        });
-
-                let cycle = Cycle::new(half_edges.clone()).insert(objects);
-
-                let global_edges =
-                    half_edges.map(|half_edge| half_edge.global_form().clone());
-
-                (cycle, global_edges)
-            };
-
-            let face = Face::new(surface, exterior, [], None).insert(objects);
-
-            (face, global_edges)
-        };
-        let back_right = {
-            let surface =
-                SurfaceBuilder::plane_from_points([b, c, d]).insert(objects);
-            let exterior = {
-                let half_edges = [([b, c], bc), ([c, d], dc), ([d, b], bd)]
-                    .map(|(points, global_form)| {
-                        HalfEdgeBuilder::line_segment_from_global_points(
-                            points, &surface, None,
-                        )
-                        .with_global_form(global_form)
-                        .build(objects)
-                        .insert(objects)
-                    });
-
-                Cycle::new(half_edges).insert(objects)
-            };
-
-            Face::new(surface, exterior, [], None).insert(objects)
-        };
+        let (front, [_, bd, da]) =
+            FaceBuilder::triangle([a, b, d], [Some(ab), None, None], objects);
+        let (left, [_, _, dc]) = FaceBuilder::triangle(
+            [c, a, d],
+            [Some(ca), Some(da), None],
+            objects,
+        );
+        let (back_right, _) = FaceBuilder::triangle(
+            [b, c, d],
+            [Some(bc), Some(dc), Some(bd)],
+            objects,
+        );
 
         Shell::new([bottom, front, left, back_right])
     }

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -6,7 +6,7 @@ use crate::{
     services::Service,
 };
 
-use super::{HalfEdgeBuilder, SurfaceBuilder};
+use super::{FaceBuilder, HalfEdgeBuilder, SurfaceBuilder};
 
 /// Builder API for [`Shell`]
 pub struct ShellBuilder {}
@@ -19,30 +19,7 @@ impl ShellBuilder {
     ) -> Shell {
         let [a, b, c, d] = points.map(Into::into);
 
-        let (bottom, [ab, bc, ca]) = {
-            let surface =
-                SurfaceBuilder::plane_from_points([a, b, c]).insert(objects);
-            let (exterior, global_edges) = {
-                let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
-                    HalfEdgeBuilder::line_segment_from_global_points(
-                        points, &surface, None,
-                    )
-                    .build(objects)
-                    .insert(objects)
-                });
-
-                let cycle = Cycle::new(half_edges.clone()).insert(objects);
-
-                let global_edges =
-                    half_edges.map(|half_edge| half_edge.global_form().clone());
-
-                (cycle, global_edges)
-            };
-
-            let face = Face::new(surface, exterior, [], None).insert(objects);
-
-            (face, global_edges)
-        };
+        let (bottom, [ab, bc, ca]) = FaceBuilder::triangle([a, b, c], objects);
         let (front, [_, bd, da]) = {
             let surface =
                 SurfaceBuilder::plane_from_points([a, b, d]).insert(objects);

--- a/crates/fj-kernel/src/builder/surface.rs
+++ b/crates/fj-kernel/src/builder/surface.rs
@@ -1,0 +1,23 @@
+use fj_math::Point;
+
+use crate::{
+    geometry::{curve::GlobalPath, surface::SurfaceGeometry},
+    objects::Surface,
+};
+
+/// Builder API for [`Surface`]
+pub struct SurfaceBuilder {}
+
+impl SurfaceBuilder {
+    /// Create a plane from the provided points
+    pub fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Surface {
+        let [a, b, c] = points.map(Into::into);
+
+        let geometry = SurfaceGeometry {
+            u: GlobalPath::line_from_points([a, b]).0,
+            v: c - a,
+        };
+
+        Surface::new(geometry)
+    }
+}

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -118,8 +118,7 @@ mod tests {
                 HalfEdgeBuilder::line_segment([[0., 0.], [1., 0.]], None);
 
             CycleBuilder::new()
-                .add_half_edges([first])
-                .add_half_edges([second])
+                .add_half_edges([first, second])
                 .build(&mut services.objects)
         };
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -118,8 +118,8 @@ mod tests {
                 HalfEdgeBuilder::line_segment([[0., 0.], [1., 0.]], None);
 
             CycleBuilder::new()
-                .add_half_edge(first)
-                .add_half_edge(second)
+                .add_half_edges([first])
+                .add_half_edges([second])
                 .build(&mut services.objects)
         };
 

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -278,11 +278,11 @@ mod tests {
                 (face, global_edges)
             };
             let (left, [_, _, dc]) = {
-                let surface = SurfaceBuilder::plane_from_points([a, c, d])
+                let surface = SurfaceBuilder::plane_from_points([c, a, d])
                     .insert(&mut services.objects);
                 let (exterior, global_edges) = {
-                    let c = [1., 0.];
-                    let a = [0., 0.];
+                    let c = [0., 0.];
+                    let a = [1., 0.];
                     let d = [0., 1.];
 
                     let half_edges = [

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -215,14 +215,12 @@ mod tests {
                 let surface = SurfaceBuilder::plane_from_points([a, b, c])
                     .insert(&mut services.objects);
                 let (exterior, global_edges) = {
-                    let a = [0., 0.];
-                    let b = [1., 0.];
-                    let c = [0., 1.];
-
                     let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
-                        HalfEdgeBuilder::line_segment(points, None)
-                            .build(&mut services.objects)
-                            .insert(&mut services.objects)
+                        HalfEdgeBuilder::line_segment_from_global_points(
+                            points, &surface, None,
+                        )
+                        .build(&mut services.objects)
+                        .insert(&mut services.objects)
                     });
 
                     let cycle = Cycle::new(half_edges.clone())
@@ -243,15 +241,13 @@ mod tests {
                 let surface = SurfaceBuilder::plane_from_points([a, b, d])
                     .insert(&mut services.objects);
                 let (exterior, global_edges) = {
-                    let a = [0., 0.];
-                    let b = [1., 0.];
-                    let d = [0., 1.];
-
                     let half_edges =
                         [([a, b], Some(ab)), ([b, d], None), ([d, a], None)]
                             .map(|(points, global_form)| {
                                 let mut builder =
-                                    HalfEdgeBuilder::line_segment(points, None);
+                            HalfEdgeBuilder::line_segment_from_global_points(
+                                points, &surface, None,
+                            );
 
                                 if let Some(global_form) = global_form {
                                     builder =
@@ -281,10 +277,6 @@ mod tests {
                 let surface = SurfaceBuilder::plane_from_points([c, a, d])
                     .insert(&mut services.objects);
                 let (exterior, global_edges) = {
-                    let c = [0., 0.];
-                    let a = [1., 0.];
-                    let d = [0., 1.];
-
                     let half_edges = [
                         ([c, a], Some(ca)),
                         ([a, d], Some(da)),
@@ -292,7 +284,9 @@ mod tests {
                     ]
                     .map(|(points, global_form)| {
                         let mut builder =
-                            HalfEdgeBuilder::line_segment(points, None);
+                            HalfEdgeBuilder::line_segment_from_global_points(
+                                points, &surface, None,
+                            );
 
                         if let Some(global_form) = global_form {
                             builder = builder.with_global_form(global_form);
@@ -321,16 +315,14 @@ mod tests {
                 let surface = SurfaceBuilder::plane_from_points([b, c, d])
                     .insert(&mut services.objects);
                 let exterior = {
-                    let b = [0., 0.];
-                    let c = [1., 0.];
-                    let d = [0., 1.];
-
                     let half_edges = [([b, c], bc), ([c, d], dc), ([d, b], bd)]
                         .map(|(points, global_form)| {
-                            HalfEdgeBuilder::line_segment(points, None)
-                                .with_global_form(global_form)
-                                .build(&mut services.objects)
-                                .insert(&mut services.objects)
+                            HalfEdgeBuilder::line_segment_from_global_points(
+                                points, &surface, None,
+                            )
+                            .with_global_form(global_form)
+                            .build(&mut services.objects)
+                            .insert(&mut services.objects)
                         });
 
                     Cycle::new(half_edges).insert(&mut services.objects)

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -246,6 +246,10 @@ mod tests {
     fn shell_not_watertight() -> anyhow::Result<()> {
         let mut services = Services::new();
 
+        let valid = ShellBuilder::tetrahedron(
+            [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
+            &mut services.objects,
+        );
         let invalid = {
             // Shell with single face is not watertight
             let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
@@ -260,6 +264,7 @@ mod tests {
             Shell::new([face])
         };
 
+        valid.validate_and_return_first_error()?;
         assert_contains_err!(
             invalid,
             ValidationError::Shell(ShellValidationError::NotWatertight)

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -195,10 +195,9 @@ mod tests {
 
     use crate::{
         assert_contains_err,
-        builder::{CycleBuilder, FaceBuilder, HalfEdgeBuilder},
-        geometry::{curve::GlobalPath, surface::SurfaceGeometry},
+        builder::{CycleBuilder, FaceBuilder, HalfEdgeBuilder, SurfaceBuilder},
         insert::Insert,
-        objects::{Cycle, Face, Shell, Surface},
+        objects::{Cycle, Face, Shell},
         services::Services,
         validate::{shell::ShellValidationError, Validate, ValidationError},
     };
@@ -208,12 +207,13 @@ mod tests {
         let mut services = Services::new();
 
         let valid = {
-            let [_a, b, c, d] =
+            let [a, b, c, d] =
                 [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]
                     .map(Point::from);
 
             let (bottom, [ab, bc, ca]) = {
-                let surface = services.objects.surfaces.xy_plane();
+                let surface = SurfaceBuilder::plane_from_points([a, b, c])
+                    .insert(&mut services.objects);
                 let (exterior, global_edges) = {
                     let a = [0., 0.];
                     let b = [1., 0.];
@@ -240,7 +240,8 @@ mod tests {
                 (face, global_edges)
             };
             let (front, [_, bd, da]) = {
-                let surface = services.objects.surfaces.xz_plane();
+                let surface = SurfaceBuilder::plane_from_points([a, b, d])
+                    .insert(&mut services.objects);
                 let (exterior, global_edges) = {
                     let a = [0., 0.];
                     let b = [1., 0.];
@@ -277,7 +278,8 @@ mod tests {
                 (face, global_edges)
             };
             let (left, [_, _, dc]) = {
-                let surface = services.objects.surfaces.yz_plane();
+                let surface = SurfaceBuilder::plane_from_points([a, c, d])
+                    .insert(&mut services.objects);
                 let (exterior, global_edges) = {
                     let c = [1., 0.];
                     let a = [0., 0.];
@@ -316,13 +318,8 @@ mod tests {
                 (face, global_edges)
             };
             let back_right = {
-                let surface = {
-                    let geometry = SurfaceGeometry {
-                        u: GlobalPath::line_from_points([b, c]).0,
-                        v: d - b,
-                    };
-                    Surface::new(geometry).insert(&mut services.objects)
-                };
+                let surface = SurfaceBuilder::plane_from_points([b, c, d])
+                    .insert(&mut services.objects);
                 let exterior = {
                     let b = [0., 0.];
                     let c = [1., 0.];

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -68,7 +68,7 @@ impl Shape for fj::Sketch {
                             }
                         };
 
-                        cycle = cycle.add_half_edge(half_edge);
+                        cycle = cycle.add_half_edges([half_edge]);
                     }
 
                     cycle.build(objects).insert(objects)


### PR DESCRIPTION
Expand the `Shell` validation tests by also testing the "valid" scenario, not just the "invalid" one. Expand the builder API to support that.

This is a step towards #1713, but it doesn't quite get us where we need to. The new builder APIs are too specialized to be of any real use outside of what they're currently used for. They definitely need some more work.

On the plus side, all previous attempts to write builder APIs like this either turned out overly complicated, or failed outright. So the recent cleanup work really did help. This also gave me some new ideas on how to evolve the builder API further, and I'll try those out next.