### PR TITLE
Make sure that the coordinate systems of locally defined curves match

### DIFF
--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -3,8 +3,9 @@ use fj_math::Point;
 use crate::{
     objects::{Face, Shell},
     operations::{
-        update::region::UpdateRegion, BuildFace, Insert, IsInserted,
-        IsInsertedNo, IsInsertedYes, JoinCycle, Polygon, UpdateFace,
+        reverse::ReverseCurveCoordinateSystems, update::region::UpdateRegion,
+        BuildFace, Insert, IsInserted, IsInsertedNo, IsInsertedYes, JoinCycle,
+        Polygon, UpdateCycle, UpdateFace,
     },
     services::Services,
 };
@@ -45,6 +46,10 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
+                        .update_nth_half_edge(0, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             abc.face.region().exterior(),
                             0..=0,
@@ -59,12 +64,20 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
+                        .update_nth_half_edge(1, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             abc.face.region().exterior(),
                             1..=1,
                             2..=2,
                             services,
                         )
+                        .update_nth_half_edge(0, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             bad.face.region().exterior(),
                             0..=0,
@@ -79,18 +92,30 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
+                        .update_nth_half_edge(0, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             abc.face.region().exterior(),
                             0..=0,
                             1..=1,
                             services,
                         )
+                        .update_nth_half_edge(1, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             bad.face.region().exterior(),
                             1..=1,
                             2..=2,
                             services,
                         )
+                        .update_nth_half_edge(2, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             dac.face.region().exterior(),
                             2..=2,

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -35,6 +35,18 @@ pub trait JoinCycle {
     ///
     /// Panics, if the ranges have different lengths.
     ///
+    /// # Assumptions
+    ///
+    /// This method makes some assumptions that need to be met, if the operation
+    /// is to result in a valid shape:
+    ///
+    /// - **The joined half-edges must be coincident.**
+    /// - **The locally defined curve coordinate systems of the edges must
+    ///   match.**
+    ///
+    /// If either of those assumptions are not met, this will result in a
+    /// validation error down the line.
+    ///
     /// # Implementation Note
     ///
     /// The use of the `RangeInclusive` type might be a bit limiting, as other

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -221,6 +221,11 @@ impl ShellValidationError {
         // data-structure like an octree.
         for (edge_a, surface_a) in &edges_and_surfaces {
             for (edge_b, surface_b) in &edges_and_surfaces {
+                // No need to check an edge against itself.
+                if edge_a.id() == edge_b.id() {
+                    continue;
+                }
+
                 let identical_according_to_global_form =
                     edge_a.global_form().id() == edge_b.global_form().id();
 

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -75,7 +75,6 @@ pub enum ShellValidationError {
 ///
 /// Returns an [`Iterator`] of the distance at each sample.
 fn distances(
-    config: &ValidationConfig,
     edge_a: Handle<HalfEdge>,
     surface_a: Handle<Surface>,
     edge_b: Handle<HalfEdge>,
@@ -91,11 +90,6 @@ fn distances(
         surface.point_from_surface_coords(surface_coords)
     }
 
-    // Check whether start positions do not match. If they don't treat second edge as flipped
-    let flip = sample(0.0, (&edge_a, surface_a.geometry()))
-        .distance_to(&sample(0.0, (&edge_b, surface_b.geometry())))
-        > config.identical_max_distance;
-
     // Three samples (start, middle, end), are enough to detect weather lines
     // and circles match. If we were to add more complicated curves, this might
     // need to change.
@@ -106,10 +100,7 @@ fn distances(
     for i in 0..sample_count {
         let percent = i as f64 * step;
         let sample1 = sample(percent, (&edge_a, surface_a.geometry()));
-        let sample2 = sample(
-            if flip { 1.0 - percent } else { percent },
-            (&edge_b, surface_b.geometry()),
-        );
+        let sample2 = sample(1.0 - percent, (&edge_b, surface_b.geometry()));
         distances.push(sample1.distance_to(&sample2))
     }
     distances.into_iter()
@@ -259,7 +250,6 @@ impl ShellValidationError {
                         // identical_max_distance, so we shouldn't have any
                         // greater than the max
                         if distances(
-                            config,
                             edge_a.clone(),
                             surface_a.clone(),
                             edge_b.clone(),
@@ -282,7 +272,6 @@ impl ShellValidationError {
                         // If all points on distinct curves are within
                         // distinct_min_distance, that's a problem.
                         if distances(
-                            config,
                             edge_a.clone(),
                             surface_a.clone(),
                             edge_b.clone(),


### PR DESCRIPTION
Curves (which define the geometry of half-edges) are defined locally, in surface coordinates. For that to be valid, those local definitions need to result in the same curves in 3D space, of course. And they already did, but the coordinate systems of those curves would not always match. That meant, if you converted a point in local curve coordinates, say `0`, into global 3D coordinates, you could get different points, according to which local definition you used.

This wasn't a problem so far, but it has started to become one. https://github.com/hannobraun/fornjot/pull/1968 is an example of that, but https://github.com/hannobraun/fornjot/issues/1937 is blocked by that also.

This pull request fixes all existing coordinate system mismatches, and adds a validation check to make sure those can never happen again, meaning any code dealing with curves can now rely on the coordinate systems to always make sense.

Close https://github.com/hannobraun/fornjot/issues/1973