### PR TITLE
Fix watertightness check requiring congruent edges

### DIFF
--- a/crates/fj-core/src/geometry/boundary/multiple.rs
+++ b/crates/fj-core/src/geometry/boundary/multiple.rs
@@ -19,6 +19,11 @@ impl<T: CurveBoundariesPayload> CurveBoundaries<T> {
         Self { inner: Vec::new() }
     }
 
+    /// Indicate whether this `CurveBoundaries` instance is empty
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
     /// Transform `self` into the payload of the single boundary requested
     ///
     /// If there are no boundaries or multiple boundaries in `self`, or if the

--- a/crates/fj-core/src/geometry/boundary/multiple.rs
+++ b/crates/fj-core/src/geometry/boundary/multiple.rs
@@ -14,6 +14,11 @@ pub struct CurveBoundaries<T: CurveBoundariesPayload = ()> {
 }
 
 impl<T: CurveBoundariesPayload> CurveBoundaries<T> {
+    /// Create an empty instance of `CurveBoundaries`
+    pub fn empty() -> Self {
+        Self { inner: Vec::new() }
+    }
+
     /// Transform `self` into the payload of the single boundary requested
     ///
     /// If there are no boundaries or multiple boundaries in `self`, or if the


### PR DESCRIPTION
From the message of the main commit:

> It used to be that coincident `Edge`s needed to be fully congruent (https://github.com/hannobraun/fornjot/issues/1937). This limitation was largely removed, but it turns out, the water-tightness check was still an unrecognized holdover. Now the limitation has been removed from there too.

This is an important step towards https://github.com/hannobraun/fornjot/issues/2023.