### PR TITLE
Mark methods from operations API as `#[must_use]` where appropriate

### DIFF
--- a/crates/fj-core/src/operations/insert.rs
+++ b/crates/fj-core/src/operations/insert.rs
@@ -21,6 +21,7 @@ pub trait Insert: Sized {
     type Inserted;
 
     /// Insert the object into its respective store
+    #[must_use]
     fn insert(self, services: &mut Services) -> Self::Inserted;
 }
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -14,6 +14,7 @@ use crate::{
 /// Join a [`Cycle`] to another
 pub trait JoinCycle {
     /// Create a cycle that is joined to the provided edges
+    #[must_use]
     fn add_joined_edges<Es>(&self, edges: Es, services: &mut Services) -> Self
     where
         Es: IntoIterator<Item = (Handle<HalfEdge>, Curve, [Point<1>; 2])>,
@@ -48,6 +49,7 @@ pub trait JoinCycle {
     ///
     /// Maybe a custom trait that is implemented for `usize` and all range types
     /// would be the best solution.
+    #[must_use]
     fn join_to(
         &self,
         other: &Cycle,

--- a/crates/fj-core/src/operations/merge.rs
+++ b/crates/fj-core/src/operations/merge.rs
@@ -5,6 +5,7 @@ use super::UpdateSolid;
 /// Merge two [`Solid`]s
 pub trait Merge {
     /// Merge this solid with another
+    #[must_use]
     fn merge(&self, other: &Self) -> Self;
 }
 

--- a/crates/fj-core/src/operations/reverse/mod.rs
+++ b/crates/fj-core/src/operations/reverse/mod.rs
@@ -8,5 +8,6 @@ mod face;
 /// Reverse the direction/orientation of an object
 pub trait Reverse {
     /// Reverse the direction/orientation of the object
+    #[must_use]
     fn reverse(&self, services: &mut Services) -> Self;
 }

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -6,6 +6,7 @@ use crate::{
 /// Update a [`Cycle`]
 pub trait UpdateCycle {
     /// Add half-edges to the cycle
+    #[must_use]
     fn add_half_edges(
         &self,
         half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
@@ -16,6 +17,7 @@ pub trait UpdateCycle {
     /// # Panics
     ///
     /// Panics, unless this operation replaces exactly one half-edge.
+    #[must_use]
     fn replace_half_edge(
         &self,
         original: &Handle<HalfEdge>,
@@ -27,6 +29,7 @@ pub trait UpdateCycle {
     /// # Panics
     ///
     /// Panics, unless this operation updates exactly one half-edge.
+    #[must_use]
     fn update_nth_half_edge(
         &self,
         index: usize,

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -6,9 +6,11 @@ use crate::{
 /// Update a [`HalfEdge`]
 pub trait UpdateHalfEdge {
     /// Update the start vertex of the half-edge
+    #[must_use]
     fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self;
 
     /// Update the global form of the half-edge
+    #[must_use]
     fn replace_global_form(&self, global_form: Handle<GlobalEdge>) -> Self;
 }
 

--- a/crates/fj-core/src/operations/update/face.rs
+++ b/crates/fj-core/src/operations/update/face.rs
@@ -9,6 +9,7 @@ use crate::{
 /// Update a [`Face`]
 pub trait UpdateFace {
     /// Replace the region of the face
+    #[must_use]
     fn update_region(
         &self,
         f: impl FnOnce(&Handle<Region>) -> Handle<Region>,

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -6,12 +6,14 @@ use crate::{
 /// Update a [`Region`]
 pub trait UpdateRegion {
     /// Update the exterior of the region
+    #[must_use]
     fn update_exterior(
         &self,
         f: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
     ) -> Self;
 
     /// Add the provides interiors to the region
+    #[must_use]
     fn add_interiors(
         &self,
         interiors: impl IntoIterator<Item = Handle<Cycle>>,

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -6,9 +6,11 @@ use crate::{
 /// Update a [`Shell`]
 pub trait UpdateShell {
     /// Add faces to the shell
+    #[must_use]
     fn add_faces(&self, faces: impl IntoIterator<Item = Handle<Face>>) -> Self;
 
     /// Update a face of the shell
+    #[must_use]
     fn replace_face(
         &self,
         original: &Handle<Face>,
@@ -16,6 +18,7 @@ pub trait UpdateShell {
     ) -> Self;
 
     /// Remove a face from the shell
+    #[must_use]
     fn remove_face(&self, handle: &Handle<Face>) -> Self;
 }
 

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -6,6 +6,7 @@ use crate::{
 /// Update a [`Sketch`]
 pub trait UpdateSketch {
     /// Add a region to the sketch
+    #[must_use]
     fn add_region(&self, region: Handle<Region>) -> Self;
 }
 

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -6,6 +6,7 @@ use crate::{
 /// Update a [`Solid`]
 pub trait UpdateSolid {
     /// Add a shell to the solid
+    #[must_use]
     fn add_shells(
         &self,
         shells: impl IntoIterator<Item = Handle<Shell>>,


### PR DESCRIPTION
Objects are immutable, and thus the operations API creates new objects instead of modifying existing ones. This can be error-prone, as it is not necessarily clear to someone using the API for the first time.

This pull request addresses this issue, by adding `#[must_use]` to all the appropriate methods, leading to a warning if the return value is not used.