### PR TITLE
Keep boundary and points separately in `CurveApprox`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -45,11 +45,11 @@ impl CurveApprox {
 
         let mut i = 0;
         loop {
-            let Some((_, segment)) = self.segments.get(i) else {
+            let Some((boundary, _)) = self.segments.get(i) else {
                 break;
             };
 
-            if segment.overlaps(&new_segment) {
+            if boundary.overlaps(&new_segment.boundary) {
                 let segment = self.segments.swap_remove(i);
                 overlapping_segments.push_back(segment);
                 continue;

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -58,16 +58,23 @@ impl CurveApprox {
             i += 1;
         }
 
-        let mut merged_segment = new_segment;
+        let mut merged_boundary = new_segment.boundary;
+        let mut merged_segment = new_segment.points;
 
         for (boundary, segment) in overlapping_segments {
             assert!(
-                merged_segment.boundary.overlaps(&boundary),
+                merged_boundary.overlaps(&boundary),
                 "Shouldn't merge segments that don't overlap."
             );
-            merged_segment.merge(&segment);
+
+            merged_boundary = merged_boundary.union(boundary);
+            merged_segment.merge(&segment.points, boundary);
         }
 
+        let merged_segment = CurveApproxSegment {
+            boundary: merged_boundary,
+            points: merged_segment,
+        };
         self.segments
             .push((merged_segment.boundary, merged_segment.clone()));
         self.segments.sort();

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -76,7 +76,7 @@ impl CurveApprox {
             points: merged_segment,
         };
         self.segments
-            .push((merged_segment.boundary, merged_segment.clone()));
+            .push((merged_boundary, merged_segment.clone()));
         self.segments.sort();
 
         merged_segment

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -78,6 +78,7 @@ impl CurveApprox {
         self.segments
             .push((merged_segment.boundary, merged_segment.clone()));
         self.segments.sort();
+
         merged_segment
     }
 }

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -30,7 +30,13 @@ impl CurveApprox {
     pub fn make_subset(&mut self, boundary: CurveBoundary<Point<1>>) {
         for (b, segment) in &mut self.segments {
             *b = b.subset(boundary);
-            segment.make_subset(boundary.normalize());
+
+            assert!(
+                segment.is_normalized(),
+                "Expected normalized segment for making subset."
+            );
+            segment.boundary = *b;
+            segment.points.make_subset(boundary.normalize());
         }
 
         self.segments.retain(|(_, segment)| !segment.is_empty());

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -60,6 +60,10 @@ impl CurveApprox {
 
         let mut merged_segment = new_segment;
         for (_, segment) in overlapping_segments {
+            assert!(
+                merged_segment.boundary.overlaps(&segment.boundary),
+                "Shouldn't merge segments that don't overlap."
+            );
             merged_segment.merge(&segment);
         }
 

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -59,9 +59,9 @@ impl CurveApprox {
         }
 
         let mut merged_segment = new_segment;
-        for (_, segment) in overlapping_segments {
+        for (boundary, segment) in overlapping_segments {
             assert!(
-                merged_segment.boundary.overlaps(&segment.boundary),
+                merged_segment.boundary.overlaps(&boundary),
                 "Shouldn't merge segments that don't overlap."
             );
             merged_segment.merge(&segment);

--- a/crates/fj-core/src/algorithms/approx/curve/approx.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/approx.rs
@@ -59,6 +59,7 @@ impl CurveApprox {
         }
 
         let mut merged_segment = new_segment;
+
         for (boundary, segment) in overlapping_segments {
             assert!(
                 merged_segment.boundary.overlaps(&boundary),

--- a/crates/fj-core/src/algorithms/approx/curve/mod.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/mod.rs
@@ -2,8 +2,10 @@
 
 mod approx;
 mod cache;
+mod points;
 mod segment;
 
 pub use self::{
-    approx::CurveApprox, cache::CurveApproxCache, segment::CurveApproxSegment,
+    approx::CurveApprox, cache::CurveApproxCache, points::CurveApproxPoints,
+    segment::CurveApproxSegment,
 };

--- a/crates/fj-core/src/algorithms/approx/curve/points.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/points.rs
@@ -1,4 +1,6 @@
-use crate::algorithms::approx::ApproxPoint;
+use fj_math::Point;
+
+use crate::{algorithms::approx::ApproxPoint, geometry::CurveBoundary};
 
 /// Points of a curve approximation
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -12,5 +14,11 @@ impl CurveApproxPoints {
     pub fn reverse(&mut self) -> &mut Self {
         self.inner.reverse();
         self
+    }
+
+    /// Reduce the approximation to the subset defined by the provided boundary
+    pub fn make_subset(&mut self, boundary: CurveBoundary<Point<1>>) {
+        self.inner
+            .retain(|point| boundary.contains(point.local_form));
     }
 }

--- a/crates/fj-core/src/algorithms/approx/curve/points.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/points.rs
@@ -21,4 +21,22 @@ impl CurveApproxPoints {
         self.inner
             .retain(|point| boundary.contains(point.local_form));
     }
+
+    /// Merge the provided points
+    ///
+    /// If there is a true overlap between these points and the other points
+    /// then the overlapping part is taken from the other points.
+    pub fn merge(
+        &mut self,
+        other: &Self,
+        other_boundary: CurveBoundary<Point<1>>,
+    ) {
+        self.inner.retain(|point| {
+            // Only retain points that don't overlap with the other points, or
+            // we might end up with duplicates.
+            !other_boundary.contains(point.local_form)
+        });
+        self.inner.extend(&other.inner);
+        self.inner.sort();
+    }
 }

--- a/crates/fj-core/src/algorithms/approx/curve/points.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/points.rs
@@ -10,6 +10,11 @@ pub struct CurveApproxPoints {
 }
 
 impl CurveApproxPoints {
+    /// Indicate whether there are any points
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     /// Reverse the orientation of the approximation
     pub fn reverse(&mut self) -> &mut Self {
         self.inner.reverse();

--- a/crates/fj-core/src/algorithms/approx/curve/points.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/points.rs
@@ -1,0 +1,8 @@
+use crate::algorithms::approx::ApproxPoint;
+
+/// Points of a curve approximation
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct CurveApproxPoints {
+    /// Points of a curve approximation
+    pub inner: Vec<ApproxPoint<1>>,
+}

--- a/crates/fj-core/src/algorithms/approx/curve/points.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/points.rs
@@ -6,3 +6,11 @@ pub struct CurveApproxPoints {
     /// Points of a curve approximation
     pub inner: Vec<ApproxPoint<1>>,
 }
+
+impl CurveApproxPoints {
+    /// Reverse the orientation of the approximation
+    pub fn reverse(&mut self) -> &mut Self {
+        self.inner.reverse();
+        self
+    }
+}

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -83,7 +83,7 @@ impl CurveApproxSegment {
         self.boundary = self.boundary.subset(boundary);
         self.points
             .inner
-            .retain(|point| self.boundary.contains(point.local_form));
+            .retain(|point| boundary.contains(point.local_form));
     }
 
     /// Merge the provided segment into this one

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -28,7 +28,7 @@ impl CurveApproxSegment {
 
         if is_empty {
             assert!(
-                self.points.inner.is_empty(),
+                self.points.is_empty(),
                 "Empty approximation still has points"
             );
         }

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -86,7 +86,7 @@ impl CurveApproxSegment {
 
     /// Merge the provided segment into this one
     ///
-    /// It there is a true overlap between both segments (as opposed to them
+    /// If there is a true overlap between both segments (as opposed to them
     /// just touching), then the overlapping part is taken from the other
     /// segment, meaning parts of this one get overwritten.
     pub fn merge(&mut self, other: &Self) {

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -52,7 +52,7 @@ impl CurveApproxSegment {
     /// Reverse the orientation of the approximation
     pub fn reverse(&mut self) -> &mut Self {
         self.boundary = self.boundary.reverse();
-        self.points.inner.reverse();
+        self.points.reverse();
         self
     }
 

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -60,21 +60,6 @@ impl CurveApproxSegment {
 
         self
     }
-
-    /// Reduce the approximation to the subset defined by the provided boundary
-    pub fn make_subset(&mut self, boundary: CurveBoundary<Point<1>>) {
-        assert!(
-            self.is_normalized(),
-            "Expected normalized segment for making subset."
-        );
-        assert!(
-            boundary.is_normalized(),
-            "Expected subset to be defined by normalized boundary."
-        );
-
-        self.boundary = self.boundary.subset(boundary);
-        self.points.make_subset(boundary);
-    }
 }
 
 impl Ord for CurveApproxSegment {

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -41,14 +41,6 @@ impl CurveApproxSegment {
         self.boundary.is_normalized()
     }
 
-    /// Indicate whether this segment overlaps another
-    ///
-    /// Segments that touch (i.e. their closest boundary is equal) count as
-    /// overlapping.
-    pub fn overlaps(&self, other: &Self) -> bool {
-        self.boundary.overlaps(&other.boundary)
-    }
-
     /// Reverse the orientation of the approximation
     pub fn reverse(&mut self) -> &mut Self {
         self.boundary = self.boundary.reverse();

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -75,22 +75,6 @@ impl CurveApproxSegment {
         self.boundary = self.boundary.subset(boundary);
         self.points.make_subset(boundary);
     }
-
-    /// Merge the provided segment into this one
-    ///
-    /// If there is a true overlap between both segments (as opposed to them
-    /// just touching), then the overlapping part is taken from the other
-    /// segment, meaning parts of this one get overwritten.
-    pub fn merge(&mut self, other: &Self) {
-        assert!(
-            self.is_normalized(),
-            "Can't merge into non-normalized segment."
-        );
-        assert!(other.is_normalized(), "Can't merge non-normalized segment.");
-
-        self.boundary = self.boundary.union(other.boundary);
-        self.points.merge(&other.points, other.boundary);
-    }
 }
 
 impl Ord for CurveApproxSegment {

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -22,20 +22,6 @@ pub struct CurveApproxSegment {
 }
 
 impl CurveApproxSegment {
-    /// Indicate whether the segment is empty
-    pub fn is_empty(&self) -> bool {
-        let is_empty = self.boundary.is_empty();
-
-        if is_empty {
-            assert!(
-                self.points.is_empty(),
-                "Empty approximation still has points"
-            );
-        }
-
-        is_empty
-    }
-
     /// Indicate whether the segment is normalized
     pub fn is_normalized(&self) -> bool {
         self.boundary.is_normalized()

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -81,9 +81,7 @@ impl CurveApproxSegment {
         );
 
         self.boundary = self.boundary.subset(boundary);
-        self.points
-            .inner
-            .retain(|point| boundary.contains(point.local_form));
+        self.points.make_subset(boundary);
     }
 
     /// Merge the provided segment into this one

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -91,10 +91,6 @@ impl CurveApproxSegment {
     /// segment, meaning parts of this one get overwritten.
     pub fn merge(&mut self, other: &Self) {
         assert!(
-            self.overlaps(other),
-            "Shouldn't merge segments that don't overlap."
-        );
-        assert!(
             self.is_normalized(),
             "Can't merge into non-normalized segment."
         );

--- a/crates/fj-core/src/algorithms/approx/curve/segment.rs
+++ b/crates/fj-core/src/algorithms/approx/curve/segment.rs
@@ -101,14 +101,7 @@ impl CurveApproxSegment {
         assert!(other.is_normalized(), "Can't merge non-normalized segment.");
 
         self.boundary = self.boundary.union(other.boundary);
-
-        self.points.inner.retain(|point| {
-            // Only retain points that don't overlap with the other segment, or
-            // we might end up with duplicates.
-            !other.boundary.contains(point.local_form)
-        });
-        self.points.inner.extend(&other.points.inner);
-        self.points.inner.sort();
+        self.points.merge(&other.points, other.boundary);
     }
 }
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -56,11 +56,14 @@ impl Approx for (&Edge, &Surface) {
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
                 match cached.segments.pop() {
-                    Some((_, segment)) if cached.segments.is_empty() => {
+                    Some((boundary, segment)) if cached.segments.is_empty() => {
                         // If the cached approximation has a single segment,
                         // that means everything we need is available, and we
                         // can use the cached approximation as-is.
-                        segment
+                        CurveApproxSegment {
+                            boundary,
+                            points: segment,
+                        }
                     }
                     _ => {
                         // If we make it here, there are holes in the

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -56,14 +56,11 @@ impl Approx for (&Edge, &Surface) {
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
                 match cached.segments.pop() {
-                    Some((boundary, segment)) if cached.segments.is_empty() => {
+                    Some((boundary, points)) if cached.segments.is_empty() => {
                         // If the cached approximation has a single segment,
                         // that means everything we need is available, and we
                         // can use the cached approximation as-is.
-                        CurveApproxSegment {
-                            boundary,
-                            points: segment,
-                        }
+                        CurveApproxSegment { boundary, points }
                     }
                     _ => {
                         // If we make it here, there are holes in the

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -16,7 +16,9 @@ use crate::{
 };
 
 use super::{
-    curve::{CurveApprox, CurveApproxCache, CurveApproxSegment},
+    curve::{
+        CurveApprox, CurveApproxCache, CurveApproxPoints, CurveApproxSegment,
+    },
     Approx, ApproxPoint, Tolerance,
 };
 
@@ -85,6 +87,7 @@ impl Approx for (&Edge, &Surface) {
 
             segment
                 .points
+                .inner
                 .into_iter()
                 .map(|point| {
                     let point_surface =
@@ -194,7 +197,10 @@ fn approx_curve(
             ApproxPoint::new(point_curve, point_global)
         })
         .collect();
-    CurveApproxSegment { boundary, points }
+    CurveApproxSegment {
+        boundary,
+        points: CurveApproxPoints { inner: points },
+    }
 }
 
 /// Cache for edge approximations

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -56,7 +56,7 @@ impl Approx for (&Edge, &Surface) {
                     .get_curve_approx(edge.curve().clone(), edge.boundary());
 
                 match cached.segments.pop() {
-                    Some(segment) if cached.segments.is_empty() => {
+                    Some((_, segment)) if cached.segments.is_empty() => {
                         // If the cached approximation has a single segment,
                         // that means everything we need is available, and we
                         // can use the cached approximation as-is.


### PR DESCRIPTION
This prepares `CurveApprox` for moving the code that deals with boundaries, but is not specific to approximation, into a reusable API. I need this to make further progress on https://github.com/hannobraun/fornjot/issues/2023.