### PR TITLE
Improve `Sketch` operations

### DIFF
--- a/crates/fj-core/src/operations/build/mod.rs
+++ b/crates/fj-core/src/operations/build/mod.rs
@@ -1,6 +1,7 @@
 pub mod cycle;
 pub mod edge;
 pub mod face;
+pub mod region;
 pub mod shell;
 pub mod sketch;
 pub mod solid;

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -1,6 +1,22 @@
-use crate::objects::Region;
+use fj_math::{Point, Scalar};
+
+use crate::{
+    objects::{Cycle, Region},
+    operations::{BuildCycle, Insert},
+    services::Services,
+};
 
 /// Build a [`Region`]
-pub trait BuildRegion {}
+pub trait BuildRegion {
+    /// Build a circle
+    fn circle(
+        center: impl Into<Point<2>>,
+        radius: impl Into<Scalar>,
+        services: &mut Services,
+    ) -> Region {
+        let exterior = Cycle::circle(center, radius, services).insert(services);
+        Region::new(exterior, [], None)
+    }
+}
 
 impl BuildRegion for Region {}

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -1,0 +1,6 @@
+use crate::objects::Region;
+
+/// Build a [`Region`]
+pub trait BuildRegion {}
+
+impl BuildRegion for Region {}

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -17,6 +17,17 @@ pub trait BuildRegion {
         let exterior = Cycle::circle(center, radius, services).insert(services);
         Region::new(exterior, [], None)
     }
+
+    /// Build a polygon
+    fn polygon<P, Ps>(points: Ps, services: &mut Services) -> Region
+    where
+        P: Into<Point<2>>,
+        Ps: IntoIterator<Item = P>,
+        Ps::IntoIter: Clone + ExactSizeIterator,
+    {
+        let exterior = Cycle::polygon(points, services).insert(services);
+        Region::new(exterior, [], None)
+    }
 }
 
 impl BuildRegion for Region {}

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -10,6 +10,7 @@ pub use self::{
         cycle::BuildCycle,
         edge::BuildHalfEdge,
         face::{BuildFace, Polygon},
+        region::BuildRegion,
         shell::{BuildShell, TetrahedronShell},
         sketch::BuildSketch,
         solid::{BuildSolid, Tetrahedron},

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -1,9 +1,5 @@
-use fj_math::Point;
-
 use crate::{
     objects::{Region, Sketch},
-    operations::{BuildRegion, Insert},
-    services::Services,
     storage::Handle,
 };
 
@@ -11,27 +7,10 @@ use crate::{
 pub trait UpdateSketch {
     /// Add a region to the sketch
     fn add_region(&self, region: Handle<Region>) -> Self;
-
-    /// Add a polygon to the sketch
-    fn add_polygon<P, Ps>(&self, points: Ps, services: &mut Services) -> Self
-    where
-        P: Into<Point<2>>,
-        Ps: IntoIterator<Item = P>,
-        Ps::IntoIter: Clone + ExactSizeIterator;
 }
 
 impl UpdateSketch for Sketch {
     fn add_region(&self, region: Handle<Region>) -> Self {
         Sketch::new(self.regions().cloned().chain([region]))
-    }
-
-    fn add_polygon<P, Ps>(&self, points: Ps, services: &mut Services) -> Self
-    where
-        P: Into<Point<2>>,
-        Ps: IntoIterator<Item = P>,
-        Ps::IntoIter: Clone + ExactSizeIterator,
-    {
-        let region = Region::polygon(points, services).insert(services);
-        self.add_region(region)
     }
 }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -1,8 +1,8 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Cycle, Region, Sketch},
-    operations::{BuildCycle, Insert},
+    objects::{Region, Sketch},
+    operations::{BuildRegion, Insert},
     services::Services,
     storage::Handle,
 };
@@ -31,8 +31,7 @@ impl UpdateSketch for Sketch {
         Ps: IntoIterator<Item = P>,
         Ps::IntoIter: Clone + ExactSizeIterator,
     {
-        let exterior = Cycle::polygon(points, services).insert(services);
-        let region = Region::new(exterior, [], None).insert(services);
+        let region = Region::polygon(points, services).insert(services);
         self.add_region(region)
     }
 }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -2,7 +2,7 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{Cycle, Region, Sketch},
-    operations::{BuildCycle, Insert},
+    operations::{BuildCycle, BuildRegion, Insert},
     services::Services,
     storage::Handle,
 };
@@ -39,8 +39,7 @@ impl UpdateSketch for Sketch {
         radius: impl Into<Scalar>,
         services: &mut Services,
     ) -> Self {
-        let exterior = Cycle::circle(center, radius, services).insert(services);
-        let region = Region::new(exterior, [], None).insert(services);
+        let region = Region::circle(center, radius, services).insert(services);
         self.add_region(region)
     }
 

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -1,8 +1,8 @@
-use fj_math::{Point, Scalar};
+use fj_math::Point;
 
 use crate::{
     objects::{Cycle, Region, Sketch},
-    operations::{BuildCycle, BuildRegion, Insert},
+    operations::{BuildCycle, Insert},
     services::Services,
     storage::Handle,
 };
@@ -11,14 +11,6 @@ use crate::{
 pub trait UpdateSketch {
     /// Add a region to the sketch
     fn add_region(&self, region: Handle<Region>) -> Self;
-
-    /// Add a circle to the sketch
-    fn add_circle(
-        &self,
-        center: impl Into<Point<2>>,
-        radius: impl Into<Scalar>,
-        services: &mut Services,
-    ) -> Self;
 
     /// Add a polygon to the sketch
     fn add_polygon<P, Ps>(&self, points: Ps, services: &mut Services) -> Self
@@ -31,16 +23,6 @@ pub trait UpdateSketch {
 impl UpdateSketch for Sketch {
     fn add_region(&self, region: Handle<Region>) -> Self {
         Sketch::new(self.regions().cloned().chain([region]))
-    }
-
-    fn add_circle(
-        &self,
-        center: impl Into<Point<2>>,
-        radius: impl Into<Scalar>,
-        services: &mut Services,
-    ) -> Self {
-        let region = Region::circle(center, radius, services).insert(services);
-        self.add_region(region)
     }
 
     fn add_polygon<P, Ps>(&self, points: Ps, services: &mut Services) -> Self

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -1,8 +1,8 @@
 use fj::{
     core::{
         algorithms::sweep::Sweep,
-        objects::{Sketch, Solid},
-        operations::{BuildSketch, Insert, UpdateSketch},
+        objects::{Region, Sketch, Solid},
+        operations::{BuildRegion, BuildSketch, Insert, UpdateSketch},
         services::Services,
         storage::Handle,
     },
@@ -13,14 +13,17 @@ pub fn cuboid(x: f64, y: f64, z: f64) -> Handle<Solid> {
     let mut services = Services::new();
 
     let sketch = Sketch::empty()
-        .add_polygon(
-            [
-                [-x / 2., -y / 2.],
-                [x / 2., -y / 2.],
-                [x / 2., y / 2.],
-                [-x / 2., y / 2.],
-            ],
-            &mut services,
+        .add_region(
+            Region::polygon(
+                [
+                    [-x / 2., -y / 2.],
+                    [x / 2., -y / 2.],
+                    [x / 2., y / 2.],
+                    [-x / 2., y / 2.],
+                ],
+                &mut services,
+            )
+            .insert(&mut services),
         )
         .insert(&mut services);
 


### PR DESCRIPTION
Make `UpdateSketch` more flexible with the help of the new `BuildRegion` trait. This is another step towards #1868.