### PR TITLE
Document edge caching behavior and its limitations

### DIFF
--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -264,7 +264,7 @@ mod tests {
         algorithms::approx::{path::RangeOnPath, Approx, ApproxPoint},
         geometry::{curve::GlobalPath, surface::SurfaceGeometry},
         objects::{HalfEdge, Surface},
-        operations::{BuildHalfEdge, Insert},
+        operations::BuildHalfEdge,
         services::Services,
     };
 
@@ -289,13 +289,12 @@ mod tests {
         let surface = Surface::new(SurfaceGeometry {
             u: GlobalPath::circle_from_radius(1.),
             v: [0., 0., 1.].into(),
-        })
-        .insert(&mut services);
+        });
         let half_edge =
             HalfEdge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
 
         let tolerance = 1.;
-        let approx = (&half_edge, surface.deref()).approx(tolerance);
+        let approx = (&half_edge, &surface).approx(tolerance);
 
         assert_eq!(approx.points, Vec::new());
     }
@@ -310,8 +309,7 @@ mod tests {
         let surface = Surface::new(SurfaceGeometry {
             u: path,
             v: [0., 0., 1.].into(),
-        })
-        .insert(&mut services);
+        });
         let half_edge = HalfEdge::line_segment(
             [[0., 1.], [TAU, 1.]],
             Some(range.boundary),
@@ -319,7 +317,7 @@ mod tests {
         );
 
         let tolerance = 1.;
-        let approx = (&half_edge, surface.deref()).approx(tolerance);
+        let approx = (&half_edge, &surface).approx(tolerance);
 
         let expected_approx = (path, range)
             .approx(tolerance)

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -46,23 +46,24 @@ impl Approx for (&HalfEdge, &Surface) {
         let first = ApproxPoint::new(position_surface, position_global);
 
         let points = {
-            let approx =
-                match cache.get_edge(half_edge.global_form().clone(), range) {
-                    Some(approx) => approx,
-                    None => {
-                        let approx = approx_edge(
-                            &half_edge.curve(),
-                            surface,
-                            range,
-                            tolerance,
-                        );
-                        cache.insert_edge(
-                            half_edge.global_form().clone(),
-                            range,
-                            approx,
-                        )
-                    }
-                };
+            let cached_approx =
+                cache.get_edge(half_edge.global_form().clone(), range);
+            let approx = match cached_approx {
+                Some(approx) => approx,
+                None => {
+                    let approx = approx_edge(
+                        &half_edge.curve(),
+                        surface,
+                        range,
+                        tolerance,
+                    );
+                    cache.insert_edge(
+                        half_edge.global_form().clone(),
+                        range,
+                        approx,
+                    )
+                }
+            };
 
             approx
                 .points


### PR DESCRIPTION
I've been looking into the limitation that coincident `HalfEdge`s must always be congruent (see https://github.com/hannobraun/fornjot/issues/1608), and found that while the limitation itself is documented, the reason for it is not. I've added a comment to that effect, to make sure that my current understanding of the problem is documented.