### PR TITLE
Add `cuboid` example model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuboid"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fj-kernel",
+ "fj-math",
+ "fj-window",
+ "itertools",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "crates/fj-viewer",
     "crates/fj-window",
 
+    "models/cuboid",
+
     "tools/autolib",
     "tools/automator",
     "tools/cross-compiler",

--- a/models/cuboid/Cargo.toml
+++ b/models/cuboid/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cuboid"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+anyhow = "1.0.71"
+itertools = "0.10.5"
+
+[dependencies.fj-kernel]
+path = "../../crates/fj-kernel"
+
+[dependencies.fj-math]
+path = "../../crates/fj-math"
+
+[dependencies.fj-window]
+path = "../../crates/fj-window"

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -1,0 +1,52 @@
+use fj_kernel::{
+    algorithms::sweep::Sweep,
+    geometry::region::Region,
+    objects::{Cycle, HalfEdge, Sketch, Solid},
+    operations::{BuildCycle, BuildHalfEdge, Insert, UpdateCycle},
+    services::Services,
+    storage::Handle,
+};
+use fj_math::{Point, Vector};
+use itertools::Itertools;
+
+pub fn cuboid(x: f64, y: f64, z: f64) -> Handle<Solid> {
+    let mut services = Services::new();
+
+    let sketch = {
+        let exterior = {
+            #[rustfmt::skip]
+            let rectangle = [
+                [-x / 2., -y / 2.],
+                [ x / 2., -y / 2.],
+                [ x / 2.,  y / 2.],
+                [-x / 2.,  y / 2.],
+            ];
+
+            let mut cycle = Cycle::empty();
+
+            let segments = rectangle
+                .into_iter()
+                .map(Point::from)
+                .circular_tuple_windows();
+
+            for (start, end) in segments {
+                let half_edge =
+                    HalfEdge::line_segment([start, end], None, &mut services)
+                        .insert(&mut services);
+
+                cycle = cycle.add_half_edges([half_edge]);
+            }
+
+            cycle.insert(&mut services)
+        };
+
+        let region = Region::new(exterior, Vec::new(), None);
+
+        Sketch::new([region]).insert(&mut services)
+    };
+
+    let surface = services.objects.surfaces.xy_plane();
+
+    let path = Vector::from([0., 0., z]);
+    (sketch, surface).sweep(path, &mut services)
+}

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,0 +1,16 @@
+use std::ops::Deref;
+
+use fj_kernel::algorithms::{approx::Tolerance, triangulate::Triangulate};
+
+fn main() -> anyhow::Result<()> {
+    let cuboid = cuboid::cuboid(3., 2., 1.);
+
+    // The tolerance makes no difference for this model, as there aren't any
+    // curves.
+    let tolerance = Tolerance::from_scalar(1.)?;
+
+    let mesh = (cuboid.deref(), tolerance).triangulate();
+    fj_window::run(mesh, false)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This doesn't look great right now, as the usability of the kernel APIs is lacking, and this model includes a lot of code adapted from the former `fj-operations` crate.