### PR TITLE
Add `Curve` object

### DIFF
--- a/crates/fj-core/src/algorithms/transform/curve.rs
+++ b/crates/fj-core/src/algorithms/transform/curve.rs
@@ -1,0 +1,19 @@
+use fj_math::Transform;
+
+use crate::{objects::Curve, services::Services};
+
+use super::{TransformCache, TransformObject};
+
+impl TransformObject for Curve {
+    fn transform_with_cache(
+        self,
+        _: &Transform,
+        _: &mut Services,
+        _: &mut TransformCache,
+    ) -> Self {
+        // There's nothing to actually transform here, as `Curve` holds no data.
+        // We still need this implementation though, as a new `Curve` object
+        // must be created to represent the new and transformed curve.
+        Self::new()
+    }
+}

--- a/crates/fj-core/src/algorithms/transform/edge.rs
+++ b/crates/fj-core/src/algorithms/transform/edge.rs
@@ -18,6 +18,10 @@ impl TransformObject for HalfEdge {
         // coordinates.
         let path = self.path();
         let boundary = self.boundary();
+        let curve = self
+            .curve()
+            .clone()
+            .transform_with_cache(transform, services, cache);
         let start_vertex = self
             .start_vertex()
             .clone()
@@ -27,7 +31,7 @@ impl TransformObject for HalfEdge {
             .clone()
             .transform_with_cache(transform, services, cache);
 
-        Self::new(path, boundary, start_vertex, global_form)
+        Self::new(path, boundary, curve, start_vertex, global_form)
     }
 }
 

--- a/crates/fj-core/src/algorithms/transform/mod.rs
+++ b/crates/fj-core/src/algorithms/transform/mod.rs
@@ -1,5 +1,6 @@
 //! API for transforming objects
 
+mod curve;
 mod cycle;
 mod edge;
 mod face;

--- a/crates/fj-core/src/objects/kinds/curve.rs
+++ b/crates/fj-core/src/objects/kinds/curve.rs
@@ -1,0 +1,32 @@
+/// A curve
+///
+/// `Curve` represents a curve in space, but holds no data to define that curve.
+/// It is referenced by [`HalfEdge`], which defines the curve in the coordinates
+/// of its surface.
+///
+/// `Curve` exists to allow identifying which [`HalfEdge`]s are supposed to be
+/// coincident in global space.
+///
+/// # Equality
+///
+/// `Curve` contains no data and exists purely to be used within a `Handle`,
+/// where `Handle::id` can be used to compare different instances of `Curve`.
+///
+/// If `Curve` had `Eq`/`PartialEq` implementations, it containing no data would
+/// mean that all instances of `Curve` would be considered equal. This would be
+/// very error-prone.
+///
+/// If you need to reference a `Curve` from a struct that needs to derive
+/// `Eq`/`Ord`/..., you can use `HandleWrapper<Curve>` to do that. It will use
+/// `Handle::id` to provide those `Eq`/`Ord`/... implementations.
+///
+/// [`HalfEdge`]: crate::objects::HalfEdge
+#[derive(Clone, Debug, Default, Hash)]
+pub struct Curve {}
+
+impl Curve {
+    /// Create a new instance
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/fj-core/src/objects/kinds/edge.rs
+++ b/crates/fj-core/src/objects/kinds/edge.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::{BoundaryOnCurve, SurfacePath},
-    objects::Vertex,
+    objects::{Curve, Vertex},
     storage::{Handle, HandleWrapper},
 };
 
