### PR TITLE
Lift limitation, that coincident `Edge`s must be congruent

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve/cache.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/cache.rs
@@ -22,10 +22,10 @@ impl CurveApproxCache {
         &self,
         curve: &Handle<Curve>,
         boundary: &CurveBoundary<Point<1>>,
-    ) -> Option<CurveApprox> {
+    ) -> CurveApprox {
         let curve = HandleWrapper::from(curve.clone());
 
-        let mut approx = self.inner.get(&curve).cloned()?;
+        let mut approx = self.inner.get(&curve).cloned().unwrap_or_default();
         approx.make_subset(boundary);
 
         // Approximations within the cache are stored in normalized form. If the
@@ -35,7 +35,7 @@ impl CurveApproxCache {
             approx.reverse();
         }
 
-        Some(approx)
+        approx
     }
 
     /// Insert an approximated segment of the curve into the cache
@@ -143,9 +143,9 @@ pub mod tests {
         let cached = cache.get(&curve, &boundary);
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![existing_segment]
-            })
+            }
         );
     }
 
@@ -180,7 +180,7 @@ pub mod tests {
         let cached = cache.get(&curve, &CurveBoundary::from([[0.], [1.]]));
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![
                     CurveApproxSegment {
                         boundary: CurveBoundary::from([[0.], [0.25]]),
@@ -197,7 +197,7 @@ pub mod tests {
                         )],
                     }
                 ]
-            })
+            }
         );
     }
 
@@ -250,7 +250,7 @@ pub mod tests {
         let cached = cache.get(&curve, &boundary);
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![CurveApproxSegment {
                     boundary,
                     points: vec![
@@ -262,7 +262,7 @@ pub mod tests {
                         ApproxPoint::new([1.375], [1.375, 1.375, 1.375]),
                     ],
                 }]
-            })
+            }
         );
     }
 
@@ -301,9 +301,9 @@ pub mod tests {
         let cached = cache.get(&curve, &boundary);
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![segment]
-            })
+            }
         );
     }
 
@@ -343,13 +343,13 @@ pub mod tests {
         let cached = cache.get(&curve, &boundary.reverse());
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![{
                     let mut segment = segment;
                     segment.reverse();
                     segment
                 }]
-            })
+            }
         );
     }
 
@@ -377,7 +377,7 @@ pub mod tests {
         let cached = cache.get(&curve, &CurveBoundary::from([[-0.5], [0.5]]));
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![CurveApproxSegment {
                     boundary: CurveBoundary::from([[0.], [0.5]]),
                     points: vec![
@@ -385,7 +385,7 @@ pub mod tests {
                         ApproxPoint::new([0.375], [0.375, 0.375, 0.375]),
                     ],
                 }]
-            })
+            }
         );
     }
 
@@ -413,7 +413,7 @@ pub mod tests {
         let cached = cache.get(&curve, &CurveBoundary::from([[0.5], [1.5]]));
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![CurveApproxSegment {
                     boundary: CurveBoundary::from([[0.5], [1.0]]),
                     points: vec![
@@ -421,7 +421,7 @@ pub mod tests {
                         ApproxPoint::new([0.875], [0.875, 0.875, 0.875]),
                     ],
                 }]
-            })
+            }
         );
     }
 
