### PR TITLE
Clean up `UpdateCycle`

### DIFF
--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -96,26 +96,26 @@ pub trait BuildShell {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })
+                        .update_nth_edge(1, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
+                        .update_nth_edge(2, |edge| {
+                            edge.reverse_curve_coordinate_systems(services)
+                                .insert(services)
+                        })
                         .join_to(
                             abc.face.region().exterior(),
                             0..=0,
                             1..=1,
                             services,
                         )
-                        .update_nth_edge(1, |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
                         .join_to(
                             bad.face.region().exterior(),
                             1..=1,
                             2..=2,
                             services,
                         )
-                        .update_nth_edge(2, |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
                         .join_to(
                             dac.face.region().exterior(),
                             2..=2,

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -46,7 +46,7 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_nth_edge(0, |edge| {
+                        .update_edge(cycle.edges().nth_circular(0), |edge| {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })
@@ -64,7 +64,7 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_nth_edge(1, |edge| {
+                        .update_edge(cycle.edges().nth_circular(1), |edge| {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })
@@ -74,7 +74,7 @@ pub trait BuildShell {
                             2..=2,
                             services,
                         )
-                        .update_nth_edge(0, |edge| {
+                        .update_edge(cycle.edges().nth_circular(0), |edge| {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })
@@ -92,15 +92,15 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_nth_edge(0, |edge| {
+                        .update_edge(cycle.edges().nth_circular(0), |edge| {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })
-                        .update_nth_edge(1, |edge| {
+                        .update_edge(cycle.edges().nth_circular(1), |edge| {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })
-                        .update_nth_edge(2, |edge| {
+                        .update_edge(cycle.edges().nth_circular(2), |edge| {
                             edge.reverse_curve_coordinate_systems(services)
                                 .insert(services)
                         })

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -104,11 +104,9 @@ impl JoinCycle for Cycle {
             "Ranges have different lengths",
         );
 
-        let cycle = self.clone();
-
-        range
-            .zip(range_other)
-            .fold(cycle, |cycle, (index, index_other)| {
+        range.zip(range_other).fold(
+            self.clone(),
+            |cycle, (index, index_other)| {
                 let edge_other = other.edges().nth_circular(index_other);
 
                 cycle
@@ -129,6 +127,7 @@ impl JoinCycle for Cycle {
                         )
                         .insert(services)
                     })
-            })
+            },
+        )
     }
 }

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -118,17 +118,20 @@ impl JoinCycle for Cycle {
                 .clone();
             let vertex_b = edge_other.start_vertex().clone();
 
-            let next_edge = self.edges().nth_circular(index + 1);
-
             cycle = cycle
                 .update_edge(edge, |edge| {
                     edge.replace_curve(edge_other.curve().clone())
                         .replace_start_vertex(vertex_a)
                         .insert(services)
                 })
-                .update_edge(next_edge, |next_edge| {
-                    next_edge.replace_start_vertex(vertex_b).insert(services)
-                })
+                .update_edge(
+                    self.edges().nth_circular(index + 1),
+                    |next_edge| {
+                        next_edge
+                            .replace_start_vertex(vertex_b)
+                            .insert(services)
+                    },
+                )
         }
 
         cycle

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -124,14 +124,9 @@ impl JoinCycle for Cycle {
                         .replace_start_vertex(vertex_a)
                         .insert(services)
                 })
-                .update_edge(
-                    self.edges().nth_circular(index + 1),
-                    |next_edge| {
-                        next_edge
-                            .replace_start_vertex(vertex_b)
-                            .insert(services)
-                    },
-                )
+                .update_edge(self.edges().nth_circular(index + 1), |edge| {
+                    edge.replace_start_vertex(vertex_b).insert(services)
+                })
         }
 
         cycle

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -118,10 +118,7 @@ impl JoinCycle for Cycle {
                 .clone();
             let vertex_b = edge_other.start_vertex().clone();
 
-            let next_edge = self
-                .edges()
-                .after(edge)
-                .expect("Cycle must contain edge; just obtained edge from it");
+            let next_edge = self.edges().nth_circular(index + 1);
 
             cycle = cycle
                 .update_edge(edge, |edge| {

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -109,16 +109,16 @@ impl JoinCycle for Cycle {
         for (index, index_other) in range.zip(range_other) {
             let edge_other = other.edges().nth_circular(index_other);
 
-            let vertex_a = other
-                .edges()
-                .nth_circular(index_other + 1)
-                .start_vertex()
-                .clone();
-
             cycle = cycle
                 .update_edge(self.edges().nth_circular(index), |edge| {
                     edge.replace_curve(edge_other.curve().clone())
-                        .replace_start_vertex(vertex_a)
+                        .replace_start_vertex(
+                            other
+                                .edges()
+                                .nth_circular(index_other + 1)
+                                .start_vertex()
+                                .clone(),
+                        )
                         .insert(services)
                 })
                 .update_edge(self.edges().nth_circular(index + 1), |edge| {

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -123,15 +123,15 @@ impl JoinCycle for Cycle {
                 .after(edge)
                 .expect("Cycle must contain edge; just obtained edge from it");
 
-            let this_joined = edge
-                .replace_curve(edge_other.curve().clone())
-                .replace_start_vertex(vertex_a)
-                .insert(services);
             let next_joined =
                 next_edge.replace_start_vertex(vertex_b).insert(services);
 
             cycle = cycle
-                .update_edge(edge, |_| this_joined)
+                .update_edge(edge, |_| {
+                    edge.replace_curve(edge_other.curve().clone())
+                        .replace_start_vertex(vertex_a)
+                        .insert(services)
+                })
                 .update_edge(next_edge, |_| next_joined)
         }
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -115,7 +115,6 @@ impl JoinCycle for Cycle {
                 .expect("Cycle must contain edge; just obtained edge from it")
                 .start_vertex()
                 .clone();
-            let vertex_b = edge_other.start_vertex().clone();
 
             cycle = cycle
                 .update_edge(self.edges().nth_circular(index), |edge| {
@@ -124,7 +123,8 @@ impl JoinCycle for Cycle {
                         .insert(services)
                 })
                 .update_edge(self.edges().nth_circular(index + 1), |edge| {
-                    edge.replace_start_vertex(vertex_b).insert(services)
+                    edge.replace_start_vertex(edge_other.start_vertex().clone())
+                        .insert(services)
                 })
         }
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -104,29 +104,31 @@ impl JoinCycle for Cycle {
             "Ranges have different lengths",
         );
 
-        let mut cycle = self.clone();
+        let cycle = self.clone();
 
-        for (index, index_other) in range.zip(range_other) {
-            let edge_other = other.edges().nth_circular(index_other);
+        range
+            .zip(range_other)
+            .fold(cycle, |cycle, (index, index_other)| {
+                let edge_other = other.edges().nth_circular(index_other);
 
-            cycle = cycle
-                .update_edge(self.edges().nth_circular(index), |edge| {
-                    edge.replace_curve(edge_other.curve().clone())
-                        .replace_start_vertex(
-                            other
-                                .edges()
-                                .nth_circular(index_other + 1)
-                                .start_vertex()
-                                .clone(),
+                cycle
+                    .update_edge(self.edges().nth_circular(index), |edge| {
+                        edge.replace_curve(edge_other.curve().clone())
+                            .replace_start_vertex(
+                                other
+                                    .edges()
+                                    .nth_circular(index_other + 1)
+                                    .start_vertex()
+                                    .clone(),
+                            )
+                            .insert(services)
+                    })
+                    .update_edge(self.edges().nth_circular(index + 1), |edge| {
+                        edge.replace_start_vertex(
+                            edge_other.start_vertex().clone(),
                         )
                         .insert(services)
-                })
-                .update_edge(self.edges().nth_circular(index + 1), |edge| {
-                    edge.replace_start_vertex(edge_other.start_vertex().clone())
-                        .insert(services)
-                })
-        }
-
-        cycle
+                    })
+            })
     }
 }

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -111,8 +111,7 @@ impl JoinCycle for Cycle {
 
             let vertex_a = other
                 .edges()
-                .after(edge_other)
-                .expect("Cycle must contain edge; just obtained edge from it")
+                .nth_circular(index_other + 1)
                 .start_vertex()
                 .clone();
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -124,12 +124,12 @@ impl JoinCycle for Cycle {
                 .expect("Cycle must contain edge; just obtained edge from it");
 
             cycle = cycle
-                .update_edge(edge, |_| {
+                .update_edge(edge, |edge| {
                     edge.replace_curve(edge_other.curve().clone())
                         .replace_start_vertex(vertex_a)
                         .insert(services)
                 })
-                .update_edge(next_edge, |_| {
+                .update_edge(next_edge, |next_edge| {
                     next_edge.replace_start_vertex(vertex_b).insert(services)
                 })
         }

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -131,8 +131,8 @@ impl JoinCycle for Cycle {
                 next_edge.replace_start_vertex(vertex_b).insert(services);
 
             cycle = cycle
-                .replace_edge(edge, this_joined)
-                .replace_edge(next_edge, next_joined)
+                .update_edge(edge, this_joined)
+                .update_edge(next_edge, next_joined)
         }
 
         cycle

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -131,8 +131,8 @@ impl JoinCycle for Cycle {
                 next_edge.replace_start_vertex(vertex_b).insert(services);
 
             cycle = cycle
-                .update_edge(edge, this_joined)
-                .update_edge(next_edge, next_joined)
+                .update_edge(edge, |_| this_joined)
+                .update_edge(next_edge, |_| next_joined)
         }
 
         cycle

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -123,16 +123,15 @@ impl JoinCycle for Cycle {
                 .after(edge)
                 .expect("Cycle must contain edge; just obtained edge from it");
 
-            let next_joined =
-                next_edge.replace_start_vertex(vertex_b).insert(services);
-
             cycle = cycle
                 .update_edge(edge, |_| {
                     edge.replace_curve(edge_other.curve().clone())
                         .replace_start_vertex(vertex_a)
                         .insert(services)
                 })
-                .update_edge(next_edge, |_| next_joined)
+                .update_edge(next_edge, |_| {
+                    next_edge.replace_start_vertex(vertex_b).insert(services)
+                })
         }
 
         cycle

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -107,7 +107,6 @@ impl JoinCycle for Cycle {
         let mut cycle = self.clone();
 
         for (index, index_other) in range.zip(range_other) {
-            let edge = self.edges().nth_circular(index);
             let edge_other = other.edges().nth_circular(index_other);
 
             let vertex_a = other
@@ -119,7 +118,7 @@ impl JoinCycle for Cycle {
             let vertex_b = edge_other.start_vertex().clone();
 
             cycle = cycle
-                .update_edge(edge, |edge| {
+                .update_edge(self.edges().nth_circular(index), |edge| {
                     edge.replace_curve(edge_other.curve().clone())
                         .replace_start_vertex(vertex_a)
                         .insert(services)

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -17,7 +17,7 @@ pub trait UpdateCycle {
     #[must_use]
     fn update_edge(
         &self,
-        original: &Handle<Edge>,
+        edge: &Handle<Edge>,
         replacement: Handle<Edge>,
     ) -> Self;
 
@@ -42,13 +42,13 @@ impl UpdateCycle for Cycle {
 
     fn update_edge(
         &self,
-        original: &Handle<Edge>,
+        edge: &Handle<Edge>,
         replacement: Handle<Edge>,
     ) -> Self {
         let mut num_replacements = 0;
 
         let edges = self.edges().iter().map(|e| {
-            if e.id() == original.id() {
+            if e.id() == edge.id() {
                 num_replacements += 1;
                 replacement.clone()
             } else {

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -15,7 +15,7 @@ pub trait UpdateCycle {
     ///
     /// Panics, unless this operation replaces exactly one edge.
     #[must_use]
-    fn replace_edge(
+    fn update_edge(
         &self,
         original: &Handle<Edge>,
         replacement: Handle<Edge>,
@@ -40,7 +40,7 @@ impl UpdateCycle for Cycle {
         Cycle::new(edges)
     }
 
-    fn replace_edge(
+    fn update_edge(
         &self,
         original: &Handle<Edge>,
         replacement: Handle<Edge>,

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -47,12 +47,12 @@ impl UpdateCycle for Cycle {
     ) -> Self {
         let mut num_replacements = 0;
 
-        let edges = self.edges().iter().map(|edge| {
-            if edge.id() == original.id() {
+        let edges = self.edges().iter().map(|e| {
+            if e.id() == original.id() {
                 num_replacements += 1;
                 replacement.clone()
             } else {
-                edge.clone()
+                e.clone()
             }
         });
 

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -45,27 +45,19 @@ impl UpdateCycle for Cycle {
         edge: &Handle<Edge>,
         update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self {
-        let updated = update(edge);
-
-        let mut num_replacements = 0;
+        let mut updated = Some(update(edge));
 
         let edges = self.edges().iter().map(|e| {
             if e.id() == edge.id() {
-                num_replacements += 1;
-                updated.clone()
+                updated
+                    .take()
+                    .expect("Cycle should not contain same edge twice")
             } else {
                 e.clone()
             }
         });
 
-        let cycle = Cycle::new(edges);
-
-        assert_eq!(
-            num_replacements, 1,
-            "Expected operation to replace exactly one edge"
-        );
-
-        cycle
+        Cycle::new(edges)
     }
 
     fn update_nth_edge(

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -9,11 +9,7 @@ pub trait UpdateCycle {
     #[must_use]
     fn add_edges(&self, edges: impl IntoIterator<Item = Handle<Edge>>) -> Self;
 
-    /// Replace the provided edge
-    ///
-    /// # Panics
-    ///
-    /// Panics, unless this operation replaces exactly one edge.
+    /// Update the provided edge
     #[must_use]
     fn update_edge(
         &self,

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -20,18 +20,6 @@ pub trait UpdateCycle {
         edge: &Handle<Edge>,
         update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self;
-
-    /// Update the edge at the given index
-    ///
-    /// # Panics
-    ///
-    /// Panics, unless this operation updates exactly one edge.
-    #[must_use]
-    fn update_nth_edge(
-        &self,
-        index: usize,
-        f: impl FnMut(&Handle<Edge>) -> Handle<Edge>,
-    ) -> Self;
 }
 
 impl UpdateCycle for Cycle {
@@ -58,31 +46,5 @@ impl UpdateCycle for Cycle {
         });
 
         Cycle::new(edges)
-    }
-
-    fn update_nth_edge(
-        &self,
-        index: usize,
-        mut f: impl FnMut(&Handle<Edge>) -> Handle<Edge>,
-    ) -> Self {
-        let mut num_replacements = 0;
-
-        let edges = self.edges().iter().enumerate().map(|(i, edge)| {
-            if i == index {
-                num_replacements += 1;
-                f(edge)
-            } else {
-                edge.clone()
-            }
-        });
-
-        let cycle = Cycle::new(edges);
-
-        assert_eq!(
-            num_replacements, 1,
-            "Expected operation to replace exactly one edge"
-        );
-
-        cycle
     }
 }

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -18,7 +18,7 @@ pub trait UpdateCycle {
     fn update_edge(
         &self,
         edge: &Handle<Edge>,
-        replacement: Handle<Edge>,
+        update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self;
 
     /// Update the edge at the given index
@@ -43,14 +43,16 @@ impl UpdateCycle for Cycle {
     fn update_edge(
         &self,
         edge: &Handle<Edge>,
-        replacement: Handle<Edge>,
+        update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self {
+        let updated = update(edge);
+
         let mut num_replacements = 0;
 
         let edges = self.edges().iter().map(|e| {
             if e.id() == edge.id() {
                 num_replacements += 1;
-                replacement.clone()
+                updated.clone()
             } else {
                 e.clone()
             }

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -400,13 +400,16 @@ mod tests {
                     region
                         .update_exterior(|cycle| {
                             cycle
-                                .update_nth_edge(0, |edge| {
-                                    edge.replace_path(edge.path().reverse())
-                                        .replace_boundary(
-                                            edge.boundary().reverse(),
-                                        )
-                                        .insert(&mut services)
-                                })
+                                .update_edge(
+                                    cycle.edges().nth_circular(0),
+                                    |edge| {
+                                        edge.replace_path(edge.path().reverse())
+                                            .replace_boundary(
+                                                edge.boundary().reverse(),
+                                            )
+                                            .insert(&mut services)
+                                    },
+                                )
                                 .insert(&mut services)
                         })
                         .insert(&mut services)
@@ -442,13 +445,16 @@ mod tests {
                     region
                         .update_exterior(|cycle| {
                             cycle
-                                .update_nth_edge(0, |edge| {
-                                    let curve =
-                                        Curve::new().insert(&mut services);
+                                .update_edge(
+                                    cycle.edges().nth_circular(0),
+                                    |edge| {
+                                        let curve =
+                                            Curve::new().insert(&mut services);
 
-                                    edge.replace_curve(curve)
-                                        .insert(&mut services)
-                                })
+                                        edge.replace_curve(curve)
+                                            .insert(&mut services)
+                                    },
+                                )
                                 .insert(&mut services)
                         })
                         .insert(&mut services)


### PR DESCRIPTION
Replace two of its trait methods, `replace_edge` and `update_nth_edge`, with a single new one, `update_edge`. The new method is designed to work with the methods on `Handles`, which was added recently. Now updating an edge and selecting which edge to update are orthogonal, which is a bit nicer overall.

This is another step towards https://github.com/hannobraun/fornjot/issues/2025. I plan to tackle the other update traits next.