### PR TITLE
Make `ApproxPoint::new` more flexible

### DIFF
--- a/crates/fj-core/src/algorithms/approx/mod.rs
+++ b/crates/fj-core/src/algorithms/approx/mod.rs
@@ -59,10 +59,13 @@ pub struct ApproxPoint<const D: usize> {
 
 impl<const D: usize> ApproxPoint<D> {
     /// Create an instance of `ApproxPoint`, without a source
-    pub fn new(local_form: Point<D>, global_form: Point<3>) -> Self {
+    pub fn new(
+        local_form: impl Into<Point<D>>,
+        global_form: impl Into<Point<3>>,
+    ) -> Self {
         Self {
-            local_form,
-            global_form,
+            local_form: local_form.into(),
+            global_form: global_form.into(),
         }
     }
 }


### PR DESCRIPTION
This is a small improvement that came out of my work on https://github.com/hannobraun/fornjot/issues/1937.