### PR TITLE
Further prepare for more sophisticated curve approximation

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -52,11 +52,10 @@ impl CurveApproxCache {
         mut new_segment: CurveApproxSegment,
     ) -> CurveApproxSegment {
         let curve = HandleWrapper::from(curve);
-        let cache_key = curve;
 
         new_segment.normalize();
 
-        let existing_approx = self.inner.remove(&cache_key);
+        let existing_approx = self.inner.remove(&curve);
         let (approx, segment) = match existing_approx {
             Some(mut existing_approx) => {
                 // An approximation for this curve already exists. We need to
@@ -99,7 +98,7 @@ impl CurveApproxCache {
             }
         };
 
-        self.inner.insert(cache_key, approx);
+        self.inner.insert(curve, approx);
 
         segment
     }

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -50,6 +50,8 @@ impl CurveApproxCache {
         curve: Handle<Curve>,
         mut new_segment: CurveApproxSegment,
     ) -> CurveApproxSegment {
+        let curve = HandleWrapper::from(curve);
+
         new_segment.normalize();
 
         // We assume that curve approximation segments never overlap, so so we
@@ -63,7 +65,7 @@ impl CurveApproxCache {
         };
 
         self.inner
-            .insert((curve.into(), new_segment.boundary), approx)
+            .insert((curve, new_segment.boundary), approx)
             .map(|approx| {
                 let mut segments = approx.segments.into_iter();
                 let segment = segments

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -61,12 +61,13 @@ impl CurveApproxCache {
                 // An approximation for this curve already exists. We need to
                 // merge the new segment into it.
 
-                // We assume that approximated curve segments never overlap. As
-                // a consequence of this, and the current structure of the
-                // cache, we can assume that the existing approximation
-                // contains exactly one segment that is congruent with the one
-                // we are meant to insert. This means we can just extract that
-                // segment and return it to the caller.
+                // We assume that approximated curve segments never overlap,
+                // unless they are completely congruent. As a consequence of
+                // this, and the current structure of the cache, we can assume
+                // that the existing approximation contains exactly one segment
+                // that is congruent with the one we are meant to insert. This
+                // means we can just extract that segment and return it to the
+                // caller.
                 //
                 // For now, this is a valid assumption, as it matches the uses
                 // of this method, due to documented limitations elsewhere in

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -86,11 +86,11 @@ impl CurveApproxCache {
             None => {
                 // No approximation for this curve exists. We need to create a
                 // new one.
-                let approx = CurveApprox {
+                let new_approx = CurveApprox {
                     segments: vec![new_segment.clone()],
                 };
 
-                (approx, new_segment)
+                (new_approx, new_segment)
             }
         };
 

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -51,6 +51,7 @@ impl CurveApproxCache {
         mut new_segment: CurveApproxSegment,
     ) -> CurveApproxSegment {
         let curve = HandleWrapper::from(curve);
+        let cache_key = (curve, new_segment.boundary);
 
         new_segment.normalize();
 
@@ -65,7 +66,7 @@ impl CurveApproxCache {
         };
 
         self.inner
-            .insert((curve, new_segment.boundary), approx)
+            .insert(cache_key, approx)
             .map(|approx| {
                 let mut segments = approx.segments.into_iter();
                 let segment = segments

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -57,7 +57,7 @@ impl CurveApproxCache {
 
         let existing_approx = self.inner.remove(&cache_key);
         let (approx, segment) = match existing_approx {
-            Some(approx) => {
+            Some(existing_approx) => {
                 // An approximation for this curve already exists. We need to
                 // merge the new segment into it.
 
@@ -72,7 +72,7 @@ impl CurveApproxCache {
                 // of this method, due to documented limitations elsewhere in
                 // the system.
 
-                let mut segments = approx.segments.iter().cloned();
+                let mut segments = existing_approx.segments.iter().cloned();
                 let existing_segment = segments
                     .next()
                     .expect("Empty approximations should not exist in cache");
@@ -81,7 +81,7 @@ impl CurveApproxCache {
                     "Cached approximations should have exactly 1 segment"
                 );
 
-                (approx, existing_segment)
+                (existing_approx, existing_segment)
             }
             None => {
                 // No approximation for this curve exists. We need to create a

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -54,8 +54,8 @@ impl CurveApproxCache {
 
         new_segment.normalize();
 
-        // We assume that curve approximation segments never overlap, so we
-        // don't have to do any merging of this segment with a possibly existing
+        // We assume that approximated curve segments never overlap, so we don't
+        // have to do any merging of this segment with a possibly existing
         // approximation for this curve.
         //
         // For now, this is a valid assumption, as it matches the uses of this

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -54,7 +54,7 @@ impl CurveApproxCache {
 
         new_segment.normalize();
 
-        // We assume that curve approximation segments never overlap, so so we
+        // We assume that curve approximation segments never overlap, so we
         // don't have to do any merging of this segment with a possibly existing
         // approximation for this curve.
         //

--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -33,15 +33,14 @@ impl CurveApproxCache {
         let was_already_normalized = boundary.is_normalized();
         let normalized_boundary = boundary.normalize();
 
-        self.inner.get(&(curve, normalized_boundary)).cloned().map(
-            |mut approx| {
-                if !was_already_normalized {
-                    approx.reverse();
-                }
+        let mut approx =
+            self.inner.get(&(curve, normalized_boundary)).cloned()?;
 
-                approx
-            },
-        )
+        if !was_already_normalized {
+            approx.reverse();
+        }
+
+        Some(approx)
     }
 
     /// Insert an approximated segment of the curve into the cache


### PR DESCRIPTION
Add a test suite for `CurveApproxCache`, fix a bug, and move the cache more towards what it needs to be, to support more flexible caching. This is more progress towards https://github.com/hannobraun/fornjot/issues/1937, specifically the work described in https://github.com/hannobraun/fornjot/issues/1937#issuecomment-1708058960.