### PR TITLE
Add "update" operations; use them to clean up `Shell` validation tests

### DIFF
--- a/crates/fj-kernel/src/operations/build/mod.rs
+++ b/crates/fj-kernel/src/operations/build/mod.rs
@@ -4,6 +4,6 @@ mod surface;
 
 pub use self::{
     face::{BuildFace, Triangle},
-    shell::BuildShell,
+    shell::{BuildShell, Tetrahedron},
     surface::BuildSurface,
 };

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -4,6 +4,7 @@ use crate::{
     objects::{Face, Objects, Shell},
     operations::Insert,
     services::Service,
+    storage::Handle,
 };
 
 use super::{BuildFace, Triangle};
@@ -14,7 +15,7 @@ pub trait BuildShell {
     fn tetrahedron(
         points: [impl Into<Point<3>>; 4],
         objects: &mut Service<Objects>,
-    ) -> Shell {
+    ) -> Tetrahedron {
         let [a, b, c, d] = points.map(Into::into);
 
         let Triangle {
@@ -34,8 +35,42 @@ pub trait BuildShell {
 
         let faces = [face_abc, face_abd, face_cad, face_bcd]
             .map(|face| face.insert(objects));
-        Shell::new(faces)
+        let shell = Shell::new(faces.clone());
+
+        let [face_abc, face_abd, face_cad, face_bcd] = faces;
+
+        Tetrahedron {
+            shell,
+            face_abc,
+            face_abd,
+            face_cad,
+            face_bcd,
+        }
     }
 }
 
 impl BuildShell for Shell {}
+
+/// A tetrahedron
+///
+/// A tetrahedron is constructed from 4 points and has 4 faces. For the purpose
+/// of naming the fields of this struct, the points are named `a`, `b`, `c`, and
+/// `d`, in the order in which they are passed.
+///
+/// Returned by [`BuildShell::tetrahedron`].
+pub struct Tetrahedron {
+    /// The shell that forms the tetrahedron
+    pub shell: Shell,
+
+    /// The face formed by the points `a`, `b`, and `c`.
+    pub face_abc: Handle<Face>,
+
+    /// The face formed by the points `a`, `b`, and `d`.
+    pub face_abd: Handle<Face>,
+
+    /// The face formed by the points `c`, `a`, and `d`.
+    pub face_cad: Handle<Face>,
+
+    /// The face formed by the points `b`, `c`, and `d`.
+    pub face_bcd: Handle<Face>,
+}

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -18,22 +18,22 @@ pub trait BuildShell {
         let [a, b, c, d] = points.map(Into::into);
 
         let Triangle {
-            face: base,
+            face: face_abc,
             edges: [ab, bc, ca],
         } = Face::triangle([a, b, c], [None, None, None], objects);
         let Triangle {
-            face: side_a,
+            face: face_abd,
             edges: [_, bd, da],
         } = Face::triangle([a, b, d], [Some(ab), None, None], objects);
         let Triangle {
-            face: side_b,
+            face: face_cad,
             edges: [_, _, dc],
         } = Face::triangle([c, a, d], [Some(ca), Some(da), None], objects);
-        let Triangle { face: side_c, .. } =
+        let Triangle { face: face_bcd, .. } =
             Face::triangle([b, c, d], [Some(bc), Some(dc), Some(bd)], objects);
 
-        let faces =
-            [base, side_a, side_b, side_c].map(|face| face.insert(objects));
+        let faces = [face_abc, face_abd, face_cad, face_bcd]
+            .map(|face| face.insert(objects));
         Shell::new(faces)
     }
 }

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -2,8 +2,10 @@
 
 mod build;
 mod insert;
+mod update;
 
 pub use self::{
     build::{BuildFace, BuildShell, BuildSurface, Tetrahedron, Triangle},
     insert::Insert,
+    update::UpdateShell,
 };

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -7,5 +7,5 @@ mod update;
 pub use self::{
     build::{BuildFace, BuildShell, BuildSurface, Tetrahedron, Triangle},
     insert::Insert,
-    update::{UpdateFace, UpdateShell},
+    update::{UpdateCycle, UpdateFace, UpdateShell},
 };

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -7,5 +7,5 @@ mod update;
 pub use self::{
     build::{BuildFace, BuildShell, BuildSurface, Tetrahedron, Triangle},
     insert::Insert,
-    update::{UpdateCycle, UpdateFace, UpdateShell},
+    update::{UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateShell},
 };

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -7,5 +7,5 @@ mod update;
 pub use self::{
     build::{BuildFace, BuildShell, BuildSurface, Tetrahedron, Triangle},
     insert::Insert,
-    update::UpdateShell,
+    update::{UpdateFace, UpdateShell},
 };

--- a/crates/fj-kernel/src/operations/mod.rs
+++ b/crates/fj-kernel/src/operations/mod.rs
@@ -4,6 +4,6 @@ mod build;
 mod insert;
 
 pub use self::{
-    build::{BuildFace, BuildShell, BuildSurface, Triangle},
+    build::{BuildFace, BuildShell, BuildSurface, Tetrahedron, Triangle},
     insert::Insert,
 };

--- a/crates/fj-kernel/src/operations/update/cycle.rs
+++ b/crates/fj-kernel/src/operations/update/cycle.rs
@@ -1,0 +1,32 @@
+use crate::{
+    objects::{Cycle, HalfEdge},
+    storage::Handle,
+};
+
+/// Update a [`Cycle`]
+pub trait UpdateCycle {
+    /// Update a half-edge of the cycle
+    fn update_half_edge(
+        &self,
+        index: usize,
+        f: impl FnMut(&Handle<HalfEdge>) -> Handle<HalfEdge>,
+    ) -> Cycle;
+}
+
+impl UpdateCycle for Cycle {
+    fn update_half_edge(
+        &self,
+        index: usize,
+        mut f: impl FnMut(&Handle<HalfEdge>) -> Handle<HalfEdge>,
+    ) -> Cycle {
+        let half_edges = self.half_edges().enumerate().map(|(i, cycle)| {
+            if i == index {
+                f(cycle)
+            } else {
+                cycle.clone()
+            }
+        });
+
+        Cycle::new(half_edges)
+    }
+}

--- a/crates/fj-kernel/src/operations/update/edge.rs
+++ b/crates/fj-kernel/src/operations/update/edge.rs
@@ -1,0 +1,21 @@
+use crate::{
+    objects::{GlobalEdge, HalfEdge},
+    storage::Handle,
+};
+
+/// Update a [`HalfEdge`]
+pub trait UpdateHalfEdge {
+    /// Update the global form of the half-edge
+    fn update_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge;
+}
+
+impl UpdateHalfEdge for HalfEdge {
+    fn update_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge {
+        HalfEdge::new(
+            self.curve(),
+            self.boundary(),
+            self.start_vertex().clone(),
+            global_form,
+        )
+    }
+}

--- a/crates/fj-kernel/src/operations/update/face.rs
+++ b/crates/fj-kernel/src/operations/update/face.rs
@@ -1,0 +1,29 @@
+use crate::{
+    objects::{Cycle, Face},
+    storage::Handle,
+};
+
+/// Update a [`Face`]
+pub trait UpdateFace {
+    /// Update the exterior of the face
+    fn update_exterior(
+        &self,
+        f: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
+    ) -> Face;
+}
+
+impl UpdateFace for Face {
+    fn update_exterior(
+        &self,
+        f: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
+    ) -> Face {
+        let exterior = f(self.exterior());
+
+        Face::new(
+            self.surface().clone(),
+            exterior,
+            self.interiors().cloned(),
+            self.color(),
+        )
+    }
+}

--- a/crates/fj-kernel/src/operations/update/mod.rs
+++ b/crates/fj-kernel/src/operations/update/mod.rs
@@ -1,0 +1,3 @@
+mod shell;
+
+pub use self::shell::UpdateShell;

--- a/crates/fj-kernel/src/operations/update/mod.rs
+++ b/crates/fj-kernel/src/operations/update/mod.rs
@@ -1,3 +1,4 @@
+mod face;
 mod shell;
 
-pub use self::shell::UpdateShell;
+pub use self::{face::UpdateFace, shell::UpdateShell};

--- a/crates/fj-kernel/src/operations/update/mod.rs
+++ b/crates/fj-kernel/src/operations/update/mod.rs
@@ -1,4 +1,5 @@
+mod cycle;
 mod face;
 mod shell;
 
-pub use self::{face::UpdateFace, shell::UpdateShell};
+pub use self::{cycle::UpdateCycle, face::UpdateFace, shell::UpdateShell};

--- a/crates/fj-kernel/src/operations/update/mod.rs
+++ b/crates/fj-kernel/src/operations/update/mod.rs
@@ -1,5 +1,9 @@
 mod cycle;
+mod edge;
 mod face;
 mod shell;
 
-pub use self::{cycle::UpdateCycle, face::UpdateFace, shell::UpdateShell};
+pub use self::{
+    cycle::UpdateCycle, edge::UpdateHalfEdge, face::UpdateFace,
+    shell::UpdateShell,
+};

--- a/crates/fj-kernel/src/operations/update/shell.rs
+++ b/crates/fj-kernel/src/operations/update/shell.rs
@@ -1,0 +1,32 @@
+use crate::{
+    objects::{Face, Shell},
+    storage::Handle,
+};
+
+/// Update a [`Shell`]
+pub trait UpdateShell {
+    /// Update a face of the shell
+    fn update_face(
+        &self,
+        handle: &Handle<Face>,
+        f: impl FnMut(&Handle<Face>) -> Handle<Face>,
+    ) -> Shell;
+}
+
+impl UpdateShell for Shell {
+    fn update_face(
+        &self,
+        handle: &Handle<Face>,
+        mut f: impl FnMut(&Handle<Face>) -> Handle<Face>,
+    ) -> Shell {
+        let faces = self.faces().into_iter().map(|face| {
+            if face.id() == handle.id() {
+                f(face)
+            } else {
+                face.clone()
+            }
+        });
+
+        Shell::new(faces)
+    }
+}

--- a/crates/fj-kernel/src/operations/update/shell.rs
+++ b/crates/fj-kernel/src/operations/update/shell.rs
@@ -11,6 +11,9 @@ pub trait UpdateShell {
         handle: &Handle<Face>,
         f: impl FnMut(&Handle<Face>) -> Handle<Face>,
     ) -> Shell;
+
+    /// Remove a face from the shell
+    fn remove_face(&self, handle: &Handle<Face>) -> Shell;
 }
 
 impl UpdateShell for Shell {
@@ -26,6 +29,16 @@ impl UpdateShell for Shell {
                 face.clone()
             }
         });
