### PR TITLE
Add `UpdateCycle::replace_edge`

### DIFF
--- a/crates/fj-core/src/objects/handles.rs
+++ b/crates/fj-core/src/objects/handles.rs
@@ -128,7 +128,7 @@ impl<T> Handles<T> {
 
         let handles = items.collect();
 
-        assert!(updated.is_none(), "Edge not found in cycle");
+        assert!(updated.is_none(), "Item not found");
 
         handles
     }

--- a/crates/fj-core/src/objects/handles.rs
+++ b/crates/fj-core/src/objects/handles.rs
@@ -114,6 +114,27 @@ impl<T> Handles<T> {
     where
         T: Debug + Ord,
     {
+        self.replace(handle, |handle| [update(handle)])
+    }
+
+    /// Create a new instance in which the provided item has been replaced
+    ///
+    /// This is a more general version of [`Handles::update`] which can replace
+    /// a single item with multiple others.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the provided item is not present.
+    /// Panics, if the update results in a duplicate item.
+    #[must_use]
+    pub fn replace<const N: usize>(
+        &self,
+        handle: &Handle<T>,
+        replace: impl FnOnce(&Handle<T>) -> [Handle<T>; N],
+    ) -> Self
+    where
+        T: Debug + Ord,
+    {
         let mut iter = self.iter().cloned().peekable();
 
         // Collect all items before the item we want to update.
@@ -135,10 +156,10 @@ impl<T> Handles<T> {
             before.push(next.clone());
         }
 
-        let updated = update(handle);
+        let replaced = replace(handle);
         let after = iter;
 
-        before.into_iter().chain([updated]).chain(after).collect()
+        before.into_iter().chain(replaced).chain(after).collect()
     }
 }
 

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -22,6 +22,23 @@ pub trait UpdateCycle {
         edge: &Handle<Edge>,
         update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self;
+
+    /// Replace the provided edge
+    ///
+    /// This is a more general version of [`UpdateCycle::update_edge`] which can
+    /// replace a single edge with multiple others.
+    ///
+    /// # Panics
+    ///
+    /// Uses [`Handles::update`] internally, and panics for the same reasons.
+    ///
+    /// [`Handles::update`]: crate::objects::Handles::update
+    #[must_use]
+    fn replace_edge<const N: usize>(
+        &self,
+        edge: &Handle<Edge>,
+        replace: impl FnOnce(&Handle<Edge>) -> [Handle<Edge>; N],
+    ) -> Self;
 }
 
 impl UpdateCycle for Cycle {
@@ -36,6 +53,15 @@ impl UpdateCycle for Cycle {
         update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
     ) -> Self {
         let edges = self.edges().update(edge, update);
+        Cycle::new(edges)
+    }
+
+    fn replace_edge<const N: usize>(
+        &self,
+        edge: &Handle<Edge>,
+        replace: impl FnOnce(&Handle<Edge>) -> [Handle<Edge>; N],
+    ) -> Self {
+        let edges = self.edges().replace(edge, replace);
         Cycle::new(edges)
     }
 }


### PR DESCRIPTION
This is a more general version of `update_edge`, which can replace a single edge with multiple others. This new primitive is required for https://github.com/hannobraun/fornjot/issues/2023.