### PR TITLE
Add standardized CLI for models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,10 +629,7 @@ dependencies = [
 name = "cuboid"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "clap",
  "fj",
- "itertools",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
 name = "fj"
 version = "0.46.0"
 dependencies = [
+ "clap",
  "fj-core",
  "fj-export",
  "fj-interop",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,7 @@ dependencies = [
  "fj-math",
  "fj-viewer",
  "fj-window",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/fj-window/src/lib.rs
+++ b/crates/fj-window/src/lib.rs
@@ -13,4 +13,4 @@
 mod run;
 mod window;
 
-pub use self::run::run;
+pub use self::run::{run, Error};

--- a/crates/fj/Cargo.toml
+++ b/crates/fj/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+
 [dependencies]
 fj-core.workspace = true
 fj-export.workspace = true
@@ -17,3 +18,7 @@ fj-interop.workspace = true
 fj-math.workspace = true
 fj-viewer.workspace = true
 fj-window.workspace = true
+
+[dependencies.clap]
+version = "4.3.1"
+features = ["derive"]

--- a/crates/fj/Cargo.toml
+++ b/crates/fj/Cargo.toml
@@ -18,6 +18,7 @@ fj-interop.workspace = true
 fj-math.workspace = true
 fj-viewer.workspace = true
 fj-window.workspace = true
+thiserror = "1.0.40"
 
 [dependencies.clap]
 version = "4.3.1"

--- a/crates/fj/src/args.rs
+++ b/crates/fj/src/args.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+/// Standardized CLI for Fornjot models
+#[derive(clap::Parser)]
+pub struct Args {
+    /// Export model to this path
+    #[arg(short, long, value_name = "PATH")]
+    pub export: Option<PathBuf>,
+}
+
+impl Args {
+    /// Parse the command-line arguments
+    ///
+    /// Convenience method that saves the caller from having to import the
+    /// `clap::Parser` trait.
+    pub fn parse() -> Self {
+        <Self as clap::Parser>::parse()
+    }
+}

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -1,0 +1,44 @@
+use std::ops::Deref;
+
+use fj_core::algorithms::{approx::Tolerance, triangulate::Triangulate};
+
+use crate::Args;
+
+/// Export or display a model, according to CLI arguments
+///
+/// This function is intended to be called by applications that define a model
+/// and want to provide a standardized CLI interface for dealing with that
+/// model.
+///
+/// This function is used by Fornjot's own testing infrastructure, but is useful
+/// beyond that, when using Fornjot directly to define a model.
+pub fn handle_model<Model>(
+    model: impl Deref<Target = Model>,
+    tolerance: impl Into<Tolerance>,
+) -> Result<(), Error>
+where
+    for<'r> (&'r Model, Tolerance): Triangulate,
+{
+    let mesh = (model.deref(), tolerance.into()).triangulate();
+
+    let args = Args::parse();
+    if let Some(path) = args.export {
+        crate::export::export(&mesh, &path)?;
+    } else {
+        crate::window::run(mesh, false)?;
+    }
+
+    Ok(())
+}
+
+/// Error returned by [`handle_model`]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error displaying model
+    #[error("Error displaying model")]
+    Display(#[from] crate::window::Error),
+
+    /// Error exporting model
+    #[error("Error exporting model")]
+    Export(#[from] crate::export::Error),
+}

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -15,7 +15,7 @@ use crate::Args;
 pub fn handle_model<Model>(
     model: impl Deref<Target = Model>,
     tolerance: impl Into<Tolerance>,
-) -> Result<(), Error>
+) -> Result
 where
     for<'r> (&'r Model, Tolerance): Triangulate,
 {
@@ -30,6 +30,9 @@ where
 
     Ok(())
 }
+
+/// Return value of [`handle_model`]
+pub type Result = std::result::Result<(), Error>;
 
 /// Error returned by [`handle_model`]
 #[derive(Debug, thiserror::Error)]

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -16,7 +16,7 @@ mod handle_model;
 
 pub use self::{
     args::Args,
-    handle_model::{handle_model, Error},
+    handle_model::{handle_model, Error, Result},
 };
 
 pub use fj_core as core;

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -12,8 +12,13 @@
 #![warn(missing_docs)]
 
 mod args;
+mod handle_model;
 
-pub use self::args::Args;
+pub use self::{
+    args::Args,
+    handle_model::{handle_model, Error},
+};
+
 pub use fj_core as core;
 pub use fj_export as export;
 pub use fj_interop as interop;

--- a/crates/fj/src/lib.rs
+++ b/crates/fj/src/lib.rs
@@ -11,6 +11,9 @@
 
 #![warn(missing_docs)]
 
+mod args;
+
+pub use self::args::Args;
 pub use fj_core as core;
 pub use fj_export as export;
 pub use fj_interop as interop;

--- a/models/cuboid/Cargo.toml
+++ b/models/cuboid/Cargo.toml
@@ -3,14 +3,5 @@ name = "cuboid"
 version = "0.1.0"
 edition = "2021"
 
-
-[dependencies]
-anyhow = "1.0.71"
-itertools = "0.10.5"
-
-[dependencies.clap]
-version = "4.3.1"
-features = ["derive"]
-
 [dependencies.fj]
 path = "../../crates/fj"

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,6 +1,6 @@
 use fj::handle_model;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), fj::Error> {
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
     // The tolerance makes no difference for this model, as there aren't any

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,26 +1,12 @@
-use std::ops::Deref;
-
-use fj::{
-    core::algorithms::{approx::Tolerance, triangulate::Triangulate},
-    Args,
-};
+use fj::{core::algorithms::approx::Tolerance, handle_model};
 
 fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
     // The tolerance makes no difference for this model, as there aren't any
     // curves.
     let tolerance = Tolerance::from_scalar(1.)?;
-
-    let mesh = (cuboid.deref(), tolerance).triangulate();
-
-    if let Some(path) = args.export {
-        fj::export::export(&mesh, &path)?;
-    } else {
-        fj::window::run(mesh, false)?;
-    }
+    handle_model(cuboid, tolerance)?;
 
     Ok(())
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,11 +1,11 @@
-use fj::{core::algorithms::approx::Tolerance, handle_model};
+use fj::handle_model;
 
 fn main() -> anyhow::Result<()> {
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
     // The tolerance makes no difference for this model, as there aren't any
     // curves.
-    let tolerance = Tolerance::from_scalar(1.)?;
+    let tolerance = 1.;
     handle_model(cuboid, tolerance)?;
 
     Ok(())

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,6 +1,6 @@
 use fj::handle_model;
 
-fn main() -> Result<(), fj::Error> {
+fn main() -> fj::Result {
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
     // The tolerance makes no difference for this model, as there aren't any

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,6 +1,9 @@
-use std::{ops::Deref, path::PathBuf};
+use std::ops::Deref;
 
-use fj::core::algorithms::{approx::Tolerance, triangulate::Triangulate};
+use fj::{
+    core::algorithms::{approx::Tolerance, triangulate::Triangulate},
+    Args,
+};
 
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -20,22 +23,4 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-/// Standardized CLI for Fornjot models
-#[derive(clap::Parser)]
-pub struct Args {
-    /// Export model to this path
-    #[arg(short, long, value_name = "PATH")]
-    pub export: Option<PathBuf>,
-}
-
-impl Args {
-    /// Parse the command-line arguments
-    ///
-    /// Convenience method that saves the caller from having to import the
-    /// `clap::Parser` trait.
-    pub fn parse() -> Self {
-        <Self as clap::Parser>::parse()
-    }
 }


### PR DESCRIPTION
This adds infrastructure to the `fj` crate that implements a standardized CLI (the same that was already used in `cuboid`). This standardized CLI is required for the testing infrastructure in this repository, and having it in `fj` means all example models can use it without creating redundant code.

Anyone writing models using Fornjot outside of this repository might also want to use this functionality, as it provides easy access to both displaying and exporting the model.