### PR TITLE
Add `CurveBoundary::is_normalized`, simplify `CurveBoundary::normalize`

### DIFF
--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -45,11 +45,11 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     ///
     /// This can be used to compare a boundary while disregarding its direction.
     #[must_use]
-    pub fn normalize(self) -> (Self, bool) {
+    pub fn normalize(self) -> Self {
         if self.is_normalized() {
-            (self, false)
+            self
         } else {
-            (self.reverse(), true)
+            self.reverse()
         }
     }
 }

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -38,10 +38,10 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     #[must_use]
     pub fn normalize(self) -> (Self, bool) {
         let [a, b] = &self.inner;
-        if a > b {
-            (self.reverse(), true)
-        } else {
+        if a <= b {
             (self, false)
+        } else {
+            (self.reverse(), true)
         }
     }
 }

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -40,10 +40,8 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     /// Normalize the boundary
     ///
     /// Returns a new instance of this struct, which has the bounding elements
-    /// in a defined order, alongside a boolean that indicates whether the new
-    /// instance is different from the original one.
-    ///
-    /// This can be used to compare a boundary while disregarding its direction.
+    /// in a defined order. This can be used to compare boundaries while
+    /// disregarding their direction.
     #[must_use]
     pub fn normalize(self) -> Self {
         if self.is_normalized() {

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -28,6 +28,15 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
         Self { inner: [b, a] }
     }
 
+    /// Indicate whether the boundary is normalized
+    ///
+    /// If the boundary is normalized, its bounding elements are in a defined
+    /// order, and calling `normalize` will return an identical instance.
+    pub fn is_normalized(&self) -> bool {
+        let [a, b] = &self.inner;
+        a <= b
+    }
+
     /// Normalize the boundary
     ///
     /// Returns a new instance of this struct, which has the bounding elements
@@ -37,8 +46,7 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     /// This can be used to compare a boundary while disregarding its direction.
     #[must_use]
     pub fn normalize(self) -> (Self, bool) {
-        let [a, b] = &self.inner;
-        if a <= b {
+        if self.is_normalized() {
             (self, false)
         } else {
             (self.reverse(), true)

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -235,7 +235,6 @@ impl ShellValidationError {
                                 .bounding_vertices_of_edge(edge)
                                 .expect("Expected edge to be part of shell")
                                 .normalize()
-                                .0
                         };
 
                         bounding_vertices_of(edge_a)
@@ -315,8 +314,7 @@ impl ShellValidationError {
                         .expect(
                             "Cycle should provide bounds of its own half-edge",
                         )
-                        .normalize()
-                        .0;
+                        .normalize();
 
                     let edge = (curve, bounding_vertices);
 
@@ -396,8 +394,7 @@ impl ShellValidationError {
                         .expect(
                             "Just got edge from this cycle; must be part of it",
                         )
-                        .normalize()
-                        .0;
+                        .normalize();
 
                     edges_by_coincidence
                         .entry((curve, boundary))


### PR DESCRIPTION
This came out of my work on https://github.com/hannobraun/fornjot/issues/1937. I'm using `CurveBoundary` quite heavily in the code I'm currently writing.