### PR TITLE
Use consistent nomenclature across update API

### DIFF
--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -86,7 +86,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                     .replace_start_vertex(start_vertex);
 
                     let half_edge = if let Some(global_edge) = global_edge {
-                        half_edge.update_global_form(global_edge)
+                        half_edge.replace_global_form(global_edge)
                     } else {
                         half_edge
                     };

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -83,7 +83,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                         Some(boundary),
                         objects,
                     )
-                    .update_start_vertex(start_vertex);
+                    .replace_start_vertex(start_vertex);
 
                     let half_edge = if let Some(global_edge) = global_edge {
                         half_edge.update_global_form(global_edge)

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -42,7 +42,7 @@ impl CycleBuilder {
             .map(|((prev, _, _), (half_edge, curve, boundary))| {
                 HalfEdge::unjoined(curve, boundary, objects)
                     .replace_start_vertex(prev.start_vertex().clone())
-                    .update_global_form(half_edge.global_form().clone())
+                    .replace_global_form(half_edge.global_form().clone())
             })
             .collect();
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -41,7 +41,7 @@ impl CycleBuilder {
             .circular_tuple_windows()
             .map(|((prev, _, _), (half_edge, curve, boundary))| {
                 HalfEdge::unjoined(curve, boundary, objects)
-                    .update_start_vertex(prev.start_vertex().clone())
+                    .replace_start_vertex(prev.start_vertex().clone())
                     .update_global_form(half_edge.global_form().clone())
             })
             .collect();

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -30,7 +30,7 @@ pub trait BuildFace {
                         );
 
                     if let Some(global_form) = global_form {
-                        half_edge = half_edge.update_global_form(global_form);
+                        half_edge = half_edge.replace_global_form(global_form);
                     }
 
                     half_edge.insert(objects)

--- a/crates/fj-kernel/src/operations/update/cycle.rs
+++ b/crates/fj-kernel/src/operations/update/cycle.rs
@@ -27,7 +27,7 @@ pub trait UpdateCycle {
     /// # Panics
     ///
     /// Panics, unless this operation replaces exactly one half-edge.
-    fn replace_nth_half_edge(
+    fn update_nth_half_edge(
         &self,
         index: usize,
         f: impl FnMut(&Handle<HalfEdge>) -> Handle<HalfEdge>,
@@ -69,7 +69,7 @@ impl UpdateCycle for Cycle {
         cycle
     }
 
-    fn replace_nth_half_edge(
+    fn update_nth_half_edge(
         &self,
         index: usize,
         mut f: impl FnMut(&Handle<HalfEdge>) -> Handle<HalfEdge>,

--- a/crates/fj-kernel/src/operations/update/cycle.rs
+++ b/crates/fj-kernel/src/operations/update/cycle.rs
@@ -12,6 +12,10 @@ pub trait UpdateCycle {
     ) -> Cycle;
 
     /// Replace the provided half-edge
+    ///
+    /// # Panics
+    ///
+    /// Panics, unless this operation replaces exactly one half-edge.
     fn replace_half_edge(
         &self,
         original: &Handle<HalfEdge>,
@@ -19,6 +23,10 @@ pub trait UpdateCycle {
     ) -> Cycle;
 
     /// Replace the half-edge at the given index
+    ///
+    /// # Panics
+    ///
+    /// Panics, unless this operation replaces exactly one half-edge.
     fn replace_nth_half_edge(
         &self,
         index: usize,
@@ -40,15 +48,25 @@ impl UpdateCycle for Cycle {
         original: &Handle<HalfEdge>,
         replacement: Handle<HalfEdge>,
     ) -> Cycle {
+        let mut num_replacements = 0;
+
         let half_edges = self.half_edges().map(|half_edge| {
             if half_edge.id() == original.id() {
+                num_replacements += 1;
                 replacement.clone()
             } else {
                 half_edge.clone()
             }
         });
 
-        Cycle::new(half_edges)
+        let cycle = Cycle::new(half_edges);
+
+        assert_eq!(
+            num_replacements, 1,
+            "Expected operation to replace exactly one half-edge"
+        );
+
+        cycle
     }
 
     fn replace_nth_half_edge(
@@ -56,14 +74,24 @@ impl UpdateCycle for Cycle {
         index: usize,
         mut f: impl FnMut(&Handle<HalfEdge>) -> Handle<HalfEdge>,
     ) -> Cycle {
+        let mut num_replacements = 0;
+
         let half_edges = self.half_edges().enumerate().map(|(i, half_edge)| {
             if i == index {
+                num_replacements += 1;
                 f(half_edge)
             } else {
                 half_edge.clone()
             }
         });
 
-        Cycle::new(half_edges)
+        let cycle = Cycle::new(half_edges);
+
+        assert_eq!(
+            num_replacements, 1,
+            "Expected operation to replace exactly one half-edge"
+        );
+
+        cycle
     }
 }

--- a/crates/fj-kernel/src/operations/update/edge.rs
+++ b/crates/fj-kernel/src/operations/update/edge.rs
@@ -9,7 +9,7 @@ pub trait UpdateHalfEdge {
     fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> HalfEdge;
 
     /// Update the global form of the half-edge
-    fn update_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge;
+    fn replace_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge;
 }
 
 impl UpdateHalfEdge for HalfEdge {
@@ -22,7 +22,7 @@ impl UpdateHalfEdge for HalfEdge {
         )
     }
 
-    fn update_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge {
+    fn replace_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge {
         HalfEdge::new(
             self.curve(),
             self.boundary(),

--- a/crates/fj-kernel/src/operations/update/edge.rs
+++ b/crates/fj-kernel/src/operations/update/edge.rs
@@ -6,14 +6,14 @@ use crate::{
 /// Update a [`HalfEdge`]
 pub trait UpdateHalfEdge {
     /// Update the start vertex of the half-edge
-    fn update_start_vertex(&self, start_vertex: Handle<Vertex>) -> HalfEdge;
+    fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> HalfEdge;
 
     /// Update the global form of the half-edge
     fn update_global_form(&self, global_form: Handle<GlobalEdge>) -> HalfEdge;
 }
 
 impl UpdateHalfEdge for HalfEdge {
-    fn update_start_vertex(&self, start_vertex: Handle<Vertex>) -> HalfEdge {
+    fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> HalfEdge {
         HalfEdge::new(
             self.curve(),
             self.boundary(),

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -213,7 +213,7 @@ mod tests {
         let invalid = valid.shell.update_face(&valid.face_abc, |face| {
             face.update_exterior(|cycle| {
                 cycle
-                    .replace_nth_half_edge(0, |half_edge| {
+                    .update_nth_half_edge(0, |half_edge| {
                         let global_form =
                             GlobalEdge::new().insert(&mut services.objects);
                         half_edge

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -217,7 +217,7 @@ mod tests {
                         let global_form =
                             GlobalEdge::new().insert(&mut services.objects);
                         half_edge
-                            .update_global_form(global_form)
+                            .replace_global_form(global_form)
                             .insert(&mut services.objects)
                     })
                     .insert(&mut services.objects)


### PR DESCRIPTION
Also snuck in a commit that tightens down some update methods, making them panic if they're misused. This came out of my work on #1713.