### PR TITLE
Improve handling of validation errors

### DIFF
--- a/crates/fj-core/src/services/mod.rs
+++ b/crates/fj-core/src/services/mod.rs
@@ -6,7 +6,10 @@ mod objects;
 mod service;
 mod validation;
 
-use crate::objects::{Object, ObjectSet, Objects, WithHandle};
+use crate::{
+    objects::{Object, ObjectSet, Objects, WithHandle},
+    validate::ValidationErrors,
+};
 
 pub use self::{
     objects::{InsertObject, Operation},
@@ -60,6 +63,19 @@ impl Services {
         let mut events = Vec::new();
         self.validation
             .execute(ValidationCommand::OnlyValidate { objects }, &mut events);
+    }
+
+    /// Drop `Services`; return any unhandled validation error
+    pub fn drop_and_validate(self) -> Result<(), ValidationErrors> {
+        let errors = ValidationErrors(
+            self.validation.errors.values().cloned().collect(),
+        );
+
+        if errors.0.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }
 

--- a/crates/fj-core/src/services/validation.rs
+++ b/crates/fj-core/src/services/validation.rs
@@ -11,7 +11,8 @@ use super::State;
 /// Errors that occurred while validating the objects inserted into the stores
 #[derive(Default)]
 pub struct Validation {
-    errors: BTreeMap<ObjectId, ValidationError>,
+    /// All unhandled validation errors
+    pub errors: BTreeMap<ObjectId, ValidationError>,
 }
 
 impl Drop for Validation {

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -16,7 +16,7 @@ pub use self::{
     solid::SolidValidationError,
 };
 
-use std::convert::Infallible;
+use std::{convert::Infallible, fmt};
 
 use fj_math::Scalar;
 
@@ -122,5 +122,23 @@ pub enum ValidationError {
 impl From<Infallible> for ValidationError {
     fn from(infallible: Infallible) -> Self {
         match infallible {}
+    }
+}
+
+/// A collection of validation errors
+#[derive(Debug, thiserror::Error)]
+pub struct ValidationErrors(pub Vec<ValidationError>);
+
+impl fmt::Display for ValidationErrors {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let num_errors = self.0.len();
+
+        writeln!(f, "{num_errors} unhandled validation errors:")?;
+
+        for err in &self.0 {
+            writeln!(f, "{err}")?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/fj/src/args.rs
+++ b/crates/fj/src/args.rs
@@ -23,6 +23,10 @@ pub struct Args {
     /// How much the export can deviate from the original model
     #[arg(short, long, value_parser = parse_tolerance)]
     pub tolerance: Option<Tolerance>,
+
+    /// Ignore validation errors
+    #[arg(short, long)]
+    pub ignore_validation: bool,
 }
 
 impl Args {

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{mem, ops::Deref};
 
 use fj_core::{
     algorithms::{
@@ -32,7 +32,11 @@ where
 {
     let args = Args::parse();
 
-    services.drop_and_validate()?;
+    if args.ignore_validation {
+        mem::forget(services);
+    } else {
+        services.drop_and_validate()?;
+    }
 
     let aabb = model.aabb().unwrap_or(Aabb {
         min: Point::origin(),

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -1,9 +1,12 @@
 use std::ops::Deref;
 
-use fj_core::algorithms::{
-    approx::{InvalidTolerance, Tolerance},
-    bounding_volume::BoundingVolume,
-    triangulate::Triangulate,
+use fj_core::{
+    algorithms::{
+        approx::{InvalidTolerance, Tolerance},
+        bounding_volume::BoundingVolume,
+        triangulate::Triangulate,
+    },
+    services::Services,
 };
 use fj_interop::model::Model;
 use fj_math::{Aabb, Point, Scalar};
@@ -18,12 +21,20 @@ use crate::Args;
 ///
 /// This function is used by Fornjot's own testing infrastructure, but is useful
 /// beyond that, when using Fornjot directly to define a model.
-pub fn handle_model<M>(model: impl Deref<Target = M>) -> Result
+pub fn handle_model<M>(
+    model: impl Deref<Target = M>,
+    services: Services,
+) -> Result
 where
     for<'r> (&'r M, Tolerance): Triangulate,
     M: BoundingVolume<3>,
 {
     let args = Args::parse();
+
+    // Dropping `Services` will cause a panic, if there are any unhandled
+    // validation errors. It would be better to return an error, but this will
+    // do for now.
+    drop(services);
 
     let aabb = model.aabb().unwrap_or(Aabb {
         min: Point::origin(),

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -7,6 +7,7 @@ use fj_core::{
         triangulate::Triangulate,
     },
     services::Services,
+    validate::ValidationErrors,
 };
 use fj_interop::model::Model;
 use fj_math::{Aabb, Point, Scalar};
@@ -31,10 +32,7 @@ where
 {
     let args = Args::parse();
 
-    // Dropping `Services` will cause a panic, if there are any unhandled
-    // validation errors. It would be better to return an error, but this will
-    // do for now.
-    drop(services);
+    services.drop_and_validate()?;
 
     let aabb = model.aabb().unwrap_or(Aabb {
         min: Point::origin(),
@@ -91,4 +89,8 @@ pub enum Error {
     /// Invalid tolerance
     #[error(transparent)]
     Tolerance(#[from] InvalidTolerance),
+
+    /// Unhandled validation errors
+    #[error(transparent)]
+    Validation(#[from] ValidationErrors),
 }

--- a/models/all/src/main.rs
+++ b/models/all/src/main.rs
@@ -1,7 +1,8 @@
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = all::model(&mut Services::new());
-    handle_model(model)?;
+    let mut services = Services::new();
+    let model = all::model(&mut services);
+    handle_model(model, services)?;
     Ok(())
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,7 +1,8 @@
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = cuboid::model(3., 2., 1., &mut Services::new());
-    handle_model(model)?;
+    let mut services = Services::new();
+    let model = cuboid::model(3., 2., 1., &mut services);
+    handle_model(model, services)?;
     Ok(())
 }

--- a/models/spacer/src/main.rs
+++ b/models/spacer/src/main.rs
@@ -1,7 +1,8 @@
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = spacer::model(1., 0.5, 1., &mut Services::new());
-    handle_model(model)?;
+    let mut services = Services::new();
+    let model = spacer::model(1., 0.5, 1., &mut services);
+    handle_model(model, services)?;
     Ok(())
 }

--- a/models/star/src/main.rs
+++ b/models/star/src/main.rs
@@ -1,7 +1,8 @@
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
-    let model = star::model(5, 1., 2., 1., &mut Services::new());
-    handle_model(model)?;
+    let mut services = Services::new();
+    let model = star::model(5, 1., 2., 1., &mut services);
+    handle_model(model, services)?;
     Ok(())
 }


### PR DESCRIPTION
Previously, it was pretty easy to accidentally not drop `Services`, meaning any validation errors would be ignored. This pull request updates `fj::handle_model` to take `Services`, making sure that validation errors get surfaced properly. It also adds a `--ignore-validation` flag to the standard model CLI.