### PR TITLE
Expand `CurveBoundary` API

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -79,10 +79,8 @@ impl CurveApproxSegment {
         );
 
         self.boundary = self.boundary.subset(boundary);
-
-        let [min, max] = self.boundary.inner;
         self.points
-            .retain(|point| point.local_form > min && point.local_form < max);
+            .retain(|point| self.boundary.contains(point.local_form));
     }
 
     /// Merge the provided segment into this one
@@ -112,7 +110,7 @@ impl CurveApproxSegment {
         self.points.retain(|point| {
             // Only retain points that don't overlap with the other segment, or
             // we might end up with duplicates.
-            point.local_form < other_min || point.local_form > other_max
+            !other.boundary.contains(point.local_form)
         });
         self.points.extend(&other.points);
         self.points.sort();

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -78,17 +78,9 @@ impl CurveApproxSegment {
             "Expected subset to be defined by normalized boundary."
         );
 
-        let [min, max] = boundary.inner;
+        self.boundary = self.boundary.subset(boundary);
 
-        self.boundary.inner = {
-            let [self_min, self_max] = self.boundary.inner;
-
-            let min = cmp::max(self_min, min);
-            let max = cmp::min(self_max, max);
-
-            [min, max]
-        };
-
+        let [min, max] = self.boundary.inner;
         self.points
             .retain(|point| point.local_form > min && point.local_form < max);
     }

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -99,13 +99,7 @@ impl CurveApproxSegment {
         );
         assert!(other.is_normalized(), "Can't merge non-normalized segment.");
 
