### PR TITLE
Fully integrate `Curve`

### DIFF
--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -27,11 +27,11 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
 
         // Next, we need to define the boundaries of the face. Let's start with
         // the global vertices and edges.
-        let (vertices, global_edges) = {
+        let (vertices, global_edges, curves) = {
             let [a, b] = [edge.start_vertex(), next_vertex].map(Clone::clone);
-            let (_, edge_up, [_, c]) =
+            let (curve_up, edge_up, [_, c]) =
                 b.clone().sweep_with_cache(path, cache, services);
-            let (_, edge_down, [_, d]) =
+            let (curve_down, edge_down, [_, d]) =
                 a.clone().sweep_with_cache(path, cache, services);
 
             (
@@ -41,6 +41,12 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                     Some(edge_up),
                     None,
                     Some(edge_down),
+                ],
+                [
+                    Some(edge.curve().clone()),
+                    Some(curve_up),
+                    None,
+                    Some(curve_down),
                 ],
             )
         };
@@ -78,34 +84,46 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
             .zip_ext(surface_points)
             .zip_ext(surface_points_next)
             .zip_ext(vertices)
+            .zip_ext(curves)
             .zip_ext(global_edges)
-            .map(|((((boundary, start), end), start_vertex), global_edge)| {
-                let half_edge = {
-                    let half_edge = HalfEdge::line_segment(
-                        [start, end],
-                        Some(boundary),
-                        services,
-                    )
-                    .replace_start_vertex(start_vertex);
+            .map(
+                |(
+                    ((((boundary, start), end), start_vertex), curve),
+                    global_edge,
+                )| {
+                    let half_edge = {
+                        let half_edge = HalfEdge::line_segment(
+                            [start, end],
+                            Some(boundary),
+                            services,
+                        )
+                        .replace_start_vertex(start_vertex);
 
-                    let half_edge = if let Some(global_edge) = global_edge {
-                        half_edge.replace_global_form(global_edge)
-                    } else {
-                        half_edge
+                        let half_edge = if let Some(curve) = curve {
+                            half_edge.replace_curve(curve)
+                        } else {
+                            half_edge
+                        };
+
+                        let half_edge = if let Some(global_edge) = global_edge {
+                            half_edge.replace_global_form(global_edge)
+                        } else {
+                            half_edge
+                        };
+
+                        half_edge.insert(services)
                     };
 
-                    half_edge.insert(services)
-                };
+                    exterior = Some(
+                        exterior
+                            .take()
+                            .unwrap()
+                            .add_half_edges([half_edge.clone()]),
+                    );
 
-                exterior = Some(
-                    exterior
-                        .take()
-                        .unwrap()
-                        .add_half_edges([half_edge.clone()]),
-                );
-
-                half_edge
-            });
+                    half_edge
+                },
+            );
 
         let region = Region::new(exterior.unwrap().insert(services), [], color)
             .insert(services);

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -29,9 +29,9 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
         // the global vertices and edges.
         let (vertices, global_edges) = {
             let [a, b] = [edge.start_vertex(), next_vertex].map(Clone::clone);
-            let (edge_up, [_, c]) =
+            let (_, edge_up, [_, c]) =
                 b.clone().sweep_with_cache(path, cache, services);
-            let (edge_down, [_, d]) =
+            let (_, edge_down, [_, d]) =
                 a.clone().sweep_with_cache(path, cache, services);
 
             (

--- a/crates/fj-core/src/algorithms/sweep/mod.rs
+++ b/crates/fj-core/src/algorithms/sweep/mod.rs
@@ -46,7 +46,7 @@ pub trait Sweep: Sized {
 #[derive(Default)]
 pub struct SweepCache {
     /// Cache for global vertices
-    pub global_vertex: BTreeMap<ObjectId, Handle<Vertex>>,
+    pub vertices: BTreeMap<ObjectId, Handle<Vertex>>,
 
     /// Cache for global edges
     pub global_edge: BTreeMap<ObjectId, Handle<GlobalEdge>>,

--- a/crates/fj-core/src/algorithms/sweep/mod.rs
+++ b/crates/fj-core/src/algorithms/sweep/mod.rs
@@ -49,5 +49,5 @@ pub struct SweepCache {
     pub vertices: BTreeMap<ObjectId, Handle<Vertex>>,
 
     /// Cache for global edges
-    pub global_edge: BTreeMap<ObjectId, Handle<GlobalEdge>>,
+    pub global_edges: BTreeMap<ObjectId, Handle<GlobalEdge>>,
 }

--- a/crates/fj-core/src/algorithms/sweep/mod.rs
+++ b/crates/fj-core/src/algorithms/sweep/mod.rs
@@ -45,7 +45,7 @@ pub trait Sweep: Sized {
 /// See [`Sweep`].
 #[derive(Default)]
 pub struct SweepCache {
-    /// Cache for global vertices
+    /// Cache for vertices
     pub vertices: BTreeMap<ObjectId, Handle<Vertex>>,
 
     /// Cache for global edges

--- a/crates/fj-core/src/algorithms/sweep/mod.rs
+++ b/crates/fj-core/src/algorithms/sweep/mod.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use fj_math::Vector;
 
 use crate::{
-    objects::{GlobalEdge, Vertex},
+    objects::{Curve, GlobalEdge, Vertex},
     services::Services,
     storage::{Handle, ObjectId},
 };
@@ -45,6 +45,9 @@ pub trait Sweep: Sized {
 /// See [`Sweep`].
 #[derive(Default)]
 pub struct SweepCache {
+    /// Cache for curves
+    pub curves: BTreeMap<ObjectId, Handle<Curve>>,
+
     /// Cache for vertices
     pub vertices: BTreeMap<ObjectId, Handle<Vertex>>,
 

--- a/crates/fj-core/src/algorithms/sweep/mod.rs
+++ b/crates/fj-core/src/algorithms/sweep/mod.rs
@@ -47,6 +47,7 @@ pub trait Sweep: Sized {
 pub struct SweepCache {
     /// Cache for global vertices
     pub global_vertex: BTreeMap<ObjectId, Handle<Vertex>>,
+
     /// Cache for global edges
     pub global_edge: BTreeMap<ObjectId, Handle<GlobalEdge>>,
 }

--- a/crates/fj-core/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-core/src/algorithms/sweep/vertex.rs
@@ -32,9 +32,6 @@ impl Sweep for Handle<Vertex> {
             .or_insert_with(|| GlobalEdge::new().insert(services))
             .clone();
 
-        // The vertices of the returned `GlobalEdge` are in normalized order,
-        // which means the order can't be relied upon by the caller. Return the
-        // ordered vertices in addition.
         (global_edge, vertices)
     }
 }

--- a/crates/fj-core/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-core/src/algorithms/sweep/vertex.rs
@@ -27,7 +27,7 @@ impl Sweep for Handle<Vertex> {
 
         let vertices = [a, b];
         let global_edge = cache
-            .global_edge
+            .global_edges
             .entry(self.id())
             .or_insert_with(|| GlobalEdge::new().insert(services))
             .clone();

--- a/crates/fj-core/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-core/src/algorithms/sweep/vertex.rs
@@ -20,7 +20,7 @@ impl Sweep for Handle<Vertex> {
     ) -> Self::Swept {
         let a = self.clone();
         let b = cache
-            .global_vertex
+            .vertices
             .entry(self.id())
             .or_insert_with(|| Vertex::new().insert(services))
             .clone();

--- a/crates/fj-core/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-core/src/algorithms/sweep/vertex.rs
@@ -1,7 +1,7 @@
 use fj_math::Vector;
 
 use crate::{
-    objects::{GlobalEdge, Vertex},
+    objects::{Curve, GlobalEdge, Vertex},
     operations::Insert,
     services::Services,
     storage::Handle,
@@ -10,7 +10,7 @@ use crate::{
 use super::{Sweep, SweepCache};
 
 impl Sweep for Handle<Vertex> {
-    type Swept = (Handle<GlobalEdge>, [Self; 2]);
+    type Swept = (Handle<Curve>, Handle<GlobalEdge>, [Self; 2]);
 
     fn sweep_with_cache(
         self,
@@ -18,6 +18,12 @@ impl Sweep for Handle<Vertex> {
         cache: &mut SweepCache,
         services: &mut Services,
     ) -> Self::Swept {
+        let curve = cache
+            .curves
+            .entry(self.id())
+            .or_insert_with(|| Curve::new().insert(services))
+            .clone();
+
         let a = self.clone();
         let b = cache
             .vertices
@@ -32,6 +38,6 @@ impl Sweep for Handle<Vertex> {
             .or_insert_with(|| GlobalEdge::new().insert(services))
             .clone();
 
-        (global_edge, vertices)
+        (curve, global_edge, vertices)
     }
 }

--- a/crates/fj-core/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-core/src/algorithms/sweep/vertex.rs
@@ -24,8 +24,8 @@ impl Sweep for Handle<Vertex> {
             .entry(self.id())
             .or_insert_with(|| Vertex::new().insert(services))
             .clone();
-
         let vertices = [a, b];
+
         let global_edge = cache
             .global_edges
             .entry(self.id())

--- a/crates/fj-core/src/geometry/bounding_vertices.rs
+++ b/crates/fj-core/src/geometry/bounding_vertices.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// The bounding vertices of an edge
-#[derive(Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BoundingVertices {
     /// The bounding vertices
     pub inner: [HandleWrapper<Vertex>; 2],

--- a/crates/fj-core/src/geometry/bounding_vertices.rs
+++ b/crates/fj-core/src/geometry/bounding_vertices.rs
@@ -10,6 +10,18 @@ pub struct BoundingVertices {
     pub inner: [HandleWrapper<Vertex>; 2],
 }
 
+impl BoundingVertices {
+    /// Normalize the bounding vertices
+    ///
+    /// Returns a new instance of this struct, which has the vertices in a
+    /// defined order. This can be used to compare bounding vertices while
+    /// disregarding their order.
+    pub fn normalize(mut self) -> Self {
+        self.inner.sort();
+        self
+    }
+}
+
 impl From<[Handle<Vertex>; 2]> for BoundingVertices {
     fn from(vertices: [Handle<Vertex>; 2]) -> Self {
         Self {

--- a/crates/fj-core/src/geometry/bounding_vertices.rs
+++ b/crates/fj-core/src/geometry/bounding_vertices.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// The bounding vertices of an edge
-#[derive(Eq, PartialEq)]
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
 pub struct BoundingVertices {
     /// The bounding vertices
     pub inner: [HandleWrapper<Vertex>; 2],

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -115,6 +115,7 @@ impl JoinCycle for Cycle {
                 .expect("Expected this cycle to contain edge");
 
             let this_joined = half_edge
+                .replace_curve(half_edge_other.curve().clone())
                 .replace_start_vertex(vertex_a)
                 .replace_global_form(half_edge_other.global_form().clone())
                 .insert(services);

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -71,6 +71,7 @@ impl JoinCycle for Cycle {
         self.add_half_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (half_edge, curve, boundary))| {
                 HalfEdge::unjoined(curve, boundary, services)
+                    .replace_curve(half_edge.curve().clone())
                     .replace_start_vertex(prev.start_vertex().clone())
                     .replace_global_form(half_edge.global_form().clone())
                     .insert(services)

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -1,10 +1,14 @@
 use crate::{
-    objects::{GlobalEdge, HalfEdge, Vertex},
+    objects::{Curve, GlobalEdge, HalfEdge, Vertex},
     storage::Handle,
 };
 
 /// Update a [`HalfEdge`]
 pub trait UpdateHalfEdge {
+    /// Replace the curve of the half-edge
+    #[must_use]
+    fn replace_curve(&self, curve: Handle<Curve>) -> Self;
+
     /// Replace the start vertex of the half-edge
     #[must_use]
     fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self;
@@ -15,6 +19,16 @@ pub trait UpdateHalfEdge {
 }
 
 impl UpdateHalfEdge for HalfEdge {
+    fn replace_curve(&self, curve: Handle<Curve>) -> Self {
+        HalfEdge::new(
+            self.path(),
+            self.boundary(),
+            curve,
+            self.start_vertex().clone(),
+            self.global_form().clone(),
+        )
+    }
+
     fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self {
         HalfEdge::new(
             self.path(),

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -5,11 +5,11 @@ use crate::{
 
 /// Update a [`HalfEdge`]
 pub trait UpdateHalfEdge {
-    /// Update the start vertex of the half-edge
+    /// Replace the start vertex of the half-edge
     #[must_use]
     fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self;
 
-    /// Update the global form of the half-edge
+    /// Replace the global form of the half-edge
     #[must_use]
     fn replace_global_form(&self, global_form: Handle<GlobalEdge>) -> Self;
 }

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -127,10 +127,10 @@ impl ShellValidationError {
         // data-structure like an octree.
         for (edge_a, surface_a) in &edges_and_surfaces {
             for (edge_b, surface_b) in &edges_and_surfaces {
-                let identical =
+                let identical_according_to_global_form =
                     edge_a.global_form().id() == edge_b.global_form().id();
 
-                match identical {
+                match identical_according_to_global_form {
                     true => {
                         // All points on identical curves should be within
                         // identical_max_distance, so we shouldn't have any

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -210,7 +210,7 @@ impl ShellValidationError {
 mod tests {
     use crate::{
         assert_contains_err,
-        objects::{GlobalEdge, Shell},
+        objects::{Curve, GlobalEdge, Shell},
         operations::{
             BuildShell, Insert, UpdateCycle, UpdateFace, UpdateHalfEdge,
             UpdateRegion, UpdateShell,
@@ -237,9 +237,13 @@ mod tests {
                         .update_exterior(|cycle| {
                             cycle
                                 .update_nth_half_edge(0, |half_edge| {
+                                    let curve =
+                                        Curve::new().insert(&mut services);
                                     let global_form =
                                         GlobalEdge::new().insert(&mut services);
+
                                     half_edge
+                                        .replace_curve(curve)
                                         .replace_global_form(global_form)
                                         .insert(&mut services)
                                 })


### PR DESCRIPTION
`Curve` was added earlier in https://github.com/hannobraun/fornjot/pull/1950, but it wasn't really used yet. The correct curves weren't added were they had to be, and there was no validation code to check that.

This changes in this pull request. All code that needs to take `Curve`s into account has been updated to do so, as have the relevant validation tests. `GlobalEdge` still exists, and both basically fulfill the same purpose. I intend to remove it in a follow-up pull request.

This is a big step towards addressing https://github.com/hannobraun/fornjot/issues/1937. What's still missing is to update the approximation code to use `Curve` instead of `GlobalEdge`.