### PR TITLE
Compute tolerance manually, if not provided via CLI

### DIFF
--- a/crates/fj/src/args.rs
+++ b/crates/fj/src/args.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{num::ParseFloatError, path::PathBuf, str::FromStr};
+
+use fj_core::algorithms::approx::{InvalidTolerance, Tolerance};
+use fj_math::Scalar;
 
 /// Standardized CLI for Fornjot models
 #[derive(clap::Parser)]
@@ -6,6 +9,10 @@ pub struct Args {
     /// Export model to this path
     #[arg(short, long, value_name = "PATH")]
     pub export: Option<PathBuf>,
+
+    /// How much the export can deviate from the original model
+    #[arg(short, long, value_parser = parse_tolerance)]
+    pub tolerance: Option<Tolerance>,
 }
 
 impl Args {
@@ -16,4 +23,21 @@ impl Args {
     pub fn parse() -> Self {
         <Self as clap::Parser>::parse()
     }
+}
+
+fn parse_tolerance(input: &str) -> Result<Tolerance, ArgsError> {
+    let tolerance = f64::from_str(input)?;
+    let tolerance = Scalar::from_f64(tolerance);
+    let tolerance = Tolerance::from_scalar(tolerance)?;
+
+    Ok(tolerance)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ArgsError {
+    #[error("Error parsing tolerance")]
+    ParseTolerance(#[from] ParseFloatError),
+
+    #[error(transparent)]
+    InvalidTolerance(#[from] InvalidTolerance),
 }

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -18,16 +18,11 @@ use crate::Args;
 ///
 /// This function is used by Fornjot's own testing infrastructure, but is useful
 /// beyond that, when using Fornjot directly to define a model.
-pub fn handle_model<M>(
-    model: impl Deref<Target = M>,
-    tolerance: Option<impl Into<Tolerance>>,
-) -> Result
+pub fn handle_model<M>(model: impl Deref<Target = M>) -> Result
 where
     for<'r> (&'r M, Tolerance): Triangulate,
     M: BoundingVolume<3>,
 {
-    let tolerance = tolerance.map(Into::into);
-
     let args = Args::parse();
 
     let aabb = model.aabb().unwrap_or(Aabb {
@@ -35,7 +30,7 @@ where
         max: Point::origin(),
     });
 
-    let tolerance = match tolerance {
+    let tolerance = match args.tolerance {
         None => {
             // Compute a reasonable default for the tolerance value. To do
             // this, we just look at the smallest non-zero extent of the

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -28,6 +28,8 @@ where
 {
     let tolerance = tolerance.map(Into::into);
 
+    let args = Args::parse();
+
     let aabb = model.aabb().unwrap_or(Aabb {
         min: Point::origin(),
         max: Point::origin(),
@@ -54,7 +56,6 @@ where
 
     let mesh = (model.deref(), tolerance).triangulate();
 
-    let args = Args::parse();
     if let Some(path) = args.export {
         crate::export::export(&mesh, &path)?;
         return Ok(());

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -3,9 +3,7 @@ use fj::handle_model;
 fn main() -> fj::Result {
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
-    // The tolerance makes no difference for this model, as there aren't any
-    // curves.
-    let tolerance = 1.;
+    let tolerance: Option<f64> = None;
     handle_model(cuboid, tolerance)?;
 
     Ok(())

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,7 +1,7 @@
 use fj::handle_model;
 
 fn main() -> fj::Result {
-    let cuboid = cuboid::cuboid(3., 2., 1.);
-    handle_model(cuboid)?;
+    let model = cuboid::cuboid(3., 2., 1.);
+    handle_model(model)?;
     Ok(())
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -2,8 +2,6 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let cuboid = cuboid::cuboid(3., 2., 1.);
-
     handle_model(cuboid)?;
-
     Ok(())
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -3,8 +3,7 @@ use fj::handle_model;
 fn main() -> fj::Result {
     let cuboid = cuboid::cuboid(3., 2., 1.);
 
-    let tolerance: Option<f64> = None;
-    handle_model(cuboid, tolerance)?;
+    handle_model(cuboid)?;
 
     Ok(())
 }


### PR DESCRIPTION
Update the default model CLI to take an optional `--tolerance` parameter. If this is not provided, compute the tolerance automatically.

This is another step towards #1868, preparing for re-adding the models which require a tolerance value.