### PR TITLE
Remove out-of-date note

### DIFF
--- a/crates/fj-core/src/objects/kinds/shell.rs
+++ b/crates/fj-core/src/objects/kinds/shell.rs
@@ -4,11 +4,6 @@ use crate::{
 };
 
 /// A 3-dimensional closed shell
-///
-/// # Implementation Note
-///
-/// The faces that make up a shell should be closed ("watertight"). This is not
-/// currently validated.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Shell {
     faces: FaceSet,


### PR DESCRIPTION
We do validate that a shell is watertight, see: https://github.com/hannobraun/fornjot/blob/40b364814a6f9f0c85f508e637941ee0cc2bd0eb/crates/fj-core/src/validate/shell.rs#L24C40-L24C40