-        let [self_min, self_max] = self.boundary.inner;
-        let [other_min, other_max] = other.boundary.inner;
-
-        let min = cmp::min(self_min, other_min);
-        let max = cmp::max(self_max, other_max);
-
-        self.boundary.inner = [min, max];
+        self.boundary = self.boundary.union(other.boundary);
 
         self.points.retain(|point| {
             // Only retain points that don't overlap with the other segment, or

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -22,10 +22,7 @@ pub struct CurveApproxSegment {
 impl CurveApproxSegment {
     /// Indicate whether the segment is empty
     pub fn is_empty(&self) -> bool {
-        let is_empty = {
-            let [min, max] = self.boundary.inner;
-            min >= max
-        };
+        let is_empty = self.boundary.is_empty();
 
         if is_empty {
             assert!(

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -44,10 +44,7 @@ impl CurveApproxSegment {
     /// Segments that touch (i.e. their closest boundary is equal) count as
     /// overlapping.
     pub fn overlaps(&self, other: &Self) -> bool {
-        let [a_low, a_high] = self.boundary.normalize().inner;
-        let [b_low, b_high] = other.boundary.normalize().inner;
-
-        a_low <= b_high && a_high >= b_low
+        self.boundary.overlaps(&other.boundary)
     }
 
     /// Reverse the orientation of the approximation

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -101,18 +101,18 @@ impl CurveApproxSegment {
         );
         assert!(other.is_normalized(), "Can't merge non-normalized segment.");
 
-        let [a_min, a_max] = self.boundary.inner;
-        let [b_min, b_max] = other.boundary.inner;
+        let [self_min, self_max] = self.boundary.inner;
+        let [other_min, other_max] = other.boundary.inner;
 
-        let min = cmp::min(a_min, b_min);
-        let max = cmp::max(a_max, b_max);
+        let min = cmp::min(self_min, other_min);
+        let max = cmp::max(self_max, other_max);
 
         self.boundary.inner = [min, max];
 
         self.points.retain(|point| {
             // Only retain points that don't overlap with the other segment, or
             // we might end up with duplicates.
-            point.local_form < b_min || point.local_form > b_max
+            point.local_form < other_min || point.local_form > other_max
         });
         self.points.extend(&other.points);
         self.points.sort();

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -146,32 +146,3 @@ impl PartialOrd for CurveApproxSegment {
         Some(self.cmp(other))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::algorithms::approx::curve::CurveApproxSegment;
-
-    #[test]
-    fn overlaps() {
-        assert!(overlap([0., 2.], [1., 3.])); // regular overlap
-        assert!(overlap([0., 1.], [1., 2.])); // just touching
-        assert!(overlap([2., 0.], [3., 1.])); // not normalized
-        assert!(overlap([1., 3.], [0., 2.])); // lower boundary comes second
-
-        assert!(!overlap([0., 1.], [2., 3.])); // regular non-overlap
-        assert!(!overlap([2., 3.], [0., 1.])); // lower boundary comes second
-
-        fn overlap(a: [f64; 2], b: [f64; 2]) -> bool {
-            let a = CurveApproxSegment {
-                boundary: a.map(|coord| [coord]).into(),
-                points: Vec::new(),
-            };
-            let b = CurveApproxSegment {
-                boundary: b.map(|coord| [coord]).into(),
-                points: Vec::new(),
-            };
-
-            a.overlaps(&b)
-        }
-    }
-}

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -70,7 +70,7 @@ impl CurveApproxSegment {
     /// Reduce the approximation to the subset defined by the provided boundary
     pub fn make_subset(&mut self, boundary: CurveBoundary<Point<1>>) {
         assert!(
-            self.boundary.is_normalized(),
+            self.is_normalized(),
             "Expected normalized segment for making subset."
         );
         assert!(

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -52,6 +52,20 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     }
 }
 
+// Technically, these methods could be implemented for all
+// `CurveBoundaryElement`s, but that would be misleading. While
+// `HandleWrapper<Vertex>` implements `Ord`, which is useful for putting it (and
+// by extension, `CurveBoundary<Vertex>`) into `BTreeMap`s, this `Ord`
+// implementation doesn't actually define the geometrically meaningful ordering
+// that the following methods rely on.
+impl CurveBoundary<Point<1>> {
+    /// Indicate whether the boundary is empty
+    pub fn is_empty(&self) -> bool {
+        let [min, max] = &self.inner;
+        min >= max
+    }
+}
+
 impl<T: CurveBoundaryElement> Eq for CurveBoundary<T> {}
 
 impl<T: CurveBoundaryElement> PartialEq for CurveBoundary<T> {

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -130,3 +130,32 @@ impl CurveBoundaryElement for Point<1> {
 impl CurveBoundaryElement for Vertex {
     type Repr = HandleWrapper<Vertex>;
 }
+
+#[cfg(test)]
+mod tests {
+    use fj_math::Point;
+
+    use crate::geometry::CurveBoundary;
+
+    #[test]
+    fn overlaps() {
+        assert!(overlap([0., 2.], [1., 3.])); // regular overlap
+        assert!(overlap([0., 1.], [1., 2.])); // just touching
+        assert!(overlap([2., 0.], [3., 1.])); // not normalized
+        assert!(overlap([1., 3.], [0., 2.])); // lower boundary comes second
+
+        assert!(!overlap([0., 1.], [2., 3.])); // regular non-overlap
+        assert!(!overlap([2., 3.], [0., 1.])); // lower boundary comes second
+
+        fn overlap(a: [f64; 2], b: [f64; 2]) -> bool {
+            let a = array_to_boundary(a);
+            let b = array_to_boundary(b);
+
+            a.overlaps(&b)
+        }
+
+        fn array_to_boundary(array: [f64; 2]) -> CurveBoundary<Point<1>> {
+            CurveBoundary::from(array.map(|element| [element]))
+        }
+    }
+}

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -19,15 +19,6 @@ pub struct CurveBoundary<T: CurveBoundaryElement> {
 }
 
 impl<T: CurveBoundaryElement> CurveBoundary<T> {
-    /// Reverse the direction of the boundary
-    ///
-    /// Returns a new instance of this struct, which has its direction reversed.
-    #[must_use]
-    pub fn reverse(self) -> Self {
-        let [a, b] = self.inner;
-        Self { inner: [b, a] }
-    }
-
     /// Indicate whether the boundary is normalized
     ///
     /// If the boundary is normalized, its bounding elements are in a defined
@@ -35,6 +26,15 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     pub fn is_normalized(&self) -> bool {
         let [a, b] = &self.inner;
         a <= b
+    }
+
+    /// Reverse the direction of the boundary
+    ///
+    /// Returns a new instance of this struct, which has its direction reversed.
+    #[must_use]
+    pub fn reverse(self) -> Self {
+        let [a, b] = self.inner;
+        Self { inner: [b, a] }
     }
 
     /// Normalize the boundary

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -64,6 +64,17 @@ impl CurveBoundary<Point<1>> {
         let [min, max] = &self.inner;
         min >= max
     }
+
+    /// Indicate whether the boundary overlaps another
+    ///
+    /// Boundaries that touch (i.e. their closest boundary elements are equal)
+    /// count as overlapping.
+    pub fn overlaps(&self, other: &Self) -> bool {
+        let [a_low, a_high] = self.normalize().inner;
+        let [b_low, b_high] = other.normalize().inner;
+
+        a_low <= b_high && a_high >= b_low
+    }
 }
 
 impl<S, T: CurveBoundaryElement> From<[S; 2]> for CurveBoundary<T>

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -65,6 +65,12 @@ impl CurveBoundary<Point<1>> {
         min >= max
     }
 
+    /// Indicate whether the boundary contains the given element
+    pub fn contains(&self, point: Point<1>) -> bool {
+        let [min, max] = self.inner;
+        point > min && point < max
+    }
+
     /// Indicate whether the boundary overlaps another
     ///
     /// Boundaries that touch (i.e. their closest boundary elements are equal)

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -98,6 +98,32 @@ impl CurveBoundary<Point<1>> {
 
         Self { inner: [min, max] }
     }
+
+    /// Create the union of this boundary and another
+    ///
+    /// The result will be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the two boundaries don't overlap (touching counts as
+    /// overlapping).
+    pub fn union(self, other: Self) -> Self {
+        let self_ = self.normalize();
+        let other = other.normalize();
+
+        assert!(
+            self.overlaps(&other),
+            "Can't merge boundaries that don't at least touch"
+        );
+
+        let [self_min, self_max] = self_.inner;
+        let [other_min, other_max] = other.inner;
+
+        let min = cmp::min(self_min, other_min);
+        let max = cmp::max(self_max, other_max);
+
+        Self { inner: [min, max] }
+    }
 }
 
 impl<S, T: CurveBoundaryElement> From<[S; 2]> for CurveBoundary<T>

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -66,14 +66,6 @@ impl CurveBoundary<Point<1>> {
     }
 }
 
-impl<T: CurveBoundaryElement> Eq for CurveBoundary<T> {}
-
-impl<T: CurveBoundaryElement> PartialEq for CurveBoundary<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
-    }
-}
-
 impl<S, T: CurveBoundaryElement> From<[S; 2]> for CurveBoundary<T>
 where
     S: Into<T::Repr>,
@@ -81,6 +73,14 @@ where
     fn from(boundary: [S; 2]) -> Self {
         let inner = boundary.map(Into::into);
         Self { inner }
+    }
+}
+
+impl<T: CurveBoundaryElement> Eq for CurveBoundary<T> {}
+
+impl<T: CurveBoundaryElement> PartialEq for CurveBoundary<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
     }
 }
 

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::Ordering,
+    cmp::{self, Ordering},
     hash::{Hash, Hasher},
 };
 
@@ -74,6 +74,23 @@ impl CurveBoundary<Point<1>> {
         let [b_low, b_high] = other.normalize().inner;
 
         a_low <= b_high && a_high >= b_low
+    }
+
+    /// Create the subset of this boundary and another
+    ///
+    /// The result will be normalized.
+    #[must_use]
+    pub fn subset(self, other: Self) -> Self {
+        let self_ = self.normalize();
+        let other = other.normalize();
+
+        let [self_min, self_max] = self_.inner;
+        let [other_min, other_max] = other.inner;
+
+        let min = cmp::max(self_min, other_min);
+        let max = cmp::min(self_max, other_max);
+
+        Self { inner: [min, max] }
     }
 }
 


### PR DESCRIPTION
Move some functionality that relates to `CurveBoundary` from `CurveApproxSegment` to `CurveBoundary` itself. I need to do some work with `CurveBoundary` in another context (part of https://github.com/hannobraun/fornjot/issues/2023), and not having to duplicate this functionality will come in handy.