### PR TITLE
Clean up in-kernel services API

### DIFF
--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -346,7 +346,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let half_edge = HalfEdge::circle(1., &mut services.objects);
+        let half_edge = HalfEdge::circle(1., &mut services);
 
         let tolerance = 1.;
         let approx = (&half_edge, surface.deref()).approx(tolerance);

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -273,11 +273,8 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let half_edge = HalfEdge::line_segment(
-            [[1., 1.], [2., 1.]],
-            None,
-            &mut services.objects,
-        );
+        let half_edge =
+            HalfEdge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
 
         let tolerance = 1.;
         let approx = (&half_edge, surface.deref()).approx(tolerance);
@@ -294,11 +291,8 @@ mod tests {
             v: [0., 0., 1.].into(),
         })
         .insert(&mut services.objects);
-        let half_edge = HalfEdge::line_segment(
-            [[1., 1.], [2., 1.]],
-            None,
-            &mut services.objects,
-        );
+        let half_edge =
+            HalfEdge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
 
         let tolerance = 1.;
         let approx = (&half_edge, surface.deref()).approx(tolerance);
@@ -321,7 +315,7 @@ mod tests {
         let half_edge = HalfEdge::line_segment(
             [[0., 1.], [TAU, 1.]],
             Some(range.boundary),
-            &mut services.objects,
+            &mut services,
         );
 
         let tolerance = 1.;

--- a/crates/fj-kernel/src/algorithms/approx/edge.rs
+++ b/crates/fj-kernel/src/algorithms/approx/edge.rs
@@ -290,7 +290,7 @@ mod tests {
             u: GlobalPath::circle_from_radius(1.),
             v: [0., 0., 1.].into(),
         })
-        .insert(&mut services.objects);
+        .insert(&mut services);
         let half_edge =
             HalfEdge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
 
@@ -311,7 +311,7 @@ mod tests {
             u: path,
             v: [0., 0., 1.].into(),
         })
