### PR TITLE
Correctly join triangles in `BuildShell::tetrahedron`

### DIFF
--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -1,9 +1,8 @@
-use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
-    objects::{Cycle, Face, GlobalEdge, HalfEdge, Objects, Surface},
-    operations::{Insert, UpdateHalfEdge},
+    objects::{Cycle, Face, HalfEdge, Objects, Surface},
+    operations::Insert,
     services::Service,
     storage::Handle,
 };
@@ -15,27 +14,19 @@ pub trait BuildFace {
     /// Build a triangle
     fn triangle(
         points: [impl Into<Point<3>>; 3],
-        edges: [Option<Handle<GlobalEdge>>; 3],
         objects: &mut Service<Objects>,
     ) -> Triangle {
         let [a, b, c] = points.map(Into::into);
 
         let surface = Surface::plane_from_points([a, b, c]).insert(objects);
         let (exterior, edges) = {
-            let half_edges = [[a, b], [b, c], [c, a]].zip_ext(edges).map(
-                |(points, global_form)| {
-                    let mut half_edge =
-                        HalfEdge::line_segment_from_global_points(
-                            points, &surface, None, objects,
-                        );
+            let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
+                let half_edge = HalfEdge::line_segment_from_global_points(
+                    points, &surface, None, objects,
+                );
 
-                    if let Some(global_form) = global_form {
-                        half_edge = half_edge.replace_global_form(global_form);
-                    }
-
-                    half_edge.insert(objects)
-                },
-            );
+                half_edge.insert(objects)
+            });
 
             let cycle = Cycle::new(half_edges.clone()).insert(objects);
 

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -39,10 +39,7 @@ pub trait BuildFace {
 
             let cycle = Cycle::new(half_edges.clone()).insert(objects);
 
-            let global_edges =
-                half_edges.map(|half_edge| half_edge.global_form().clone());
-
-            (cycle, global_edges)
+            (cycle, half_edges)
         };
 
         let face = Face::new(surface, exterior, [], None);
@@ -61,5 +58,5 @@ pub struct Triangle {
     pub face: Face,
 
     /// The edges of the triangle
-    pub edges: [Handle<GlobalEdge>; 3],
+    pub edges: [Handle<HalfEdge>; 3],
 }

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -38,11 +38,11 @@ pub trait BuildShell {
         let [Triangle {
             face: face_abc,
             edges: [ab, bc, ca],
-            ..
+            vertices: [a, b, c],
         }, Triangle {
             face: face_bad,
             edges: [ba, ad, db],
-            ..
+            vertices: [_, _, d],
         }, Triangle {
             face: face_dac,
             edges: [da, ac, cd],
@@ -60,32 +60,44 @@ pub trait BuildShell {
 
         let face_bad = face_bad.update_exterior(|cycle| {
             let ba_joined = ba
+                .replace_start_vertex(b.clone())
                 .replace_global_form(ab.global_form().clone())
                 .insert(objects);
+            let ad_joined = ad.replace_start_vertex(a.clone()).insert(objects);
 
-            cycle.replace_half_edge(&ba, ba_joined).insert(objects)
+            cycle
+                .replace_half_edge(&ba, ba_joined)
+                .replace_half_edge(&ad, ad_joined)
+                .insert(objects)
         });
         let face_dac = face_dac.update_exterior(|cycle| {
             let da_joined = da
+                .replace_start_vertex(d.clone())
                 .replace_global_form(ad.global_form().clone())
                 .insert(objects);
             let ac_joined = ac
+                .replace_start_vertex(a)
                 .replace_global_form(ca.global_form().clone())
                 .insert(objects);
+            let cd_joined = cd.replace_start_vertex(c.clone()).insert(objects);
 
             cycle
                 .replace_half_edge(&da, da_joined)
                 .replace_half_edge(&ac, ac_joined)
+                .replace_half_edge(&cd, cd_joined)
                 .insert(objects)
         });
         let face_cbd = face_cbd.update_exterior(|cycle| {
             let cb_joined = cb
+                .replace_start_vertex(c)
                 .replace_global_form(bc.global_form().clone())
                 .insert(objects);
             let bd_joined = bd
+                .replace_start_vertex(b)
                 .replace_global_form(db.global_form().clone())
                 .insert(objects);
             let dc_joined = dc
+                .replace_start_vertex(d)
                 .replace_global_form(cd.global_form().clone())
                 .insert(objects);
 

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -42,13 +42,32 @@ pub trait BuildShell {
         let Triangle {
             face: face_bad,
             edges: [_, ad, db],
-        } = Face::triangle([b, a, d], [Some(ab), None, None], objects);
+        } = Face::triangle(
+            [b, a, d],
+            [Some(ab.global_form().clone()), None, None],
+            objects,
+        );
         let Triangle {
             face: face_dac,
             edges: [_, _, cd],
-        } = Face::triangle([d, a, c], [Some(ad), Some(ca), None], objects);
-        let Triangle { face: face_cbd, .. } =
-            Face::triangle([c, b, d], [Some(bc), Some(db), Some(cd)], objects);
+        } = Face::triangle(
+            [d, a, c],
+            [
+                Some(ad.global_form().clone()),
+                Some(ca.global_form().clone()),
+                None,
+            ],
+            objects,
+        );
+        let Triangle { face: face_cbd, .. } = Face::triangle(
+            [c, b, d],
+            [
+                Some(bc.global_form().clone()),
+                Some(db.global_form().clone()),
+                Some(cd.global_form().clone()),
+            ],
+            objects,
+        );
 
         let faces = [face_abc, face_bad, face_dac, face_cbd]
             .map(|face| face.insert(objects));

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -35,26 +35,28 @@ pub trait BuildShell {
     ) -> Tetrahedron {
         let [a, b, c, d] = points.map(Into::into);
 
-        let Triangle {
+        let [Triangle {
             face: face_abc,
             edges: [ab, bc, ca],
             ..
-        } = Face::triangle([a, b, c], objects);
-        let Triangle {
+        }, Triangle {
             face: face_bad,
             edges: [ba, ad, db],
             ..
-        } = Face::triangle([b, a, d], objects);
-        let Triangle {
+        }, Triangle {
             face: face_dac,
             edges: [da, ac, cd],
             ..
-        } = Face::triangle([d, a, c], objects);
-        let Triangle {
+        }, Triangle {
             face: face_cbd,
             edges: [cb, bd, dc],
             ..
-        } = Face::triangle([c, b, d], objects);
+        }] = [
+            Face::triangle([a, b, c], objects),
+            Face::triangle([b, a, d], objects),
+            Face::triangle([d, a, c], objects),
+            Face::triangle([c, b, d], objects),
+        ];
 
         let face_bad = face_bad.update_exterior(|cycle| {
             let ba_joined = ba

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -122,12 +122,12 @@ pub struct Tetrahedron {
     /// The face formed by the points `a`, `b`, and `c`.
     pub face_abc: Handle<Face>,
 
-    /// The face formed by the points `a`, `b`, and `d`.
+    /// The face formed by the points `b`, `a`, and `d`.
     pub face_bad: Handle<Face>,
 
-    /// The face formed by the points `c`, `a`, and `d`.
+    /// The face formed by the points `d`, `a`, and `c`.
     pub face_dac: Handle<Face>,
 
-    /// The face formed by the points `b`, `c`, and `d`.
+    /// The face formed by the points `c`, `b`, and `d`.
     pub face_cbd: Handle<Face>,
 }

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{Face, Objects, Shell},
-    operations::Insert,
+    operations::{Insert, UpdateCycle, UpdateFace, UpdateHalfEdge},
     services::Service,
     storage::Handle,
 };
@@ -38,36 +38,57 @@ pub trait BuildShell {
         let Triangle {
             face: face_abc,
             edges: [ab, bc, ca],
-        } = Face::triangle([a, b, c], [None, None, None], objects);
+        } = Face::triangle([a, b, c], objects);
         let Triangle {
             face: face_bad,
-            edges: [_, ad, db],
-        } = Face::triangle(
-            [b, a, d],
-            [Some(ab.global_form().clone()), None, None],
-            objects,
-        );
+            edges: [ba, ad, db],
+        } = Face::triangle([b, a, d], objects);
         let Triangle {
             face: face_dac,
-            edges: [_, _, cd],
-        } = Face::triangle(
-            [d, a, c],
-            [
-                Some(ad.global_form().clone()),
-                Some(ca.global_form().clone()),
-                None,
-            ],
-            objects,
-        );
-        let Triangle { face: face_cbd, .. } = Face::triangle(
-            [c, b, d],
-            [
-                Some(bc.global_form().clone()),
-                Some(db.global_form().clone()),
-                Some(cd.global_form().clone()),
-            ],
-            objects,
-        );
+            edges: [da, ac, cd],
+        } = Face::triangle([d, a, c], objects);
+        let Triangle {
+            face: face_cbd,
+            edges: [cb, bd, dc],
+        } = Face::triangle([c, b, d], objects);
+
+        let face_bad = face_bad.update_exterior(|cycle| {
+            let ba_joined = ba
+                .replace_global_form(ab.global_form().clone())
+                .insert(objects);
+
+            cycle.replace_half_edge(&ba, ba_joined).insert(objects)
+        });
+        let face_dac = face_dac.update_exterior(|cycle| {
+            let da_joined = da
+                .replace_global_form(ad.global_form().clone())
+                .insert(objects);
+            let ac_joined = ac
+                .replace_global_form(ca.global_form().clone())
+                .insert(objects);
+
+            cycle
+                .replace_half_edge(&da, da_joined)
+                .replace_half_edge(&ac, ac_joined)
+                .insert(objects)
+        });
+        let face_cbd = face_cbd.update_exterior(|cycle| {
+            let cb_joined = cb
+                .replace_global_form(bc.global_form().clone())
+                .insert(objects);
+            let bd_joined = bd
+                .replace_global_form(db.global_form().clone())
+                .insert(objects);
+            let dc_joined = dc
+                .replace_global_form(cd.global_form().clone())
+                .insert(objects);
+
+            cycle
+                .replace_half_edge(&cb, cb_joined)
+                .replace_half_edge(&bd, bd_joined)
+                .replace_half_edge(&dc, dc_joined)
+                .insert(objects)
+        });
 
         let faces = [face_abc, face_bad, face_dac, face_cbd]
             .map(|face| face.insert(objects));

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -38,18 +38,22 @@ pub trait BuildShell {
         let Triangle {
             face: face_abc,
             edges: [ab, bc, ca],
+            ..
         } = Face::triangle([a, b, c], objects);
         let Triangle {
             face: face_bad,
             edges: [ba, ad, db],
+            ..
         } = Face::triangle([b, a, d], objects);
         let Triangle {
             face: face_dac,
             edges: [da, ac, cd],
+            ..
         } = Face::triangle([d, a, c], objects);
         let Triangle {
             face: face_cbd,
             edges: [cb, bd, dc],
+            ..
         } = Face::triangle([c, b, d], objects);
 
         let face_bad = face_bad.update_exterior(|cycle| {

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -94,14 +94,14 @@ pub trait BuildShell {
             .map(|face| face.insert(objects));
         let shell = Shell::new(faces.clone());
 
-        let [face_abc, face_abd, face_cad, face_bcd] = faces;
+        let [face_abc, face_bad, face_dac, face_cbd] = faces;
 
         Tetrahedron {
             shell,
             face_abc,
-            face_abd,
-            face_cad,
-            face_bcd,
+            face_bad,
+            face_dac,
+            face_cbd,
         }
     }
 }
@@ -123,11 +123,11 @@ pub struct Tetrahedron {
     pub face_abc: Handle<Face>,
 
     /// The face formed by the points `a`, `b`, and `d`.
-    pub face_abd: Handle<Face>,
+    pub face_bad: Handle<Face>,
 
     /// The face formed by the points `c`, `a`, and `d`.
-    pub face_cad: Handle<Face>,
+    pub face_dac: Handle<Face>,
 
     /// The face formed by the points `b`, `c`, and `d`.
-    pub face_bcd: Handle<Face>,
+    pub face_cbd: Handle<Face>,
 }


### PR DESCRIPTION
Previously, the edges weren't joined correctly, as the vertices were ignored. This came out of my work on #1713.