@@ -449,7 +449,7 @@ pub mod tests {
         let cached = cache.get(&curve, &CurveBoundary::from([[0.25], [0.75]]));
         assert_eq!(
             cached,
-            Some(CurveApprox {
+            CurveApprox {
                 segments: vec![CurveApproxSegment {
                     boundary: CurveBoundary::from([[0.25], [0.75]]),
                     points: vec![
@@ -457,7 +457,7 @@ pub mod tests {
                         ApproxPoint::new([0.625], [0.625, 0.625, 0.625]),
                     ],
                 }]
-            })
+            }
         );
     }
 }

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -84,9 +84,9 @@ impl Approx for (&Edge, &Surface) {
             // even if those boundaries aren't identical. The cache needs to be
             // able to deliver partial results for a given boundary, then
             // generating (and caching) the rest of it on the fly.
-            let cached_approx =
+            let cached_segment =
                 cache.get_curve_approx(edge.curve().clone(), edge.boundary());
-            let approx = match cached_approx {
+            let approx = match cached_segment {
                 Some(approx) => approx,
                 None => {
                     let approx = approx_curve(

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -49,41 +49,6 @@ impl Approx for (&Edge, &Surface) {
         let first = ApproxPoint::new(start_position_surface, start_position);
 
         let rest = {
-            // We cache approximated `Edge`s using the `Curve`s they reference
-            // and their boundary on that curve as the key. That bakes in the
-            // undesirable assumption that all coincident `Edge`s are also
-            // congruent. Let me explain.
-            //
-            // When two `Edge`s are coincident, we need to make sure their
-            // approximations are identical where they overlap. Otherwise, we'll
-            // get an invalid triangle mesh in the end. Hence, we cache
-            // approximations.
-            //
-            // Caching works like this: We check whether there already is a
-            // cache entry for the curve/boundary. If there isn't, we create the
-            // 3D approximation from the 2D `Edge`. Next time we check for a
-            // coincident `Edge`, we'll find the cache and use that, getting
-            // the exact same 3D approximation, instead of generating a slightly
-            // different one from the different 2D `Edge`.
-            //
-            // So what if we had two coincident `Edge`s that aren't congruent?
-            // Meaning, they overlap partially, but not fully. Then obviously,
-            // they wouldn't refer to the same combination of curve and
-            // boundary. And since those are the key in our cache, those `Edge`s
-            // would not share an approximation where they overlap, leading to
-            // exactly the problems that the cache is supposed to prevent.
-            //
-            // As of this writing, it is a documented (but not validated)
-            // limitation, that coincident `Edge`s must always be congruent.
-            // However, we're going to need to lift this limitation going
-            // forward, as it is, well, too limiting. This means things here
-            // will need to change.
-            //
-            // What we need here, is more intelligent caching, that can reuse
-            // already cached curve approximations where the boundaries overlap,
-            // even if those boundaries aren't identical. The cache needs to be
-            // able to deliver partial results for a given boundary, then
-            // generating (and caching) the rest of it on the fly.
             let segment = {
                 let mut cached = cache
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
@@ -95,18 +60,26 @@ impl Approx for (&Edge, &Surface) {
                         // can use the cached approximation as-is.
                         segment
                     }
-                    Some(_) => panic!(
-                        "Cached approximations should have 1 segment max"
-                    ),
-                    None => cache.insert_curve_approx(
-                        edge.curve().clone(),
-                        approx_curve(
-                            &edge.path(),
-                            surface,
-                            edge.boundary(),
-                            tolerance,
-                        ),
-                    ),
+                    _ => {
+                        // If we make it here, there are holes in the
+                        // approximation, in some way or another. We could be
+                        // really surgical and fill in exactly those holes, and
+                        // in the future we might want to, for performance
+                        // reasons.
+                        //
+                        // For now, let's just approximate *all* we need and
+                        // insert that into the cache. The cache takes care of
+                        // merging that with whatever is already there.
+                        cache.insert_curve_approx(
+                            edge.curve().clone(),
+                            approx_curve(
+                                &edge.path(),
+                                surface,
+                                edge.boundary(),
+                                tolerance,
+                            ),
+                        )
+                    }
                 }
             };
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -89,14 +89,10 @@ impl Approx for (&Edge, &Surface) {
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
                 match cached.segments.pop() {
-                    Some(segment) => {
-                        assert!(
-                            cached.segments.is_empty(),
-                            "Cached approximations should have 1 segment max"
-                        );
-
-                        segment
-                    }
+                    Some(segment) if cached.segments.is_empty() => segment,
+                    Some(_) => panic!(
+                        "Cached approximations should have 1 segment max"
+                    ),
                     None => cache.insert_curve_approx(
                         edge.curve().clone(),
                         approx_curve(

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -85,10 +85,10 @@ impl Approx for (&Edge, &Surface) {
             // able to deliver partial results for a given boundary, then
             // generating (and caching) the rest of it on the fly.
             let cached_segment = 'segment: {
-                let approx = cache
+                let cached = cache
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
-                let mut segments = approx.segments.into_iter();
+                let mut segments = cached.segments.into_iter();
 
                 let Some(segment) = segments.next() else {
                     break 'segment None;

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -245,17 +245,17 @@ impl EdgeApproxCache {
         handle: Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,
     ) -> Option<CurveApproxSegment> {
-        self.curve_approx.get(&handle, &boundary).map(|approx| {
-            let mut segments = approx.segments.into_iter();
-            let segment = segments
-                .next()
-                .expect("Empty approximations should not exist in cache");
-            assert!(
-                segments.next().is_none(),
-                "Cached approximations should have exactly 1 segment"
-            );
-            segment
-        })
+        let approx = self.curve_approx.get(&handle, &boundary);
+
+        let mut segments = approx.segments.into_iter();
+
+        let segment = segments.next()?;
+        assert!(
+            segments.next().is_none(),
+            "Cached approximations should have exactly 1 segment"
+        );
+
+        Some(segment)
     }
 
     fn insert_curve_approx(

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -85,15 +85,13 @@ impl Approx for (&Edge, &Surface) {
             // able to deliver partial results for a given boundary, then
             // generating (and caching) the rest of it on the fly.
             let segment = {
-                let cached = cache
+                let mut cached = cache
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
-                let mut segments = cached.segments.into_iter();
-
-                match segments.next() {
+                match cached.segments.pop() {
                     Some(segment) => {
                         assert!(
-                            segments.next().is_none(),
+                            cached.segments.is_empty(),
                             "Cached approximations should have 1 segment max"
                         );
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -84,21 +84,19 @@ impl Approx for (&Edge, &Surface) {
             // even if those boundaries aren't identical. The cache needs to be
             // able to deliver partial results for a given boundary, then
             // generating (and caching) the rest of it on the fly.
-            let cached_segment = 'segment: {
+            let cached_segment = {
                 let cached = cache
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
                 let mut segments = cached.segments.into_iter();
 
-                let Some(segment) = segments.next() else {
-                    break 'segment None;
-                };
+                let segment = segments.next();
                 assert!(
                     segments.next().is_none(),
                     "Cached approximations should have at most 1 segment"
                 );
 
-                Some(segment)
+                segment
             };
             let segment = match cached_segment {
                 Some(segment) => segment,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -252,7 +252,7 @@ impl EdgeApproxCache {
         let segment = segments.next()?;
         assert!(
             segments.next().is_none(),
-            "Cached approximations should have exactly 1 segment"
+            "Cached approximations should have at most 1 segment"
         );
 
         Some(segment)

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -100,7 +100,7 @@ impl Approx for (&Edge, &Surface) {
 
                 Some(segment)
             };
-            let approx = match cached_segment {
+            let segment = match cached_segment {
                 Some(segment) => segment,
                 None => cache.insert_curve_approx(
                     edge.curve().clone(),
@@ -113,7 +113,7 @@ impl Approx for (&Edge, &Surface) {
                 ),
             };
 
-            approx
+            segment
                 .points
                 .into_iter()
                 .map(|point| {

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -93,7 +93,7 @@ impl Approx for (&Edge, &Surface) {
                 let segment = segments.next();
                 assert!(
                     segments.next().is_none(),
-                    "Cached approximations should have at most 1 segment"
+                    "Cached approximations should have 1 segment max"
                 );
 
                 segment

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -87,7 +87,7 @@ impl Approx for (&Edge, &Surface) {
             let cached_segment =
                 cache.get_curve_approx(edge.curve().clone(), edge.boundary());
             let approx = match cached_segment {
-                Some(approx) => approx,
+                Some(segment) => segment,
                 None => {
                     let approx = approx_curve(
                         &edge.path(),

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -102,15 +102,15 @@ impl Approx for (&Edge, &Surface) {
             };
             let approx = match cached_segment {
                 Some(segment) => segment,
-                None => {
-                    let approx = approx_curve(
+                None => cache.insert_curve_approx(
+                    edge.curve().clone(),
+                    approx_curve(
                         &edge.path(),
                         surface,
                         edge.boundary(),
                         tolerance,
-                    );
-                    cache.insert_curve_approx(edge.curve().clone(), approx)
-                }
+                    ),
+                ),
             };
 
             approx

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -66,7 +66,7 @@ impl Approx for (&Edge, &Surface) {
             // the exact same 3D approximation, instead of generating a slightly
             // different one from the different 2D `Edge`.
             //
-            // So what if we had two coincident `fEdge`s that aren't congruent?
+            // So what if we had two coincident `Edge`s that aren't congruent?
             // Meaning, they overlap partially, but not fully. Then obviously,
             // they wouldn't refer to the same combination of curve and
             // boundary. And since those are the key in our cache, those `Edge`s

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -89,7 +89,12 @@ impl Approx for (&Edge, &Surface) {
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
                 match cached.segments.pop() {
-                    Some(segment) if cached.segments.is_empty() => segment,
+                    Some(segment) if cached.segments.is_empty() => {
+                        // If the cached approximation has a single segment,
+                        // that means everything we need is available, and we
+                        // can use the cached approximation as-is.
+                        segment
+                    }
                     Some(_) => panic!(
                         "Cached approximations should have 1 segment max"
                     ),

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -84,7 +84,7 @@ impl Approx for (&Edge, &Surface) {
             // even if those boundaries aren't identical. The cache needs to be
             // able to deliver partial results for a given boundary, then
             // generating (and caching) the rest of it on the fly.
-            let cached_segment = {
+            let segment = {
                 let cached = cache
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
@@ -97,22 +97,18 @@ impl Approx for (&Edge, &Surface) {
                             "Cached approximations should have 1 segment max"
                         );
 
-                        Some(segment)
+                        segment
                     }
-                    None => None,
-                }
-            };
-            let segment = match cached_segment {
-                Some(segment) => segment,
-                None => cache.insert_curve_approx(
-                    edge.curve().clone(),
-                    approx_curve(
-                        &edge.path(),
-                        surface,
-                        edge.boundary(),
-                        tolerance,
+                    None => cache.insert_curve_approx(
+                        edge.curve().clone(),
+                        approx_curve(
+                            &edge.path(),
+                            surface,
+                            edge.boundary(),
+                            tolerance,
+                        ),
                     ),
-                ),
+                }
             };
 
             segment

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -90,13 +90,17 @@ impl Approx for (&Edge, &Surface) {
 
                 let mut segments = cached.segments.into_iter();
 
-                let segment = segments.next();
-                assert!(
-                    segments.next().is_none(),
-                    "Cached approximations should have 1 segment max"
-                );
+                match segments.next() {
+                    Some(segment) => {
+                        assert!(
+                            segments.next().is_none(),
+                            "Cached approximations should have 1 segment max"
+                        );
 
-                segment
+                        Some(segment)
+                    }
+                    None => None,
+                }
             };
             let segment = match cached_segment {
                 Some(segment) => segment,

--- a/crates/fj-core/src/objects/kinds/edge.rs
+++ b/crates/fj-core/src/objects/kinds/edge.rs
@@ -10,25 +10,8 @@ use crate::{
 ///
 /// When multiple faces, which are bound by edges, are combined to form a solid,
 /// the `Edge`s that bound the face on the surface are then coincident with the
-/// `Edge`s of other faces, where those faces touch. Those coincident `Edge`s
-/// are different representations of the same edge, and this fact must be
-/// represented in the following way:
-///
-/// - The coincident `Edge`s must refer to the same `Curve`.
-/// - The coincident `Edge`s must have the same boundary.
-///
-/// There is another, implicit requirement hidden here:
-///
-/// `Edge`s that are coincident, i.e. located in the same space, must always be
-/// congruent. This means they must coincide *exactly*. The overlap must be
-/// complete. None of the coincident `Edge`s must overlap with just a section of
-/// another.
-///
-/// # Implementation Note
-///
-/// The limitation that coincident `Edge`s must be congruent is currently
-/// being lifted:
-/// <https://github.com/hannobraun/fornjot/issues/1937>
+/// `Edge`s of other faces, where those faces touch. Suche coincident `Edge`s
+///  must always refer to the same `Curve`.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Edge {
     path: SurfacePath,


### PR DESCRIPTION
This pull request is the culmination of lots of work over many weeks. I've refactored the object graph and wrote new (non-trivial) infrastructure for caching curve approximations. This pull request takes the final step in that journey, using that new infrastructure to make edge approximation more flexible.

As a result, it should now be possible to have coincident edges that are not fully congruent. This should enable more useful modeling tools to be built. The one I have in mind, which motivated this work in the first place, is an API for splitting a face (which would have otherwise been more complicated to implement, and less convenient for the user). But this makes the representation of geometry more flexible overall, and is sure to be useful yet unforeseen ways.

Please note that this new flexibility is not exercised, as the tools it enables don't exist yet. There might still be bugs, and those can be addressed as they come up, but the big architectural hurdles are out of the way now.

Close https://github.com/hannobraun/fornjot/issues/1937