### PR TITLE
Adapt `fj-viewer` to model-related changes in `fj-interop`

### DIFF
--- a/crates/fj-viewer/src/camera.rs
+++ b/crates/fj-viewer/src/camera.rs
@@ -82,10 +82,10 @@ impl Camera {
     pub fn focus_point(
         &self,
         cursor: Option<NormalizedScreenPosition>,
-        shape: &Model,
+        model: &Model,
     ) -> FocusPoint {
-        self.calculate_focus_point(cursor, &shape.mesh)
-            .unwrap_or_else(|| FocusPoint(shape.aabb.center()))
+        self.calculate_focus_point(cursor, &model.mesh)
+            .unwrap_or_else(|| FocusPoint(model.aabb.center()))
     }
 
     fn calculate_focus_point(

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -83,7 +83,6 @@ impl Viewer {
 
     /// Compute and store a focus point, unless one is already stored
     pub fn add_focus_point(&mut self) {
-        // Don't recompute the focus point unnecessarily.
         if let Some(model) = &self.model {
             if self.focus_point.is_none() {
                 self.focus_point =

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -60,7 +60,7 @@ impl Viewer {
     }
 
     /// Handle the shape being updated
-    pub fn handle_shape_update(&mut self, model: Model) {
+    pub fn handle_model_update(&mut self, model: Model) {
         self.renderer.update_geometry((&model.mesh).into());
 
         let aabb = model.aabb;

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -59,7 +59,7 @@ impl Viewer {
         }
     }
 
-    /// Handle the shape being updated
+    /// Handle the model being updated
     pub fn handle_model_update(&mut self, model: Model) {
         self.renderer.update_geometry((&model.mesh).into());
 

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -27,7 +27,7 @@ pub struct Viewer {
     /// The renderer
     pub renderer: Renderer,
 
-    /// The shape
+    /// The model
     pub model: Option<Model>,
 }
 

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -28,7 +28,7 @@ pub struct Viewer {
     pub renderer: Renderer,
 
     /// The shape
-    pub shape: Option<Model>,
+    pub model: Option<Model>,
 }
 
 impl Viewer {
@@ -43,7 +43,7 @@ impl Viewer {
             focus_point: None,
             input_handler: InputHandler::default(),
             renderer,
-            shape: None,
+            model: None,
         })
     }
 
@@ -64,7 +64,7 @@ impl Viewer {
         self.renderer.update_geometry((&shape.mesh).into());
 
         let aabb = shape.aabb;
-        if self.shape.replace(shape).is_none() {
+        if self.model.replace(shape).is_none() {
             self.camera.init_planes(&aabb);
         }
     }
@@ -84,7 +84,7 @@ impl Viewer {
     /// Compute and store a focus point, unless one is already stored
     pub fn add_focus_point(&mut self) {
         // Don't recompute the focus point unnecessarily.
-        if let Some(shape) = &self.shape {
+        if let Some(shape) = &self.model {
             if self.focus_point.is_none() {
                 self.focus_point =
                     Some(self.camera.focus_point(self.cursor, shape));
@@ -100,7 +100,7 @@ impl Viewer {
     /// Draw the graphics
     pub fn draw(&mut self) {
         let aabb = self
-            .shape
+            .model
             .as_ref()
             .map(|shape| shape.aabb)
             .unwrap_or_else(Aabb::default);

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -84,10 +84,10 @@ impl Viewer {
     /// Compute and store a focus point, unless one is already stored
     pub fn add_focus_point(&mut self) {
         // Don't recompute the focus point unnecessarily.
-        if let Some(shape) = &self.model {
+        if let Some(model) = &self.model {
             if self.focus_point.is_none() {
                 self.focus_point =
-                    Some(self.camera.focus_point(self.cursor, shape));
+                    Some(self.camera.focus_point(self.cursor, model));
             }
         }
     }

--- a/crates/fj-viewer/src/viewer.rs
+++ b/crates/fj-viewer/src/viewer.rs
@@ -60,11 +60,11 @@ impl Viewer {
     }
 
     /// Handle the shape being updated
-    pub fn handle_shape_update(&mut self, shape: Model) {
-        self.renderer.update_geometry((&shape.mesh).into());
+    pub fn handle_shape_update(&mut self, model: Model) {
+        self.renderer.update_geometry((&model.mesh).into());
 
-        let aabb = shape.aabb;
-        if self.model.replace(shape).is_none() {
+        let aabb = model.aabb;
+        if self.model.replace(model).is_none() {
             self.camera.init_planes(&aabb);
         }
     }

--- a/crates/fj-window/src/display.rs
+++ b/crates/fj-window/src/display.rs
@@ -22,7 +22,7 @@ pub fn display(mesh: Mesh<Point<3>>, invert_zoom: bool) -> Result<(), Error> {
     let window = Window::new(&event_loop)?;
     let mut viewer = block_on(Viewer::new(&window))?;
 
-    viewer.handle_shape_update(Model {
+    viewer.handle_model_update(Model {
         aabb: Aabb::<3>::from_points(mesh.vertices()),
         mesh,
     });


### PR DESCRIPTION
Following up on https://github.com/hannobraun/fornjot/pull/1863, make further cleanups (including changes to the public API) in `fj-viewer`.