### PR TITLE
Re-enable `export-validator`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,5 @@ jobs:
         run: cargo build --all-features
       - name: Run `cargo test`
         run: cargo test --all-features
-      # - name: Run `export-validator`
-      #   run: cargo run --package export-validator
+      - name: Run `export-validator`
+        run: cargo run --package export-validator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "fj-export",
  "fj-kernel",
  "fj-math",
  "fj-window",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ name = "cuboid"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "fj-kernel",
  "fj-math",
  "fj-window",

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ export RUSTDOCFLAGS := "-D warnings"
 # For a full build that mirrors the CI build, see `just ci`.
 test:
     cargo test --all-features
-    # cargo run --package export-validator
+    cargo run --package export-validator
 
 # Run a full build that mirrors the CI build
 #

--- a/models/cuboid/Cargo.toml
+++ b/models/cuboid/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2021"
 anyhow = "1.0.71"
 itertools = "0.10.5"
 
+[dependencies.clap]
+version = "4.3.0"
+features = ["derive"]
+
 [dependencies.fj-kernel]
 path = "../../crates/fj-kernel"
 

--- a/models/cuboid/Cargo.toml
+++ b/models/cuboid/Cargo.toml
@@ -12,6 +12,9 @@ itertools = "0.10.5"
 version = "4.3.0"
 features = ["derive"]
 
+[dependencies.fj-export]
+path = "../../crates/fj-export"
+
 [dependencies.fj-kernel]
 path = "../../crates/fj-kernel"
 

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,8 +1,10 @@
-use std::ops::Deref;
+use std::{ops::Deref, path::PathBuf};
 
 use fj_kernel::algorithms::{approx::Tolerance, triangulate::Triangulate};
 
 fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
     // The tolerance makes no difference for this model, as there aren't any
@@ -10,7 +12,30 @@ fn main() -> anyhow::Result<()> {
     let tolerance = Tolerance::from_scalar(1.)?;
 
     let mesh = (cuboid.deref(), tolerance).triangulate();
-    fj_window::run(mesh, false)?;
+
+    if let Some(path) = args.export {
+        fj_export::export(&mesh, &path)?;
+    } else {
+        fj_window::run(mesh, false)?;
+    }
 
     Ok(())
+}
+
+/// Standardized CLI for Fornjot models
+#[derive(clap::Parser)]
+pub struct Args {
+    /// Export model to this path
+    #[arg(short, long, value_name = "PATH")]
+    pub export: Option<PathBuf>,
+}
+
+impl Args {
+    /// Parse the command-line arguments
+    ///
+    /// Convenience method that saves the caller from having to import the
+    /// `clap::Parser` trait.
+    pub fn parse() -> Self {
+        <Self as clap::Parser>::parse()
+    }
 }

--- a/tools/export-validator/src/main.rs
+++ b/tools/export-validator/src/main.rs
@@ -35,8 +35,8 @@ fn handle_model(model: String) -> Result<(), anyhow::Error> {
     let export_file_path_str = export_file_path.to_str().unwrap();
     let exit_status = Command::new("cargo")
         .arg("run")
+        .args(["-p", &model])
         .arg("--")
-        .arg(&model)
         .args(["--export", export_file_path_str])
         .status()?;
     if !exit_status.success() {


### PR DESCRIPTION
`export-validator` is a program within this repository that used to run the app for each model in the repository, exporting the model to a 3MF file and validating that file using `lib3mf`. With the [recent changes](https://github.com/hannobraun/fornjot/pull/1822), `export-validator` stopped working, and was disabled temporarily.

This pull request creates a new setup for `export-validator` to use, and enables it again in the CI build.