@@ -42,6 +42,7 @@ use crate::{
 pub struct HalfEdge {
     path: SurfacePath,
     boundary: BoundaryOnCurve,
+    curve: HandleWrapper<Curve>,
     start_vertex: HandleWrapper<Vertex>,
     global_form: HandleWrapper<GlobalEdge>,
 }
@@ -51,12 +52,14 @@ impl HalfEdge {
     pub fn new(
         path: SurfacePath,
         boundary: impl Into<BoundaryOnCurve>,
+        curve: Handle<Curve>,
         start_vertex: Handle<Vertex>,
         global_form: Handle<GlobalEdge>,
     ) -> Self {
         Self {
             path,
             boundary: boundary.into(),
+            curve: curve.into(),
             start_vertex: start_vertex.into(),
             global_form: global_form.into(),
         }
@@ -80,6 +83,11 @@ impl HalfEdge {
 
         let [start, _] = self.boundary.inner;
         self.path.point_from_path_coords(start)
+    }
+
+    /// Access the curve of the half-edge
+    pub fn curve(&self) -> &Handle<Curve> {
+        &self.curve
     }
 
     /// Access the vertex from where this half-edge starts

--- a/crates/fj-core/src/objects/kinds/mod.rs
+++ b/crates/fj-core/src/objects/kinds/mod.rs
@@ -1,3 +1,4 @@
+pub mod curve;
 pub mod cycle;
 pub mod edge;
 pub mod face;

--- a/crates/fj-core/src/objects/mod.rs
+++ b/crates/fj-core/src/objects/mod.rs
@@ -46,6 +46,7 @@ mod stores;
 
 pub use self::{
     kinds::{
+        curve::Curve,
         cycle::{Cycle, HalfEdgesOfCycle},
         edge::{GlobalEdge, HalfEdge},
         face::{Face, FaceSet, Handedness},

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -1,7 +1,7 @@
 use crate::{
     objects::{
-        Cycle, Face, GlobalEdge, HalfEdge, Objects, Region, Shell, Sketch,
-        Solid, Surface, Vertex,
+        Curve, Cycle, Face, GlobalEdge, HalfEdge, Objects, Region, Shell,
+        Sketch, Solid, Surface, Vertex,
     },
     storage::{Handle, HandleWrapper, ObjectId},
     validate::{Validate, ValidationError},
@@ -91,6 +91,7 @@ macro_rules! object {
 }
 
 object!(
+    Curve, "curve", curves;
     Cycle, "cycle", cycles;
     Face, "face", faces;
     GlobalEdge, "global edge", global_edges;

--- a/crates/fj-core/src/objects/stores.rs
+++ b/crates/fj-core/src/objects/stores.rs
@@ -6,13 +6,16 @@ use crate::{
 };
 
 use super::{
-    Cycle, Face, GlobalEdge, HalfEdge, Region, Shell, Sketch, Solid, Surface,
-    Vertex,
+    Curve, Cycle, Face, GlobalEdge, HalfEdge, Region, Shell, Sketch, Solid,
+    Surface, Vertex,
 };
 
 /// The available object stores
 #[derive(Debug, Default)]
 pub struct Objects {
+    /// Store for [`Curve`]s
+    pub curves: Store<Curve>,
+
     /// Store for [`Cycle`]s
     pub cycles: Store<Cycle>,
 

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -3,7 +3,7 @@ use fj_math::{Arc, Point, Scalar};
 
 use crate::{
     geometry::{BoundaryOnCurve, SurfacePath},
-    objects::{GlobalEdge, HalfEdge, Vertex},
+    objects::{Curve, GlobalEdge, HalfEdge, Vertex},
     operations::Insert,
     services::Services,
 };
@@ -16,10 +16,11 @@ pub trait BuildHalfEdge {
         boundary: impl Into<BoundaryOnCurve>,
         services: &mut Services,
     ) -> HalfEdge {
+        let curve = Curve::new().insert(services);
         let start_vertex = Vertex::new().insert(services);
         let global_form = GlobalEdge::new().insert(services);
 
-        HalfEdge::new(path, boundary, start_vertex, global_form)
+        HalfEdge::new(path, boundary, curve, start_vertex, global_form)
     }
 
     /// Create an arc

--- a/crates/fj-core/src/operations/insert.rs
+++ b/crates/fj-core/src/operations/insert.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{
-        Cycle, Face, GlobalEdge, HalfEdge, Region, Shell, Sketch, Solid,
+        Curve, Cycle, Face, GlobalEdge, HalfEdge, Region, Shell, Sketch, Solid,
         Surface, Vertex,
     },
     services::Services,
@@ -43,6 +43,7 @@ macro_rules! impl_insert {
 }
 
 impl_insert!(
+    Curve, curves;
     Cycle, cycles;
     Face, faces;
     GlobalEdge, global_edges;

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -14,6 +14,7 @@ impl Reverse for Cycle {
                 HalfEdge::new(
                     current.path(),
                     current.boundary().reverse(),
+                    current.curve().clone(),
                     next.start_vertex().clone(),
                     current.global_form().clone(),
                 )

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -19,6 +19,7 @@ impl UpdateHalfEdge for HalfEdge {
         HalfEdge::new(
             self.path(),
             self.boundary(),
+            self.curve().clone(),
             start_vertex,
             self.global_form().clone(),
         )
@@ -28,6 +29,7 @@ impl UpdateHalfEdge for HalfEdge {
         HalfEdge::new(
             self.path(),
             self.boundary(),
+            self.curve().clone(),
             self.start_vertex().clone(),
             global_form,
         )

--- a/crates/fj-core/src/validate/curve.rs
+++ b/crates/fj-core/src/validate/curve.rs
@@ -1,0 +1,12 @@
+use crate::objects::Curve;
+
+use super::{Validate, ValidationConfig, ValidationError};
+
+impl Validate for Curve {
+    fn validate_with_config(
+        &self,
+        _: &ValidationConfig,
+        _: &mut Vec<ValidationError>,
+    ) {
+    }
+}

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -95,6 +95,7 @@ mod tests {
             HalfEdge::new(
                 valid.path(),
                 boundary,
+                valid.curve().clone(),
                 valid.start_vertex().clone(),
                 valid.global_form().clone(),
             )

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -1,5 +1,6 @@
 //! Infrastructure for validating objects
 
+mod curve;
 mod cycle;
 mod edge;
 mod face;


### PR DESCRIPTION
This is another step towards https://github.com/hannobraun/fornjot/issues/1937. The new `Curve` object being added here isn't useful yet. There's no validation to make sure it is used correctly within the object graph, and in fact it isn't. But my local branch is getting a bit unwieldy, and I want to get more of it merged. Worst case, I have to revert all of this again, if the design doesn't work out :smile: 