### PR TITLE
Extract build operations from builder API

### DIFF
--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -3,12 +3,12 @@ use fj_math::Point;
 
 use crate::{
     objects::{Cycle, Face, GlobalEdge, Objects, Surface},
-    operations::Insert,
+    operations::{BuildSurface, Insert},
     services::Service,
     storage::Handle,
 };
 
-use super::{CycleBuilder, HalfEdgeBuilder, SurfaceBuilder};
+use super::{CycleBuilder, HalfEdgeBuilder};
 
 /// Builder API for [`Face`]
 pub struct FaceBuilder {
@@ -36,8 +36,7 @@ impl FaceBuilder {
     ) -> (Handle<Face>, [Handle<GlobalEdge>; 3]) {
         let [a, b, c] = points.map(Into::into);
 
-        let surface =
-            SurfaceBuilder::plane_from_points([a, b, c]).insert(objects);
+        let surface = Surface::plane_from_points([a, b, c]).insert(objects);
         let (exterior, global_edges) = {
             let half_edges = [[a, b], [b, c], [c, a]].zip_ext(edges).map(
                 |(points, global_form)| {

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -4,9 +4,5 @@
 mod cycle;
 mod edge;
 mod face;
-mod shell;
 
-pub use self::{
-    cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder,
-    shell::ShellBuilder,
-};
+pub use self::{cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder};

--- a/crates/fj-kernel/src/builder/mod.rs
+++ b/crates/fj-kernel/src/builder/mod.rs
@@ -5,9 +5,8 @@ mod cycle;
 mod edge;
 mod face;
 mod shell;
-mod surface;
 
 pub use self::{
     cycle::CycleBuilder, edge::HalfEdgeBuilder, face::FaceBuilder,
-    shell::ShellBuilder, surface::SurfaceBuilder,
+    shell::ShellBuilder,
 };

--- a/crates/fj-kernel/src/builder/shell.rs
+++ b/crates/fj-kernel/src/builder/shell.rs
@@ -1,11 +1,10 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Objects, Shell},
+    objects::{Face, Objects, Shell},
+    operations::BuildFace,
     services::Service,
 };
-
-use super::FaceBuilder;
 
 /// Builder API for [`Shell`]
 pub struct ShellBuilder {}
@@ -19,19 +18,13 @@ impl ShellBuilder {
         let [a, b, c, d] = points.map(Into::into);
 
         let (base, [ab, bc, ca]) =
-            FaceBuilder::triangle([a, b, c], [None, None, None], objects);
+            Face::triangle([a, b, c], [None, None, None], objects);
         let (side_a, [_, bd, da]) =
-            FaceBuilder::triangle([a, b, d], [Some(ab), None, None], objects);
-        let (side_b, [_, _, dc]) = FaceBuilder::triangle(
-            [c, a, d],
-            [Some(ca), Some(da), None],
-            objects,
-        );
-        let (side_c, _) = FaceBuilder::triangle(
-            [b, c, d],
-            [Some(bc), Some(dc), Some(bd)],
-            objects,
-        );
+            Face::triangle([a, b, d], [Some(ab), None, None], objects);
+        let (side_b, [_, _, dc]) =
+            Face::triangle([c, a, d], [Some(ca), Some(da), None], objects);
+        let (side_c, _) =
+            Face::triangle([b, c, d], [Some(bc), Some(dc), Some(bd)], objects);
 
         Shell::new([base, side_a, side_b, side_c])
     }

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -22,7 +22,7 @@ pub trait BuildFace {
         let [a, b, c] = points.map(Into::into);
 
         let surface = Surface::plane_from_points([a, b, c]).insert(objects);
-        let (exterior, global_edges) = {
+        let (exterior, edges) = {
             let half_edges = [[a, b], [b, c], [c, a]].zip_ext(edges).map(
                 |(points, global_form)| {
                     let mut builder =
@@ -48,10 +48,7 @@ pub trait BuildFace {
 
         let face = Face::new(surface, exterior, [], None);
 
-        Triangle {
-            face,
-            edges: global_edges,
-        }
+        Triangle { face, edges }
     }
 }
 

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -1,0 +1,55 @@
+use fj_interop::ext::ArrayExt;
+use fj_math::Point;
+
+use crate::{
+    builder::HalfEdgeBuilder,
+    objects::{Cycle, Face, GlobalEdge, Objects, Surface},
+    operations::Insert,
+    services::Service,
+    storage::Handle,
+};
+
+use super::BuildSurface;
+
+/// Build a [`Face`]
+pub trait BuildFace {
+    /// Build a triangle
+    fn triangle(
+        points: [impl Into<Point<3>>; 3],
+        edges: [Option<Handle<GlobalEdge>>; 3],
+        objects: &mut Service<Objects>,
+    ) -> (Handle<Face>, [Handle<GlobalEdge>; 3]) {
+        let [a, b, c] = points.map(Into::into);
+
+        let surface = Surface::plane_from_points([a, b, c]).insert(objects);
+        let (exterior, global_edges) = {
+            let half_edges = [[a, b], [b, c], [c, a]].zip_ext(edges).map(
+                |(points, global_form)| {
+                    let mut builder =
+                        HalfEdgeBuilder::line_segment_from_global_points(
+                            points, &surface, None,
+                        );
+
+                    if let Some(global_form) = global_form {
+                        builder = builder.with_global_form(global_form);
+                    }
+
+                    builder.build(objects).insert(objects)
+                },
+            );
+
+            let cycle = Cycle::new(half_edges.clone()).insert(objects);
+
+            let global_edges =
+                half_edges.map(|half_edge| half_edge.global_form().clone());
+
+            (cycle, global_edges)
+        };
+
+        let face = Face::new(surface, exterior, [], None).insert(objects);
+
+        (face, global_edges)
+    }
+}
+
+impl BuildFace for Face {}

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -18,7 +18,7 @@ pub trait BuildFace {
         points: [impl Into<Point<3>>; 3],
         edges: [Option<Handle<GlobalEdge>>; 3],
         objects: &mut Service<Objects>,
-    ) -> (Handle<Face>, [Handle<GlobalEdge>; 3]) {
+    ) -> (Face, [Handle<GlobalEdge>; 3]) {
         let [a, b, c] = points.map(Into::into);
 
         let surface = Surface::plane_from_points([a, b, c]).insert(objects);
@@ -46,7 +46,7 @@ pub trait BuildFace {
             (cycle, global_edges)
         };
 
-        let face = Face::new(surface, exterior, [], None).insert(objects);
+        let face = Face::new(surface, exterior, [], None);
 
         (face, global_edges)
     }

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -18,7 +18,7 @@ pub trait BuildFace {
         points: [impl Into<Point<3>>; 3],
         edges: [Option<Handle<GlobalEdge>>; 3],
         objects: &mut Service<Objects>,
-    ) -> (Face, [Handle<GlobalEdge>; 3]) {
+    ) -> Triangle {
         let [a, b, c] = points.map(Into::into);
 
         let surface = Surface::plane_from_points([a, b, c]).insert(objects);
@@ -48,8 +48,22 @@ pub trait BuildFace {
 
         let face = Face::new(surface, exterior, [], None);
 
-        (face, global_edges)
+        Triangle {
+            face,
+            edges: global_edges,
+        }
     }
 }
 
 impl BuildFace for Face {}
+
+/// A triangle
+///
+/// Returned by [`BuildFace::triangle`].
+pub struct Triangle {
+    /// The face that forms the triangle
+    pub face: Face,
+
+    /// The edges of the triangle
+    pub edges: [Handle<GlobalEdge>; 3],
+}

--- a/crates/fj-kernel/src/operations/build/mod.rs
+++ b/crates/fj-kernel/src/operations/build/mod.rs
@@ -2,4 +2,8 @@ mod face;
 mod shell;
 mod surface;
 
-pub use self::{face::BuildFace, shell::BuildShell, surface::BuildSurface};
+pub use self::{
+    face::{BuildFace, Triangle},
+    shell::BuildShell,
+    surface::BuildSurface,
+};

--- a/crates/fj-kernel/src/operations/build/mod.rs
+++ b/crates/fj-kernel/src/operations/build/mod.rs
@@ -1,4 +1,5 @@
 mod face;
+mod shell;
 mod surface;
 
-pub use self::{face::BuildFace, surface::BuildSurface};
+pub use self::{face::BuildFace, shell::BuildShell, surface::BuildSurface};

--- a/crates/fj-kernel/src/operations/build/mod.rs
+++ b/crates/fj-kernel/src/operations/build/mod.rs
@@ -1,3 +1,4 @@
+mod face;
 mod surface;
 
-pub use self::surface::BuildSurface;
+pub use self::{face::BuildFace, surface::BuildSurface};

--- a/crates/fj-kernel/src/operations/build/mod.rs
+++ b/crates/fj-kernel/src/operations/build/mod.rs
@@ -1,0 +1,3 @@
+mod surface;
+
+pub use self::surface::BuildSurface;

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -25,7 +25,8 @@ pub trait BuildShell {
         let (side_c, _) =
             Face::triangle([b, c, d], [Some(bc), Some(dc), Some(bd)], objects);
 
-        Shell::new([base, side_a, side_b, side_c])
+        let faces = [base, side_a, side_b, side_c];
+        Shell::new(faces)
     }
 }
 

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -2,6 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{Face, Objects, Shell},
+    operations::Insert,
     services::Service,
 };
 
@@ -25,7 +26,8 @@ pub trait BuildShell {
         let (side_c, _) =
             Face::triangle([b, c, d], [Some(bc), Some(dc), Some(bd)], objects);
 
-        let faces = [base, side_a, side_b, side_c];
+        let faces =
+            [base, side_a, side_b, side_c].map(|face| face.insert(objects));
         Shell::new(faces)
     }
 }

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -6,7 +6,7 @@ use crate::{
     services::Service,
 };
 
-use super::BuildFace;
+use super::{BuildFace, Triangle};
 
 /// Build a [`Shell`]
 pub trait BuildShell {
@@ -17,13 +17,19 @@ pub trait BuildShell {
     ) -> Shell {
         let [a, b, c, d] = points.map(Into::into);
 
-        let (base, [ab, bc, ca]) =
-            Face::triangle([a, b, c], [None, None, None], objects);
-        let (side_a, [_, bd, da]) =
-            Face::triangle([a, b, d], [Some(ab), None, None], objects);
-        let (side_b, [_, _, dc]) =
-            Face::triangle([c, a, d], [Some(ca), Some(da), None], objects);
-        let (side_c, _) =
+        let Triangle {
+            face: base,
+            edges: [ab, bc, ca],
+        } = Face::triangle([a, b, c], [None, None, None], objects);
+        let Triangle {
+            face: side_a,
+            edges: [_, bd, da],
+        } = Face::triangle([a, b, d], [Some(ab), None, None], objects);
+        let Triangle {
+            face: side_b,
+            edges: [_, _, dc],
+        } = Face::triangle([c, a, d], [Some(ca), Some(da), None], objects);
+        let Triangle { face: side_c, .. } =
             Face::triangle([b, c, d], [Some(bc), Some(dc), Some(bd)], objects);
 
         let faces =

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -2,16 +2,15 @@ use fj_math::Point;
 
 use crate::{
     objects::{Face, Objects, Shell},
-    operations::BuildFace,
     services::Service,
 };
 
-/// Builder API for [`Shell`]
-pub struct ShellBuilder {}
+use super::BuildFace;
 
-impl ShellBuilder {
-    /// Create a tetrahedron from the provided points
-    pub fn tetrahedron(
+/// Build a [`Shell`]
+pub trait BuildShell {
+    /// Build a tetrahedron from the provided points
+    fn tetrahedron(
         points: [impl Into<Point<3>>; 4],
         objects: &mut Service<Objects>,
     ) -> Shell {
@@ -29,3 +28,5 @@ impl ShellBuilder {
         Shell::new([base, side_a, side_b, side_c])
     }
 }
+
+impl BuildShell for Shell {}

--- a/crates/fj-kernel/src/operations/build/surface.rs
+++ b/crates/fj-kernel/src/operations/build/surface.rs
@@ -5,12 +5,10 @@ use crate::{
     objects::Surface,
 };
 
-/// Builder API for [`Surface`]
-pub struct SurfaceBuilder {}
-
-impl SurfaceBuilder {
-    /// Create a plane from the provided points
-    pub fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Surface {
+/// Build a [`Surface`]
+pub trait BuildSurface {
+    /// Build a plane from the provided points
+    fn plane_from_points(points: [impl Into<Point<3>>; 3]) -> Surface {
         let [a, b, c] = points.map(Into::into);
 
         let geometry = SurfaceGeometry {
@@ -21,3 +19,5 @@ impl SurfaceBuilder {
         Surface::new(geometry)
     }
 }
+
+impl BuildSurface for Surface {}

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -1,5 +1,6 @@
 //! Operations to update shapes
 
+mod build;
 mod insert;
 
-pub use self::insert::Insert;
+pub use self::{build::BuildSurface, insert::Insert};

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -4,6 +4,6 @@ mod build;
 mod insert;
 
 pub use self::{
-    build::{BuildFace, BuildShell, BuildSurface},
+    build::{BuildFace, BuildShell, BuildSurface, Triangle},
     insert::Insert,
 };

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -3,4 +3,7 @@
 mod build;
 mod insert;
 
-pub use self::{build::BuildSurface, insert::Insert};
+pub use self::{
+    build::{BuildFace, BuildSurface},
+    insert::Insert,
+};

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -4,6 +4,6 @@ mod build;
 mod insert;
 
 pub use self::{
-    build::{BuildFace, BuildSurface},
+    build::{BuildFace, BuildShell, BuildSurface},
     insert::Insert,
 };

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -193,9 +193,9 @@ impl ShellValidationError {
 mod tests {
     use crate::{
         assert_contains_err,
-        builder::{CycleBuilder, FaceBuilder, ShellBuilder},
+        builder::{CycleBuilder, FaceBuilder},
         objects::Shell,
-        operations::Insert,
+        operations::{BuildShell, Insert},
         services::Services,
         validate::{shell::ShellValidationError, Validate, ValidationError},
     };
@@ -204,7 +204,7 @@ mod tests {
     fn coincident_not_identical() -> anyhow::Result<()> {
         let mut services = Services::new();
 
-        let valid = ShellBuilder::tetrahedron(
+        let valid = Shell::tetrahedron(
             [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
             &mut services.objects,
         );
@@ -246,7 +246,7 @@ mod tests {
     fn shell_not_watertight() -> anyhow::Result<()> {
         let mut services = Services::new();
 
-        let valid = ShellBuilder::tetrahedron(
+        let valid = Shell::tetrahedron(
             [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
             &mut services.objects,
         );


### PR DESCRIPTION
Extract a certain kind of operation (which I'm calling "build" operations) from the builder API, and move them into the `operations` module. The plan is to create more kinds of operations there, to replace the builder API fully.

This is another step towards addressing #1713.