-        .insert(&mut services.objects);
+        .insert(&mut services);
         let half_edge = HalfEdge::line_segment(
             [[0., 1.], [TAU, 1.]],
             Some(range.boundary),

--- a/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_edge.rs
@@ -83,11 +83,8 @@ mod tests {
         let mut services = Services::new();
 
         let curve = Curve::u_axis();
-        let half_edge = HalfEdge::line_segment(
-            [[1., -1.], [1., 1.]],
-            None,
-            &mut services.objects,
-        );
+        let half_edge =
+            HalfEdge::line_segment([[1., -1.], [1., 1.]], None, &mut services);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 
@@ -107,7 +104,7 @@ mod tests {
         let half_edge = HalfEdge::line_segment(
             [[-1., -1.], [-1., 1.]],
             None,
-            &mut services.objects,
+            &mut services,
         );
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -128,7 +125,7 @@ mod tests {
         let half_edge = HalfEdge::line_segment(
             [[-1., -1.], [1., -1.]],
             None,
-            &mut services.objects,
+            &mut services,
         );
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
@@ -141,11 +138,8 @@ mod tests {
         let mut services = Services::new();
 
         let curve = Curve::u_axis();
-        let half_edge = HalfEdge::line_segment(
-            [[-1., 0.], [1., 0.]],
-            None,
-            &mut services.objects,
-        );
+        let half_edge =
+            HalfEdge::line_segment([[-1., 0.], [1., 0.]], None, &mut services);
 
         let intersection = CurveEdgeIntersection::compute(&curve, &half_edge);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -181,11 +181,11 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 exterior_points,
-                &mut services.objects,
+                &mut services,
             ))
             .with_interior(CycleBuilder::polygon(
                 interior_points,
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
 

--- a/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/curve_face.rs
@@ -187,7 +187,7 @@ mod tests {
                 interior_points,
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -87,7 +87,7 @@ mod tests {
         .map(|surface| {
             FaceBuilder::new(surface)
                 .with_exterior(CycleBuilder::polygon(points, &mut services))
-                .build(&mut services.objects)
+                .build(&mut services)
         });
 
         let intersection = FaceFaceIntersection::compute([&a, &b]);
@@ -113,7 +113,7 @@ mod tests {
         let [a, b] = surfaces.clone().map(|surface| {
             FaceBuilder::new(surface)
                 .with_exterior(CycleBuilder::polygon(points, &mut services))
-                .build(&mut services.objects)
+                .build(&mut services)
         });
 
         let intersection = FaceFaceIntersection::compute([&a, &b]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_face.rs
@@ -86,10 +86,7 @@ mod tests {
         ]
         .map(|surface| {
             FaceBuilder::new(surface)
-                .with_exterior(CycleBuilder::polygon(
-                    points,
-                    &mut services.objects,
-                ))
+                .with_exterior(CycleBuilder::polygon(points, &mut services))
                 .build(&mut services.objects)
         });
 
@@ -115,10 +112,7 @@ mod tests {
         ];
         let [a, b] = surfaces.clone().map(|surface| {
             FaceBuilder::new(surface)
-                .with_exterior(CycleBuilder::polygon(
-                    points,
-                    &mut services.objects,
-                ))
+                .with_exterior(CycleBuilder::polygon(points, &mut services))
                 .build(&mut services.objects)
         });
 

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -149,7 +149,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [1., 1.], [0., 2.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([2., 1.]);
@@ -165,7 +165,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [2., 1.], [0., 2.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -184,7 +184,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[4., 2.], [0., 4.], [0., 0.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 2.]);
@@ -203,7 +203,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -222,7 +222,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -241,7 +241,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 1.]);
@@ -260,7 +260,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [2., 0.], [0., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 0.]);
@@ -285,7 +285,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [1., 0.], [0., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let point = Point::from([1., 0.]);

--- a/crates/fj-kernel/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/face_point.rs
@@ -151,7 +151,7 @@ mod tests {
                 [[0., 0.], [1., 1.], [0., 2.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([2., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -167,7 +167,7 @@ mod tests {
                 [[0., 0.], [2., 1.], [0., 2.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -186,7 +186,7 @@ mod tests {
                 [[4., 2.], [0., 4.], [0., 0.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 2.]);
 
         let intersection = (&face, &point).intersect();
@@ -205,7 +205,7 @@ mod tests {
                 [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -224,7 +224,7 @@ mod tests {
                 [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -243,7 +243,7 @@ mod tests {
                 [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -262,7 +262,7 @@ mod tests {
                 [[0., 0.], [2., 0.], [0., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();
@@ -287,7 +287,7 @@ mod tests {
                 [[0., 0.], [1., 0.], [0., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -165,7 +165,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.yz_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let face = face.translate([-1., 0., 0.], &mut services);
@@ -182,7 +182,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.yz_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let face = face.translate([1., 0., 0.], &mut services);
@@ -202,7 +202,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.yz_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let face = face.translate([0., 0., 2.], &mut services);
@@ -219,7 +219,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.yz_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let face = face.translate([1., 1., 0.], &mut services);
@@ -244,7 +244,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.yz_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let face = face.translate([1., 1., 1.], &mut services);
@@ -272,7 +272,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
 
@@ -291,7 +291,7 @@ mod tests {
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let face = face.translate([0., 0., 1.], &mut services);

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -168,7 +168,7 @@ mod tests {
                 &mut services.objects,
             ))
             .build(&mut services.objects);
-        let face = face.translate([-1., 0., 0.], &mut services.objects);
+        let face = face.translate([-1., 0., 0.], &mut services);
 
         assert_eq!((&ray, &face).intersect(), None);
     }
@@ -185,7 +185,7 @@ mod tests {
                 &mut services.objects,
             ))
             .build(&mut services.objects);
-        let face = face.translate([1., 0., 0.], &mut services.objects);
+        let face = face.translate([1., 0., 0.], &mut services);
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -205,7 +205,7 @@ mod tests {
                 &mut services.objects,
             ))
             .build(&mut services.objects);
-        let face = face.translate([0., 0., 2.], &mut services.objects);
+        let face = face.translate([0., 0., 2.], &mut services);
 
         assert_eq!((&ray, &face).intersect(), None);
     }
@@ -222,7 +222,7 @@ mod tests {
                 &mut services.objects,
             ))
             .build(&mut services.objects);
-        let face = face.translate([1., 1., 0.], &mut services.objects);
+        let face = face.translate([1., 1., 0.], &mut services);
 
         let edge = face
             .exterior()
@@ -247,7 +247,7 @@ mod tests {
                 &mut services.objects,
             ))
             .build(&mut services.objects);
-        let face = face.translate([1., 1., 1.], &mut services.objects);
+        let face = face.translate([1., 1., 1.], &mut services);
 
         let vertex = face
             .exterior()
@@ -294,7 +294,7 @@ mod tests {
                 &mut services.objects,
             ))
             .build(&mut services.objects);
-        let face = face.translate([0., 0., 1.], &mut services.objects);
+        let face = face.translate([0., 0., 1.], &mut services);
 
         assert_eq!((&ray, &face).intersect(), None);
     }

--- a/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/ray_face.rs
@@ -167,7 +167,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let face = face.translate([-1., 0., 0.], &mut services);
 
         assert_eq!((&ray, &face).intersect(), None);
@@ -184,7 +184,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let face = face.translate([1., 0., 0.], &mut services);
 
         assert_eq!(
@@ -204,7 +204,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let face = face.translate([0., 0., 2.], &mut services);
 
         assert_eq!((&ray, &face).intersect(), None);
@@ -221,7 +221,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let face = face.translate([1., 1., 0.], &mut services);
 
         let edge = face
@@ -246,7 +246,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let face = face.translate([1., 1., 1.], &mut services);
 
         let vertex = face
@@ -274,7 +274,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -293,7 +293,7 @@ mod tests {
                 [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let face = face.translate([0., 0., 1.], &mut services);
 
         assert_eq!((&ray, &face).intersect(), None);

--- a/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-kernel/src/algorithms/intersect/surface_surface.rs
@@ -94,7 +94,7 @@ mod tests {
                 xy.clone(),
                 xy.clone().transform(
                     &Transform::translation([0., 0., 1.],),
-                    &mut services.objects
+                    &mut services
                 )
             ],),
             None,

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -27,12 +27,12 @@ impl Reverse for Handle<Cycle> {
                     next.start_vertex().clone(),
                     current.global_form().clone(),
                 )
-                .insert(&mut services.objects)
+                .insert(services)
             })
             .collect::<Vec<_>>();
 
         edges.reverse();
 
-        Cycle::new(edges).insert(&mut services.objects)
+        Cycle::new(edges).insert(services)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/cycle.rs
@@ -1,16 +1,16 @@
 use itertools::Itertools;
 
 use crate::{
-    objects::{Cycle, HalfEdge, Objects},
+    objects::{Cycle, HalfEdge},
     operations::Insert,
-    services::Service,
+    services::Services,
     storage::Handle,
 };
 
 use super::Reverse;
 
 impl Reverse for Handle<Cycle> {
-    fn reverse(self, objects: &mut Service<Objects>) -> Self {
+    fn reverse(self, services: &mut Services) -> Self {
         let mut edges = self
             .half_edges()
             .cloned()
@@ -27,12 +27,12 @@ impl Reverse for Handle<Cycle> {
                     next.start_vertex().clone(),
                     current.global_form().clone(),
                 )
-                .insert(objects)
+                .insert(&mut services.objects)
             })
             .collect::<Vec<_>>();
 
         edges.reverse();
 
-        Cycle::new(edges).insert(objects)
+        Cycle::new(edges).insert(&mut services.objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -13,6 +13,6 @@ impl Reverse for Handle<Face> {
             .collect::<Vec<_>>();
 
         Face::new(self.surface().clone(), exterior, interiors, self.color())
-            .insert(&mut services.objects)
+            .insert(services)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/face.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/face.rs
@@ -1,21 +1,18 @@
 use crate::{
-    objects::{Face, Objects},
-    operations::Insert,
-    services::Service,
-    storage::Handle,
+    objects::Face, operations::Insert, services::Services, storage::Handle,
 };
 
 use super::Reverse;
 
 impl Reverse for Handle<Face> {
-    fn reverse(self, objects: &mut Service<Objects>) -> Self {
-        let exterior = self.exterior().clone().reverse(objects);
+    fn reverse(self, services: &mut Services) -> Self {
+        let exterior = self.exterior().clone().reverse(services);
         let interiors = self
             .interiors()
-            .map(|cycle| cycle.clone().reverse(objects))
+            .map(|cycle| cycle.clone().reverse(services))
             .collect::<Vec<_>>();
 
         Face::new(self.surface().clone(), exterior, interiors, self.color())
-            .insert(objects)
+            .insert(&mut services.objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/reverse/mod.rs
+++ b/crates/fj-kernel/src/algorithms/reverse/mod.rs
@@ -1,6 +1,6 @@
 //! Reverse the direction/orientation of objects
 
-use crate::{objects::Objects, services::Service};
+use crate::services::Services;
 
 mod cycle;
 mod face;
@@ -8,5 +8,5 @@ mod face;
 /// Reverse the direction/orientation of an object
 pub trait Reverse: Sized {
     /// Reverse the direction/orientation of the object
-    fn reverse(self, objects: &mut Service<Objects>) -> Self;
+    fn reverse(self, services: &mut Services) -> Self;
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -5,9 +5,9 @@ use crate::{
         curve::{Curve, GlobalPath},
         surface::SurfaceGeometry,
     },
-    objects::{Objects, Surface},
+    objects::Surface,
     operations::Insert,
-    services::Service,
+    services::Services,
     storage::Handle,
 };
 
@@ -20,7 +20,7 @@ impl Sweep for (Curve, &Surface) {
         self,
         path: impl Into<Vector<3>>,
         _: &mut SweepCache,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self::Swept {
         let (curve, surface) = self;
 
@@ -75,6 +75,7 @@ impl Sweep for (Curve, &Surface) {
             }
         };
 
-        Surface::new(SurfaceGeometry { u, v: path.into() }).insert(objects)
+        Surface::new(SurfaceGeometry { u, v: path.into() })
+            .insert(&mut services.objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/curve.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/curve.rs
@@ -75,7 +75,6 @@ impl Sweep for (Curve, &Surface) {
             }
         };
 
-        Surface::new(SurfaceGeometry { u, v: path.into() })
-            .insert(&mut services.objects)
+        Surface::new(SurfaceGeometry { u, v: path.into() }).insert(services)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -91,7 +91,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                         half_edge
                     };
 
-                    half_edge.insert(&mut services.objects)
+                    half_edge.insert(services)
                 };
 
                 exterior = Some(
@@ -106,14 +106,14 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
 
         let face = Face::new(
             (edge.curve(), surface).sweep_with_cache(path, cache, services),
-            exterior.unwrap().insert(&mut services.objects),
+            exterior.unwrap().insert(services),
             Vec::new(),
             color,
         );
 
         // And we're done creating the face! All that's left to do is build our
         // return values.
-        let face = face.insert(&mut services.objects);
+        let face = face.insert(services);
         (face, edge_top)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/edge.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/edge.rs
@@ -81,7 +81,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                     let half_edge = HalfEdge::line_segment(
                         [start, end],
                         Some(boundary),
-                        &mut services.objects,
+                        services,
                     )
                     .replace_start_vertex(start_vertex);
 

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -47,7 +47,7 @@ impl Sweep for Handle<Face> {
             if is_negative_sweep {
                 self.clone()
             } else {
-                self.clone().reverse(&mut services.objects)
+                self.clone().reverse(services)
             }
         };
         faces.push(bottom_face.clone());
@@ -61,7 +61,7 @@ impl Sweep for Handle<Face> {
         let mut interiors = Vec::new();
 
         for (i, cycle) in bottom_face.all_cycles().cloned().enumerate() {
-            let cycle = cycle.reverse(&mut services.objects);
+            let cycle = cycle.reverse(services);
 
             let mut top_edges = Vec::new();
             for (half_edge, next) in

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -52,10 +52,8 @@ impl Sweep for Handle<Face> {
         };
         faces.push(bottom_face.clone());
 
-        let top_surface = bottom_face
-            .surface()
-            .clone()
-            .translate(path, &mut services.objects);
+        let top_surface =
+            bottom_face.surface().clone().translate(path, services);
 
         let mut exterior = None;
         let mut interiors = Vec::new();

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -86,18 +86,18 @@ impl Sweep for Handle<Face> {
                 .build(services);
 
             if i == 0 {
-                exterior = Some(top_cycle.insert(&mut services.objects));
+                exterior = Some(top_cycle.insert(services));
             } else {
-                interiors.push(top_cycle.insert(&mut services.objects));
+                interiors.push(top_cycle.insert(services));
             };
         }
 
         let top_face =
             Face::new(top_surface, exterior.unwrap(), interiors, self.color());
 
-        let top_face = top_face.insert(&mut services.objects);
+        let top_face = top_face.insert(services);
         faces.push(top_face);
 
-        Shell::new(faces).insert(&mut services.objects)
+        Shell::new(faces).insert(services)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -82,11 +82,8 @@ impl Sweep for Handle<Face> {
                 ));
             }
 
-            let top_cycle = CycleBuilder::connect_to_edges(
-                top_edges,
-                &mut services.objects,
-            )
-            .build(&mut services.objects);
+            let top_cycle = CycleBuilder::connect_to_edges(top_edges, services)
+                .build(&mut services.objects);
 
             if i == 0 {
                 exterior = Some(top_cycle.insert(&mut services.objects));

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -7,9 +7,9 @@ use crate::{
     algorithms::{reverse::Reverse, transform::TransformObject},
     builder::CycleBuilder,
     geometry::curve::GlobalPath,
-    objects::{Face, Objects, Shell},
+    objects::{Face, Shell},
     operations::Insert,
-    services::Service,
+    services::Services,
     storage::Handle,
 };
 
@@ -22,7 +22,7 @@ impl Sweep for Handle<Face> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self::Swept {
         let path = path.into();
 
@@ -47,19 +47,21 @@ impl Sweep for Handle<Face> {
             if is_negative_sweep {
                 self.clone()
             } else {
-                self.clone().reverse(objects)
+                self.clone().reverse(&mut services.objects)
             }
         };
         faces.push(bottom_face.clone());
 
-        let top_surface =
-            bottom_face.surface().clone().translate(path, objects);
+        let top_surface = bottom_face
+            .surface()
+            .clone()
+            .translate(path, &mut services.objects);
 
         let mut exterior = None;
         let mut interiors = Vec::new();
 
         for (i, cycle) in bottom_face.all_cycles().cloned().enumerate() {
-            let cycle = cycle.reverse(objects);
+            let cycle = cycle.reverse(&mut services.objects);
 
             let mut top_edges = Vec::new();
             for (half_edge, next) in
@@ -71,7 +73,7 @@ impl Sweep for Handle<Face> {
                     self.surface().deref(),
                     self.color(),
                 )
-                    .sweep_with_cache(path, cache, objects);
+                    .sweep_with_cache(path, cache, services);
 
                 faces.push(face);
 
@@ -82,22 +84,25 @@ impl Sweep for Handle<Face> {
                 ));
             }
 
-            let top_cycle = CycleBuilder::connect_to_edges(top_edges, objects)
-                .build(objects);
+            let top_cycle = CycleBuilder::connect_to_edges(
+                top_edges,
+                &mut services.objects,
+            )
+            .build(&mut services.objects);
 
             if i == 0 {
-                exterior = Some(top_cycle.insert(objects));
+                exterior = Some(top_cycle.insert(&mut services.objects));
             } else {
-                interiors.push(top_cycle.insert(objects));
+                interiors.push(top_cycle.insert(&mut services.objects));
             };
         }
 
         let top_face =
             Face::new(top_surface, exterior.unwrap(), interiors, self.color());
 
-        let top_face = top_face.insert(objects);
+        let top_face = top_face.insert(&mut services.objects);
         faces.push(top_face);
 
-        Shell::new(faces).insert(objects)
+        Shell::new(faces).insert(&mut services.objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/face.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/face.rs
@@ -83,7 +83,7 @@ impl Sweep for Handle<Face> {
             }
 
             let top_cycle = CycleBuilder::connect_to_edges(top_edges, services)
-                .build(&mut services.objects);
+                .build(services);
 
             if i == 0 {
                 exterior = Some(top_cycle.insert(&mut services.objects));

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -12,7 +12,7 @@ use fj_math::Vector;
 
 use crate::{
     objects::{GlobalEdge, Objects, Vertex},
-    services::Service,
+    services::{Service, Services},
     storage::{Handle, ObjectId},
 };
 
@@ -25,10 +25,10 @@ pub trait Sweep: Sized {
     fn sweep(
         self,
         path: impl Into<Vector<3>>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self::Swept {
         let mut cache = SweepCache::default();
-        self.sweep_with_cache(path, &mut cache, objects)
+        self.sweep_with_cache(path, &mut cache, &mut services.objects)
     }
 
     /// Sweep the object along the given path, using the provided cache

--- a/crates/fj-kernel/src/algorithms/sweep/mod.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/mod.rs
@@ -11,8 +11,8 @@ use std::collections::BTreeMap;
 use fj_math::Vector;
 
 use crate::{
-    objects::{GlobalEdge, Objects, Vertex},
-    services::{Service, Services},
+    objects::{GlobalEdge, Vertex},
+    services::Services,
     storage::{Handle, ObjectId},
 };
 
@@ -28,7 +28,7 @@ pub trait Sweep: Sized {
         services: &mut Services,
     ) -> Self::Swept {
         let mut cache = SweepCache::default();
-        self.sweep_with_cache(path, &mut cache, &mut services.objects)
+        self.sweep_with_cache(path, &mut cache, services)
     }
 
     /// Sweep the object along the given path, using the provided cache
@@ -36,7 +36,7 @@ pub trait Sweep: Sized {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self::Swept;
 }
 

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -1,9 +1,9 @@
 use fj_math::Vector;
 
 use crate::{
-    objects::{Objects, Sketch, Solid},
+    objects::{Sketch, Solid},
     operations::Insert,
-    services::Service,
+    services::Services,
     storage::Handle,
 };
 
@@ -16,16 +16,16 @@ impl Sweep for Handle<Sketch> {
         self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self::Swept {
         let path = path.into();
 
         let mut shells = Vec::new();
         for face in self.faces().clone() {
-            let shell = face.sweep_with_cache(path, cache, objects);
+            let shell = face.sweep_with_cache(path, cache, services);
             shells.push(shell);
         }
 
-        Solid::new(shells).insert(objects)
+        Solid::new(shells).insert(&mut services.objects)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/sketch.rs
@@ -26,6 +26,6 @@ impl Sweep for Handle<Sketch> {
             shells.push(shell);
         }
 
-        Solid::new(shells).insert(&mut services.objects)
+        Solid::new(shells).insert(services)
     }
 }

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -1,9 +1,9 @@
 use fj_math::Vector;
 
 use crate::{
-    objects::{GlobalEdge, Objects, Vertex},
+    objects::{GlobalEdge, Vertex},
     operations::Insert,
-    services::Service,
+    services::Services,
     storage::Handle,
 };
 
@@ -16,20 +16,20 @@ impl Sweep for Handle<Vertex> {
         self,
         _: impl Into<Vector<3>>,
         cache: &mut SweepCache,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self::Swept {
         let a = self.clone();
         let b = cache
             .global_vertex
             .entry(self.id())
-            .or_insert_with(|| Vertex::new().insert(objects))
+            .or_insert_with(|| Vertex::new().insert(&mut services.objects))
             .clone();
 
         let vertices = [a, b];
         let global_edge = cache
             .global_edge
             .entry(self.id())
-            .or_insert_with(|| GlobalEdge::new().insert(objects))
+            .or_insert_with(|| GlobalEdge::new().insert(&mut services.objects))
             .clone();
 
         // The vertices of the returned `GlobalEdge` are in normalized order,

--- a/crates/fj-kernel/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/sweep/vertex.rs
@@ -22,14 +22,14 @@ impl Sweep for Handle<Vertex> {
         let b = cache
             .global_vertex
             .entry(self.id())
-            .or_insert_with(|| Vertex::new().insert(&mut services.objects))
+            .or_insert_with(|| Vertex::new().insert(services))
             .clone();
 
         let vertices = [a, b];
         let global_edge = cache
             .global_edge
             .entry(self.id())
-            .or_insert_with(|| GlobalEdge::new().insert(&mut services.objects))
+            .or_insert_with(|| GlobalEdge::new().insert(services))
             .clone();
 
         // The vertices of the returned `GlobalEdge` are in normalized order,

--- a/crates/fj-kernel/src/algorithms/transform/cycle.rs
+++ b/crates/fj-kernel/src/algorithms/transform/cycle.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::{Cycle, Objects},
-    services::Service,
-};
+use crate::{objects::Cycle, services::Services};
 
 use super::{TransformCache, TransformObject};
 
@@ -11,13 +8,13 @@ impl TransformObject for Cycle {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         let half_edges = self.half_edges().map(|half_edge| {
             half_edge
                 .clone()
-                .transform_with_cache(transform, objects, cache)
+                .transform_with_cache(transform, services, cache)
         });
 
         Self::new(half_edges)

--- a/crates/fj-kernel/src/algorithms/transform/edge.rs
+++ b/crates/fj-kernel/src/algorithms/transform/edge.rs
@@ -1,8 +1,8 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{GlobalEdge, HalfEdge, Objects},
-    services::Service,
+    objects::{GlobalEdge, HalfEdge},
+    services::Services,
 };
 
 use super::{TransformCache, TransformObject};
@@ -11,7 +11,7 @@ impl TransformObject for HalfEdge {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         // Don't need to transform curve, as that's defined in surface
@@ -21,11 +21,11 @@ impl TransformObject for HalfEdge {
         let start_vertex = self
             .start_vertex()
             .clone()
-            .transform_with_cache(transform, objects, cache);
+            .transform_with_cache(transform, services, cache);
         let global_form = self
             .global_form()
             .clone()
-            .transform_with_cache(transform, objects, cache);
+            .transform_with_cache(transform, services, cache);
 
         Self::new(curve, boundary, start_vertex, global_form)
     }
@@ -35,7 +35,7 @@ impl TransformObject for GlobalEdge {
     fn transform_with_cache(
         self,
         _: &Transform,
-        _: &mut Service<Objects>,
+        _: &mut Services,
         _: &mut TransformCache,
     ) -> Self {
         // There's nothing to actually transform here, as `GlobalEdge` holds no

--- a/crates/fj-kernel/src/algorithms/transform/face.rs
+++ b/crates/fj-kernel/src/algorithms/transform/face.rs
@@ -1,8 +1,8 @@
 use fj_math::Transform;
 
 use crate::{
-    objects::{Face, FaceSet, Objects},
-    services::Service,
+    objects::{Face, FaceSet},
+    services::Services,
 };
 
 use super::{TransformCache, TransformObject};
@@ -11,7 +11,7 @@ impl TransformObject for Face {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         // Color does not need to be transformed.
@@ -20,13 +20,13 @@ impl TransformObject for Face {
         let surface = self
             .surface()
             .clone()
-            .transform_with_cache(transform, objects, cache);
+            .transform_with_cache(transform, services, cache);
         let exterior = self
             .exterior()
             .clone()
-            .transform_with_cache(transform, objects, cache);
+            .transform_with_cache(transform, services, cache);
         let interiors = self.interiors().cloned().map(|interior| {
-            interior.transform_with_cache(transform, objects, cache)
+            interior.transform_with_cache(transform, services, cache)
         });
 
         Self::new(surface, exterior, interiors, color)
@@ -37,13 +37,13 @@ impl TransformObject for FaceSet {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         let mut faces = Self::new();
         faces.extend(
             self.into_iter().map(|face| {
-                face.transform_with_cache(transform, objects, cache)
+                face.transform_with_cache(transform, services, cache)
             }),
         );
         faces

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -55,9 +55,9 @@ pub trait TransformObject: Sized {
     fn translate(
         self,
         offset: impl Into<Vector<3>>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self {
-        self.transform(&Transform::translation(offset), objects)
+        self.transform(&Transform::translation(offset), &mut services.objects)
     }
 
     /// Rotate the object

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -32,13 +32,9 @@ use crate::{
 /// hasn't been done so far, is that no one has put in the work yet.
 pub trait TransformObject: Sized {
     /// Transform the object
-    fn transform(
-        self,
-        transform: &Transform,
-        objects: &mut Service<Objects>,
-    ) -> Self {
+    fn transform(self, transform: &Transform, services: &mut Services) -> Self {
         let mut cache = TransformCache::default();
-        self.transform_with_cache(transform, objects, &mut cache)
+        self.transform_with_cache(transform, &mut services.objects, &mut cache)
     }
 
     /// Transform the object using the provided cache
@@ -57,7 +53,7 @@ pub trait TransformObject: Sized {
         offset: impl Into<Vector<3>>,
         services: &mut Services,
     ) -> Self {
-        self.transform(&Transform::translation(offset), &mut services.objects)
+        self.transform(&Transform::translation(offset), services)
     }
 
     /// Rotate the object
@@ -68,7 +64,7 @@ pub trait TransformObject: Sized {
         axis_angle: impl Into<Vector<3>>,
         services: &mut Services,
     ) -> Self {
-        self.transform(&Transform::rotation(axis_angle), &mut services.objects)
+        self.transform(&Transform::rotation(axis_angle), services)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -84,7 +84,7 @@ where
         let transformed = self
             .clone_object()
             .transform_with_cache(transform, services, cache)
-            .insert(&mut services.objects);
+            .insert(services);
 
         cache.insert(self.clone(), transformed.clone());
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -17,7 +17,7 @@ use type_map::TypeMap;
 use crate::{
     objects::Objects,
     operations::Insert,
-    services::Service,
+    services::{Service, Services},
     storage::{Handle, ObjectId},
 };
 
@@ -66,9 +66,9 @@ pub trait TransformObject: Sized {
     fn rotate(
         self,
         axis_angle: impl Into<Vector<3>>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self {
-        self.transform(&Transform::rotation(axis_angle), objects)
+        self.transform(&Transform::rotation(axis_angle), &mut services.objects)
     }
 }
 

--- a/crates/fj-kernel/src/algorithms/transform/mod.rs
+++ b/crates/fj-kernel/src/algorithms/transform/mod.rs
@@ -15,9 +15,8 @@ use fj_math::{Transform, Vector};
 use type_map::TypeMap;
 
 use crate::{
-    objects::Objects,
     operations::Insert,
-    services::{Service, Services},
+    services::Services,
     storage::{Handle, ObjectId},
 };
 
@@ -34,14 +33,14 @@ pub trait TransformObject: Sized {
     /// Transform the object
     fn transform(self, transform: &Transform, services: &mut Services) -> Self {
         let mut cache = TransformCache::default();
-        self.transform_with_cache(transform, &mut services.objects, &mut cache)
+        self.transform_with_cache(transform, services, &mut cache)
     }
 
     /// Transform the object using the provided cache
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self;
 
@@ -75,7 +74,7 @@ where
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         if let Some(object) = cache.get(&self) {
@@ -84,8 +83,8 @@ where
 
         let transformed = self
             .clone_object()
-            .transform_with_cache(transform, objects, cache)
-            .insert(objects);
+            .transform_with_cache(transform, services, cache)
+            .insert(&mut services.objects);
 
         cache.insert(self.clone(), transformed.clone());
 

--- a/crates/fj-kernel/src/algorithms/transform/shell.rs
+++ b/crates/fj-kernel/src/algorithms/transform/shell.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::{Objects, Shell},
-    services::Service,
-};
+use crate::{objects::Shell, services::Services};
 
 use super::{TransformCache, TransformObject};
 
@@ -11,12 +8,12 @@ impl TransformObject for Shell {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         let faces =
             self.faces().clone().into_iter().map(|face| {
-                face.transform_with_cache(transform, objects, cache)
+                face.transform_with_cache(transform, services, cache)
             });
 
         Self::new(faces)

--- a/crates/fj-kernel/src/algorithms/transform/sketch.rs
+++ b/crates/fj-kernel/src/algorithms/transform/sketch.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::{Objects, Sketch},
-    services::Service,
-};
+use crate::{objects::Sketch, services::Services};
 
 use super::{TransformCache, TransformObject};
 
@@ -11,12 +8,12 @@ impl TransformObject for Sketch {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
         let faces =
             self.faces().into_iter().cloned().map(|face| {
-                face.transform_with_cache(transform, objects, cache)
+                face.transform_with_cache(transform, services, cache)
             });
 
         Self::new(faces)

--- a/crates/fj-kernel/src/algorithms/transform/solid.rs
+++ b/crates/fj-kernel/src/algorithms/transform/solid.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::{Objects, Solid},
-    services::Service,
-};
+use crate::{objects::Solid, services::Services};
 
 use super::{TransformCache, TransformObject};
 
@@ -11,13 +8,12 @@ impl TransformObject for Solid {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
-        let shells = self
-            .shells()
-            .cloned()
-            .map(|shell| shell.transform_with_cache(transform, objects, cache));
+        let shells = self.shells().cloned().map(|shell| {
+            shell.transform_with_cache(transform, services, cache)
+        });
 
         Self::new(shells)
     }

--- a/crates/fj-kernel/src/algorithms/transform/surface.rs
+++ b/crates/fj-kernel/src/algorithms/transform/surface.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::{Objects, Surface},
-    services::Service,
-};
+use crate::{objects::Surface, services::Services};
 
 use super::{TransformCache, TransformObject};
 
@@ -11,7 +8,7 @@ impl TransformObject for Surface {
     fn transform_with_cache(
         self,
         transform: &Transform,
-        _: &mut Service<Objects>,
+        _: &mut Services,
         _: &mut TransformCache,
     ) -> Self {
         let geometry = self.geometry().transform(transform);

--- a/crates/fj-kernel/src/algorithms/transform/vertex.rs
+++ b/crates/fj-kernel/src/algorithms/transform/vertex.rs
@@ -1,9 +1,6 @@
 use fj_math::Transform;
 
-use crate::{
-    objects::{Objects, Vertex},
-    services::Service,
-};
+use crate::{objects::Vertex, services::Services};
 
 use super::{TransformCache, TransformObject};
 
@@ -11,7 +8,7 @@ impl TransformObject for Vertex {
     fn transform_with_cache(
         self,
         _: &Transform,
-        _: &mut Service<Objects>,
+        _: &mut Services,
         _: &mut TransformCache,
     ) -> Self {
         // There's nothing to actually transform here, as `Vertex` holds no

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -97,7 +97,7 @@ mod tests {
 
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon([a, b, c, d], &mut services))
-            .build(&mut services.objects);
+            .build(&mut services);
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
@@ -133,7 +133,7 @@ mod tests {
         let face = FaceBuilder::new(surface.clone())
             .with_exterior(CycleBuilder::polygon([a, b, c, d], &mut services))
             .with_interior(CycleBuilder::polygon([e, f, g, h], &mut services))
-            .build(&mut services.objects);
+            .build(&mut services);
 
         let triangles = triangulate(face)?;
 
@@ -193,7 +193,7 @@ mod tests {
                 [a, b, c, d, e],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
 
         let triangles = triangulate(face)?;
 

--- a/crates/fj-kernel/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-kernel/src/algorithms/triangulate/mod.rs
@@ -96,10 +96,7 @@ mod tests {
         let d = [0., 1.];
 
         let face = FaceBuilder::new(services.objects.surfaces.xy_plane())
-            .with_exterior(CycleBuilder::polygon(
-                [a, b, c, d],
-                &mut services.objects,
-            ))
+            .with_exterior(CycleBuilder::polygon([a, b, c, d], &mut services))
             .build(&mut services.objects);
 
         let a = Point::from(a).to_xyz();
@@ -134,14 +131,8 @@ mod tests {
         let surface = services.objects.surfaces.xy_plane();
 
         let face = FaceBuilder::new(surface.clone())
-            .with_exterior(CycleBuilder::polygon(
-                [a, b, c, d],
-                &mut services.objects,
-            ))
-            .with_interior(CycleBuilder::polygon(
-                [e, f, g, h],
-                &mut services.objects,
-            ))
+            .with_exterior(CycleBuilder::polygon([a, b, c, d], &mut services))
+            .with_interior(CycleBuilder::polygon([e, f, g, h], &mut services))
             .build(&mut services.objects);
 
         let triangles = triangulate(face)?;
@@ -200,7 +191,7 @@ mod tests {
         let face = FaceBuilder::new(surface.clone())
             .with_exterior(CycleBuilder::polygon(
                 [a, b, c, d, e],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -47,7 +47,7 @@ impl CycleBuilder {
     }
 
     /// Create a polygon
-    pub fn polygon<P, Ps>(points: Ps, objects: &mut Service<Objects>) -> Self
+    pub fn polygon<P, Ps>(points: Ps, services: &mut Services) -> Self
     where
         P: Into<Point<2>>,
         Ps: IntoIterator<Item = P>,
@@ -58,7 +58,11 @@ impl CycleBuilder {
             .map(Into::into)
             .circular_tuple_windows()
             .map(|(start, end)| {
-                HalfEdge::line_segment([start, end], None, objects)
+                HalfEdge::line_segment(
+                    [start, end],
+                    None,
+                    &mut services.objects,
+                )
             })
             .collect();
 

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -70,7 +70,7 @@ impl CycleBuilder {
         let half_edges = self
             .half_edges
             .into_iter()
-            .map(|half_edge| half_edge.insert(&mut services.objects));
+            .map(|half_edge| half_edge.insert(services));
         Cycle::new(half_edges)
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -5,7 +5,7 @@ use crate::{
     geometry::curve::Curve,
     objects::{Cycle, HalfEdge, Objects},
     operations::{BuildHalfEdge, Insert, UpdateHalfEdge},
-    services::Service,
+    services::{Service, Services},
     storage::Handle,
 };
 
@@ -28,10 +28,7 @@ impl CycleBuilder {
     ///
     /// Assumes that the provided half-edges, once translated into local
     /// equivalents of this cycle, form a cycle themselves.
-    pub fn connect_to_edges<Es>(
-        edges: Es,
-        objects: &mut Service<Objects>,
-    ) -> Self
+    pub fn connect_to_edges<Es>(edges: Es, services: &mut Services) -> Self
     where
         Es: IntoIterator<Item = (Handle<HalfEdge>, Curve, [Point<1>; 2])>,
         Es::IntoIter: Clone + ExactSizeIterator,
@@ -40,7 +37,7 @@ impl CycleBuilder {
             .into_iter()
             .circular_tuple_windows()
             .map(|((prev, _, _), (half_edge, curve, boundary))| {
-                HalfEdge::unjoined(curve, boundary, objects)
+                HalfEdge::unjoined(curve, boundary, &mut services.objects)
                     .replace_start_vertex(prev.start_vertex().clone())
                     .replace_global_form(half_edge.global_form().clone())
             })

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -37,7 +37,7 @@ impl CycleBuilder {
             .into_iter()
             .circular_tuple_windows()
             .map(|((prev, _, _), (half_edge, curve, boundary))| {
-                HalfEdge::unjoined(curve, boundary, &mut services.objects)
+                HalfEdge::unjoined(curve, boundary, services)
                     .replace_start_vertex(prev.start_vertex().clone())
                     .replace_global_form(half_edge.global_form().clone())
             })

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -3,9 +3,9 @@ use itertools::Itertools;
 
 use crate::{
     geometry::curve::Curve,
-    objects::{Cycle, HalfEdge, Objects},
+    objects::{Cycle, HalfEdge},
     operations::{BuildHalfEdge, Insert, UpdateHalfEdge},
-    services::{Service, Services},
+    services::Services,
     storage::Handle,
 };
 
@@ -70,11 +70,11 @@ impl CycleBuilder {
     }
 
     /// Build the cycle
-    pub fn build(self, objects: &mut Service<Objects>) -> Cycle {
+    pub fn build(self, services: &mut Services) -> Cycle {
         let half_edges = self
             .half_edges
             .into_iter()
-            .map(|half_edge| half_edge.insert(objects));
+            .map(|half_edge| half_edge.insert(&mut services.objects));
         Cycle::new(half_edges)
     }
 }

--- a/crates/fj-kernel/src/builder/cycle.rs
+++ b/crates/fj-kernel/src/builder/cycle.rs
@@ -58,11 +58,7 @@ impl CycleBuilder {
             .map(Into::into)
             .circular_tuple_windows()
             .map(|(start, end)| {
-                HalfEdge::line_segment(
-                    [start, end],
-                    None,
-                    &mut services.objects,
-                )
+                HalfEdge::line_segment([start, end], None, services)
             })
             .collect();
 

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -1,9 +1,9 @@
 use fj_interop::mesh::Color;
 
 use crate::{
-    objects::{Face, Objects, Surface},
+    objects::{Face, Surface},
     operations::Insert,
-    services::Service,
+    services::Services,
     storage::Handle,
 };
 
@@ -46,12 +46,16 @@ impl FaceBuilder {
     }
 
     /// Build the face
-    pub fn build(self, objects: &mut Service<Objects>) -> Face {
-        let exterior = self.exterior.build(objects).insert(objects);
-        let interiors = self
-            .interiors
-            .into_iter()
-            .map(|cycle| cycle.build(objects).insert(objects));
+    pub fn build(self, services: &mut Services) -> Face {
+        let exterior = self
+            .exterior
+            .build(&mut services.objects)
+            .insert(&mut services.objects);
+        let interiors = self.interiors.into_iter().map(|cycle| {
+            cycle
+                .build(&mut services.objects)
+                .insert(&mut services.objects)
+        });
 
         Face::new(self.surface, exterior, interiors, self.color)
     }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -47,12 +47,11 @@ impl FaceBuilder {
 
     /// Build the face
     pub fn build(self, services: &mut Services) -> Face {
-        let exterior =
-            self.exterior.build(services).insert(&mut services.objects);
+        let exterior = self.exterior.build(services).insert(services);
         let interiors = self
             .interiors
             .into_iter()
-            .map(|cycle| cycle.build(services).insert(&mut services.objects));
+            .map(|cycle| cycle.build(services).insert(services));
 
         Face::new(self.surface, exterior, interiors, self.color)
     }

--- a/crates/fj-kernel/src/builder/face.rs
+++ b/crates/fj-kernel/src/builder/face.rs
@@ -47,15 +47,12 @@ impl FaceBuilder {
 
     /// Build the face
     pub fn build(self, services: &mut Services) -> Face {
-        let exterior = self
-            .exterior
-            .build(&mut services.objects)
-            .insert(&mut services.objects);
-        let interiors = self.interiors.into_iter().map(|cycle| {
-            cycle
-                .build(&mut services.objects)
-                .insert(&mut services.objects)
-        });
+        let exterior =
+            self.exterior.build(services).insert(&mut services.objects);
+        let interiors = self
+            .interiors
+            .into_iter()
+            .map(|cycle| cycle.build(services).insert(&mut services.objects));
 
         Face::new(self.surface, exterior, interiors, self.color)
     }

--- a/crates/fj-kernel/src/operations/build/edge.rs
+++ b/crates/fj-kernel/src/operations/build/edge.rs
@@ -61,7 +61,7 @@ pub trait BuildHalfEdge {
     fn line_segment(
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> HalfEdge {
         let boundary =
             boundary.unwrap_or_else(|| [[0.], [1.]].map(Point::from));
@@ -69,7 +69,7 @@ pub trait BuildHalfEdge {
             boundary.zip_ext(points_surface),
         );
 
-        HalfEdge::unjoined(curve, boundary, objects)
+        HalfEdge::unjoined(curve, boundary, &mut services.objects)
     }
 
     /// Create a line segment from global points
@@ -81,7 +81,7 @@ pub trait BuildHalfEdge {
     ) -> HalfEdge {
         let points_surface = points_global
             .map(|point| surface.geometry().project_global_point(point));
-        HalfEdge::line_segment(points_surface, boundary, &mut services.objects)
+        HalfEdge::line_segment(points_surface, boundary, services)
     }
 }
 

--- a/crates/fj-kernel/src/operations/build/edge.rs
+++ b/crates/fj-kernel/src/operations/build/edge.rs
@@ -16,8 +16,8 @@ pub trait BuildHalfEdge {
         boundary: [Point<1>; 2],
         services: &mut Services,
     ) -> HalfEdge {
-        let start_vertex = Vertex::new().insert(&mut services.objects);
-        let global_form = GlobalEdge::new().insert(&mut services.objects);
+        let start_vertex = Vertex::new().insert(services);
+        let global_form = GlobalEdge::new().insert(services);
 
         HalfEdge::new(curve, boundary, start_vertex, global_form)
     }

--- a/crates/fj-kernel/src/operations/build/edge.rs
+++ b/crates/fj-kernel/src/operations/build/edge.rs
@@ -49,15 +49,12 @@ pub trait BuildHalfEdge {
     }
 
     /// Create a circle
-    fn circle(
-        radius: impl Into<Scalar>,
-        objects: &mut Service<Objects>,
-    ) -> HalfEdge {
+    fn circle(radius: impl Into<Scalar>, services: &mut Services) -> HalfEdge {
         let curve = Curve::circle_from_radius(radius);
         let boundary =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        HalfEdge::unjoined(curve, boundary, objects)
+        HalfEdge::unjoined(curve, boundary, &mut services.objects)
     }
 
     /// Create a line segment

--- a/crates/fj-kernel/src/operations/build/edge.rs
+++ b/crates/fj-kernel/src/operations/build/edge.rs
@@ -77,11 +77,11 @@ pub trait BuildHalfEdge {
         points_global: [impl Into<Point<3>>; 2],
         surface: &Surface,
         boundary: Option<[Point<1>; 2]>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> HalfEdge {
         let points_surface = points_global
             .map(|point| surface.geometry().project_global_point(point));
-        HalfEdge::line_segment(points_surface, boundary, objects)
+        HalfEdge::line_segment(points_surface, boundary, &mut services.objects)
     }
 }
 

--- a/crates/fj-kernel/src/operations/build/edge.rs
+++ b/crates/fj-kernel/src/operations/build/edge.rs
@@ -5,7 +5,7 @@ use crate::{
     geometry::curve::Curve,
     objects::{GlobalEdge, HalfEdge, Objects, Surface, Vertex},
     operations::Insert,
-    services::Service,
+    services::{Service, Services},
 };
 
 /// Build a [`HalfEdge`]
@@ -31,7 +31,7 @@ pub trait BuildHalfEdge {
         start: impl Into<Point<2>>,
         end: impl Into<Point<2>>,
         angle_rad: impl Into<Scalar>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> HalfEdge {
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
@@ -45,7 +45,7 @@ pub trait BuildHalfEdge {
         let boundary =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
-        HalfEdge::unjoined(curve, boundary, objects)
+        HalfEdge::unjoined(curve, boundary, &mut services.objects)
     }
 
     /// Create a circle

--- a/crates/fj-kernel/src/operations/build/edge.rs
+++ b/crates/fj-kernel/src/operations/build/edge.rs
@@ -3,9 +3,9 @@ use fj_math::{Arc, Point, Scalar};
 
 use crate::{
     geometry::curve::Curve,
-    objects::{GlobalEdge, HalfEdge, Objects, Surface, Vertex},
+    objects::{GlobalEdge, HalfEdge, Surface, Vertex},
     operations::Insert,
-    services::{Service, Services},
+    services::Services,
 };
 
 /// Build a [`HalfEdge`]
@@ -14,10 +14,10 @@ pub trait BuildHalfEdge {
     fn unjoined(
         curve: Curve,
         boundary: [Point<1>; 2],
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> HalfEdge {
-        let start_vertex = Vertex::new().insert(objects);
-        let global_form = GlobalEdge::new().insert(objects);
+        let start_vertex = Vertex::new().insert(&mut services.objects);
+        let global_form = GlobalEdge::new().insert(&mut services.objects);
 
         HalfEdge::new(curve, boundary, start_vertex, global_form)
     }
@@ -45,7 +45,7 @@ pub trait BuildHalfEdge {
         let boundary =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
-        HalfEdge::unjoined(curve, boundary, &mut services.objects)
+        HalfEdge::unjoined(curve, boundary, services)
     }
 
     /// Create a circle
@@ -54,7 +54,7 @@ pub trait BuildHalfEdge {
         let boundary =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        HalfEdge::unjoined(curve, boundary, &mut services.objects)
+        HalfEdge::unjoined(curve, boundary, services)
     }
 
     /// Create a line segment
@@ -69,7 +69,7 @@ pub trait BuildHalfEdge {
             boundary.zip_ext(points_surface),
         );
 
-        HalfEdge::unjoined(curve, boundary, &mut services.objects)
+        HalfEdge::unjoined(curve, boundary, services)
     }
 
     /// Create a line segment from global points

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -24,10 +24,7 @@ pub trait BuildFace {
         let (exterior, edges, vertices) = {
             let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
                 let half_edge = HalfEdge::line_segment_from_global_points(
-                    points,
-                    &surface,
-                    None,
-                    &mut services.objects,
+                    points, &surface, None, services,
                 );
 
                 half_edge.insert(&mut services.objects)

--- a/crates/fj-kernel/src/operations/build/face.rs
+++ b/crates/fj-kernel/src/operations/build/face.rs
@@ -19,22 +19,20 @@ pub trait BuildFace {
     ) -> Polygon<3> {
         let [a, b, c] = points.map(Into::into);
 
-        let surface =
-            Surface::plane_from_points([a, b, c]).insert(&mut services.objects);
+        let surface = Surface::plane_from_points([a, b, c]).insert(services);
         let (exterior, edges, vertices) = {
             let half_edges = [[a, b], [b, c], [c, a]].map(|points| {
                 let half_edge = HalfEdge::line_segment_from_global_points(
                     points, &surface, None, services,
                 );
 
-                half_edge.insert(&mut services.objects)
+                half_edge.insert(services)
             });
             let vertices = half_edges
                 .each_ref_ext()
                 .map(|half_edge| half_edge.start_vertex().clone());
 
-            let cycle =
-                Cycle::new(half_edges.clone()).insert(&mut services.objects);
+            let cycle = Cycle::new(half_edges.clone()).insert(services);
 
             (cycle, half_edges, vertices)
         };

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -41,12 +41,7 @@ pub trait BuildShell {
                 .face
                 .update_exterior(|cycle| {
                     cycle
-                        .join_to(
-                            abc.exterior(),
-                            0..=0,
-                            0..=0,
-                            &mut services.objects,
-                        )
+                        .join_to(abc.exterior(), 0..=0, 0..=0, services)
                         .insert(&mut services.objects)
                 });
         let dac =
@@ -54,18 +49,8 @@ pub trait BuildShell {
                 .face
                 .update_exterior(|cycle| {
                     cycle
-                        .join_to(
-                            abc.exterior(),
-                            1..=1,
-                            2..=2,
-                            &mut services.objects,
-                        )
-                        .join_to(
-                            bad.exterior(),
-                            0..=0,
-                            1..=1,
-                            &mut services.objects,
-                        )
+                        .join_to(abc.exterior(), 1..=1, 2..=2, services)
+                        .join_to(bad.exterior(), 0..=0, 1..=1, services)
                         .insert(&mut services.objects)
                 });
         let cbd =
@@ -73,24 +58,9 @@ pub trait BuildShell {
                 .face
                 .update_exterior(|cycle| {
                     cycle
-                        .join_to(
-                            abc.exterior(),
-                            0..=0,
-                            1..=1,
-                            &mut services.objects,
-                        )
-                        .join_to(
-                            bad.exterior(),
-                            1..=1,
-                            2..=2,
-                            &mut services.objects,
-                        )
-                        .join_to(
-                            dac.exterior(),
-                            2..=2,
-                            2..=2,
-                            &mut services.objects,
-                        )
+                        .join_to(abc.exterior(), 0..=0, 1..=1, services)
+                        .join_to(bad.exterior(), 1..=1, 2..=2, services)
+                        .join_to(dac.exterior(), 2..=2, 2..=2, services)
                         .insert(&mut services.objects)
                 });
 

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -42,7 +42,7 @@ pub trait BuildShell {
                 .update_exterior(|cycle| {
                     cycle
                         .join_to(abc.exterior(), 0..=0, 0..=0, services)
-                        .insert(&mut services.objects)
+                        .insert(services)
                 });
         let dac =
             Face::triangle([d, a, c], services)
@@ -51,7 +51,7 @@ pub trait BuildShell {
                     cycle
                         .join_to(abc.exterior(), 1..=1, 2..=2, services)
                         .join_to(bad.exterior(), 0..=0, 1..=1, services)
-                        .insert(&mut services.objects)
+                        .insert(services)
                 });
         let cbd =
             Face::triangle([c, b, d], services)
@@ -61,11 +61,10 @@ pub trait BuildShell {
                         .join_to(abc.exterior(), 0..=0, 1..=1, services)
                         .join_to(bad.exterior(), 1..=1, 2..=2, services)
                         .join_to(dac.exterior(), 2..=2, 2..=2, services)
-                        .insert(&mut services.objects)
+                        .insert(services)
                 });
 
-        let faces =
-            [abc, bad, dac, cbd].map(|face| face.insert(&mut services.objects));
+        let faces = [abc, bad, dac, cbd].map(|face| face.insert(services));
         let shell = Shell::new(faces.clone());
 
         let [abc, bad, dac, cbd] = faces;

--- a/crates/fj-kernel/src/operations/build/shell.rs
+++ b/crates/fj-kernel/src/operations/build/shell.rs
@@ -35,61 +35,64 @@ pub trait BuildShell {
     ) -> Tetrahedron {
         let [a, b, c, d] = points.map(Into::into);
 
-        let abc = Face::triangle([a, b, c], &mut services.objects).face;
-        let bad = Face::triangle([b, a, d], &mut services.objects)
-            .face
-            .update_exterior(|cycle| {
-                cycle
-                    .join_to(
-                        abc.exterior(),
-                        0..=0,
-                        0..=0,
-                        &mut services.objects,
-                    )
-                    .insert(&mut services.objects)
-            });
-        let dac = Face::triangle([d, a, c], &mut services.objects)
-            .face
-            .update_exterior(|cycle| {
-                cycle
-                    .join_to(
-                        abc.exterior(),
-                        1..=1,
-                        2..=2,
-                        &mut services.objects,
-                    )
-                    .join_to(
-                        bad.exterior(),
-                        0..=0,
-                        1..=1,
-                        &mut services.objects,
-                    )
-                    .insert(&mut services.objects)
-            });
-        let cbd = Face::triangle([c, b, d], &mut services.objects)
-            .face
-            .update_exterior(|cycle| {
-                cycle
-                    .join_to(
-                        abc.exterior(),
-                        0..=0,
-                        1..=1,
-                        &mut services.objects,
-                    )
-                    .join_to(
-                        bad.exterior(),
-                        1..=1,
-                        2..=2,
-                        &mut services.objects,
-                    )
-                    .join_to(
-                        dac.exterior(),
-                        2..=2,
-                        2..=2,
-                        &mut services.objects,
-                    )
-                    .insert(&mut services.objects)
-            });
+        let abc = Face::triangle([a, b, c], services).face;
+        let bad =
+            Face::triangle([b, a, d], services)
+                .face
+                .update_exterior(|cycle| {
+                    cycle
+                        .join_to(
+                            abc.exterior(),
+                            0..=0,
+                            0..=0,
+                            &mut services.objects,
+                        )
+                        .insert(&mut services.objects)
+                });
+        let dac =
+            Face::triangle([d, a, c], services)
+                .face
+                .update_exterior(|cycle| {
+                    cycle
+                        .join_to(
+                            abc.exterior(),
+                            1..=1,
+                            2..=2,
+                            &mut services.objects,
+                        )
+                        .join_to(
+                            bad.exterior(),
+                            0..=0,
+                            1..=1,
+                            &mut services.objects,
+                        )
+                        .insert(&mut services.objects)
+                });
+        let cbd =
+            Face::triangle([c, b, d], services)
+                .face
+                .update_exterior(|cycle| {
+                    cycle
+                        .join_to(
+                            abc.exterior(),
+                            0..=0,
+                            1..=1,
+                            &mut services.objects,
+                        )
+                        .join_to(
+                            bad.exterior(),
+                            1..=1,
+                            2..=2,
+                            &mut services.objects,
+                        )
+                        .join_to(
+                            dac.exterior(),
+                            2..=2,
+                            2..=2,
+                            &mut services.objects,
+                        )
+                        .insert(&mut services.objects)
+                });
 
         let faces =
             [abc, bad, dac, cbd].map(|face| face.insert(&mut services.objects));

--- a/crates/fj-kernel/src/operations/insert.rs
+++ b/crates/fj-kernel/src/operations/insert.rs
@@ -3,7 +3,7 @@ use crate::{
         Cycle, Face, GlobalEdge, HalfEdge, Shell, Sketch, Solid, Surface,
         Vertex,
     },
-    services::{Operation, Services},
+    services::Services,
     storage::Handle,
 };
 
@@ -23,8 +23,7 @@ macro_rules! impl_insert {
                 fn insert(self, services: &mut Services) -> Handle<Self> {
                     let handle = services.objects.$store.reserve();
                     let object = (handle.clone(), self).into();
-                    services.objects
-                        .execute(Operation::InsertObject { object });
+                    services.insert_object(object);
                     handle
                 }
             }

--- a/crates/fj-kernel/src/operations/insert.rs
+++ b/crates/fj-kernel/src/operations/insert.rs
@@ -20,8 +20,7 @@ macro_rules! impl_insert {
     ($($ty:ty, $store:ident;)*) => {
         $(
             impl Insert for $ty {
-                fn insert(self, services: &mut Services,) -> Handle<Self>
-                {
+                fn insert(self, services: &mut Services) -> Handle<Self> {
                     let handle = services.objects.$store.reserve();
                     let object = (handle.clone(), self).into();
                     services.objects

--- a/crates/fj-kernel/src/operations/insert.rs
+++ b/crates/fj-kernel/src/operations/insert.rs
@@ -1,9 +1,9 @@
 use crate::{
     objects::{
-        Cycle, Face, GlobalEdge, HalfEdge, Objects, Shell, Sketch, Solid,
-        Surface, Vertex,
+        Cycle, Face, GlobalEdge, HalfEdge, Shell, Sketch, Solid, Surface,
+        Vertex,
     },
-    services::{Operation, Service},
+    services::{Operation, Services},
     storage::Handle,
 };
 
@@ -13,18 +13,19 @@ use crate::{
 /// `Service<Objects>`. All other operations are built on top of it.
 pub trait Insert: Sized {
     /// Insert the object into its respective store
-    fn insert(self, objects: &mut Service<Objects>) -> Handle<Self>;
+    fn insert(self, services: &mut Services) -> Handle<Self>;
 }
 
 macro_rules! impl_insert {
     ($($ty:ty, $store:ident;)*) => {
         $(
             impl Insert for $ty {
-                fn insert(self, objects: &mut Service<Objects>) -> Handle<Self>
+                fn insert(self, services: &mut Services,) -> Handle<Self>
                 {
-                    let handle = objects.$store.reserve();
+                    let handle = services.objects.$store.reserve();
                     let object = (handle.clone(), self).into();
-                    objects.execute(Operation::InsertObject { object });
+                    services.objects
+                        .execute(Operation::InsertObject { object });
                     handle
                 }
             }

--- a/crates/fj-kernel/src/operations/join/cycle.rs
+++ b/crates/fj-kernel/src/operations/join/cycle.rs
@@ -1,9 +1,9 @@
 use std::ops::RangeInclusive;
 
 use crate::{
-    objects::{Cycle, Objects},
+    objects::Cycle,
     operations::{Insert, UpdateCycle, UpdateHalfEdge},
-    services::Service,
+    services::Services,
 };
 
 /// Join a [`Cycle`] to another
@@ -42,7 +42,7 @@ pub trait JoinCycle {
         other: &Cycle,
         range: RangeInclusive<usize>,
         other_range: RangeInclusive<usize>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self;
 }
 
@@ -52,7 +52,7 @@ impl JoinCycle for Cycle {
         other: &Cycle,
         range: RangeInclusive<usize>,
         range_other: RangeInclusive<usize>,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
     ) -> Self {
         assert_eq!(
             range.end() - range.start(),
@@ -86,9 +86,10 @@ impl JoinCycle for Cycle {
             let this_joined = half_edge
                 .replace_start_vertex(vertex_a)
                 .replace_global_form(half_edge_other.global_form().clone())
-                .insert(objects);
-            let next_joined =
-                next_edge.replace_start_vertex(vertex_b).insert(objects);
+                .insert(&mut services.objects);
+            let next_joined = next_edge
+                .replace_start_vertex(vertex_b)
+                .insert(&mut services.objects);
 
             cycle = cycle
                 .replace_half_edge(half_edge, this_joined)

--- a/crates/fj-kernel/src/operations/join/cycle.rs
+++ b/crates/fj-kernel/src/operations/join/cycle.rs
@@ -86,10 +86,9 @@ impl JoinCycle for Cycle {
             let this_joined = half_edge
                 .replace_start_vertex(vertex_a)
                 .replace_global_form(half_edge_other.global_form().clone())
-                .insert(&mut services.objects);
-            let next_joined = next_edge
-                .replace_start_vertex(vertex_b)
-                .insert(&mut services.objects);
+                .insert(services);
+            let next_joined =
+                next_edge.replace_start_vertex(vertex_b).insert(services);
 
             cycle = cycle
                 .replace_half_edge(half_edge, this_joined)

--- a/crates/fj-kernel/src/services/mod.rs
+++ b/crates/fj-kernel/src/services/mod.rs
@@ -34,10 +34,8 @@ pub struct Services {
 impl Services {
     /// Construct an instance of `Services`
     pub fn new() -> Self {
-        let mut objects = Service::<Objects>::default();
+        let objects = Service::<Objects>::default();
         let validation = Arc::new(Mutex::new(Service::default()));
-
-        objects.subscribe(validation.clone());
 
         Self {
             objects,
@@ -50,6 +48,12 @@ impl Services {
         let mut object_events = Vec::new();
         self.objects
             .execute(Operation::InsertObject { object }, &mut object_events);
+
+        for object_event in object_events {
+            self.validation
+                .lock()
+                .execute(object_event, &mut Vec::new());
+        }
     }
 }
 

--- a/crates/fj-kernel/src/services/mod.rs
+++ b/crates/fj-kernel/src/services/mod.rs
@@ -47,7 +47,9 @@ impl Services {
 
     /// Insert an object into the stores
     pub fn insert_object(&mut self, object: Object<WithHandle>) {
-        self.objects.execute(Operation::InsertObject { object });
+        let mut object_events = Vec::new();
+        self.objects
+            .execute(Operation::InsertObject { object }, &mut object_events);
     }
 }
 

--- a/crates/fj-kernel/src/services/mod.rs
+++ b/crates/fj-kernel/src/services/mod.rs
@@ -6,10 +6,6 @@ mod objects;
 mod service;
 mod validation;
 
-use std::sync::Arc;
-
-use parking_lot::Mutex;
-
 use crate::objects::{Object, Objects, WithHandle};
 
 pub use self::{
@@ -28,14 +24,14 @@ pub struct Services {
     /// The validation service
     ///
     /// Validates objects that are inserted using the objects service.
-    pub validation: Arc<Mutex<Service<Validation>>>,
+    pub validation: Service<Validation>,
 }
 
 impl Services {
     /// Construct an instance of `Services`
     pub fn new() -> Self {
         let objects = Service::<Objects>::default();
-        let validation = Arc::new(Mutex::new(Service::default()));
+        let validation = Service::default();
 
         Self {
             objects,
@@ -50,9 +46,7 @@ impl Services {
             .execute(Operation::InsertObject { object }, &mut object_events);
 
         for object_event in object_events {
-            self.validation
-                .lock()
-                .execute(object_event, &mut Vec::new());
+            self.validation.execute(object_event, &mut Vec::new());
         }
     }
 }

--- a/crates/fj-kernel/src/services/mod.rs
+++ b/crates/fj-kernel/src/services/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::objects::Objects;
+use crate::objects::{Object, Objects, WithHandle};
 
 pub use self::{
     objects::{InsertObject, Operation},
@@ -43,6 +43,11 @@ impl Services {
             objects,
             validation,
         }
+    }
+
+    /// Insert an object into the stores
+    pub fn insert_object(&mut self, object: Object<WithHandle>) {
+        self.objects.execute(Operation::InsertObject { object });
     }
 }
 

--- a/crates/fj-kernel/src/services/service.rs
+++ b/crates/fj-kernel/src/services/service.rs
@@ -23,7 +23,6 @@ use parking_lot::Mutex;
 /// <https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider>
 pub struct Service<S: State> {
     state: S,
-    events: Vec<S::Event>,
     subscribers: Vec<Arc<Mutex<dyn Subscriber<S::Event>>>>,
 }
 
@@ -32,7 +31,6 @@ impl<S: State> Service<S> {
     pub fn new(state: S) -> Self {
         Self {
             state,
-            events: Vec::new(),
             subscribers: Vec::new(),
         }
     }
@@ -61,13 +59,6 @@ impl<S: State> Service<S> {
                 subscriber.handle_event(event);
             }
         }
-
-        self.events.extend(events);
-    }
-
-    /// Access the events
-    pub fn events(&self) -> impl Iterator<Item = &S::Event> {
-        self.events.iter()
     }
 
     /// Replay the provided events on the given state

--- a/crates/fj-kernel/src/services/service.rs
+++ b/crates/fj-kernel/src/services/service.rs
@@ -47,11 +47,10 @@ impl<S: State> Service<S> {
     ///
     /// The command is executed synchronously. When this method returns, the
     /// state has been updated and any events have been logged.
-    pub fn execute(&mut self, command: S::Command) {
-        let mut events = Vec::new();
-        self.state.decide(command, &mut events);
+    pub fn execute(&mut self, command: S::Command, events: &mut Vec<S::Event>) {
+        self.state.decide(command, events);
 
-        for event in &events {
+        for event in events {
             self.state.evolve(event);
 
             for subscriber in &self.subscribers {
@@ -96,7 +95,7 @@ where
     S::Command: Clone,
 {
     fn handle_event(&mut self, event: &S::Command) {
-        self.execute(event.clone());
+        self.execute(event.clone(), &mut Vec::new());
     }
 }
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -111,7 +111,7 @@ mod tests {
             [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
             &mut services,
         )
-        .build(&mut services.objects);
+        .build(&mut services);
 
         valid.validate_and_return_first_error()?;
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -120,12 +120,12 @@ mod tests {
                 HalfEdge::line_segment(
                     [[0., 0.], [1., 0.]],
                     None,
-                    &mut services.objects,
+                    &mut services,
                 ),
                 HalfEdge::line_segment(
                     [[0., 0.], [1., 0.]],
                     None,
-                    &mut services.objects,
+                    &mut services,
                 ),
             ];
             let half_edges = half_edges

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -128,8 +128,8 @@ mod tests {
                     &mut services,
                 ),
             ];
-            let half_edges = half_edges
-                .map(|half_edge| half_edge.insert(&mut services.objects));
+            let half_edges =
+                half_edges.map(|half_edge| half_edge.insert(&mut services));
 
             Cycle::empty().add_half_edges(half_edges)
         };

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -109,7 +109,7 @@ mod tests {
 
         let valid = CycleBuilder::polygon(
             [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
-            &mut services.objects,
+            &mut services,
         )
         .build(&mut services.objects);
 

--- a/crates/fj-kernel/src/validate/edge.rs
+++ b/crates/fj-kernel/src/validate/edge.rs
@@ -87,11 +87,8 @@ mod tests {
     fn half_edge_vertices_are_coincident() -> anyhow::Result<()> {
         let mut services = Services::new();
 
-        let valid = HalfEdge::line_segment(
-            [[0., 0.], [1., 0.]],
-            None,
-            &mut services.objects,
-        );
+        let valid =
+            HalfEdge::line_segment([[0., 0.], [1., 0.]], None, &mut services);
         let invalid = {
             let boundary = [Point::from([0.]); 2];
 

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -86,11 +86,11 @@ mod tests {
         let valid = FaceBuilder::new(services.objects.surfaces.xy_plane())
             .with_exterior(CycleBuilder::polygon(
                 [[0., 0.], [3., 0.], [0., 3.]],
-                &mut services.objects,
+                &mut services,
             ))
             .with_interior(CycleBuilder::polygon(
                 [[1., 1.], [1., 2.], [2., 1.]],
-                &mut services.objects,
+                &mut services,
             ))
             .build(&mut services.objects);
         let invalid = {

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -97,7 +97,7 @@ mod tests {
             let interiors = valid
                 .interiors()
                 .cloned()
-                .map(|cycle| cycle.reverse(&mut services.objects))
+                .map(|cycle| cycle.reverse(&mut services))
                 .collect::<Vec<_>>();
 
             Face::new(

--- a/crates/fj-kernel/src/validate/face.rs
+++ b/crates/fj-kernel/src/validate/face.rs
@@ -92,7 +92,7 @@ mod tests {
                 [[1., 1.], [1., 2.], [2., 1.]],
                 &mut services,
             ))
-            .build(&mut services.objects);
+            .build(&mut services);
         let invalid = {
             let interiors = valid
                 .interiors()

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -215,14 +215,14 @@ mod tests {
                 cycle
                     .update_nth_half_edge(0, |half_edge| {
                         let global_form =
-                            GlobalEdge::new().insert(&mut services.objects);
+                            GlobalEdge::new().insert(&mut services);
                         half_edge
                             .replace_global_form(global_form)
-                            .insert(&mut services.objects)
+                            .insert(&mut services)
                     })
-                    .insert(&mut services.objects)
+                    .insert(&mut services)
             })
-            .insert(&mut services.objects)
+            .insert(&mut services)
         });
 
         valid.shell.validate_and_return_first_error()?;

--- a/crates/fj-kernel/src/validate/shell.rs
+++ b/crates/fj-kernel/src/validate/shell.rs
@@ -208,7 +208,7 @@ mod tests {
 
         let valid = Shell::tetrahedron(
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
-            &mut services.objects,
+            &mut services,
         );
         let invalid = valid.shell.update_face(&valid.abc, |face| {
             face.update_exterior(|cycle| {
@@ -241,7 +241,7 @@ mod tests {
 
         let valid = Shell::tetrahedron(
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
-            &mut services.objects,
+            &mut services,
         );
         let invalid = valid.shell.remove_face(&valid.abc);
 

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -46,8 +46,7 @@ impl Shape for fj::Difference2d {
 
                 exteriors.push(face.exterior().clone());
                 for cycle in face.interiors() {
-                    interiors
-                        .push(cycle.clone().reverse(&mut services.objects));
+                    interiors.push(cycle.clone().reverse(services));
                 }
             }
 
@@ -58,9 +57,7 @@ impl Shape for fj::Difference2d {
                     "Trying to subtract faces with different surfaces.",
                 );
 
-                interiors.push(
-                    face.exterior().clone().reverse(&mut services.objects),
-                );
+                interiors.push(face.exterior().clone().reverse(services));
             }
 
             // Faces only support one exterior, while the code here comes from

--- a/crates/fj-operations/src/difference_2d.rs
+++ b/crates/fj-operations/src/difference_2d.rs
@@ -83,10 +83,10 @@ impl Shape for fj::Difference2d {
                 interiors,
                 Some(Color(self.color())),
             );
-            faces.push(face.insert(&mut services.objects));
+            faces.push(face.insert(services));
         }
 
-        let difference = Sketch::new(faces).insert(&mut services.objects);
+        let difference = Sketch::new(faces).insert(services);
         difference.deref().clone()
     }
 

--- a/crates/fj-operations/src/group.rs
+++ b/crates/fj-operations/src/group.rs
@@ -1,8 +1,5 @@
 use fj_interop::debug::DebugInfo;
-use fj_kernel::{
-    objects::{FaceSet, Objects},
-    services::Service,
-};
+use fj_kernel::{objects::FaceSet, services::Services};
 use fj_math::Aabb;
 
 use super::Shape;
@@ -12,13 +9,13 @@ impl Shape for fj::Group {
 
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep {
         let mut faces = FaceSet::new();
 
-        let a = self.a.compute_brep(objects, debug_info);
-        let b = self.b.compute_brep(objects, debug_info);
+        let a = self.a.compute_brep(services, debug_info);
+        let b = self.b.compute_brep(services, debug_info);
 
         faces.extend(a);
         faces.extend(b);

--- a/crates/fj-operations/src/lib.rs
+++ b/crates/fj-operations/src/lib.rs
@@ -26,8 +26,8 @@ mod transform;
 
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
-    objects::{FaceSet, Objects, Sketch},
-    services::Service,
+    objects::{FaceSet, Sketch},
+    services::Services,
 };
 use fj_math::Aabb;
 
@@ -39,7 +39,7 @@ pub trait Shape {
     /// Compute the boundary representation of the shape
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep;
 
@@ -55,16 +55,16 @@ impl Shape for fj::Shape {
 
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep {
         match self {
             Self::Shape2d(shape) => {
-                shape.compute_brep(objects, debug_info).faces().clone()
+                shape.compute_brep(services, debug_info).faces().clone()
             }
-            Self::Group(shape) => shape.compute_brep(objects, debug_info),
+            Self::Group(shape) => shape.compute_brep(services, debug_info),
             Self::Sweep(shape) => shape
-                .compute_brep(objects, debug_info)
+                .compute_brep(services, debug_info)
                 .shells()
                 .map(|shell| shell.faces().clone())
                 .reduce(|mut a, b| {
@@ -72,7 +72,7 @@ impl Shape for fj::Shape {
                     a
                 })
                 .unwrap_or_default(),
-            Self::Transform(shape) => shape.compute_brep(objects, debug_info),
+            Self::Transform(shape) => shape.compute_brep(services, debug_info),
         }
     }
 
@@ -91,12 +91,12 @@ impl Shape for fj::Shape2d {
 
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep {
         match self {
-            Self::Difference(shape) => shape.compute_brep(objects, debug_info),
-            Self::Sketch(shape) => shape.compute_brep(objects, debug_info),
+            Self::Difference(shape) => shape.compute_brep(services, debug_info),
+            Self::Sketch(shape) => shape.compute_brep(services, debug_info),
         }
     }
 

--- a/crates/fj-operations/src/shape_processor.rs
+++ b/crates/fj-operations/src/shape_processor.rs
@@ -44,7 +44,7 @@ impl ShapeProcessor {
 
         let mut services = Services::new();
         let mut debug_info = DebugInfo::new();
-        let shape = shape.compute_brep(&mut services.objects, &mut debug_info);
+        let shape = shape.compute_brep(&mut services, &mut debug_info);
         let mesh = (&shape, tolerance).triangulate();
 
         Ok(ProcessedShape {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -60,7 +60,7 @@ impl Shape for fj::Sketch {
                                 HalfEdge::line_segment(
                                     [start, end],
                                     None,
-                                    &mut services.objects,
+                                    services,
                                 )
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -2,9 +2,9 @@ use std::ops::Deref;
 
 use fj_interop::{debug::DebugInfo, mesh::Color};
 use fj_kernel::{
-    objects::{Cycle, Face, HalfEdge, Objects, Sketch},
+    objects::{Cycle, Face, HalfEdge, Sketch},
     operations::{BuildCycle, BuildHalfEdge, Insert, UpdateCycle},
-    services::Service,
+    services::Services,
 };
 use fj_math::{Aabb, Point};
 use itertools::Itertools;
@@ -16,16 +16,18 @@ impl Shape for fj::Sketch {
 
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         _: &mut DebugInfo,
     ) -> Self::Brep {
-        let surface = objects.surfaces.xy_plane();
+        let surface = services.objects.surfaces.xy_plane();
 
         let face = match self.chain() {
             fj::Chain::Circle(circle) => {
                 let half_edge =
-                    HalfEdge::circle(circle.radius(), objects).insert(objects);
-                let exterior = Cycle::new([half_edge]).insert(objects);
+                    HalfEdge::circle(circle.radius(), &mut services.objects)
+                        .insert(&mut services.objects);
+                let exterior =
+                    Cycle::new([half_edge]).insert(&mut services.objects);
 
                 Face::new(
                     surface,
@@ -59,19 +61,24 @@ impl Shape for fj::Sketch {
                                 HalfEdge::line_segment(
                                     [start, end],
                                     None,
-                                    objects,
+                                    &mut services.objects,
                                 )
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
-                                HalfEdge::arc(start, end, angle.rad(), objects)
+                                HalfEdge::arc(
+                                    start,
+                                    end,
+                                    angle.rad(),
+                                    &mut services.objects,
+                                )
                             }
                         };
-                        let half_edge = half_edge.insert(objects);
+                        let half_edge = half_edge.insert(&mut services.objects);
 
                         cycle = cycle.add_half_edges([half_edge]);
                     }
 
-                    cycle.insert(objects)
+                    cycle.insert(&mut services.objects)
                 };
 
                 Face::new(
@@ -83,7 +90,8 @@ impl Shape for fj::Sketch {
             }
         };
 
-        let sketch = Sketch::new(vec![face.insert(objects)]).insert(objects);
+        let sketch = Sketch::new(vec![face.insert(&mut services.objects)])
+            .insert(&mut services.objects);
         sketch.deref().clone()
     }
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -24,9 +24,8 @@ impl Shape for fj::Sketch {
         let face = match self.chain() {
             fj::Chain::Circle(circle) => {
                 let half_edge = HalfEdge::circle(circle.radius(), services)
-                    .insert(&mut services.objects);
-                let exterior =
-                    Cycle::new([half_edge]).insert(&mut services.objects);
+                    .insert(services);
+                let exterior = Cycle::new([half_edge]).insert(services);
 
                 Face::new(
                     surface,
@@ -67,12 +66,12 @@ impl Shape for fj::Sketch {
                                 HalfEdge::arc(start, end, angle.rad(), services)
                             }
                         };
-                        let half_edge = half_edge.insert(&mut services.objects);
+                        let half_edge = half_edge.insert(services);
 
                         cycle = cycle.add_half_edges([half_edge]);
                     }
 
-                    cycle.insert(&mut services.objects)
+                    cycle.insert(services)
                 };
 
                 Face::new(
@@ -84,8 +83,7 @@ impl Shape for fj::Sketch {
             }
         };
 
-        let sketch = Sketch::new(vec![face.insert(&mut services.objects)])
-            .insert(&mut services.objects);
+        let sketch = Sketch::new(vec![face.insert(services)]).insert(services);
         sketch.deref().clone()
     }
 

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -65,12 +65,7 @@ impl Shape for fj::Sketch {
                                 )
                             }
                             fj::SketchSegmentRoute::Arc { angle } => {
-                                HalfEdge::arc(
-                                    start,
-                                    end,
-                                    angle.rad(),
-                                    &mut services.objects,
-                                )
+                                HalfEdge::arc(start, end, angle.rad(), services)
                             }
                         };
                         let half_edge = half_edge.insert(&mut services.objects);

--- a/crates/fj-operations/src/sketch.rs
+++ b/crates/fj-operations/src/sketch.rs
@@ -23,9 +23,8 @@ impl Shape for fj::Sketch {
 
         let face = match self.chain() {
             fj::Chain::Circle(circle) => {
-                let half_edge =
-                    HalfEdge::circle(circle.radius(), &mut services.objects)
-                        .insert(&mut services.objects);
+                let half_edge = HalfEdge::circle(circle.radius(), services)
+                    .insert(&mut services.objects);
                 let exterior =
                     Cycle::new([half_edge]).insert(&mut services.objects);
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -2,10 +2,8 @@ use std::ops::Deref;
 
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
-    algorithms::sweep::Sweep,
-    objects::{Objects, Solid},
-    operations::Insert,
-    services::Service,
+    algorithms::sweep::Sweep, objects::Solid, operations::Insert,
+    services::Services,
 };
 use fj_math::{Aabb, Vector};
 
@@ -16,15 +14,15 @@ impl Shape for fj::Sweep {
 
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep {
-        let sketch = self.shape().compute_brep(objects, debug_info);
-        let sketch = sketch.insert(objects);
+        let sketch = self.shape().compute_brep(services, debug_info);
+        let sketch = sketch.insert(&mut services.objects);
 
         let path = Vector::from(self.path());
 
-        let solid = sketch.sweep(path, objects);
+        let solid = sketch.sweep(path, &mut services.objects);
         solid.deref().clone()
     }
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -20,7 +20,7 @@ impl Shape for fj::Sweep {
         let sketch = self
             .shape()
             .compute_brep(services, debug_info)
-            .insert(&mut services.objects);
+            .insert(services);
 
         let path = Vector::from(self.path());
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -17,8 +17,10 @@ impl Shape for fj::Sweep {
         services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep {
-        let sketch = self.shape().compute_brep(services, debug_info);
-        let sketch = sketch.insert(&mut services.objects);
+        let sketch = self
+            .shape()
+            .compute_brep(services, debug_info)
+            .insert(&mut services.objects);
 
         let path = Vector::from(self.path());
 

--- a/crates/fj-operations/src/sweep.rs
+++ b/crates/fj-operations/src/sweep.rs
@@ -22,7 +22,7 @@ impl Shape for fj::Sweep {
 
         let path = Vector::from(self.path());
 
-        let solid = sketch.sweep(path, &mut services.objects);
+        let solid = sketch.sweep(path, services);
         solid.deref().clone()
     }
 

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -1,8 +1,7 @@
 use fj_interop::debug::DebugInfo;
 use fj_kernel::{
-    algorithms::transform::TransformObject,
-    objects::{FaceSet, Objects},
-    services::Service,
+    algorithms::transform::TransformObject, objects::FaceSet,
+    services::Services,
 };
 use fj_math::{Aabb, Transform, Vector};
 
@@ -13,12 +12,12 @@ impl Shape for fj::Transform {
 
     fn compute_brep(
         &self,
-        objects: &mut Service<Objects>,
+        services: &mut Services,
         debug_info: &mut DebugInfo,
     ) -> Self::Brep {
         self.shape
-            .compute_brep(objects, debug_info)
-            .transform(&make_transform(self), objects)
+            .compute_brep(services, debug_info)
+            .transform(&make_transform(self), &mut services.objects)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {

--- a/crates/fj-operations/src/transform.rs
+++ b/crates/fj-operations/src/transform.rs
@@ -17,7 +17,7 @@ impl Shape for fj::Transform {
     ) -> Self::Brep {
         self.shape
             .compute_brep(services, debug_info)
-            .transform(&make_transform(self), &mut services.objects)
+            .transform(&make_transform(self), services)
     }
 
     fn bounding_volume(&self) -> Aabb<3> {


### PR DESCRIPTION
Add a top-level API to `Services` (which currently consists of a single method, `insert_object`). This enables a simplification of service subscriptions, also included in this pull request. Now, services no longer know anything about subscriptions. It is the top-level `Services` struct that handles all that, routing objects to other services as required.

The complexity that was necessary to make the previous subscription model work was getting in the way of my work on #1713, which triggered this cleanup.