### PR TITLE
Validate shell orientations

### DIFF
--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -371,7 +371,7 @@ impl ShellValidationError {
         for (_, halfs) in global_to_half {
             if let (Some(a), Some(b)) = (halfs.get(0), halfs.get(1)) {
                 // Check if a is reverse of b
-                if a.start_vertex().id() == b.start_vertex().id() {
+                if a.boundary().reverse() != b.boundary() {
                     errors.push(Self::MixedOrientations.into());
                     dbg!(a, b);
                     return;

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -329,13 +329,13 @@ impl ShellValidationError {
             errors.push(Self::NotWatertight.into());
         }
 
-        let mut half_edge_to_faces: HashMap<ObjectId, usize> = HashMap::new();
+        let mut global_edge_to_faces: HashMap<ObjectId, usize> = HashMap::new();
 
         for face in shell.faces() {
             for cycle in face.region().all_cycles() {
                 for half_edge in cycle.half_edges() {
                     let id = half_edge.global_form().id();
-                    let entry = half_edge_to_faces.entry(id);
+                    let entry = global_edge_to_faces.entry(id);
                     *entry.or_insert(0) += 1;
                 }
             }
@@ -343,7 +343,7 @@ impl ShellValidationError {
 
         // Each global edge should have exactly two half edges that are part of
         // the shell
-        if half_edge_to_faces.iter().any(|(_, c)| *c != 2) {
+        if global_edge_to_faces.iter().any(|(_, c)| *c != 2) {
             errors.push(Self::NotWatertight.into())
         }
     }


### PR DESCRIPTION
Addresses part of #1935.

Currently bugged, so marked as draft.
The problem is how to check whether two half-edges are reverse of one another:
- Make sure that start vertexes are different (fails on circles)
- Make sure that boundarys are reverse of one another (fails when different paths)
- Sample the edges?

Any help appreciated, thanks!