### PR TITLE
Improve validation error output

### DIFF
--- a/crates/fj-core/src/services/validation.rs
+++ b/crates/fj-core/src/services/validation.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, thread};
+use std::{collections::BTreeMap, error::Error, thread};
 
 use crate::{
     objects::{BehindHandle, Object, ObjectSet},
@@ -26,6 +26,14 @@ impl Drop for Validation {
 
             for err in self.errors.values() {
                 println!("{}", err);
+
+                // Once `Report` is stable, we can replace this:
+                // https://doc.rust-lang.org/std/error/struct.Report.html
+                let mut source = err.source();
+                while let Some(err) = source {
+                    println!("Caused by:\n\t{err}");
+                    source = err.source();
+                }
             }
 
             if !thread::panicking() {

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -1,8 +1,7 @@
-use crate::objects::Cycle;
-use crate::objects::HalfEdge;
-use fj_math::Point;
-use fj_math::Scalar;
+use fj_math::{Point, Scalar};
 use itertools::Itertools;
+
+use crate::objects::{Cycle, HalfEdge};
 
 use super::{Validate, ValidationConfig, ValidationError};
 


### PR DESCRIPTION
Print whole error chain, not just the top-level error.