+
+        Shell::new(faces)
+    }
+
+    fn remove_face(&self, handle: &Handle<Face>) -> Shell {
+        let faces = self
+            .faces()
+            .into_iter()
+            .filter(|face| face.id() == handle.id())
+            .cloned();
 
         Shell::new(faces)
     }

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -193,7 +193,6 @@ impl ShellValidationError {
 mod tests {
     use crate::{
         assert_contains_err,
-        builder::{CycleBuilder, FaceBuilder},
         objects::{GlobalEdge, Shell},
         operations::{
             BuildShell, Insert, UpdateCycle, UpdateFace, UpdateHalfEdge,
@@ -244,19 +243,7 @@ mod tests {
             [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
             &mut services.objects,
         );
-        let invalid = {
-            // Shell with single face is not watertight
-            let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
-                .with_exterior(CycleBuilder::polygon([
-                    [0., 0.],
-                    [0., 1.],
-                    [1., 1.],
-                    [1., 0.],
-                ]))
-                .build(&mut services.objects)
-                .insert(&mut services.objects);
-            Shell::new([face])
-        };
+        let invalid = valid.shell.remove_face(&valid.face_abc);
 
         valid.shell.validate_and_return_first_error()?;
         assert_contains_err!(

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -232,7 +232,7 @@ mod tests {
             Shell::new([face1, face2])
         };
 
-        valid.validate_and_return_first_error()?;
+        valid.shell.validate_and_return_first_error()?;
         assert_contains_err!(
             invalid,
             ValidationError::Shell(
@@ -264,7 +264,7 @@ mod tests {
             Shell::new([face])
         };
 
-        valid.validate_and_return_first_error()?;
+        valid.shell.validate_and_return_first_error()?;
         assert_contains_err!(
             invalid,
             ValidationError::Shell(ShellValidationError::NotWatertight)


### PR DESCRIPTION
Expand the operations API, adding "update" operations. Use those new operations to clean up the `Shell` validation unit tests.

This gets us most of the way towards addressing #1713. The only thing I'd like to still do, is to write unit tests for the `Solid` validation checks, expanding the operations API as necessary.