### PR TITLE
Use dedicated struct to represent boundaries on curves

### DIFF
--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -28,8 +28,6 @@ impl Approx for (&HalfEdge, &Surface) {
     ) -> Self::Approximation {
         let (half_edge, surface) = self;
 
-        let boundary = half_edge.boundary();
-
         let position_surface = half_edge.start_position();
         let position_global = match cache.get_position(half_edge.start_vertex())
         {
@@ -86,20 +84,22 @@ impl Approx for (&HalfEdge, &Surface) {
             //
             // Only item 2. is something we can do right here. Item 1. requires
             // a change to the object graph.
-            let cached_approx =
-                cache.get_edge(half_edge.global_form().clone(), boundary);
+            let cached_approx = cache.get_edge(
+                half_edge.global_form().clone(),
+                half_edge.boundary(),
+            );
             let approx = match cached_approx {
                 Some(approx) => approx,
                 None => {
                     let approx = approx_edge(
                         &half_edge.path(),
                         surface,
-                        boundary,
+                        half_edge.boundary(),
                         tolerance,
                     );
                     cache.insert_edge(
                         half_edge.global_form().clone(),
-                        boundary,
+                        half_edge.boundary(),
                         approx,
                     )
                 }

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -29,7 +29,7 @@ impl Approx for (&HalfEdge, &Surface) {
         let (half_edge, surface) = self;
 
         let boundary = BoundaryOnCurve {
-            boundary: half_edge.boundary(),
+            inner: half_edge.boundary(),
         };
 
         let position_surface = half_edge.start_position();
@@ -193,7 +193,7 @@ fn approx_edge(
         }
         (SurfacePath::Line(line), _) => {
             let range_u =
-                BoundaryOnCurve::from(boundary.boundary.map(|point_curve| {
+                BoundaryOnCurve::from(boundary.inner.map(|point_curve| {
                     [path.point_from_path_coords(point_curve).u]
                 }));
 
@@ -355,7 +355,7 @@ mod tests {
         });
         let half_edge = HalfEdge::line_segment(
             [[0., 1.], [TAU, 1.]],
-            Some(boundary.boundary),
+            Some(boundary.inner),
             &mut services,
         );
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -347,7 +347,7 @@ mod tests {
         let mut services = Services::new();
 
         let path = GlobalPath::circle_from_radius(1.);
-        let range = BoundaryOnCurve::from([[0.], [TAU]]);
+        let boundary = BoundaryOnCurve::from([[0.], [TAU]]);
 
         let surface = Surface::new(SurfaceGeometry {
             u: path,
@@ -355,14 +355,14 @@ mod tests {
         });
         let half_edge = HalfEdge::line_segment(
             [[0., 1.], [TAU, 1.]],
-            Some(range.boundary),
+            Some(boundary.boundary),
             &mut services,
         );
 
         let tolerance = 1.;
         let approx = (&half_edge, &surface).approx(tolerance);
 
-        let expected_approx = (path, range)
+        let expected_approx = (path, boundary)
             .approx(tolerance)
             .into_iter()
             .map(|(point_local, _)| {

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -29,7 +29,7 @@ impl Approx for (&HalfEdge, &Surface) {
         let (half_edge, surface) = self;
 
         let boundary = half_edge.boundary();
-        let range = BoundaryOnCurve { boundary };
+        let boundary = BoundaryOnCurve { boundary };
 
         let position_surface = half_edge.start_position();
         let position_global = match cache.get_position(half_edge.start_vertex())
@@ -88,19 +88,19 @@ impl Approx for (&HalfEdge, &Surface) {
             // Only item 2. is something we can do right here. Item 1. requires
             // a change to the object graph.
             let cached_approx =
-                cache.get_edge(half_edge.global_form().clone(), range);
+                cache.get_edge(half_edge.global_form().clone(), boundary);
             let approx = match cached_approx {
                 Some(approx) => approx,
                 None => {
                     let approx = approx_edge(
                         &half_edge.path(),
                         surface,
-                        range,
+                        boundary,
                         tolerance,
                     );
                     cache.insert_edge(
                         half_edge.global_form().clone(),
-                        range,
+                        boundary,
                         approx,
                     )
                 }

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -247,7 +247,7 @@ impl EdgeCache {
         if let Some(approx) =
             self.edge_approx.get(&(handle.id(), boundary.reverse()))
         {
-            // If we have a cache entry for the reverse range, we need to use
+            // If we have a cache entry for the reverse boundary, we need to use
             // that too!
             return Some(approx.clone().reverse());
         }

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -28,8 +28,9 @@ impl Approx for (&HalfEdge, &Surface) {
     ) -> Self::Approximation {
         let (half_edge, surface) = self;
 
-        let boundary = half_edge.boundary();
-        let boundary = BoundaryOnCurve { boundary };
+        let boundary = BoundaryOnCurve {
+            boundary: half_edge.boundary(),
+        };
 
         let position_surface = half_edge.start_position();
         let position_global = match cache.get_position(half_edge.start_vertex())

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -239,13 +239,13 @@ impl EdgeCache {
     pub fn get_edge(
         &self,
         handle: Handle<GlobalEdge>,
-        range: BoundaryOnCurve,
+        boundary: BoundaryOnCurve,
     ) -> Option<GlobalEdgeApprox> {
-        if let Some(approx) = self.edge_approx.get(&(handle.id(), range)) {
+        if let Some(approx) = self.edge_approx.get(&(handle.id(), boundary)) {
             return Some(approx.clone());
         }
         if let Some(approx) =
-            self.edge_approx.get(&(handle.id(), range.reverse()))
+            self.edge_approx.get(&(handle.id(), boundary.reverse()))
         {
             // If we have a cache entry for the reverse range, we need to use
             // that too!

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -28,9 +28,7 @@ impl Approx for (&HalfEdge, &Surface) {
     ) -> Self::Approximation {
         let (half_edge, surface) = self;
 
-        let boundary = BoundaryOnCurve {
-            inner: half_edge.boundary(),
-        };
+        let boundary = half_edge.boundary();
 
         let position_surface = half_edge.start_position();
         let position_global = match cache.get_position(half_edge.start_vertex())

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -10,12 +10,12 @@ use std::collections::BTreeMap;
 use fj_math::Point;
 
 use crate::{
-    geometry::{GlobalPath, SurfacePath},
+    geometry::{BoundaryOnCurve, GlobalPath, SurfacePath},
     objects::{GlobalEdge, HalfEdge, Surface, Vertex},
     storage::{Handle, ObjectId},
 };
 
-use super::{path::BoundaryOnCurve, Approx, ApproxPoint, Tolerance};
+use super::{Approx, ApproxPoint, Tolerance};
 
 impl Approx for (&HalfEdge, &Surface) {
     type Approximation = HalfEdgeApprox;
@@ -304,8 +304,8 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::{
-        algorithms::approx::{path::BoundaryOnCurve, Approx, ApproxPoint},
-        geometry::{GlobalPath, SurfaceGeometry},
+        algorithms::approx::{Approx, ApproxPoint},
+        geometry::{BoundaryOnCurve, GlobalPath, SurfaceGeometry},
         objects::{HalfEdge, Surface},
         operations::BuildHalfEdge,
         services::Services,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -259,11 +259,11 @@ impl EdgeCache {
     pub fn insert_edge(
         &mut self,
         handle: Handle<GlobalEdge>,
-        range: BoundaryOnCurve,
+        boundary: BoundaryOnCurve,
         approx: GlobalEdgeApprox,
     ) -> GlobalEdgeApprox {
         self.edge_approx
-            .insert((handle.id(), range), approx.clone())
+            .insert((handle.id(), boundary), approx.clone())
             .unwrap_or(approx)
     }
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -149,7 +149,7 @@ impl HalfEdgeApprox {
 fn approx_edge(
     path: &SurfacePath,
     surface: &Surface,
-    range: BoundaryOnCurve,
+    boundary: BoundaryOnCurve,
     tolerance: impl Into<Tolerance>,
 ) -> GlobalEdgeApprox {
     // There are different cases of varying complexity. Circles are the hard
@@ -165,7 +165,7 @@ fn approx_edge(
             )
         }
         (SurfacePath::Circle(_), GlobalPath::Line(_)) => {
-            (path, range)
+            (path, boundary)
                 .approx_with_cache(tolerance, &mut ())
                 .into_iter()
                 .map(|(point_curve, point_surface)| {
@@ -193,7 +193,7 @@ fn approx_edge(
         }
         (SurfacePath::Line(line), _) => {
             let range_u =
-                BoundaryOnCurve::from(range.boundary.map(|point_curve| {
+                BoundaryOnCurve::from(boundary.boundary.map(|point_curve| {
                     [path.point_from_path_coords(point_curve).u]
                 }));
 

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -36,7 +36,7 @@ use crate::geometry::{GlobalPath, SurfacePath};
 
 use super::{Approx, Tolerance};
 
-impl Approx for (&SurfacePath, RangeOnPath) {
+impl Approx for (&SurfacePath, BoundaryOnCurve) {
     type Approximation = Vec<(Point<1>, Point<2>)>;
     type Cache = ();
 
@@ -56,7 +56,7 @@ impl Approx for (&SurfacePath, RangeOnPath) {
     }
 }
 
-impl Approx for (GlobalPath, RangeOnPath) {
+impl Approx for (GlobalPath, BoundaryOnCurve) {
     type Approximation = Vec<(Point<1>, Point<3>)>;
     type Cache = ();
 
@@ -78,12 +78,12 @@ impl Approx for (GlobalPath, RangeOnPath) {
 
 /// The range on which a path should be approximated
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct RangeOnPath {
+pub struct BoundaryOnCurve {
     /// The boundary of the range
     pub boundary: [Point<1>; 2],
 }
 
-impl RangeOnPath {
+impl BoundaryOnCurve {
     /// Reverse the direction of the range
     pub fn reverse(self) -> Self {
         let [a, b] = self.boundary;
@@ -91,7 +91,7 @@ impl RangeOnPath {
     }
 }
 
-impl<T> From<[T; 2]> for RangeOnPath
+impl<T> From<[T; 2]> for BoundaryOnCurve
 where
     T: Into<Point<1>>,
 {
@@ -107,7 +107,7 @@ where
 /// from the circle.
 fn approx_circle<const D: usize>(
     circle: &Circle<D>,
-    range: impl Into<RangeOnPath>,
+    range: impl Into<BoundaryOnCurve>,
     tolerance: Tolerance,
 ) -> Vec<(Point<1>, Point<D>)> {
     let range = range.into();
@@ -152,7 +152,7 @@ impl PathApproxParams {
 
     pub fn points(
         &self,
-        range: impl Into<RangeOnPath>,
+        range: impl Into<BoundaryOnCurve>,
     ) -> impl Iterator<Item = Point<1>> + '_ {
         let range = range.into();
 
@@ -195,7 +195,7 @@ mod tests {
 
     use fj_math::{Circle, Point, Scalar};
 
-    use crate::algorithms::approx::{path::RangeOnPath, Tolerance};
+    use crate::algorithms::approx::{path::BoundaryOnCurve, Tolerance};
 
     use super::PathApproxParams;
 
@@ -245,7 +245,7 @@ mod tests {
         test_path([[TAU - 2.], [0.]], [2., 1.]);
 
         fn test_path(
-            range: impl Into<RangeOnPath>,
+            range: impl Into<BoundaryOnCurve>,
             expected_coords: impl IntoIterator<Item = impl Into<Scalar>>,
         ) {
             // Choose radius and tolerance such, that we need 4 vertices to

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -32,7 +32,7 @@ use std::iter;
 
 use fj_math::{Circle, Point, Scalar, Sign};
 
-use crate::geometry::{GlobalPath, SurfacePath};
+use crate::geometry::{BoundaryOnCurve, GlobalPath, SurfacePath};
 
 use super::{Approx, Tolerance};
 
@@ -73,31 +73,6 @@ impl Approx for (GlobalPath, BoundaryOnCurve) {
             }
             GlobalPath::Line(_) => vec![],
         }
-    }
-}
-
-/// A boundary on a curve
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct BoundaryOnCurve {
-    /// The raw representation of the boundary
-    pub inner: [Point<1>; 2],
-}
-
-impl BoundaryOnCurve {
-    /// Reverse the direction of the boundary
-    pub fn reverse(self) -> Self {
-        let [a, b] = self.inner;
-        Self { inner: [b, a] }
-    }
-}
-
-impl<T> From<[T; 2]> for BoundaryOnCurve
-where
-    T: Into<Point<1>>,
-{
-    fn from(boundary: [T; 2]) -> Self {
-        let inner = boundary.map(Into::into);
-        Self { inner }
     }
 }
 

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -80,14 +80,14 @@ impl Approx for (GlobalPath, BoundaryOnCurve) {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BoundaryOnCurve {
     /// The boundary of the range
-    pub boundary: [Point<1>; 2],
+    pub inner: [Point<1>; 2],
 }
 
 impl BoundaryOnCurve {
     /// Reverse the direction of the range
     pub fn reverse(self) -> Self {
-        let [a, b] = self.boundary;
-        Self { boundary: [b, a] }
+        let [a, b] = self.inner;
+        Self { inner: [b, a] }
     }
 }
 
@@ -96,8 +96,8 @@ where
     T: Into<Point<1>>,
 {
     fn from(boundary: [T; 2]) -> Self {
-        let boundary = boundary.map(Into::into);
-        Self { boundary }
+        let inner = boundary.map(Into::into);
+        Self { inner }
     }
 }
 
@@ -156,7 +156,7 @@ impl PathApproxParams {
     ) -> impl Iterator<Item = Point<1>> + '_ {
         let boundary = boundary.into();
 
-        let [a, b] = boundary.boundary.map(|point| point.t / self.increment());
+        let [a, b] = boundary.inner.map(|point| point.t / self.increment());
         let direction = (b - a).sign();
         let [min, max] = if a < b { [a, b] } else { [b, a] };
 

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -110,12 +110,12 @@ fn approx_circle<const D: usize>(
     boundary: impl Into<BoundaryOnCurve>,
     tolerance: Tolerance,
 ) -> Vec<(Point<1>, Point<D>)> {
-    let range = boundary.into();
+    let boundary = boundary.into();
 
     let params = PathApproxParams::for_circle(circle, tolerance);
     let mut points = Vec::new();
 
-    for point_curve in params.points(range) {
+    for point_curve in params.points(boundary) {
         let point_global = circle.point_from_circle_coords(point_curve);
         points.push((point_curve, point_global));
     }

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -152,9 +152,9 @@ impl PathApproxParams {
 
     pub fn points(
         &self,
-        range: impl Into<BoundaryOnCurve>,
+        boundary: impl Into<BoundaryOnCurve>,
     ) -> impl Iterator<Item = Point<1>> + '_ {
-        let range = range.into();
+        let range = boundary.into();
 
         let [a, b] = range.boundary.map(|point| point.t / self.increment());
         let direction = (b - a).sign();

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -107,10 +107,10 @@ where
 /// from the circle.
 fn approx_circle<const D: usize>(
     circle: &Circle<D>,
-    range: impl Into<BoundaryOnCurve>,
+    boundary: impl Into<BoundaryOnCurve>,
     tolerance: Tolerance,
 ) -> Vec<(Point<1>, Point<D>)> {
-    let range = range.into();
+    let range = boundary.into();
 
     let params = PathApproxParams::for_circle(circle, tolerance);
     let mut points = Vec::new();

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -154,9 +154,9 @@ impl PathApproxParams {
         &self,
         boundary: impl Into<BoundaryOnCurve>,
     ) -> impl Iterator<Item = Point<1>> + '_ {
-        let range = boundary.into();
+        let boundary = boundary.into();
 
-        let [a, b] = range.boundary.map(|point| point.t / self.increment());
+        let [a, b] = boundary.boundary.map(|point| point.t / self.increment());
         let direction = (b - a).sign();
         let [min, max] = if a < b { [a, b] } else { [b, a] };
 

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -245,7 +245,7 @@ mod tests {
         test_path([[TAU - 2.], [0.]], [2., 1.]);
 
         fn test_path(
-            range: impl Into<BoundaryOnCurve>,
+            boundary: impl Into<BoundaryOnCurve>,
             expected_coords: impl IntoIterator<Item = impl Into<Scalar>>,
         ) {
             // Choose radius and tolerance such, that we need 4 vertices to
@@ -257,7 +257,7 @@ mod tests {
             let circle = Circle::from_center_and_radius([0., 0.], radius);
             let params = PathApproxParams::for_circle(&circle, tolerance);
 
-            let points = params.points(range).collect::<Vec<_>>();
+            let points = params.points(boundary).collect::<Vec<_>>();
 
             let expected_points = expected_coords
                 .into_iter()

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -76,15 +76,15 @@ impl Approx for (GlobalPath, BoundaryOnCurve) {
     }
 }
 
-/// The range on which a path should be approximated
+/// A boundary on a curve
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BoundaryOnCurve {
-    /// The boundary of the range
+    /// The raw representation of the boundary
     pub inner: [Point<1>; 2],
 }
 
 impl BoundaryOnCurve {
-    /// Reverse the direction of the range
+    /// Reverse the direction of the boundary
     pub fn reverse(self) -> Self {
         let [a, b] = self.inner;
         Self { inner: [b, a] }

--- a/crates/fj-core/src/algorithms/bounding_volume/edge.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/edge.rs
@@ -18,7 +18,7 @@ impl super::BoundingVolume<2> for HalfEdge {
                 })
             }
             SurfacePath::Line(_) => {
-                let points = self.boundary().map(|point_curve| {
+                let points = self.boundary().inner.map(|point_curve| {
                     self.path().point_from_path_coords(point_curve)
                 });
 

--- a/crates/fj-core/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_edge.rs
@@ -44,6 +44,7 @@ impl CurveEdgeIntersection {
 
             let edge_vertices = half_edge
                 .boundary()
+                .inner
                 .map(|point| edge_path_as_line.point_from_line_coords(point));
 
             Segment::from_points(edge_vertices)

--- a/crates/fj-core/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_edge.rs
@@ -26,6 +26,7 @@ impl Intersect for (&HorizontalRayToTheRight<2>, &Handle<HalfEdge>) {
 
         let points = edge
             .boundary()
+            .inner
             .map(|point| line.point_from_line_coords(point));
         let segment = Segment::from_points(points);
 

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -47,7 +47,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
 
         // Let's figure out the surface coordinates of the edge vertices.
         let surface_points = {
-            let [a, b] = edge.boundary();
+            let [a, b] = edge.boundary().inner;
 
             [
                 [a.t, Scalar::ZERO],
@@ -65,7 +65,7 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
 
         // Now, the boundaries of each edge.
         let boundaries = {
-            let [a, b] = edge.boundary();
+            let [a, b] = edge.boundary().inner;
             let [c, d] = [0., 1.].map(|coord| Point::from([coord]));
 
             [[a, b], [c, d], [b, a], [d, c]]

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -75,7 +75,7 @@ impl Sweep for Handle<Face> {
                 top_edges.push((
                     top_edge,
                     half_edge.path(),
-                    half_edge.boundary(),
+                    half_edge.boundary().inner,
                 ));
             }
 

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -75,7 +75,7 @@ impl Sweep for Handle<Face> {
                 top_edges.push((
                     top_edge,
                     half_edge.path(),
-                    half_edge.boundary().inner,
+                    half_edge.boundary(),
                 ));
             }
 

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -1,0 +1,26 @@
+use fj_math::Point;
+
+/// A boundary on a curve
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BoundaryOnCurve {
+    /// The raw representation of the boundary
+    pub inner: [Point<1>; 2],
+}
+
+impl BoundaryOnCurve {
+    /// Reverse the direction of the boundary
+    pub fn reverse(self) -> Self {
+        let [a, b] = self.inner;
+        Self { inner: [b, a] }
+    }
+}
+
+impl<T> From<[T; 2]> for BoundaryOnCurve
+where
+    T: Into<Point<1>>,
+{
+    fn from(boundary: [T; 2]) -> Self {
+        let inner = boundary.map(Into::into);
+        Self { inner }
+    }
+}

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 /// A boundary on a curve
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct BoundaryOnCurve {
     /// The raw representation of the boundary
     pub inner: [Point<1>; 2],

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -1,9 +1,11 @@
 //! Types that are tied to objects, but aren't objects themselves
 
+mod boundary;
 mod path;
 mod surface;
 
 pub use self::{
+    boundary::BoundaryOnCurve,
     path::{GlobalPath, SurfacePath},
     surface::SurfaceGeometry,
 };

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -82,7 +82,7 @@ impl Cycle {
                 .next()
                 .expect("Invalid cycle: expected at least one half-edge");
 
-            let [a, b] = first.boundary();
+            let [a, b] = first.boundary().inner;
             let edge_direction_positive = a < b;
 
             let circle = match first.path() {

--- a/crates/fj-core/src/objects/kinds/edge.rs
+++ b/crates/fj-core/src/objects/kinds/edge.rs
@@ -68,8 +68,8 @@ impl HalfEdge {
     }
 
     /// Access the boundary points of the half-edge on the curve
-    pub fn boundary(&self) -> [Point<1>; 2] {
-        self.boundary.inner
+    pub fn boundary(&self) -> BoundaryOnCurve {
+        self.boundary
     }
 
     /// Compute the surface position where the half-edge starts

--- a/crates/fj-core/src/objects/kinds/edge.rs
+++ b/crates/fj-core/src/objects/kinds/edge.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 use crate::{
-    geometry::SurfacePath,
+    geometry::{BoundaryOnCurve, SurfacePath},
     objects::Vertex,
     storage::{Handle, HandleWrapper},
 };
@@ -41,7 +41,7 @@ use crate::{
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
     path: SurfacePath,
-    boundary: [Point<1>; 2],
+    boundary: BoundaryOnCurve,
     start_vertex: HandleWrapper<Vertex>,
     global_form: HandleWrapper<GlobalEdge>,
 }
@@ -50,13 +50,13 @@ impl HalfEdge {
     /// Create an instance of `HalfEdge`
     pub fn new(
         path: SurfacePath,
-        boundary: [Point<1>; 2],
+        boundary: impl Into<BoundaryOnCurve>,
         start_vertex: Handle<Vertex>,
         global_form: Handle<GlobalEdge>,
     ) -> Self {
         Self {
             path,
-            boundary,
+            boundary: boundary.into(),
             start_vertex: start_vertex.into(),
             global_form: global_form.into(),
         }
@@ -69,7 +69,7 @@ impl HalfEdge {
 
     /// Access the boundary points of the half-edge on the curve
     pub fn boundary(&self) -> [Point<1>; 2] {
-        self.boundary
+        self.boundary.inner
     }
 
     /// Compute the surface position where the half-edge starts
@@ -78,7 +78,7 @@ impl HalfEdge {
         // `HalfEdge` "owns" its start position. There is no competing code that
         // could compute the surface position from slightly different data.
 
-        let [start, _] = self.boundary;
+        let [start, _] = self.boundary.inner;
         self.path.point_from_path_coords(start)
     }
 

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -2,7 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::{Arc, Point, Scalar};
 
 use crate::{
-    geometry::SurfacePath,
+    geometry::{BoundaryOnCurve, SurfacePath},
     objects::{GlobalEdge, HalfEdge, Vertex},
     operations::Insert,
     services::Services,
@@ -13,7 +13,7 @@ pub trait BuildHalfEdge {
     /// Create a half-edge that is not joined to another
     fn unjoined(
         path: SurfacePath,
-        boundary: [Point<1>; 2],
+        boundary: impl Into<BoundaryOnCurve>,
         services: &mut Services,
     ) -> HalfEdge {
         let start_vertex = Vertex::new().insert(services);

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -1,10 +1,9 @@
 use std::ops::RangeInclusive;
 
-use fj_math::Point;
 use itertools::Itertools;
 
 use crate::{
-    geometry::SurfacePath,
+    geometry::{BoundaryOnCurve, SurfacePath},
     objects::{Cycle, HalfEdge},
     operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
     services::Services,
@@ -17,7 +16,9 @@ pub trait JoinCycle {
     #[must_use]
     fn add_joined_edges<Es>(&self, edges: Es, services: &mut Services) -> Self
     where
-        Es: IntoIterator<Item = (Handle<HalfEdge>, SurfacePath, [Point<1>; 2])>,
+        Es: IntoIterator<
+            Item = (Handle<HalfEdge>, SurfacePath, BoundaryOnCurve),
+        >,
         Es::IntoIter: Clone + ExactSizeIterator;
 
     /// Join the cycle to another
@@ -62,12 +63,14 @@ pub trait JoinCycle {
 impl JoinCycle for Cycle {
     fn add_joined_edges<Es>(&self, edges: Es, services: &mut Services) -> Self
     where
-        Es: IntoIterator<Item = (Handle<HalfEdge>, SurfacePath, [Point<1>; 2])>,
+        Es: IntoIterator<
+            Item = (Handle<HalfEdge>, SurfacePath, BoundaryOnCurve),
+        >,
         Es::IntoIter: Clone + ExactSizeIterator,
     {
         self.add_half_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (half_edge, curve, boundary))| {
-                HalfEdge::unjoined(curve, boundary, services)
+                HalfEdge::unjoined(curve, boundary.inner, services)
                     .replace_start_vertex(prev.start_vertex().clone())
                     .replace_global_form(half_edge.global_form().clone())
                     .insert(services)

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -70,7 +70,7 @@ impl JoinCycle for Cycle {
     {
         self.add_half_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (half_edge, curve, boundary))| {
-                HalfEdge::unjoined(curve, boundary.inner, services)
+                HalfEdge::unjoined(curve, boundary, services)
                     .replace_start_vertex(prev.start_vertex().clone())
                     .replace_global_form(half_edge.global_form().clone())
                     .insert(services)

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -12,7 +12,7 @@ impl Reverse for Cycle {
             .half_edge_pairs()
             .map(|(current, next)| {
                 let boundary = {
-                    let [a, b] = current.boundary();
+                    let [a, b] = current.boundary().inner;
                     [b, a]
                 };
 

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -11,14 +11,9 @@ impl Reverse for Cycle {
         let mut edges = self
             .half_edge_pairs()
             .map(|(current, next)| {
-                let boundary = {
-                    let [a, b] = current.boundary().inner;
-                    [b, a]
-                };
-
                 HalfEdge::new(
                     current.path(),
-                    boundary,
+                    current.boundary().reverse(),
                     next.start_vertex().clone(),
                     current.global_form().clone(),
                 )

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -65,7 +65,7 @@ impl CycleValidationError {
     ) {
         for (first, second) in cycle.half_edge_pairs() {
             let end_of_first = {
-                let [_, end] = first.boundary();
+                let [_, end] = first.boundary().inner;
                 first.path().point_from_path_coords(end)
             };
             let start_of_second = second.start_position();

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -54,7 +54,7 @@ impl HalfEdgeValidationError {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        let [back_position, front_position] = half_edge.boundary();
+        let [back_position, front_position] = half_edge.boundary().inner;
         let distance = (back_position - front_position).magnitude();
 
         if distance < config.distinct_min_distance {

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -73,8 +73,8 @@ fn distances(
         percent: f64,
         (edge, surface): (&Handle<HalfEdge>, SurfaceGeometry),
     ) -> Point<3> {
-        let boundary = edge.boundary();
-        let path_coords = boundary[0] + (boundary[1] - boundary[0]) * percent;
+        let [start, end] = edge.boundary();
+        let path_coords = start + (end - start) * percent;
         let surface_coords = edge.path().point_from_path_coords(path_coords);
         surface.point_from_surface_coords(surface_coords)
     }

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -73,7 +73,7 @@ fn distances(
         percent: f64,
         (edge, surface): (&Handle<HalfEdge>, SurfaceGeometry),
     ) -> Point<3> {
-        let [start, end] = edge.boundary();
+        let [start, end] = edge.boundary().inner;
         let path_coords = start + (end - start) * percent;
         let surface_coords = edge.path().point_from_path_coords(path_coords);
         surface.point_from_surface_coords(surface_coords)


### PR DESCRIPTION
Using a dedicated type here provides a place to implement functionality like reversing and normalizing a boundary. This came out of my work on https://github.com/hannobraun/fornjot/issues/1937.