### PR TITLE
Add new `fj` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fj"
+version = "0.46.0"
+dependencies = [
+ "fj-core",
+ "fj-export",
+ "fj-interop",
+ "fj-math",
+ "fj-viewer",
+ "fj-window",
+]
+
+[[package]]
 name = "fj-core"
 version = "0.46.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,10 +630,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "fj-core",
- "fj-export",
- "fj-math",
- "fj-window",
+ "fj",
  "itertools",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/fj",
     "crates/fj-core",
     "crates/fj-export",
     "crates/fj-interop",
@@ -17,6 +18,7 @@ members = [
     "tools/release-operator",
 ]
 default-members = [
+    "crates/fj",
     "crates/fj-core",
     "crates/fj-export",
     "crates/fj-interop",
@@ -74,3 +76,7 @@ path = "crates/fj-proc"
 [workspace.dependencies.fj-viewer]
 version = "0.46.0"
 path = "crates/fj-viewer"
+
+[workspace.dependencies.fj-window]
+version = "0.46.0"
+path = "crates/fj-window"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default-members = [
     "crates/fj-interop",
     "crates/fj-math",
     "crates/fj-viewer",
+    "crates/fj-window",
 ]
 
 

--- a/crates/fj/Cargo.toml
+++ b/crates/fj/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fj"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+fj-core.workspace = true
+fj-export.workspace = true
+fj-interop.workspace = true
+fj-math.workspace = true
+fj-viewer.workspace = true
+fj-window.workspace = true

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -1,0 +1,19 @@
+//! # Fornjot
+//!
+//! [Fornjot] is an early-stage b-rep CAD kernel written in Rust. The kernel is
+//! split into multiple libraries that can be used semi-independently, and this
+//! is one of those.
+//!
+//! This crate serves as a convenient entryway to Fornjot, re-exporting all
+//! crates that make up Fornjot.
+//!
+//! [Fornjot]: https://www.fornjot.app/
+
+#![warn(missing_docs)]
+
+pub use fj_core as core;
+pub use fj_export as export;
+pub use fj_interop as interop;
+pub use fj_math as math;
+pub use fj_viewer as viewer;
+pub use fj_window as window;

--- a/models/cuboid/Cargo.toml
+++ b/models/cuboid/Cargo.toml
@@ -12,14 +12,5 @@ itertools = "0.10.5"
 version = "4.3.0"
 features = ["derive"]
 
-[dependencies.fj-core]
-path = "../../crates/fj-core"
-
-[dependencies.fj-export]
-path = "../../crates/fj-export"
-
-[dependencies.fj-math]
-path = "../../crates/fj-math"
-
-[dependencies.fj-window]
-path = "../../crates/fj-window"
+[dependencies.fj]
+path = "../../crates/fj"

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -1,11 +1,11 @@
-use fj_core::{
+use fj::core::{
     algorithms::sweep::Sweep,
     objects::{Sketch, Solid},
     operations::{BuildSketch, Insert},
     services::Services,
     storage::Handle,
 };
-use fj_math::Vector;
+use fj::math::Vector;
 
 pub fn cuboid(x: f64, y: f64, z: f64) -> Handle<Solid> {
     let mut services = Services::new();

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -1,11 +1,13 @@
-use fj::core::{
-    algorithms::sweep::Sweep,
-    objects::{Sketch, Solid},
-    operations::{BuildSketch, Insert},
-    services::Services,
-    storage::Handle,
+use fj::{
+    core::{
+        algorithms::sweep::Sweep,
+        objects::{Sketch, Solid},
+        operations::{BuildSketch, Insert},
+        services::Services,
+        storage::Handle,
+    },
+    math::Vector,
 };
-use fj::math::Vector;
 
 pub fn cuboid(x: f64, y: f64, z: f64) -> Handle<Solid> {
     let mut services = Services::new();

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, path::PathBuf};
 
-use fj_core::algorithms::{approx::Tolerance, triangulate::Triangulate};
+use fj::core::algorithms::{approx::Tolerance, triangulate::Triangulate};
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -14,9 +14,9 @@ fn main() -> anyhow::Result<()> {
     let mesh = (cuboid.deref(), tolerance).triangulate();
 
     if let Some(path) = args.export {
-        fj_export::export(&mesh, &path)?;
+        fj::export::export(&mesh, &path)?;
     } else {
-        fj_window::run(mesh, false)?;
+        fj::window::run(mesh, false)?;
     }
 
     Ok(())


### PR DESCRIPTION
Adds a new crate, re-using the name of the previously existing `fj` crate. The new `fj` crate re-exports all other Fornjot crates, serving as a convenient entry point Fornjot's API.