### PR TITLE
Add `Cycle::half_edge_pairs`

### DIFF
--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -1,7 +1,6 @@
 //! Intersection between faces and points in 2D
 
 use fj_math::Point;
-use itertools::Itertools;
 
 use crate::{
     objects::{Face, HalfEdge},
@@ -34,9 +33,7 @@ impl Intersect for (&Face, &Point<2>) {
                 .cloned()
                 .and_then(|edge| (&ray, &edge).intersect());
 
-            for (half_edge, next_half_edge) in
-                cycle.half_edges().circular_tuple_windows::<(_, _)>()
-            {
+            for (half_edge, next_half_edge) in cycle.half_edge_pairs() {
                 let hit = (&ray, half_edge).intersect();
 
                 let count_hit = match (hit, previous_hit) {

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -1,7 +1,6 @@
 use std::ops::Deref;
 
 use fj_math::{Scalar, Vector};
-use itertools::Itertools;
 
 use crate::{
     algorithms::transform::TransformObject,
@@ -62,9 +61,7 @@ impl Sweep for Handle<Face> {
             let cycle = cycle.reverse(services);
 
             let mut top_edges = Vec::new();
-            for (half_edge, next) in
-                cycle.half_edges().cloned().circular_tuple_windows()
-            {
+            for (half_edge, next) in cycle.half_edge_pairs() {
                 let (face, top_edge) = (
                     half_edge.deref(),
                     next.start_vertex(),

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -23,6 +23,13 @@ impl Cycle {
         self.half_edges.iter()
     }
 
+    /// Access the half-edges in pairs
+    pub fn half_edge_pairs(
+        &self,
+    ) -> impl Iterator<Item = (&Handle<HalfEdge>, &Handle<HalfEdge>)> {
+        self.half_edges.iter().circular_tuple_windows()
+    }
+
     /// Access the half-edge with the provided index
     pub fn nth_half_edge(&self, index: usize) -> Option<&Handle<HalfEdge>> {
         self.half_edges.get(index)
@@ -99,7 +106,7 @@ impl Cycle {
 
         let mut sum = Scalar::ZERO;
 
-        for (a, b) in self.half_edges.iter().circular_tuple_windows() {
+        for (a, b) in self.half_edge_pairs() {
             let [a, b] = [a, b].map(|half_edge| half_edge.start_position());
 
             sum += (b.u - a.u) * (b.v + a.v);

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use crate::{
     objects::{Cycle, HalfEdge},
     operations::Insert,
@@ -11,9 +9,7 @@ use super::Reverse;
 impl Reverse for Cycle {
     fn reverse(&self, services: &mut Services) -> Self {
         let mut edges = self
-            .half_edges()
-            .cloned()
-            .circular_tuple_windows()
+            .half_edge_pairs()
             .map(|(current, next)| {
                 let boundary = {
                     let [a, b] = current.boundary();

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -1,5 +1,4 @@
 use fj_math::{Point, Scalar};
-use itertools::Itertools;
 
 use crate::objects::{Cycle, HalfEdge};
 
@@ -63,7 +62,7 @@ impl CycleValidationError {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        for (first, second) in cycle.half_edges().circular_tuple_windows() {
+        for (first, second) in cycle.half_edge_pairs() {
             let end_of_first = {
                 let [_, end] = first.boundary();
                 first.curve().point_from_path_coords(end)


### PR DESCRIPTION
This is a useful shorthand for quite a bit of code within the kernel. It also allows models and other dependent code to use this functionality without depending on `itertools`.