### PR TITLE
Add `all` model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "all"
+version = "0.1.0"
+dependencies = [
+ "cuboid",
+ "fj",
+ "spacer",
+ "star",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/fj-viewer",
     "crates/fj-window",
 
+    "models/all",
     "models/cuboid",
     "models/spacer",
     "models/star",

--- a/models/all/Cargo.toml
+++ b/models/all/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "all"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.fj]
+path = "../../crates/fj"
+
+[dependencies.cuboid]
+path = "../cuboid"
+
+[dependencies.spacer]
+path = "../spacer"
+
+[dependencies.star]
+path = "../star"

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -1,0 +1,32 @@
+use fj::{
+    core::{
+        algorithms::transform::TransformObject,
+        objects::Solid,
+        operations::{Insert, Merge},
+        services::Services,
+        storage::Handle,
+    },
+    math::{Scalar, Vector},
+};
+
+pub fn model(services: &mut Services) -> Handle<Solid> {
+    // Just combine all the other models using offsets/rotations that won't
+    // result in neat vertex positions or axis-aligned edges/faces. This is
+    // useful for testing.
+
+    let offset = Vector::from([5., 5., 5.]);
+    let axis = Vector::from([1., 1., 1.]).normalize();
+    let angle_rad = Scalar::PI / 6.;
+
+    let cuboid = cuboid::model(1., 2., 3., services)
+        .translate(offset * 1., services)
+        .rotate(axis * angle_rad * 1., services);
+    let spacer = spacer::model(2., 1., 1., services)
+        .translate(offset * 2., services)
+        .rotate(axis * angle_rad * 2., services);
+    let star = star::model(5, 2., 1., 1., services)
+        .translate(offset * 3., services)
+        .rotate(axis * angle_rad * 3., services);
+
+    cuboid.merge(&spacer).merge(&star).insert(services)
+}

--- a/models/all/src/main.rs
+++ b/models/all/src/main.rs
@@ -1,0 +1,7 @@
+use fj::{core::services::Services, handle_model};
+
+fn main() -> fj::Result {
+    let model = all::model(&mut Services::new());
+    handle_model(model)?;
+    Ok(())
+}

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -9,9 +9,7 @@ use fj::{
     math::Vector,
 };
 
-pub fn model(x: f64, y: f64, z: f64) -> Handle<Solid> {
-    let mut services = Services::new();
-
+pub fn model(x: f64, y: f64, z: f64, services: &mut Services) -> Handle<Solid> {
     let sketch = Sketch::empty()
         .add_region(
             Region::polygon(
@@ -21,13 +19,13 @@ pub fn model(x: f64, y: f64, z: f64) -> Handle<Solid> {
                     [x / 2., y / 2.],
                     [-x / 2., y / 2.],
                 ],
-                &mut services,
+                services,
             )
-            .insert(&mut services),
+            .insert(services),
         )
-        .insert(&mut services);
+        .insert(services);
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., z]);
-    (sketch, surface).sweep(path, &mut services)
+    (sketch, surface).sweep(path, services)
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,7 +1,7 @@
-use fj::handle_model;
+use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = cuboid::model(3., 2., 1.);
+    let model = cuboid::model(3., 2., 1., &mut Services::new());
     handle_model(model)?;
     Ok(())
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -12,24 +12,27 @@ use fj::{
     math::{Point, Vector},
 };
 
-pub fn model(outer: f64, inner: f64, height: f64) -> Handle<Solid> {
-    let mut services = Services::new();
-
+pub fn model(
+    outer: f64,
+    inner: f64,
+    height: f64,
+    services: &mut Services,
+) -> Handle<Solid> {
     let sketch = Sketch::empty()
         .add_region(
-            Region::circle(Point::origin(), outer, &mut services)
+            Region::circle(Point::origin(), outer, services)
                 .add_interiors([Cycle::circle(
                     Point::origin(),
                     inner,
-                    &mut services,
+                    services,
                 )
-                .reverse(&mut services)
-                .insert(&mut services)])
-                .insert(&mut services),
+                .reverse(services)
+                .insert(services)])
+                .insert(services),
         )
-        .insert(&mut services);
+        .insert(services);
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., height]);
-    (sketch, surface).sweep(path, &mut services)
+    (sketch, surface).sweep(path, services)
 }

--- a/models/spacer/src/main.rs
+++ b/models/spacer/src/main.rs
@@ -1,7 +1,7 @@
-use fj::handle_model;
+use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = spacer::model(1., 0.5, 1.);
+    let model = spacer::model(1., 0.5, 1., &mut Services::new());
     handle_model(model)?;
     Ok(())
 }

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -14,9 +14,13 @@ use fj::{
     math::Vector,
 };
 
-pub fn model(num_points: u64, r1: f64, r2: f64, h: f64) -> Handle<Solid> {
-    let mut services = Services::new();
-
+pub fn model(
+    num_points: u64,
+    r1: f64,
+    r2: f64,
+    h: f64,
+    services: &mut Services,
+) -> Handle<Solid> {
     let num_vertices = num_points * 2;
     let vertex_iter = (0..num_vertices).map(|i| {
         let angle_rad = 2. * PI / num_vertices as f64 * i as f64;
@@ -39,15 +43,15 @@ pub fn model(num_points: u64, r1: f64, r2: f64, h: f64) -> Handle<Solid> {
 
     let sketch = Sketch::empty()
         .add_region(
-            Region::polygon(outer_points, &mut services)
-                .add_interiors([Cycle::polygon(inner_points, &mut services)
-                    .reverse(&mut services)
-                    .insert(&mut services)])
-                .insert(&mut services),
+            Region::polygon(outer_points, services)
+                .add_interiors([Cycle::polygon(inner_points, services)
+                    .reverse(services)
+                    .insert(services)])
+                .insert(services),
         )
-        .insert(&mut services);
+        .insert(services);
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., h]);
-    (sketch, surface).sweep(path, &mut services)
+    (sketch, surface).sweep(path, services)
 }

--- a/models/star/src/main.rs
+++ b/models/star/src/main.rs
@@ -1,7 +1,7 @@
-use fj::handle_model;
+use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = star::model(5, 1., 2., 1.);
+    let model = star::model(5, 1., 2., 1., &mut Services::new());
     handle_model(model)?;
     Ok(())
 }


### PR DESCRIPTION
This model combines all the other ones, making it a useful default model for testing. It replaces the old `test` model, getting our testing infrastructure back to where it was before #1822.

Close #1868