### PR TITLE
Expand operations API

### DIFF
--- a/crates/fj-kernel/src/operations/build/cycle.rs
+++ b/crates/fj-kernel/src/operations/build/cycle.rs
@@ -1,10 +1,38 @@
-use crate::objects::Cycle;
+use fj_math::Point;
+use itertools::Itertools;
+
+use crate::{
+    objects::{Cycle, HalfEdge},
+    operations::Insert,
+    services::Services,
+};
+
+use super::BuildHalfEdge;
 
 /// Build a [`Cycle`]
 pub trait BuildCycle {
     /// Build an empty cycle
     fn empty() -> Cycle {
         Cycle::new([])
+    }
+
+    /// Build a polygon
+    fn polygon<P, Ps>(points: Ps, services: &mut Services) -> Cycle
+    where
+        P: Into<Point<2>>,
+        Ps: IntoIterator<Item = P>,
+        Ps::IntoIter: Clone + ExactSizeIterator,
+    {
+        let half_edges = points
+            .into_iter()
+            .map(Into::into)
+            .circular_tuple_windows()
+            .map(|(start, end)| {
+                HalfEdge::line_segment([start, end], None, services)
+                    .insert(services)
+            });
+
+        Cycle::new(half_edges)
     }
 }
 

--- a/crates/fj-kernel/src/validate/cycle.rs
+++ b/crates/fj-kernel/src/validate/cycle.rs
@@ -96,7 +96,6 @@ mod tests {
 
     use crate::{
         assert_contains_err,
-        builder::CycleBuilder,
         objects::{Cycle, HalfEdge},
         operations::{BuildCycle, BuildHalfEdge, Insert, UpdateCycle},
         services::Services,
@@ -107,11 +106,8 @@ mod tests {
     fn half_edges_connected() -> anyhow::Result<()> {
         let mut services = Services::new();
 
-        let valid = CycleBuilder::polygon(
-            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
-            &mut services,
-        )
-        .build(&mut services);
+        let valid =
+            Cycle::polygon([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]], &mut services);
 
         valid.validate_and_return_first_error()?;
 


### PR DESCRIPTION
Add `BuildCycle::polygon` and migrate a test to it, away from the old builder API.