### PR TITLE
Standardize all update methods

### DIFF
--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -89,7 +89,7 @@ impl Sweep for (&Edge, &Handle<Vertex>, &Surface, Option<Color>) {
                     .replace_start_vertex(start_vertex);
 
                     let edge = if let Some(curve) = curve {
-                        edge.update_curve(curve)
+                        edge.update_curve(|_| curve)
                     } else {
                         edge
                     };

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -89,7 +89,7 @@ impl Sweep for (&Edge, &Handle<Vertex>, &Surface, Option<Color>) {
                     .replace_start_vertex(start_vertex);
 
                     let edge = if let Some(curve) = curve {
-                        edge.replace_curve(curve)
+                        edge.update_curve(curve)
                     } else {
                         edge
                     };

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -86,7 +86,7 @@ impl Sweep for (&Edge, &Handle<Vertex>, &Surface, Option<Color>) {
                         Some(boundary),
                         services,
                     )
-                    .update_start_vertex(start_vertex);
+                    .update_start_vertex(|_| start_vertex);
 
                     let edge = if let Some(curve) = curve {
                         edge.update_curve(|_| curve)

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -86,7 +86,7 @@ impl Sweep for (&Edge, &Handle<Vertex>, &Surface, Option<Color>) {
                         Some(boundary),
                         services,
                     )
-                    .replace_start_vertex(start_vertex);
+                    .update_start_vertex(start_vertex);
 
                     let edge = if let Some(curve) = curve {
                         edge.update_curve(|_| curve)

--- a/crates/fj-core/src/objects/handles.rs
+++ b/crates/fj-core/src/objects/handles.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fmt::Debug, slice};
+use std::{collections::BTreeSet, fmt::Debug, slice, vec};
 
 use itertools::Itertools;
 
@@ -106,6 +106,15 @@ where
 {
     fn from_iter<T: IntoIterator<Item = Handle<O>>>(handles: T) -> Self {
         Self::new(handles)
+    }
+}
+
+impl<T> IntoIterator for Handles<T> {
+    type Item = Handle<T>;
+    type IntoIter = vec::IntoIter<Handle<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
     }
 }
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -84,7 +84,7 @@ impl JoinCycle for Cycle {
         self.add_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (edge, curve, boundary))| {
                 Edge::unjoined(curve, boundary, services)
-                    .replace_curve(edge.curve().clone())
+                    .update_curve(edge.curve().clone())
                     .replace_start_vertex(prev.start_vertex().clone())
                     .insert(services)
             },
@@ -111,7 +111,7 @@ impl JoinCycle for Cycle {
 
                 cycle
                     .update_edge(self.edges().nth_circular(index), |edge| {
-                        edge.replace_curve(edge_other.curve().clone())
+                        edge.update_curve(edge_other.curve().clone())
                             .replace_start_vertex(
                                 other
                                     .edges()

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -85,7 +85,7 @@ impl JoinCycle for Cycle {
             |((prev, _, _), (edge, curve, boundary))| {
                 Edge::unjoined(curve, boundary, services)
                     .update_curve(|_| edge.curve().clone())
-                    .replace_start_vertex(prev.start_vertex().clone())
+                    .update_start_vertex(prev.start_vertex().clone())
                     .insert(services)
             },
         ))
@@ -112,7 +112,7 @@ impl JoinCycle for Cycle {
                 cycle
                     .update_edge(self.edges().nth_circular(index), |edge| {
                         edge.update_curve(|_| edge_other.curve().clone())
-                            .replace_start_vertex(
+                            .update_start_vertex(
                                 other
                                     .edges()
                                     .nth_circular(index_other + 1)
@@ -122,7 +122,7 @@ impl JoinCycle for Cycle {
                             .insert(services)
                     })
                     .update_edge(self.edges().nth_circular(index + 1), |edge| {
-                        edge.replace_start_vertex(
+                        edge.update_start_vertex(
                             edge_other.start_vertex().clone(),
                         )
                         .insert(services)

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -85,7 +85,7 @@ impl JoinCycle for Cycle {
             |((prev, _, _), (edge, curve, boundary))| {
                 Edge::unjoined(curve, boundary, services)
                     .update_curve(|_| edge.curve().clone())
-                    .update_start_vertex(prev.start_vertex().clone())
+                    .update_start_vertex(|_| prev.start_vertex().clone())
                     .insert(services)
             },
         ))
@@ -112,19 +112,19 @@ impl JoinCycle for Cycle {
                 cycle
                     .update_edge(self.edges().nth_circular(index), |edge| {
                         edge.update_curve(|_| edge_other.curve().clone())
-                            .update_start_vertex(
+                            .update_start_vertex(|_| {
                                 other
                                     .edges()
                                     .nth_circular(index_other + 1)
                                     .start_vertex()
-                                    .clone(),
-                            )
+                                    .clone()
+                            })
                             .insert(services)
                     })
                     .update_edge(self.edges().nth_circular(index + 1), |edge| {
-                        edge.update_start_vertex(
-                            edge_other.start_vertex().clone(),
-                        )
+                        edge.update_start_vertex(|_| {
+                            edge_other.start_vertex().clone()
+                        })
                         .insert(services)
                     })
             },

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -84,7 +84,7 @@ impl JoinCycle for Cycle {
         self.add_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (edge, curve, boundary))| {
                 Edge::unjoined(curve, boundary, services)
-                    .update_curve(edge.curve().clone())
+                    .update_curve(|_| edge.curve().clone())
                     .replace_start_vertex(prev.start_vertex().clone())
                     .insert(services)
             },
@@ -111,7 +111,7 @@ impl JoinCycle for Cycle {
 
                 cycle
                     .update_edge(self.edges().nth_circular(index), |edge| {
-                        edge.update_curve(edge_other.curve().clone())
+                        edge.update_curve(|_| edge_other.curve().clone())
                             .replace_start_vertex(
                                 other
                                     .edges()

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -13,7 +13,9 @@ pub trait UpdateCycle {
     ///
     /// # Panics
     ///
-    /// Panics, if the provided edge is not part of the cycle.
+    /// Uses [`Handles::update`] internally, and panics for the same reasons.
+    ///
+    /// [`Handles::update`]: crate::objects::Handles::update
     #[must_use]
     fn update_edge(
         &self,

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -33,22 +33,7 @@ impl UpdateCycle for Cycle {
         edge: &Handle<Edge>,
         update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self {
-        let mut updated = Some(update(edge));
-
-        let edges = self.edges().iter().map(|e| {
-            if e.id() == edge.id() {
-                updated
-                    .take()
-                    .expect("Cycle should not contain same edge twice")
-            } else {
-                e.clone()
-            }
-        });
-
-        let cycle = Cycle::new(edges);
-
-        assert!(updated.is_none(), "Edge not found in cycle");
-
-        cycle
+        let edges = self.edges().update(edge, update);
+        Cycle::new(edges)
     }
 }

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -10,6 +10,10 @@ pub trait UpdateCycle {
     fn add_edges(&self, edges: impl IntoIterator<Item = Handle<Edge>>) -> Self;
 
     /// Update the provided edge
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the provided edge is not part of the cycle.
     #[must_use]
     fn update_edge(
         &self,

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -41,6 +41,10 @@ impl UpdateCycle for Cycle {
             }
         });
 
-        Cycle::new(edges)
+        let cycle = Cycle::new(edges);
+
+        assert!(updated.is_none(), "Edge not found in cycle");
+
+        cycle
     }
 }

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -24,7 +24,7 @@ pub trait UpdateEdge {
 
     /// Replace the curve of the edge
     #[must_use]
-    fn replace_curve(&self, curve: Handle<Curve>) -> Self;
+    fn update_curve(&self, curve: Handle<Curve>) -> Self;
 
     /// Replace the start vertex of the edge
     #[must_use]
@@ -56,7 +56,7 @@ impl UpdateEdge for Edge {
         )
     }
 
-    fn replace_curve(&self, curve: Handle<Curve>) -> Self {
+    fn update_curve(&self, curve: Handle<Curve>) -> Self {
         Edge::new(
             self.path(),
             self.boundary(),

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -31,7 +31,10 @@ pub trait UpdateEdge {
 
     /// Replace the start vertex of the edge
     #[must_use]
-    fn update_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self;
+    fn update_start_vertex(
+        &self,
+        update: impl FnOnce(&Handle<Vertex>) -> Handle<Vertex>,
+    ) -> Self;
 }
 
 impl UpdateEdge for Edge {
@@ -71,12 +74,15 @@ impl UpdateEdge for Edge {
         )
     }
 
-    fn update_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self {
+    fn update_start_vertex(
+        &self,
+        update: impl FnOnce(&Handle<Vertex>) -> Handle<Vertex>,
+    ) -> Self {
         Edge::new(
             self.path(),
             self.boundary(),
             self.curve().clone(),
-            start_vertex,
+            update(self.start_vertex()),
         )
     }
 }

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -17,7 +17,10 @@ pub trait UpdateEdge {
 
     /// Replace the boundary of the edge
     #[must_use]
-    fn update_boundary(&self, boundary: CurveBoundary<Point<1>>) -> Self;
+    fn update_boundary(
+        &self,
+        update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
+    ) -> Self;
 
     /// Replace the curve of the edge
     #[must_use]
@@ -41,10 +44,13 @@ impl UpdateEdge for Edge {
         )
     }
 
-    fn update_boundary(&self, boundary: CurveBoundary<Point<1>>) -> Self {
+    fn update_boundary(
+        &self,
+        update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
+    ) -> Self {
         Edge::new(
             self.path(),
-            boundary,
+            update(self.boundary()),
             self.curve().clone(),
             self.start_vertex().clone(),
         )

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -17,7 +17,7 @@ pub trait UpdateEdge {
 
     /// Replace the boundary of the edge
     #[must_use]
-    fn replace_boundary(&self, boundary: CurveBoundary<Point<1>>) -> Self;
+    fn update_boundary(&self, boundary: CurveBoundary<Point<1>>) -> Self;
 
     /// Replace the curve of the edge
     #[must_use]
@@ -41,7 +41,7 @@ impl UpdateEdge for Edge {
         )
     }
 
-    fn replace_boundary(&self, boundary: CurveBoundary<Point<1>>) -> Self {
+    fn update_boundary(&self, boundary: CurveBoundary<Point<1>>) -> Self {
         Edge::new(
             self.path(),
             boundary,

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -31,7 +31,7 @@ pub trait UpdateEdge {
 
     /// Replace the start vertex of the edge
     #[must_use]
-    fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self;
+    fn update_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self;
 }
 
 impl UpdateEdge for Edge {
@@ -71,7 +71,7 @@ impl UpdateEdge for Edge {
         )
     }
 
-    fn replace_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self {
+    fn update_start_vertex(&self, start_vertex: Handle<Vertex>) -> Self {
         Edge::new(
             self.path(),
             self.boundary(),

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -10,7 +10,7 @@ use crate::{
 pub trait UpdateEdge {
     /// Replace the path of the edge
     #[must_use]
-    fn replace_path(&self, path: SurfacePath) -> Self;
+    fn update_path(&self, path: SurfacePath) -> Self;
 
     /// Replace the boundary of the edge
     #[must_use]
@@ -26,7 +26,7 @@ pub trait UpdateEdge {
 }
 
 impl UpdateEdge for Edge {
-    fn replace_path(&self, path: SurfacePath) -> Self {
+    fn update_path(&self, path: SurfacePath) -> Self {
         Edge::new(
             path,
             self.boundary(),

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -10,7 +10,10 @@ use crate::{
 pub trait UpdateEdge {
     /// Replace the path of the edge
     #[must_use]
-    fn update_path(&self, path: SurfacePath) -> Self;
+    fn update_path(
+        &self,
+        update: impl FnOnce(SurfacePath) -> SurfacePath,
+    ) -> Self;
 
     /// Replace the boundary of the edge
     #[must_use]
@@ -26,9 +29,12 @@ pub trait UpdateEdge {
 }
 
 impl UpdateEdge for Edge {
-    fn update_path(&self, path: SurfacePath) -> Self {
+    fn update_path(
+        &self,
+        update: impl FnOnce(SurfacePath) -> SurfacePath,
+    ) -> Self {
         Edge::new(
-            path,
+            update(self.path()),
             self.boundary(),
             self.curve().clone(),
             self.start_vertex().clone(),

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -24,7 +24,10 @@ pub trait UpdateEdge {
 
     /// Replace the curve of the edge
     #[must_use]
-    fn update_curve(&self, curve: Handle<Curve>) -> Self;
+    fn update_curve(
+        &self,
+        update: impl FnOnce(&Handle<Curve>) -> Handle<Curve>,
+    ) -> Self;
 
     /// Replace the start vertex of the edge
     #[must_use]
@@ -56,11 +59,14 @@ impl UpdateEdge for Edge {
         )
     }
 
-    fn update_curve(&self, curve: Handle<Curve>) -> Self {
+    fn update_curve(
+        &self,
+        update: impl FnOnce(&Handle<Curve>) -> Handle<Curve>,
+    ) -> Self {
         Edge::new(
             self.path(),
             self.boundary(),
-            curve,
+            update(self.curve()),
             self.start_vertex().clone(),
         )
     }

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -8,28 +8,28 @@ use crate::{
 
 /// Update a [`Edge`]
 pub trait UpdateEdge {
-    /// Replace the path of the edge
+    /// Update the path of the edge
     #[must_use]
     fn update_path(
         &self,
         update: impl FnOnce(SurfacePath) -> SurfacePath,
     ) -> Self;
 
-    /// Replace the boundary of the edge
+    /// Update the boundary of the edge
     #[must_use]
     fn update_boundary(
         &self,
         update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
     ) -> Self;
 
-    /// Replace the curve of the edge
+    /// Update the curve of the edge
     #[must_use]
     fn update_curve(
         &self,
         update: impl FnOnce(&Handle<Curve>) -> Handle<Curve>,
     ) -> Self;
 
-    /// Replace the start vertex of the edge
+    /// Update the start vertex of the edge
     #[must_use]
     fn update_start_vertex(
         &self,

--- a/crates/fj-core/src/operations/update/face.rs
+++ b/crates/fj-core/src/operations/update/face.rs
@@ -10,16 +10,16 @@ pub trait UpdateFace {
     #[must_use]
     fn update_region(
         &self,
-        f: impl FnOnce(&Handle<Region>) -> Handle<Region>,
+        update: impl FnOnce(&Handle<Region>) -> Handle<Region>,
     ) -> Self;
 }
 
 impl UpdateFace for Face {
     fn update_region(
         &self,
-        f: impl FnOnce(&Handle<Region>) -> Handle<Region>,
+        update: impl FnOnce(&Handle<Region>) -> Handle<Region>,
     ) -> Self {
-        let region = f(self.region());
+        let region = update(self.region());
         Face::new(self.surface().clone(), region)
     }
 }
@@ -27,8 +27,8 @@ impl UpdateFace for Face {
 impl<const D: usize> UpdateFace for Polygon<D> {
     fn update_region(
         &self,
-        f: impl FnOnce(&Handle<Region>) -> Handle<Region>,
+        update: impl FnOnce(&Handle<Region>) -> Handle<Region>,
     ) -> Self {
-        self.replace_face(self.face.update_region(f))
+        self.replace_face(self.face.update_region(update))
     }
 }

--- a/crates/fj-core/src/operations/update/face.rs
+++ b/crates/fj-core/src/operations/update/face.rs
@@ -6,7 +6,7 @@ use crate::{
 
 /// Update a [`Face`]
 pub trait UpdateFace {
-    /// Replace the region of the face
+    /// Update the region of the face
     #[must_use]
     fn update_region(
         &self,

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -9,7 +9,7 @@ pub trait UpdateRegion {
     #[must_use]
     fn update_exterior(
         &self,
-        f: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
+        update: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
     ) -> Self;
 
     /// Add the provided interiors to the region
@@ -23,9 +23,9 @@ pub trait UpdateRegion {
 impl UpdateRegion for Region {
     fn update_exterior(
         &self,
-        f: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
+        update: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
     ) -> Self {
-        let exterior = f(self.exterior());
+        let exterior = update(self.exterior());
         Region::new(exterior, self.interiors().iter().cloned(), self.color())
     }
 

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -12,7 +12,7 @@ pub trait UpdateRegion {
         f: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
     ) -> Self;
 
-    /// Add the provides interiors to the region
+    /// Add the provided interiors to the region
     #[must_use]
     fn add_interiors(
         &self,

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -33,11 +33,11 @@ impl UpdateShell for Shell {
         original: &Handle<Face>,
         replacement: Handle<Face>,
     ) -> Self {
-        let faces = self.faces().iter().map(|face| {
-            if face.id() == original.id() {
+        let faces = self.faces().iter().map(|f| {
+            if f.id() == original.id() {
                 replacement.clone()
             } else {
-                face.clone()
+                f.clone()
             }
         });
 

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -14,7 +14,7 @@ pub trait UpdateShell {
     fn update_face(
         &self,
         face: &Handle<Face>,
-        replacement: Handle<Face>,
+        update: impl FnOnce(&Handle<Face>) -> Handle<Face>,
     ) -> Self;
 
     /// Remove a face from the shell
@@ -31,16 +31,9 @@ impl UpdateShell for Shell {
     fn update_face(
         &self,
         face: &Handle<Face>,
-        replacement: Handle<Face>,
+        update: impl FnOnce(&Handle<Face>) -> Handle<Face>,
     ) -> Self {
-        let faces = self.faces().iter().map(|f| {
-            if f.id() == face.id() {
-                replacement.clone()
-            } else {
-                f.clone()
-            }
-        });
-
+        let faces = self.faces().update(face, update);
         Shell::new(faces)
     }
 

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -11,7 +11,7 @@ pub trait UpdateShell {
 
     /// Replace a face of the shell
     #[must_use]
-    fn replace_face(
+    fn update_face(
         &self,
         original: &Handle<Face>,
         replacement: Handle<Face>,
@@ -28,7 +28,7 @@ impl UpdateShell for Shell {
         Shell::new(faces)
     }
 
-    fn replace_face(
+    fn update_face(
         &self,
         original: &Handle<Face>,
         replacement: Handle<Face>,

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -13,7 +13,7 @@ pub trait UpdateShell {
     #[must_use]
     fn update_face(
         &self,
-        original: &Handle<Face>,
+        face: &Handle<Face>,
         replacement: Handle<Face>,
     ) -> Self;
 
@@ -30,11 +30,11 @@ impl UpdateShell for Shell {
 
     fn update_face(
         &self,
-        original: &Handle<Face>,
+        face: &Handle<Face>,
         replacement: Handle<Face>,
     ) -> Self {
         let faces = self.faces().iter().map(|f| {
-            if f.id() == original.id() {
+            if f.id() == face.id() {
                 replacement.clone()
             } else {
                 f.clone()

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -9,7 +9,13 @@ pub trait UpdateShell {
     #[must_use]
     fn add_faces(&self, faces: impl IntoIterator<Item = Handle<Face>>) -> Self;
 
-    /// Replace a face of the shell
+    /// Update a face of the shell
+    ///
+    /// # Panics
+    ///
+    /// Uses [`Handles::update`] internally, and panics for the same reasons.
+    ///
+    /// [`Handles::update`]: crate::objects::Handles::update
     #[must_use]
     fn update_face(
         &self,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -448,11 +448,10 @@ mod tests {
                                 .update_edge(
                                     cycle.edges().nth_circular(0),
                                     |edge| {
-                                        let curve =
-                                            Curve::new().insert(&mut services);
-
-                                        edge.update_curve(|_| curve)
-                                            .insert(&mut services)
+                                        edge.update_curve(|_| {
+                                            Curve::new().insert(&mut services)
+                                        })
+                                        .insert(&mut services)
                                     },
                                 )
                                 .insert(&mut services)

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -404,8 +404,8 @@ mod tests {
                                     cycle.edges().nth_circular(0),
                                     |edge| {
                                         edge.update_path(|path| path.reverse())
-                                            .update_boundary(|_| {
-                                                edge.boundary().reverse()
+                                            .update_boundary(|boundary| {
+                                                boundary.reverse()
                                             })
                                             .insert(&mut services)
                                     },

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -404,9 +404,9 @@ mod tests {
                                     cycle.edges().nth_circular(0),
                                     |edge| {
                                         edge.update_path(|path| path.reverse())
-                                            .update_boundary(
-                                                edge.boundary().reverse(),
-                                            )
+                                            .update_boundary(|_| {
+                                                edge.boundary().reverse()
+                                            })
                                             .insert(&mut services)
                                     },
                                 )

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -391,7 +391,7 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.replace_face(
+        let invalid = valid.shell.update_face(
             &valid.abc.face,
             valid
                 .abc
@@ -436,7 +436,7 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.replace_face(
+        let invalid = valid.shell.update_face(
             &valid.abc.face,
             valid
                 .abc
@@ -498,7 +498,7 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.replace_face(
+        let invalid = valid.shell.update_face(
             &valid.abc.face,
             valid.abc.face.reverse(&mut services).insert(&mut services),
         );

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -403,11 +403,13 @@ mod tests {
                                 .update_edge(
                                     cycle.edges().nth_circular(0),
                                     |edge| {
-                                        edge.update_path(edge.path().reverse())
-                                            .replace_boundary(
-                                                edge.boundary().reverse(),
-                                            )
-                                            .insert(&mut services)
+                                        edge.update_path(|_| {
+                                            edge.path().reverse()
+                                        })
+                                        .replace_boundary(
+                                            edge.boundary().reverse(),
+                                        )
+                                        .insert(&mut services)
                                     },
                                 )
                                 .insert(&mut services)

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -403,13 +403,11 @@ mod tests {
                                 .update_edge(
                                     cycle.edges().nth_circular(0),
                                     |edge| {
-                                        edge.update_path(|_| {
-                                            edge.path().reverse()
-                                        })
-                                        .replace_boundary(
-                                            edge.boundary().reverse(),
-                                        )
-                                        .insert(&mut services)
+                                        edge.update_path(|path| path.reverse())
+                                            .replace_boundary(
+                                                edge.boundary().reverse(),
+                                            )
+                                            .insert(&mut services)
                                     },
                                 )
                                 .insert(&mut services)

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -451,7 +451,7 @@ mod tests {
                                         let curve =
                                             Curve::new().insert(&mut services);
 
-                                        edge.update_curve(curve)
+                                        edge.update_curve(|_| curve)
                                             .insert(&mut services)
                                     },
                                 )

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -391,29 +391,26 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.update_face(&valid.abc.face, |_| {
-            valid
-                .abc
-                .face
-                .update_region(|region| {
-                    region
-                        .update_exterior(|cycle| {
-                            cycle
-                                .update_edge(
-                                    cycle.edges().nth_circular(0),
-                                    |edge| {
-                                        edge.update_path(|path| path.reverse())
-                                            .update_boundary(|boundary| {
-                                                boundary.reverse()
-                                            })
-                                            .insert(&mut services)
-                                    },
-                                )
-                                .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                })
-                .insert(&mut services)
+        let invalid = valid.shell.update_face(&valid.abc.face, |face| {
+            face.update_region(|region| {
+                region
+                    .update_exterior(|cycle| {
+                        cycle
+                            .update_edge(
+                                cycle.edges().nth_circular(0),
+                                |edge| {
+                                    edge.update_path(|path| path.reverse())
+                                        .update_boundary(|boundary| {
+                                            boundary.reverse()
+                                        })
+                                        .insert(&mut services)
+                                },
+                            )
+                            .insert(&mut services)
+                    })
+                    .insert(&mut services)
+            })
+            .insert(&mut services)
         });
 
         valid.shell.validate_and_return_first_error()?;

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -432,28 +432,25 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.update_face(&valid.abc.face, |_| {
-            valid
-                .abc
-                .face
-                .update_region(|region| {
-                    region
-                        .update_exterior(|cycle| {
-                            cycle
-                                .update_edge(
-                                    cycle.edges().nth_circular(0),
-                                    |edge| {
-                                        edge.update_curve(|_| {
-                                            Curve::new().insert(&mut services)
-                                        })
-                                        .insert(&mut services)
-                                    },
-                                )
-                                .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                })
-                .insert(&mut services)
+        let invalid = valid.shell.update_face(&valid.abc.face, |face| {
+            face.update_region(|region| {
+                region
+                    .update_exterior(|cycle| {
+                        cycle
+                            .update_edge(
+                                cycle.edges().nth_circular(0),
+                                |edge| {
+                                    edge.update_curve(|_| {
+                                        Curve::new().insert(&mut services)
+                                    })
+                                    .insert(&mut services)
+                                },
+                            )
+                            .insert(&mut services)
+                    })
+                    .insert(&mut services)
+            })
+            .insert(&mut services)
         });
 
         valid.shell.validate_and_return_first_error()?;

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -404,7 +404,7 @@ mod tests {
                                     cycle.edges().nth_circular(0),
                                     |edge| {
                                         edge.update_path(|path| path.reverse())
-                                            .replace_boundary(
+                                            .update_boundary(
                                                 edge.boundary().reverse(),
                                             )
                                             .insert(&mut services)

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -403,7 +403,7 @@ mod tests {
                                 .update_edge(
                                     cycle.edges().nth_circular(0),
                                     |edge| {
-                                        edge.replace_path(edge.path().reverse())
+                                        edge.update_path(edge.path().reverse())
                                             .replace_boundary(
                                                 edge.boundary().reverse(),
                                             )

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -490,8 +490,8 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.update_face(&valid.abc.face, |_| {
-            valid.abc.face.reverse(&mut services).insert(&mut services)
+        let invalid = valid.shell.update_face(&valid.abc.face, |face| {
+            face.reverse(&mut services).insert(&mut services)
         });
 
         valid.shell.validate_and_return_first_error()?;

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -451,7 +451,7 @@ mod tests {
                                         let curve =
                                             Curve::new().insert(&mut services);
 
-                                        edge.replace_curve(curve)
+                                        edge.update_curve(curve)
                                             .insert(&mut services)
                                     },
                                 )

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -391,8 +391,7 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.update_face(
-            &valid.abc.face,
+        let invalid = valid.shell.update_face(&valid.abc.face, |_| {
             valid
                 .abc
                 .face
@@ -414,8 +413,8 @@ mod tests {
                         })
                         .insert(&mut services)
                 })
-                .insert(&mut services),
-        );
+                .insert(&mut services)
+        });
 
         valid.shell.validate_and_return_first_error()?;
         assert_contains_err!(
@@ -436,8 +435,7 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.update_face(
-            &valid.abc.face,
+        let invalid = valid.shell.update_face(&valid.abc.face, |_| {
             valid
                 .abc
                 .face
@@ -458,8 +456,8 @@ mod tests {
                         })
                         .insert(&mut services)
                 })
-                .insert(&mut services),
-        );
+                .insert(&mut services)
+        });
 
         valid.shell.validate_and_return_first_error()?;
         assert_contains_err!(
@@ -498,10 +496,9 @@ mod tests {
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
             &mut services,
         );
-        let invalid = valid.shell.update_face(
-            &valid.abc.face,
-            valid.abc.face.reverse(&mut services).insert(&mut services),
-        );
+        let invalid = valid.shell.update_face(&valid.abc.face, |_| {
+            valid.abc.face.reverse(&mut services).insert(&mut services)
+        });
 
         valid.shell.validate_and_return_first_error()?;
         assert_contains_err!(


### PR DESCRIPTION
Use the same style pioneered in `UpdateCycle` for all of them. Close https://github.com/hannobraun/fornjot/issues/2025.