### PR TITLE
OBJ file format for export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "stl",
  "thiserror",
  "threemf",
+ "wavefront_rs",
 ]
 
 [[package]]
@@ -3920,6 +3921,12 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wavefront_rs"
+version = "2.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6ae8f49ee35d8afba6b30d1714f9043bfd2d1ef650897cb6405a600609e9a1"
 
 [[package]]
 name = "wayland-client"

--- a/crates/fj-export/Cargo.toml
+++ b/crates/fj-export/Cargo.toml
@@ -17,3 +17,4 @@ fj-math.workspace = true
 thiserror = "1.0.40"
 threemf = "0.4.0"
 stl = "0.2.1"
+wavefront_rs = "2.0.0-alpha.1"


### PR DESCRIPTION
I tested a few things using Forgot to create some shapes.
In order to export / import these I needed the OBJ format. That's what I added right into it here and thought you might be interested in having this native inside of the application.

The export uses a crate I built a few months / years ago (wavefront_rs). OBJ format is implemented. MTL format will follow.