### PR TITLE
Fix `InsertIntoSet` implementation of `HalfEdge`

### DIFF
--- a/crates/fj-core/src/objects/set.rs
+++ b/crates/fj-core/src/objects/set.rs
@@ -96,6 +96,9 @@ impl InsertIntoSet for GlobalEdge {
 
 impl InsertIntoSet for HalfEdge {
     fn insert_into_set(&self, objects: &mut ObjectSet) {
+        objects.inner.insert(self.curve().clone().into());
+        self.curve().insert_into_set(objects);
+
         objects.inner.insert(self.start_vertex().clone().into());
         self.start_vertex().insert_into_set(objects);
 

--- a/crates/fj-core/src/objects/set.rs
+++ b/crates/fj-core/src/objects/set.rs
@@ -1,7 +1,8 @@
 use std::collections::{btree_set, BTreeSet};
 
 use super::{
-    BehindHandle, Cycle, Face, GlobalEdge, HalfEdge, Object, Surface, Vertex,
+    BehindHandle, Curve, Cycle, Face, GlobalEdge, HalfEdge, Object, Surface,
+    Vertex,
 };
 
 /// A graph of objects and their relationships
@@ -55,6 +56,10 @@ impl IntoIterator for ObjectSet {
 
 trait InsertIntoSet {
     fn insert_into_set(&self, objects: &mut ObjectSet);
+}
+
+impl InsertIntoSet for Curve {
+    fn insert_into_set(&self, _: &mut ObjectSet) {}
 }
 
 impl InsertIntoSet for Cycle {


### PR DESCRIPTION
This piece of code wasn't updated when I added a reference from `HalfEdge` to `Curve`. I noticed this as I was working on https://github.com/hannobraun/fornjot/issues/1937.