### PR TITLE
Rename `Edge` to `HalfEdge`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/cycle.rs
+++ b/crates/fj-core/src/algorithms/approx/cycle.rs
@@ -26,7 +26,7 @@ impl Approx for (&Cycle, &Surface) {
         let tolerance = tolerance.into();
 
         let edges = cycle
-            .edges()
+            .half_edges()
             .iter()
             .map(|edge| {
                 (edge.deref(), surface).approx_with_cache(tolerance, cache)

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -264,7 +264,7 @@ mod tests {
         algorithms::approx::{Approx, ApproxPoint},
         geometry::{CurveBoundary, GlobalPath, SurfaceGeometry},
         objects::{HalfEdge, Surface},
-        operations::BuildEdge,
+        operations::BuildHalfEdge,
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -11,7 +11,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::{CurveBoundary, GlobalPath, SurfacePath},
-    objects::{Curve, Edge, Surface, Vertex},
+    objects::{Curve, HalfEdge, Surface, Vertex},
     storage::{Handle, HandleWrapper},
 };
 
@@ -22,7 +22,7 @@ use super::{
     Approx, ApproxPoint, Tolerance,
 };
 
-impl Approx for (&Edge, &Surface) {
+impl Approx for (&HalfEdge, &Surface) {
     type Approximation = EdgeApprox;
     type Cache = EdgeApproxCache;
 
@@ -109,7 +109,7 @@ impl Approx for (&Edge, &Surface) {
     }
 }
 
-/// An approximation of an [`Edge`]
+/// An approximation of an [`HalfEdge`]
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct EdgeApprox {
     /// The point that approximates the first vertex of the edge
@@ -263,7 +263,7 @@ mod tests {
     use crate::{
         algorithms::approx::{Approx, ApproxPoint},
         geometry::{CurveBoundary, GlobalPath, SurfaceGeometry},
-        objects::{Edge, Surface},
+        objects::{HalfEdge, Surface},
         operations::BuildEdge,
         services::Services,
     };
@@ -274,7 +274,7 @@ mod tests {
 
         let surface = services.objects.surfaces.xz_plane();
         let edge =
-            Edge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
+            HalfEdge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
 
         let tolerance = 1.;
         let approx = (&edge, surface.deref()).approx(tolerance);
@@ -291,7 +291,7 @@ mod tests {
             v: [0., 0., 1.].into(),
         });
         let edge =
-            Edge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
+            HalfEdge::line_segment([[1., 1.], [2., 1.]], None, &mut services);
 
         let tolerance = 1.;
         let approx = (&edge, &surface).approx(tolerance);
@@ -310,7 +310,7 @@ mod tests {
             u: path,
             v: [0., 0., 1.].into(),
         });
-        let edge = Edge::line_segment(
+        let edge = HalfEdge::line_segment(
             [[0., 1.], [TAU, 1.]],
             Some(boundary.inner),
             &mut services,
@@ -338,7 +338,7 @@ mod tests {
         let mut services = Services::new();
 
         let surface = services.objects.surfaces.xz_plane();
-        let edge = Edge::circle([0., 0.], 1., &mut services);
+        let edge = HalfEdge::circle([0., 0.], 1., &mut services);
 
         let tolerance = 1.;
         let approx = (&edge, surface.deref()).approx(tolerance);

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -109,7 +109,7 @@ impl Approx for (&HalfEdge, &Surface) {
     }
 }
 
-/// An approximation of an [`HalfEdge`]
+/// An approximation of a [`HalfEdge`]
 #[derive(Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct EdgeApprox {
     /// The point that approximates the first vertex of the edge

--- a/crates/fj-core/src/algorithms/bounding_volume/cycle.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/cycle.rs
@@ -6,7 +6,7 @@ impl super::BoundingVolume<2> for Cycle {
     fn aabb(&self) -> Option<Aabb<2>> {
         let mut aabb: Option<Aabb<2>> = None;
 
-        for edge in self.edges() {
+        for edge in self.half_edges() {
             let new_aabb = edge.aabb().expect("`Edge` can always compute AABB");
             aabb = Some(aabb.map_or(new_aabb, |aabb| aabb.merged(&new_aabb)));
         }

--- a/crates/fj-core/src/algorithms/bounding_volume/edge.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/edge.rs
@@ -1,8 +1,8 @@
 use fj_math::{Aabb, Vector};
 
-use crate::{geometry::SurfacePath, objects::Edge};
+use crate::{geometry::SurfacePath, objects::HalfEdge};
 
-impl super::BoundingVolume<2> for Edge {
+impl super::BoundingVolume<2> for HalfEdge {
     fn aabb(&self) -> Option<Aabb<2>> {
         match self.path() {
             SurfacePath::Circle(circle) => {

--- a/crates/fj-core/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_edge.rs
@@ -72,7 +72,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        geometry::SurfacePath, objects::HalfEdge, operations::BuildEdge,
+        geometry::SurfacePath, objects::HalfEdge, operations::BuildHalfEdge,
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_edge.rs
@@ -4,7 +4,7 @@ use crate::{geometry::SurfacePath, objects::HalfEdge};
 
 use super::LineSegmentIntersection;
 
-/// The intersection between a curve and an [`HalfEdge`]
+/// The intersection between a curve and a [`HalfEdge`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CurveEdgeIntersection {
     /// The curve and edge intersect at a point

--- a/crates/fj-core/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_edge.rs
@@ -1,10 +1,10 @@
 use fj_math::{Point, Segment};
 
-use crate::{geometry::SurfacePath, objects::Edge};
+use crate::{geometry::SurfacePath, objects::HalfEdge};
 
 use super::LineSegmentIntersection;
 
-/// The intersection between a curve and an [`Edge`]
+/// The intersection between a curve and an [`HalfEdge`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum CurveEdgeIntersection {
     /// The curve and edge intersect at a point
@@ -26,8 +26,8 @@ impl CurveEdgeIntersection {
     /// # Panics
     ///
     /// Currently, only intersections between lines and line segments can be
-    /// computed. Panics, if a different type of curve or [`Edge`] is passed.
-    pub fn compute(path: &SurfacePath, edge: &Edge) -> Option<Self> {
+    /// computed. Panics, if a different type of curve or [`HalfEdge`] is passed.
+    pub fn compute(path: &SurfacePath, edge: &HalfEdge) -> Option<Self> {
         let path_as_line = match path {
             SurfacePath::Line(line) => line,
             _ => todo!("Curve-edge intersection only supports lines"),
@@ -72,7 +72,7 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        geometry::SurfacePath, objects::Edge, operations::BuildEdge,
+        geometry::SurfacePath, objects::HalfEdge, operations::BuildEdge,
         services::Services,
     };
 
@@ -84,7 +84,7 @@ mod tests {
 
         let path = SurfacePath::u_axis();
         let edge =
-            Edge::line_segment([[1., -1.], [1., 1.]], None, &mut services);
+            HalfEdge::line_segment([[1., -1.], [1., 1.]], None, &mut services);
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
 
@@ -101,8 +101,11 @@ mod tests {
         let mut services = Services::new();
 
         let path = SurfacePath::u_axis();
-        let edge =
-            Edge::line_segment([[-1., -1.], [-1., 1.]], None, &mut services);
+        let edge = HalfEdge::line_segment(
+            [[-1., -1.], [-1., 1.]],
+            None,
+            &mut services,
+        );
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
 
@@ -119,8 +122,11 @@ mod tests {
         let mut services = Services::new();
 
         let path = SurfacePath::u_axis();
-        let edge =
-            Edge::line_segment([[-1., -1.], [1., -1.]], None, &mut services);
+        let edge = HalfEdge::line_segment(
+            [[-1., -1.], [1., -1.]],
+            None,
+            &mut services,
+        );
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
 
@@ -133,7 +139,7 @@ mod tests {
 
         let path = SurfacePath::u_axis();
         let edge =
-            Edge::line_segment([[-1., 0.], [1., 0.]], None, &mut services);
+            HalfEdge::line_segment([[-1., 0.], [1., 0.]], None, &mut services);
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
 

--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -29,7 +29,10 @@ impl CurveFaceIntersection {
 
     /// Compute the intersection
     pub fn compute(path: &SurfacePath, face: &Face) -> Self {
-        let edges = face.region().all_cycles().flat_map(|cycle| cycle.edges());
+        let edges = face
+            .region()
+            .all_cycles()
+            .flat_map(|cycle| cycle.half_edges());
 
         let mut intersections = Vec::new();
 

--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -28,12 +28,12 @@ impl Intersect for (&Face, &Point<2>) {
             // as long as we initialize the `previous_hit` variable with the
             // result of the last segment.
             let mut previous_hit = cycle
-                .edges()
+                .half_edges()
                 .iter()
                 .last()
                 .and_then(|edge| (&ray, edge).intersect());
 
-            for (edge, next_edge) in cycle.edges().pairs() {
+            for (edge, next_edge) in cycle.half_edges().pairs() {
                 let hit = (&ray, edge).intersect();
 
                 let count_hit = match (hit, previous_hit) {
@@ -335,7 +335,7 @@ mod tests {
         let edge = face
             .region()
             .exterior()
-            .edges()
+            .half_edges()
             .iter()
             .find(|edge| edge.start_position() == Point::from([0., 0.]))
             .unwrap();
@@ -371,7 +371,7 @@ mod tests {
         let vertex = face
             .region()
             .exterior()
-            .edges()
+            .half_edges()
             .iter()
             .find(|edge| edge.start_position() == Point::from([1., 0.]))
             .map(|edge| edge.start_position())

--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -3,7 +3,7 @@
 use fj_math::Point;
 
 use crate::{
-    objects::{Edge, Face},
+    objects::{Face, HalfEdge},
     storage::Handle,
 };
 
@@ -122,7 +122,7 @@ pub enum FacePointIntersection {
     PointIsInsideFace,
 
     /// The point is coincident with an edge
-    PointIsOnEdge(Handle<Edge>),
+    PointIsOnEdge(Handle<HalfEdge>),
 
     /// The point is coincident with a vertex
     PointIsOnVertex(Point<2>),

--- a/crates/fj-core/src/algorithms/intersect/ray_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_edge.rs
@@ -5,13 +5,13 @@ use fj_math::Segment;
 use crate::{
     algorithms::intersect::{HorizontalRayToTheRight, Intersect},
     geometry::SurfacePath,
-    objects::Edge,
+    objects::HalfEdge,
     storage::Handle,
 };
 
 use super::ray_segment::RaySegmentIntersection;
 
-impl Intersect for (&HorizontalRayToTheRight<2>, &Handle<Edge>) {
+impl Intersect for (&HorizontalRayToTheRight<2>, &Handle<HalfEdge>) {
     type Intersection = RaySegmentIntersection;
 
     fn intersect(self) -> Option<Self::Intersection> {

--- a/crates/fj-core/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_face.rs
@@ -5,7 +5,7 @@ use fj_math::{Plane, Point, Scalar};
 use crate::{
     algorithms::intersect::face_point::FacePointIntersection,
     geometry::GlobalPath,
-    objects::{Edge, Face},
+    objects::{Face, HalfEdge},
     storage::Handle,
 };
 
@@ -134,7 +134,7 @@ pub enum RayFaceIntersection {
     RayHitsFaceAndAreParallel,
 
     /// The ray hits an edge
-    RayHitsEdge(Handle<Edge>),
+    RayHitsEdge(Handle<HalfEdge>),
 
     /// The ray hits a vertex
     RayHitsVertex(Point<2>),

--- a/crates/fj-core/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_face.rs
@@ -262,7 +262,7 @@ mod tests {
         let edge = face
             .region()
             .exterior()
-            .edges()
+            .half_edges()
             .iter()
             .find(|edge| edge.start_position() == Point::from([-1., 1.]))
             .unwrap();
@@ -298,7 +298,7 @@ mod tests {
         let vertex = face
             .region()
             .exterior()
-            .edges()
+            .half_edges()
             .iter()
             .find(|edge| edge.start_position() == Point::from([-1., -1.]))
             .map(|edge| edge.start_position())

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -3,7 +3,7 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
-    operations::{BuildEdge, Insert, UpdateCycle, UpdateEdge},
+    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateEdge},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -97,8 +97,9 @@ impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
                     edge.insert(services)
                 };
 
-                exterior =
-                    Some(exterior.take().unwrap().add_edges([edge.clone()]));
+                exterior = Some(
+                    exterior.take().unwrap().add_half_edges([edge.clone()]),
+                );
 
                 edge
             });

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -2,7 +2,7 @@ use fj_interop::{ext::ArrayExt, mesh::Color};
 use fj_math::{Point, Scalar, Vector};
 
 use crate::{
-    objects::{Cycle, Edge, Face, Region, Surface, Vertex},
+    objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
     operations::{BuildEdge, Insert, UpdateCycle, UpdateEdge},
     services::Services,
     storage::Handle,
@@ -10,8 +10,8 @@ use crate::{
 
 use super::{Sweep, SweepCache};
 
-impl Sweep for (&Edge, &Handle<Vertex>, &Surface, Option<Color>) {
-    type Swept = (Handle<Face>, Handle<Edge>);
+impl Sweep for (&HalfEdge, &Handle<Vertex>, &Surface, Option<Color>) {
+    type Swept = (Handle<Face>, Handle<HalfEdge>);
 
     fn sweep_with_cache(
         self,
@@ -81,7 +81,7 @@ impl Sweep for (&Edge, &Handle<Vertex>, &Surface, Option<Color>) {
             .zip_ext(curves)
             .map(|((((boundary, start), end), start_vertex), curve)| {
                 let edge = {
-                    let edge = Edge::line_segment(
+                    let edge = HalfEdge::line_segment(
                         [start, end],
                         Some(boundary),
                         services,

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -3,7 +3,7 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
-    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateEdge},
+    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -61,7 +61,7 @@ impl Sweep for Handle<Face> {
             let cycle = cycle.reverse(services);
 
             let mut top_edges = Vec::new();
-            for (edge, next) in cycle.edges().pairs() {
+            for (edge, next) in cycle.half_edges().pairs() {
                 let (face, top_edge) = (
                     edge.deref(),
                     next.start_vertex(),

--- a/crates/fj-core/src/algorithms/transform/cycle.rs
+++ b/crates/fj-core/src/algorithms/transform/cycle.rs
@@ -11,7 +11,7 @@ impl TransformObject for Cycle {
         services: &mut Services,
         cache: &mut TransformCache,
     ) -> Self {
-        let edges = self.edges().iter().map(|edge| {
+        let edges = self.half_edges().iter().map(|edge| {
             edge.clone()
                 .transform_with_cache(transform, services, cache)
         });

--- a/crates/fj-core/src/algorithms/transform/edge.rs
+++ b/crates/fj-core/src/algorithms/transform/edge.rs
@@ -1,10 +1,10 @@
 use fj_math::Transform;
 
-use crate::{objects::Edge, services::Services};
+use crate::{objects::HalfEdge, services::Services};
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Edge {
+impl TransformObject for HalfEdge {
     fn transform_with_cache(
         self,
         transform: &Transform,

--- a/crates/fj-core/src/objects/kinds/curve.rs
+++ b/crates/fj-core/src/objects/kinds/curve.rs
@@ -1,10 +1,10 @@
 /// A curve
 ///
 /// `Curve` represents a curve in space, but holds no data to define that curve.
-/// It is referenced by [`Edge`], which defines the curve in the coordinates of
-/// its surface.
+/// It is referenced by [`HalfEdge`], which defines the curve in the coordinates
+/// of its surface.
 ///
-/// `Curve` exists to allow identifying which [`Edge`]s are supposed to be
+/// `Curve` exists to allow identifying which [`HalfEdge`]s are supposed to be
 /// coincident in global space.
 ///
 /// # Equality
@@ -20,7 +20,7 @@
 /// `Eq`/`Ord`/..., you can use `HandleWrapper<Curve>` to do that. It will use
 /// `Handle::id` to provide those `Eq`/`Ord`/... implementations.
 ///
-/// [`Edge`]: crate::objects::Edge
+/// [`HalfEdge`]: crate::objects::HalfEdge
 #[derive(Clone, Debug, Default, Hash)]
 pub struct Curve {}
 

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -20,7 +20,7 @@ impl Cycle {
     }
 
     /// Access the edges that make up the cycle
-    pub fn edges(&self) -> &Handles<HalfEdge> {
+    pub fn half_edges(&self) -> &Handles<HalfEdge> {
         &self.half_edges
     }
 
@@ -35,7 +35,7 @@ impl Cycle {
         // first circle.
         if self.half_edges.len() < 3 {
             let first = self
-                .edges()
+                .half_edges()
                 .iter()
                 .next()
                 .expect("Invalid cycle: expected at least one edge");
@@ -64,7 +64,7 @@ impl Cycle {
 
         let mut sum = Scalar::ZERO;
 
-        for (a, b) in self.edges().pairs() {
+        for (a, b) in self.half_edges().pairs() {
             let [a, b] = [a, b].map(|edge| edge.start_position());
 
             sum += (b.u - a.u) * (b.v + a.v);

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -2,25 +2,25 @@ use fj_math::{Scalar, Winding};
 
 use crate::{
     geometry::SurfacePath,
-    objects::{handles::Handles, Edge},
+    objects::{handles::Handles, HalfEdge},
     storage::Handle,
 };
 
 /// A cycle of connected edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
-    edges: Handles<Edge>,
+    edges: Handles<HalfEdge>,
 }
 
 impl Cycle {
     /// Create an instance of `Cycle`
-    pub fn new(edges: impl IntoIterator<Item = Handle<Edge>>) -> Self {
+    pub fn new(edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
         let edges = edges.into_iter().collect();
         Self { edges }
     }
 
     /// Access the edges that make up the cycle
-    pub fn edges(&self) -> &Handles<Edge> {
+    pub fn edges(&self) -> &Handles<HalfEdge> {
         &self.edges
     }
 

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -9,19 +9,19 @@ use crate::{
 /// A cycle of connected edges
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Cycle {
-    edges: Handles<HalfEdge>,
+    half_edges: Handles<HalfEdge>,
 }
 
 impl Cycle {
     /// Create an instance of `Cycle`
     pub fn new(edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
         let edges = edges.into_iter().collect();
-        Self { edges }
+        Self { half_edges: edges }
     }
 
     /// Access the edges that make up the cycle
     pub fn edges(&self) -> &Handles<HalfEdge> {
-        &self.edges
+        &self.half_edges
     }
 
     /// Indicate the cycle's winding, assuming a right-handed coordinate system
@@ -33,7 +33,7 @@ impl Cycle {
         // The cycle could be made up of one or two circles. If that is the
         // case, the winding of the cycle is determined by the winding of the
         // first circle.
-        if self.edges.len() < 3 {
+        if self.half_edges.len() < 3 {
             let first = self
                 .edges()
                 .iter()

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -14,8 +14,8 @@ pub struct Cycle {
 
 impl Cycle {
     /// Create an instance of `Cycle`
-    pub fn new(edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
-        let half_edges = edges.into_iter().collect();
+    pub fn new(half_edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
+        let half_edges = half_edges.into_iter().collect();
         Self { half_edges }
     }
 

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -15,8 +15,8 @@ pub struct Cycle {
 impl Cycle {
     /// Create an instance of `Cycle`
     pub fn new(edges: impl IntoIterator<Item = Handle<HalfEdge>>) -> Self {
-        let edges = edges.into_iter().collect();
-        Self { half_edges: edges }
+        let half_edges = edges.into_iter().collect();
+        Self { half_edges }
     }
 
     /// Access the edges that make up the cycle

--- a/crates/fj-core/src/objects/kinds/edge.rs
+++ b/crates/fj-core/src/objects/kinds/edge.rs
@@ -13,14 +13,14 @@ use crate::{
 /// `Edge`s of other faces, where those faces touch. Such coincident `Edge`s
 ///  must always refer to the same `Curve`.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Edge {
+pub struct HalfEdge {
     path: SurfacePath,
     boundary: CurveBoundary<Point<1>>,
     curve: HandleWrapper<Curve>,
     start_vertex: HandleWrapper<Vertex>,
 }
 
-impl Edge {
+impl HalfEdge {
     /// Create an instance of `Edge`
     pub fn new(
         path: SurfacePath,

--- a/crates/fj-core/src/objects/kinds/face.rs
+++ b/crates/fj-core/src/objects/kinds/face.rs
@@ -24,10 +24,10 @@ use crate::{
 ///
 /// Interior cycles must have the opposite winding of the exterior cycle,
 /// meaning on the front side of the face, they must appear clockwise. This
-/// means that all [`Edge`]s that bound a `Face` have the interior of the face
-/// on their left side (on the face's front side).
+/// means that all [`HalfEdge`]s that bound a `Face` have the interior of the
+/// face on their left side (on the face's front side).
 ///
-/// [`Edge`]: crate::objects::Edge
+/// [`HalfEdge`]: crate::objects::HalfEdge
 /// [`Shell`]: crate::objects::Shell
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Face {

--- a/crates/fj-core/src/objects/kinds/region.rs
+++ b/crates/fj-core/src/objects/kinds/region.rs
@@ -10,10 +10,10 @@ use crate::{
 ///
 /// Interior cycles must have the opposite winding of the exterior cycle,
 /// meaning on the front side of the region, they must appear clockwise. This
-/// means that all [`Edge`]s that bound a `Region` have the interior of the
+/// means that all [`HalfEdge`]s that bound a `Region` have the interior of the
 /// region on their left side (on the region's front side).
 ///
-/// [`Edge`]: crate::objects::Edge
+/// [`HalfEdge`]: crate::objects::HalfEdge
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Region {
     exterior: Handle<Cycle>,

--- a/crates/fj-core/src/objects/mod.rs
+++ b/crates/fj-core/src/objects/mod.rs
@@ -50,7 +50,7 @@ pub use self::{
     kinds::{
         curve::Curve,
         cycle::Cycle,
-        edge::Edge,
+        edge::HalfEdge,
         face::{Face, Handedness},
         region::Region,
         shell::Shell,

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -94,7 +94,7 @@ object!(
     Curve, "curve", curves;
     Cycle, "cycle", cycles;
     Face, "face", faces;
-    HalfEdge, "edge", edges;
+    HalfEdge, "half-edge", edges;
     Region, "region", regions;
     Shell, "shell", shells;
     Sketch, "sketch", sketches;

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{
-        Curve, Cycle, Edge, Face, Objects, Region, Shell, Sketch, Solid,
+        Curve, Cycle, Face, HalfEdge, Objects, Region, Shell, Sketch, Solid,
         Surface, Vertex,
     },
     storage::{Handle, HandleWrapper, ObjectId},
@@ -94,7 +94,7 @@ object!(
     Curve, "curve", curves;
     Cycle, "cycle", cycles;
     Face, "face", faces;
-    Edge, "edge", edges;
+    HalfEdge, "edge", edges;
     Region, "region", regions;
     Shell, "shell", shells;
     Sketch, "sketch", sketches;

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -94,7 +94,7 @@ object!(
     Curve, "curve", curves;
     Cycle, "cycle", cycles;
     Face, "face", faces;
-    HalfEdge, "half-edge", edges;
+    HalfEdge, "half-edge", half_edges;
     Region, "region", regions;
     Shell, "shell", shells;
     Sketch, "sketch", sketches;

--- a/crates/fj-core/src/objects/set.rs
+++ b/crates/fj-core/src/objects/set.rs
@@ -63,7 +63,7 @@ impl InsertIntoSet for Curve {
 
 impl InsertIntoSet for Cycle {
     fn insert_into_set(&self, objects: &mut ObjectSet) {
-        for edge in self.edges() {
+        for edge in self.half_edges() {
             objects.inner.insert(edge.clone().into());
             edge.insert_into_set(objects);
         }

--- a/crates/fj-core/src/objects/set.rs
+++ b/crates/fj-core/src/objects/set.rs
@@ -1,6 +1,8 @@
 use std::collections::{btree_set, BTreeSet};
 
-use super::{BehindHandle, Curve, Cycle, Edge, Face, Object, Surface, Vertex};
+use super::{
+    BehindHandle, Curve, Cycle, Face, HalfEdge, Object, Surface, Vertex,
+};
 
 /// A graph of objects and their relationships
 pub struct ObjectSet {
@@ -87,7 +89,7 @@ impl InsertIntoSet for Face {
     }
 }
 
-impl InsertIntoSet for Edge {
+impl InsertIntoSet for HalfEdge {
     fn insert_into_set(&self, objects: &mut ObjectSet) {
         objects.inner.insert(self.curve().clone().into());
         self.curve().insert_into_set(objects);

--- a/crates/fj-core/src/objects/stores.rs
+++ b/crates/fj-core/src/objects/stores.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{
-    Curve, Cycle, Edge, Face, Region, Shell, Sketch, Solid, Surface, Vertex,
+    Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid, Surface, Vertex,
 };
 
 /// The available object stores
@@ -18,8 +18,8 @@ pub struct Objects {
     /// Store for [`Cycle`]s
     pub cycles: Store<Cycle>,
 
-    /// Store for [`Edge`]s
-    pub edges: Store<Edge>,
+    /// Store for [`HalfEdge`]s
+    pub edges: Store<HalfEdge>,
 
     /// Store for [`Face`]s
     pub faces: Store<Face>,

--- a/crates/fj-core/src/objects/stores.rs
+++ b/crates/fj-core/src/objects/stores.rs
@@ -19,7 +19,7 @@ pub struct Objects {
     pub cycles: Store<Cycle>,
 
     /// Store for [`HalfEdge`]s
-    pub edges: Store<HalfEdge>,
+    pub half_edges: Store<HalfEdge>,
 
     /// Store for [`Face`]s
     pub faces: Store<Face>,

--- a/crates/fj-core/src/objects/stores.rs
+++ b/crates/fj-core/src/objects/stores.rs
@@ -18,11 +18,11 @@ pub struct Objects {
     /// Store for [`Cycle`]s
     pub cycles: Store<Cycle>,
 
-    /// Store for [`HalfEdge`]s
-    pub half_edges: Store<HalfEdge>,
-
     /// Store for [`Face`]s
     pub faces: Store<Face>,
+
+    /// Store for [`HalfEdge`]s
+    pub half_edges: Store<HalfEdge>,
 
     /// Store for [`Region`]s
     pub regions: Store<Region>,

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::{
     objects::{Cycle, HalfEdge},
-    operations::{BuildEdge, Insert, UpdateCycle},
+    operations::{BuildHalfEdge, Insert, UpdateCycle},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -2,7 +2,7 @@ use fj_math::{Point, Scalar};
 use itertools::Itertools;
 
 use crate::{
-    objects::{Cycle, Edge},
+    objects::{Cycle, HalfEdge},
     operations::{BuildEdge, Insert, UpdateCycle},
     services::Services,
 };
@@ -20,7 +20,8 @@ pub trait BuildCycle {
         radius: impl Into<Scalar>,
         services: &mut Services,
     ) -> Cycle {
-        let circle = Edge::circle(center, radius, services).insert(services);
+        let circle =
+            HalfEdge::circle(center, radius, services).insert(services);
         Cycle::empty().add_edges([circle])
     }
 
@@ -36,7 +37,7 @@ pub trait BuildCycle {
             .map(Into::into)
             .circular_tuple_windows()
             .map(|(start, end)| {
-                Edge::line_segment([start, end], None, services)
+                HalfEdge::line_segment([start, end], None, services)
                     .insert(services)
             });
 

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -22,7 +22,7 @@ pub trait BuildCycle {
     ) -> Cycle {
         let circle =
             HalfEdge::circle(center, radius, services).insert(services);
-        Cycle::empty().add_edges([circle])
+        Cycle::empty().add_half_edges([circle])
     }
 
     /// Build a polygon

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -3,23 +3,23 @@ use fj_math::{Arc, Point, Scalar};
 
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
-    objects::{Curve, Edge, Vertex},
+    objects::{Curve, HalfEdge, Vertex},
     operations::Insert,
     services::Services,
 };
 
-/// Build an [`Edge`]
+/// Build an [`HalfEdge`]
 pub trait BuildEdge {
     /// Create an edge that is not joined to another
     fn unjoined(
         path: SurfacePath,
         boundary: impl Into<CurveBoundary<Point<1>>>,
         services: &mut Services,
-    ) -> Edge {
+    ) -> HalfEdge {
         let curve = Curve::new().insert(services);
         let start_vertex = Vertex::new().insert(services);
 
-        Edge::new(path, boundary, curve, start_vertex)
+        HalfEdge::new(path, boundary, curve, start_vertex)
     }
 
     /// Create an arc
@@ -32,7 +32,7 @@ pub trait BuildEdge {
         end: impl Into<Point<2>>,
         angle_rad: impl Into<Scalar>,
         services: &mut Services,
-    ) -> Edge {
+    ) -> HalfEdge {
         let angle_rad = angle_rad.into();
         if angle_rad <= -Scalar::TAU || angle_rad >= Scalar::TAU {
             panic!("arc angle must be in the range (-2pi, 2pi) radians");
@@ -45,7 +45,7 @@ pub trait BuildEdge {
         let boundary =
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
-        Edge::unjoined(path, boundary, services)
+        HalfEdge::unjoined(path, boundary, services)
     }
 
     /// Create a circle
@@ -53,12 +53,12 @@ pub trait BuildEdge {
         center: impl Into<Point<2>>,
         radius: impl Into<Scalar>,
         services: &mut Services,
-    ) -> Edge {
+    ) -> HalfEdge {
         let path = SurfacePath::circle_from_center_and_radius(center, radius);
         let boundary =
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
-        Edge::unjoined(path, boundary, services)
+        HalfEdge::unjoined(path, boundary, services)
     }
 
     /// Create a line segment
@@ -66,15 +66,15 @@ pub trait BuildEdge {
         points_surface: [impl Into<Point<2>>; 2],
         boundary: Option<[Point<1>; 2]>,
         services: &mut Services,
-    ) -> Edge {
+    ) -> HalfEdge {
         let boundary =
             boundary.unwrap_or_else(|| [[0.], [1.]].map(Point::from));
         let path = SurfacePath::line_from_points_with_coords(
             boundary.zip_ext(points_surface),
         );
 
-        Edge::unjoined(path, boundary, services)
+        HalfEdge::unjoined(path, boundary, services)
     }
 }
 
-impl BuildEdge for Edge {}
+impl BuildEdge for HalfEdge {}

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -8,7 +8,7 @@ use crate::{
     services::Services,
 };
 
-/// Build an [`HalfEdge`]
+/// Build a [`HalfEdge`]
 pub trait BuildEdge {
     /// Create an edge that is not joined to another
     fn unjoined(

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Build a [`HalfEdge`]
 pub trait BuildHalfEdge {
-    /// Create an edge that is not joined to another
+    /// Create a half-edge that is not joined to a sibling
     fn unjoined(
         path: SurfacePath,
         boundary: impl Into<CurveBoundary<Point<1>>>,

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Build a [`HalfEdge`]
-pub trait BuildEdge {
+pub trait BuildHalfEdge {
     /// Create an edge that is not joined to another
     fn unjoined(
         path: SurfacePath,
@@ -77,4 +77,4 @@ pub trait BuildEdge {
     }
 }
 
-impl BuildEdge for HalfEdge {}
+impl BuildHalfEdge for HalfEdge {}

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -83,7 +83,7 @@ pub struct Polygon<const D: usize, I: IsInserted = IsInsertedNo> {
     /// The face that forms the polygon
     pub face: I::T<Face>,
 
-    /// The edges of the polygon
+    /// The half-edges of the polygon
     pub half_edges: [Handle<HalfEdge>; D],
 
     /// The vertices of the polygon

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -32,7 +32,8 @@ pub trait BuildFace {
         let face = Face::polygon(surface, points_surface, services);
 
         let edges = {
-            let mut edges = face.region().exterior().edges().iter().cloned();
+            let mut edges =
+                face.region().exterior().half_edges().iter().cloned();
 
             let array = array::from_fn(|_| edges.next()).map(|edge| {
                 edge.expect("Just asserted that there are three edges")
@@ -99,7 +100,7 @@ impl<const D: usize, I: IsInserted> Polygon<D, I> {
             face.borrow()
                 .region()
                 .exterior()
-                .edges()
+                .half_edges()
                 .nth(i)
                 .expect("Operation should not have changed length of cycle")
                 .clone()
@@ -111,7 +112,7 @@ impl<const D: usize, I: IsInserted> Polygon<D, I> {
             face.borrow()
                 .region()
                 .exterior()
-                .edges()
+                .half_edges()
                 .nth(i)
                 .expect("Operation should not have changed length of cycle")
                 .start_vertex()

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -31,7 +31,7 @@ pub trait BuildFace {
 
         let face = Face::polygon(surface, points_surface, services);
 
-        let edges = {
+        let half_edges = {
             let mut edges =
                 face.region().exterior().half_edges().iter().cloned();
 
@@ -43,13 +43,13 @@ pub trait BuildFace {
 
             array
         };
-        let vertices = edges
+        let vertices = half_edges
             .each_ref_ext()
             .map(|edge: &Handle<HalfEdge>| edge.start_vertex().clone());
 
         Polygon {
             face,
-            half_edges: edges,
+            half_edges,
             vertices,
         }
     }

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -96,7 +96,7 @@ impl<const D: usize, I: IsInserted> Polygon<D, I> {
     /// Returns a new instance of `Polygon` with the replaced face. Also updates
     /// the other fields of `Polygon` to match the new face.
     pub fn replace_face(&self, face: I::T<Face>) -> Self {
-        let edges = array::from_fn(|i| {
+        let half_edges = array::from_fn(|i| {
             face.borrow()
                 .region()
                 .exterior()
@@ -121,7 +121,7 @@ impl<const D: usize, I: IsInserted> Polygon<D, I> {
 
         Self {
             face,
-            half_edges: edges,
+            half_edges,
             vertices,
         }
     }

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -49,7 +49,7 @@ pub trait BuildFace {
 
         Polygon {
             face,
-            edges,
+            half_edges: edges,
             vertices,
         }
     }
@@ -84,7 +84,7 @@ pub struct Polygon<const D: usize, I: IsInserted = IsInsertedNo> {
     pub face: I::T<Face>,
 
     /// The edges of the polygon
-    pub edges: [Handle<HalfEdge>; D],
+    pub half_edges: [Handle<HalfEdge>; D],
 
     /// The vertices of the polygon
     pub vertices: [Handle<Vertex>; D],
@@ -121,7 +121,7 @@ impl<const D: usize, I: IsInserted> Polygon<D, I> {
 
         Self {
             face,
-            edges,
+            half_edges: edges,
             vertices,
         }
     }

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -4,7 +4,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
-    objects::{Cycle, Edge, Face, Region, Surface, Vertex},
+    objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
     operations::{
         BuildCycle, BuildRegion, BuildSurface, Insert, IsInserted, IsInsertedNo,
     },
@@ -44,7 +44,7 @@ pub trait BuildFace {
         };
         let vertices = edges
             .each_ref_ext()
-            .map(|edge: &Handle<Edge>| edge.start_vertex().clone());
+            .map(|edge: &Handle<HalfEdge>| edge.start_vertex().clone());
 
         Polygon {
             face,
@@ -83,7 +83,7 @@ pub struct Polygon<const D: usize, I: IsInserted = IsInsertedNo> {
     pub face: I::T<Face>,
 
     /// The edges of the polygon
-    pub edges: [Handle<Edge>; D],
+    pub edges: [Handle<HalfEdge>; D],
 
     /// The vertices of the polygon
     pub vertices: [Handle<Vertex>; D],

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -46,7 +46,7 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_edge(
+                        .update_half_edge(
                             cycle.half_edges().nth_circular(0),
                             |edge| {
                                 edge.reverse_curve_coordinate_systems(services)
@@ -67,7 +67,7 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_edge(
+                        .update_half_edge(
                             cycle.half_edges().nth_circular(1),
                             |edge| {
                                 edge.reverse_curve_coordinate_systems(services)
@@ -80,7 +80,7 @@ pub trait BuildShell {
                             2..=2,
                             services,
                         )
-                        .update_edge(
+                        .update_half_edge(
                             cycle.half_edges().nth_circular(0),
                             |edge| {
                                 edge.reverse_curve_coordinate_systems(services)
@@ -101,21 +101,21 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_edge(
+                        .update_half_edge(
                             cycle.half_edges().nth_circular(0),
                             |edge| {
                                 edge.reverse_curve_coordinate_systems(services)
                                     .insert(services)
                             },
                         )
-                        .update_edge(
+                        .update_half_edge(
                             cycle.half_edges().nth_circular(1),
                             |edge| {
                                 edge.reverse_curve_coordinate_systems(services)
                                     .insert(services)
                             },
                         )
-                        .update_edge(
+                        .update_half_edge(
                             cycle.half_edges().nth_circular(2),
                             |edge| {
                                 edge.reverse_curve_coordinate_systems(services)

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -46,10 +46,13 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_edge(cycle.edges().nth_circular(0), |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
+                        .update_edge(
+                            cycle.half_edges().nth_circular(0),
+                            |edge| {
+                                edge.reverse_curve_coordinate_systems(services)
+                                    .insert(services)
+                            },
+                        )
                         .join_to(
                             abc.face.region().exterior(),
                             0..=0,
@@ -64,20 +67,26 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_edge(cycle.edges().nth_circular(1), |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
+                        .update_edge(
+                            cycle.half_edges().nth_circular(1),
+                            |edge| {
+                                edge.reverse_curve_coordinate_systems(services)
+                                    .insert(services)
+                            },
+                        )
                         .join_to(
                             abc.face.region().exterior(),
                             1..=1,
                             2..=2,
                             services,
                         )
-                        .update_edge(cycle.edges().nth_circular(0), |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
+                        .update_edge(
+                            cycle.half_edges().nth_circular(0),
+                            |edge| {
+                                edge.reverse_curve_coordinate_systems(services)
+                                    .insert(services)
+                            },
+                        )
                         .join_to(
                             bad.face.region().exterior(),
                             0..=0,
@@ -92,18 +101,27 @@ pub trait BuildShell {
             region
                 .update_exterior(|cycle| {
                     cycle
-                        .update_edge(cycle.edges().nth_circular(0), |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
-                        .update_edge(cycle.edges().nth_circular(1), |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
-                        .update_edge(cycle.edges().nth_circular(2), |edge| {
-                            edge.reverse_curve_coordinate_systems(services)
-                                .insert(services)
-                        })
+                        .update_edge(
+                            cycle.half_edges().nth_circular(0),
+                            |edge| {
+                                edge.reverse_curve_coordinate_systems(services)
+                                    .insert(services)
+                            },
+                        )
+                        .update_edge(
+                            cycle.half_edges().nth_circular(1),
+                            |edge| {
+                                edge.reverse_curve_coordinate_systems(services)
+                                    .insert(services)
+                            },
+                        )
+                        .update_edge(
+                            cycle.half_edges().nth_circular(2),
+                            |edge| {
+                                edge.reverse_curve_coordinate_systems(services)
+                                    .insert(services)
+                            },
+                        )
                         .join_to(
                             abc.face.region().exterior(),
                             0..=0,

--- a/crates/fj-core/src/operations/insert/insert_trait.rs
+++ b/crates/fj-core/src/operations/insert/insert_trait.rs
@@ -47,7 +47,7 @@ impl_insert!(
     Curve, curves;
     Cycle, cycles;
     Face, faces;
-    HalfEdge, edges;
+    HalfEdge, half_edges;
     Region, regions;
     Shell, shells;
     Sketch, sketches;

--- a/crates/fj-core/src/operations/insert/insert_trait.rs
+++ b/crates/fj-core/src/operations/insert/insert_trait.rs
@@ -62,7 +62,7 @@ impl<const D: usize> Insert for Polygon<D, IsInsertedNo> {
     fn insert(self, services: &mut Services) -> Self::Inserted {
         Polygon {
             face: self.face.insert(services),
-            edges: self.edges,
+            half_edges: self.half_edges,
             vertices: self.vertices,
         }
     }

--- a/crates/fj-core/src/operations/insert/insert_trait.rs
+++ b/crates/fj-core/src/operations/insert/insert_trait.rs
@@ -1,6 +1,7 @@
 use crate::{
     objects::{
-        Curve, Cycle, Edge, Face, Region, Shell, Sketch, Solid, Surface, Vertex,
+        Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid, Surface,
+        Vertex,
     },
     operations::{Polygon, TetrahedronShell},
     services::Services,
@@ -46,7 +47,7 @@ impl_insert!(
     Curve, curves;
     Cycle, cycles;
     Face, faces;
-    Edge, edges;
+    HalfEdge, edges;
     Region, regions;
     Shell, shells;
     Sketch, sketches;

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -81,7 +81,7 @@ impl JoinCycle for Cycle {
         >,
         Es::IntoIter: Clone + ExactSizeIterator,
     {
-        self.add_edges(edges.into_iter().circular_tuple_windows().map(
+        self.add_half_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (edge, curve, boundary))| {
                 HalfEdge::unjoined(curve, boundary, services)
                     .update_curve(|_| edge.curve().clone())

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
-    objects::{Cycle, Edge},
+    objects::{Cycle, HalfEdge},
     operations::{BuildEdge, Insert, UpdateCycle, UpdateEdge},
     services::Services,
     storage::Handle,
@@ -18,7 +18,7 @@ pub trait JoinCycle {
     fn add_joined_edges<Es>(&self, edges: Es, services: &mut Services) -> Self
     where
         Es: IntoIterator<
-            Item = (Handle<Edge>, SurfacePath, CurveBoundary<Point<1>>),
+            Item = (Handle<HalfEdge>, SurfacePath, CurveBoundary<Point<1>>),
         >,
         Es::IntoIter: Clone + ExactSizeIterator;
 
@@ -77,13 +77,13 @@ impl JoinCycle for Cycle {
     fn add_joined_edges<Es>(&self, edges: Es, services: &mut Services) -> Self
     where
         Es: IntoIterator<
-            Item = (Handle<Edge>, SurfacePath, CurveBoundary<Point<1>>),
+            Item = (Handle<HalfEdge>, SurfacePath, CurveBoundary<Point<1>>),
         >,
         Es::IntoIter: Clone + ExactSizeIterator,
     {
         self.add_edges(edges.into_iter().circular_tuple_windows().map(
             |((prev, _, _), (edge, curve, boundary))| {
-                Edge::unjoined(curve, boundary, services)
+                HalfEdge::unjoined(curve, boundary, services)
                     .update_curve(|_| edge.curve().clone())
                     .update_start_vertex(|_| prev.start_vertex().clone())
                     .insert(services)

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -107,26 +107,32 @@ impl JoinCycle for Cycle {
         range.zip(range_other).fold(
             self.clone(),
             |cycle, (index, index_other)| {
-                let edge_other = other.edges().nth_circular(index_other);
+                let edge_other = other.half_edges().nth_circular(index_other);
 
                 cycle
-                    .update_edge(self.edges().nth_circular(index), |edge| {
-                        edge.update_curve(|_| edge_other.curve().clone())
-                            .update_start_vertex(|_| {
-                                other
-                                    .edges()
-                                    .nth_circular(index_other + 1)
-                                    .start_vertex()
-                                    .clone()
+                    .update_edge(
+                        self.half_edges().nth_circular(index),
+                        |edge| {
+                            edge.update_curve(|_| edge_other.curve().clone())
+                                .update_start_vertex(|_| {
+                                    other
+                                        .half_edges()
+                                        .nth_circular(index_other + 1)
+                                        .start_vertex()
+                                        .clone()
+                                })
+                                .insert(services)
+                        },
+                    )
+                    .update_edge(
+                        self.half_edges().nth_circular(index + 1),
+                        |edge| {
+                            edge.update_start_vertex(|_| {
+                                edge_other.start_vertex().clone()
                             })
                             .insert(services)
-                    })
-                    .update_edge(self.edges().nth_circular(index + 1), |edge| {
-                        edge.update_start_vertex(|_| {
-                            edge_other.start_vertex().clone()
-                        })
-                        .insert(services)
-                    })
+                        },
+                    )
             },
         )
     }

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
     objects::{Cycle, HalfEdge},
-    operations::{BuildEdge, Insert, UpdateCycle, UpdateEdge},
+    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateEdge},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
     objects::{Cycle, HalfEdge},
-    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateEdge},
+    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -110,7 +110,7 @@ impl JoinCycle for Cycle {
                 let edge_other = other.half_edges().nth_circular(index_other);
 
                 cycle
-                    .update_edge(
+                    .update_half_edge(
                         self.half_edges().nth_circular(index),
                         |edge| {
                             edge.update_curve(|_| edge_other.curve().clone())
@@ -124,7 +124,7 @@ impl JoinCycle for Cycle {
                                 .insert(services)
                         },
                     )
-                    .update_edge(
+                    .update_half_edge(
                         self.half_edges().nth_circular(index + 1),
                         |edge| {
                             edge.update_start_vertex(|_| {

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
     merge::Merge,
     reverse::Reverse,
     update::{
-        cycle::UpdateCycle, edge::UpdateEdge, face::UpdateFace,
+        cycle::UpdateCycle, edge::UpdateHalfEdge, face::UpdateFace,
         region::UpdateRegion, shell::UpdateShell, sketch::UpdateSketch,
         solid::UpdateSolid,
     },

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -10,7 +10,7 @@ mod update;
 pub use self::{
     build::{
         cycle::BuildCycle,
-        edge::BuildEdge,
+        edge::BuildHalfEdge,
         face::{BuildFace, Polygon},
         region::BuildRegion,
         shell::{BuildShell, TetrahedronShell},

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -9,7 +9,7 @@ use super::{Reverse, ReverseCurveCoordinateSystems};
 impl Reverse for Cycle {
     fn reverse(&self, services: &mut Services) -> Self {
         let mut edges = self
-            .edges()
+            .half_edges()
             .pairs()
             .map(|(current, next)| {
                 HalfEdge::new(
@@ -33,7 +33,7 @@ impl ReverseCurveCoordinateSystems for Cycle {
         &self,
         services: &mut Services,
     ) -> Self {
-        let edges = self.edges().iter().map(|edge| {
+        let edges = self.half_edges().iter().map(|edge| {
             edge.reverse_curve_coordinate_systems(services)
                 .insert(services)
         });

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    objects::{Cycle, Edge},
+    objects::{Cycle, HalfEdge},
     operations::Insert,
     services::Services,
 };
@@ -12,7 +12,7 @@ impl Reverse for Cycle {
             .edges()
             .pairs()
             .map(|(current, next)| {
-                Edge::new(
+                HalfEdge::new(
                     current.path(),
                     current.boundary().reverse(),
                     current.curve().clone(),

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -1,13 +1,13 @@
-use crate::{objects::Edge, services::Services};
+use crate::{objects::HalfEdge, services::Services};
 
 use super::ReverseCurveCoordinateSystems;
 
-impl ReverseCurveCoordinateSystems for Edge {
+impl ReverseCurveCoordinateSystems for HalfEdge {
     fn reverse_curve_coordinate_systems(&self, _: &mut Services) -> Self {
         let path = self.path().reverse();
         let boundary = self.boundary().reverse();
 
-        Edge::new(
+        HalfEdge::new(
             path,
             boundary,
             self.curve().clone(),

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -37,7 +37,7 @@ pub trait UpdateCycle {
     ///
     /// [`Handles::replace`]: crate::objects::Handles::replace
     #[must_use]
-    fn replace_edge<const N: usize>(
+    fn replace_half_edge<const N: usize>(
         &self,
         handle: &Handle<HalfEdge>,
         replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
@@ -62,7 +62,7 @@ impl UpdateCycle for Cycle {
         Cycle::new(edges)
     }
 
-    fn replace_edge<const N: usize>(
+    fn replace_half_edge<const N: usize>(
         &self,
         handle: &Handle<HalfEdge>,
         replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    objects::{Cycle, Edge},
+    objects::{Cycle, HalfEdge},
     storage::Handle,
 };
 
@@ -7,7 +7,10 @@ use crate::{
 pub trait UpdateCycle {
     /// Add edges to the cycle
     #[must_use]
-    fn add_edges(&self, edges: impl IntoIterator<Item = Handle<Edge>>) -> Self;
+    fn add_edges(
+        &self,
+        edges: impl IntoIterator<Item = Handle<HalfEdge>>,
+    ) -> Self;
 
     /// Update an edge of the cycle
     ///
@@ -19,8 +22,8 @@ pub trait UpdateCycle {
     #[must_use]
     fn update_edge(
         &self,
-        handle: &Handle<Edge>,
-        update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
+        handle: &Handle<HalfEdge>,
+        update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,
     ) -> Self;
 
     /// Replace an edge of the cycle
@@ -36,21 +39,24 @@ pub trait UpdateCycle {
     #[must_use]
     fn replace_edge<const N: usize>(
         &self,
-        handle: &Handle<Edge>,
-        replace: impl FnOnce(&Handle<Edge>) -> [Handle<Edge>; N],
+        handle: &Handle<HalfEdge>,
+        replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
     ) -> Self;
 }
 
 impl UpdateCycle for Cycle {
-    fn add_edges(&self, edges: impl IntoIterator<Item = Handle<Edge>>) -> Self {
+    fn add_edges(
+        &self,
+        edges: impl IntoIterator<Item = Handle<HalfEdge>>,
+    ) -> Self {
         let edges = self.edges().iter().cloned().chain(edges);
         Cycle::new(edges)
     }
 
     fn update_edge(
         &self,
-        handle: &Handle<Edge>,
-        update: impl FnOnce(&Handle<Edge>) -> Handle<Edge>,
+        handle: &Handle<HalfEdge>,
+        update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,
     ) -> Self {
         let edges = self.edges().update(handle, update);
         Cycle::new(edges)
@@ -58,8 +64,8 @@ impl UpdateCycle for Cycle {
 
     fn replace_edge<const N: usize>(
         &self,
-        handle: &Handle<Edge>,
-        replace: impl FnOnce(&Handle<Edge>) -> [Handle<Edge>; N],
+        handle: &Handle<HalfEdge>,
+        replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
     ) -> Self {
         let edges = self.edges().replace(handle, replace);
         Cycle::new(edges)

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -20,7 +20,7 @@ pub trait UpdateCycle {
     ///
     /// [`Handles::update`]: crate::objects::Handles::update
     #[must_use]
-    fn update_edge(
+    fn update_half_edge(
         &self,
         handle: &Handle<HalfEdge>,
         update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,
@@ -28,8 +28,8 @@ pub trait UpdateCycle {
 
     /// Replace an edge of the cycle
     ///
-    /// This is a more general version of [`UpdateCycle::update_edge`] which can
-    /// replace a single edge with multiple others.
+    /// This is a more general version of [`UpdateCycle::update_half_edge`]
+    /// which can replace a single edge with multiple others.
     ///
     /// # Panics
     ///
@@ -53,7 +53,7 @@ impl UpdateCycle for Cycle {
         Cycle::new(edges)
     }
 
-    fn update_edge(
+    fn update_half_edge(
         &self,
         handle: &Handle<HalfEdge>,
         update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -49,7 +49,7 @@ impl UpdateCycle for Cycle {
         &self,
         edges: impl IntoIterator<Item = Handle<HalfEdge>>,
     ) -> Self {
-        let edges = self.edges().iter().cloned().chain(edges);
+        let edges = self.half_edges().iter().cloned().chain(edges);
         Cycle::new(edges)
     }
 
@@ -58,7 +58,7 @@ impl UpdateCycle for Cycle {
         handle: &Handle<HalfEdge>,
         update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,
     ) -> Self {
-        let edges = self.edges().update(handle, update);
+        let edges = self.half_edges().update(handle, update);
         Cycle::new(edges)
     }
 
@@ -67,7 +67,7 @@ impl UpdateCycle for Cycle {
         handle: &Handle<HalfEdge>,
         replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
     ) -> Self {
-        let edges = self.edges().replace(handle, replace);
+        let edges = self.half_edges().replace(handle, replace);
         Cycle::new(edges)
     }
 }

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -7,7 +7,7 @@ use crate::{
 pub trait UpdateCycle {
     /// Add edges to the cycle
     #[must_use]
-    fn add_edges(
+    fn add_half_edges(
         &self,
         edges: impl IntoIterator<Item = Handle<HalfEdge>>,
     ) -> Self;
@@ -45,7 +45,7 @@ pub trait UpdateCycle {
 }
 
 impl UpdateCycle for Cycle {
-    fn add_edges(
+    fn add_half_edges(
         &self,
         edges: impl IntoIterator<Item = Handle<HalfEdge>>,
     ) -> Self {

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// Update a [`HalfEdge`]
-pub trait UpdateEdge {
+pub trait UpdateHalfEdge {
     /// Update the path of the edge
     #[must_use]
     fn update_path(
@@ -37,7 +37,7 @@ pub trait UpdateEdge {
     ) -> Self;
 }
 
-impl UpdateEdge for HalfEdge {
+impl UpdateHalfEdge for HalfEdge {
     fn update_path(
         &self,
         update: impl FnOnce(SurfacePath) -> SurfacePath,

--- a/crates/fj-core/src/operations/update/edge.rs
+++ b/crates/fj-core/src/operations/update/edge.rs
@@ -2,11 +2,11 @@ use fj_math::Point;
 
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
-    objects::{Curve, Edge, Vertex},
+    objects::{Curve, HalfEdge, Vertex},
     storage::Handle,
 };
 
-/// Update a [`Edge`]
+/// Update a [`HalfEdge`]
 pub trait UpdateEdge {
     /// Update the path of the edge
     #[must_use]
@@ -37,12 +37,12 @@ pub trait UpdateEdge {
     ) -> Self;
 }
 
-impl UpdateEdge for Edge {
+impl UpdateEdge for HalfEdge {
     fn update_path(
         &self,
         update: impl FnOnce(SurfacePath) -> SurfacePath,
     ) -> Self {
-        Edge::new(
+        HalfEdge::new(
             update(self.path()),
             self.boundary(),
             self.curve().clone(),
@@ -54,7 +54,7 @@ impl UpdateEdge for Edge {
         &self,
         update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
     ) -> Self {
-        Edge::new(
+        HalfEdge::new(
             self.path(),
             update(self.boundary()),
             self.curve().clone(),
@@ -66,7 +66,7 @@ impl UpdateEdge for Edge {
         &self,
         update: impl FnOnce(&Handle<Curve>) -> Handle<Curve>,
     ) -> Self {
-        Edge::new(
+        HalfEdge::new(
             self.path(),
             self.boundary(),
             update(self.curve()),
@@ -78,7 +78,7 @@ impl UpdateEdge for Edge {
         &self,
         update: impl FnOnce(&Handle<Vertex>) -> Handle<Vertex>,
     ) -> Self {
-        Edge::new(
+        HalfEdge::new(
             self.path(),
             self.boundary(),
             self.curve().clone(),

--- a/crates/fj-core/src/queries/all_edges_with_surface.rs
+++ b/crates/fj-core/src/queries/all_edges_with_surface.rs
@@ -1,5 +1,5 @@
 use crate::{
-    objects::{Edge, Face, Shell, Surface},
+    objects::{Face, HalfEdge, Shell, Surface},
     storage::Handle,
 };
 
@@ -8,14 +8,14 @@ pub trait AllEdgesWithSurface {
     /// Access all edges referenced by the object and the surface they're on
     fn all_edges_with_surface(
         &self,
-        result: &mut Vec<(Handle<Edge>, Handle<Surface>)>,
+        result: &mut Vec<(Handle<HalfEdge>, Handle<Surface>)>,
     );
 }
 
 impl AllEdgesWithSurface for Face {
     fn all_edges_with_surface(
         &self,
-        result: &mut Vec<(Handle<Edge>, Handle<Surface>)>,
+        result: &mut Vec<(Handle<HalfEdge>, Handle<Surface>)>,
     ) {
         for cycle in self.region().all_cycles() {
             result.extend(
@@ -32,7 +32,7 @@ impl AllEdgesWithSurface for Face {
 impl AllEdgesWithSurface for Shell {
     fn all_edges_with_surface(
         &self,
-        result: &mut Vec<(Handle<Edge>, Handle<Surface>)>,
+        result: &mut Vec<(Handle<HalfEdge>, Handle<Surface>)>,
     ) {
         for face in self.faces() {
             face.all_edges_with_surface(result);

--- a/crates/fj-core/src/queries/all_edges_with_surface.rs
+++ b/crates/fj-core/src/queries/all_edges_with_surface.rs
@@ -20,7 +20,7 @@ impl AllEdgesWithSurface for Face {
         for cycle in self.region().all_cycles() {
             result.extend(
                 cycle
-                    .edges()
+                    .half_edges()
                     .iter()
                     .cloned()
                     .map(|edge| (edge, self.surface().clone())),

--- a/crates/fj-core/src/queries/bounding_vertices_of_edge.rs
+++ b/crates/fj-core/src/queries/bounding_vertices_of_edge.rs
@@ -22,7 +22,7 @@ impl BoundingVerticesOfEdge for Cycle {
         edge: &Handle<HalfEdge>,
     ) -> Option<CurveBoundary<Vertex>> {
         let start = edge.start_vertex().clone();
-        let end = self.edges().after(edge)?.start_vertex().clone();
+        let end = self.half_edges().after(edge)?.start_vertex().clone();
 
         Some(CurveBoundary::from([start, end]))
     }

--- a/crates/fj-core/src/queries/bounding_vertices_of_edge.rs
+++ b/crates/fj-core/src/queries/bounding_vertices_of_edge.rs
@@ -1,6 +1,6 @@
 use crate::{
     geometry::CurveBoundary,
-    objects::{Cycle, Edge, Face, Region, Shell, Vertex},
+    objects::{Cycle, Face, HalfEdge, Region, Shell, Vertex},
     storage::Handle,
 };
 
@@ -12,14 +12,14 @@ pub trait BoundingVerticesOfEdge {
     /// method is called on.
     fn bounding_vertices_of_edge(
         &self,
-        edge: &Handle<Edge>,
+        edge: &Handle<HalfEdge>,
     ) -> Option<CurveBoundary<Vertex>>;
 }
 
 impl BoundingVerticesOfEdge for Cycle {
     fn bounding_vertices_of_edge(
         &self,
-        edge: &Handle<Edge>,
+        edge: &Handle<HalfEdge>,
     ) -> Option<CurveBoundary<Vertex>> {
         let start = edge.start_vertex().clone();
         let end = self.edges().after(edge)?.start_vertex().clone();
@@ -31,7 +31,7 @@ impl BoundingVerticesOfEdge for Cycle {
 impl BoundingVerticesOfEdge for Region {
     fn bounding_vertices_of_edge(
         &self,
-        edge: &Handle<Edge>,
+        edge: &Handle<HalfEdge>,
     ) -> Option<CurveBoundary<Vertex>> {
         for cycle in self.all_cycles() {
             if let Some(vertices) = cycle.bounding_vertices_of_edge(edge) {
@@ -46,7 +46,7 @@ impl BoundingVerticesOfEdge for Region {
 impl BoundingVerticesOfEdge for Face {
     fn bounding_vertices_of_edge(
         &self,
-        edge: &Handle<Edge>,
+        edge: &Handle<HalfEdge>,
     ) -> Option<CurveBoundary<Vertex>> {
         self.region().bounding_vertices_of_edge(edge)
     }
@@ -55,7 +55,7 @@ impl BoundingVerticesOfEdge for Face {
 impl BoundingVerticesOfEdge for Shell {
     fn bounding_vertices_of_edge(
         &self,
-        edge: &Handle<Edge>,
+        edge: &Handle<HalfEdge>,
     ) -> Option<CurveBoundary<Vertex>> {
         for face in self.faces() {
             if let Some(vertices) = face.bounding_vertices_of_edge(edge) {

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -23,7 +23,7 @@ pub enum CycleValidationError {
         "Adjacent `Edge`s are distinct\n\
         - End position of first `Edge`: {end_of_first:?}\n\
         - Start position of second `Edge`: {start_of_second:?}\n\
-        - `Edge`s: {edges:#?}"
+        - `Edge`s: {half_edges:#?}"
     )]
     EdgesDisconnected {
         /// The end position of the first [`HalfEdge`]
@@ -36,7 +36,7 @@ pub enum CycleValidationError {
         distance: Scalar,
 
         /// The edges
-        edges: Box<(HalfEdge, HalfEdge)>,
+        half_edges: Box<(HalfEdge, HalfEdge)>,
     },
 
     /// [`Cycle`]'s should have at least one [`HalfEdge`]
@@ -76,7 +76,7 @@ impl CycleValidationError {
                         end_of_first,
                         start_of_second,
                         distance,
-                        edges: Box::new((
+                        half_edges: Box::new((
                             first.clone_object(),
                             second.clone_object(),
                         )),

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -123,7 +123,7 @@ mod tests {
             ];
             let edges = edges.map(|edge| edge.insert(&mut services));
 
-            Cycle::empty().add_edges(edges)
+            Cycle::empty().add_half_edges(edges)
         };
 
         assert_contains_err!(

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -1,6 +1,6 @@
 use fj_math::{Point, Scalar};
 
-use crate::objects::{Cycle, Edge};
+use crate::objects::{Cycle, HalfEdge};
 
 use super::{Validate, ValidationConfig, ValidationError};
 
@@ -26,20 +26,20 @@ pub enum CycleValidationError {
         - `Edge`s: {edges:#?}"
     )]
     EdgesDisconnected {
-        /// The end position of the first [`Edge`]
+        /// The end position of the first [`HalfEdge`]
         end_of_first: Point<2>,
 
-        /// The start position of the second [`Edge`]
+        /// The start position of the second [`HalfEdge`]
         start_of_second: Point<2>,
 
         /// The distance between the two vertices
         distance: Scalar,
 
         /// The edges
-        edges: Box<(Edge, Edge)>,
+        edges: Box<(HalfEdge, HalfEdge)>,
     },
 
-    /// [`Cycle`]'s should have at least one [`Edge`]
+    /// [`Cycle`]'s should have at least one [`HalfEdge`]
     #[error("Expected at least one `Edge`\n")]
     NotEnoughEdges,
 }
@@ -93,7 +93,7 @@ mod tests {
 
     use crate::{
         assert_contains_err,
-        objects::{Cycle, Edge},
+        objects::{Cycle, HalfEdge},
         operations::{BuildCycle, BuildEdge, Insert, UpdateCycle},
         services::Services,
         validate::{cycle::CycleValidationError, Validate, ValidationError},
@@ -110,8 +110,16 @@ mod tests {
 
         let disconnected = {
             let edges = [
-                Edge::line_segment([[0., 0.], [1., 0.]], None, &mut services),
-                Edge::line_segment([[0., 0.], [1., 0.]], None, &mut services),
+                HalfEdge::line_segment(
+                    [[0., 0.], [1., 0.]],
+                    None,
+                    &mut services,
+                ),
+                HalfEdge::line_segment(
+                    [[0., 0.], [1., 0.]],
+                    None,
+                    &mut services,
+                ),
             ];
             let edges = edges.map(|edge| edge.insert(&mut services));
 

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -94,7 +94,7 @@ mod tests {
     use crate::{
         assert_contains_err,
         objects::{Cycle, HalfEdge},
-        operations::{BuildCycle, BuildEdge, Insert, UpdateCycle},
+        operations::{BuildCycle, BuildHalfEdge, Insert, UpdateCycle},
         services::Services,
         validate::{cycle::CycleValidationError, Validate, ValidationError},
     };

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -51,7 +51,7 @@ impl CycleValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         // If there are no half edges
-        if cycle.edges().iter().next().is_none() {
+        if cycle.half_edges().iter().next().is_none() {
             errors.push(Self::NotEnoughEdges.into());
         }
     }
@@ -61,7 +61,7 @@ impl CycleValidationError {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        for (first, second) in cycle.edges().pairs() {
+        for (first, second) in cycle.half_edges().pairs() {
             let end_of_first = {
                 let [_, end] = first.boundary().inner;
                 first.path().point_from_path_coords(end)

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -1,10 +1,10 @@
 use fj_math::{Point, Scalar};
 
-use crate::objects::Edge;
+use crate::objects::HalfEdge;
 
 use super::{Validate, ValidationConfig, ValidationError};
 
-impl Validate for Edge {
+impl Validate for HalfEdge {
     fn validate_with_config(
         &self,
         config: &ValidationConfig,
@@ -14,10 +14,10 @@ impl Validate for Edge {
     }
 }
 
-/// [`Edge`] validation failed
+/// [`HalfEdge`] validation failed
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum EdgeValidationError {
-    /// [`Edge`]'s vertices are coincident
+    /// [`HalfEdge`]'s vertices are coincident
     #[error(
         "Vertices of `Edge` on curve are coincident\n\
         - Position of back vertex: {back_position:?}\n\
@@ -35,13 +35,13 @@ pub enum EdgeValidationError {
         distance: Scalar,
 
         /// The edge
-        edge: Edge,
+        edge: HalfEdge,
     },
 }
 
 impl EdgeValidationError {
     fn check_vertex_coincidence(
-        edge: &Edge,
+        edge: &HalfEdge,
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
@@ -68,7 +68,7 @@ mod tests {
 
     use crate::{
         assert_contains_err,
-        objects::Edge,
+        objects::HalfEdge,
         operations::BuildEdge,
         services::Services,
         validate::{EdgeValidationError, Validate, ValidationError},
@@ -79,11 +79,11 @@ mod tests {
         let mut services = Services::new();
 
         let valid =
-            Edge::line_segment([[0., 0.], [1., 0.]], None, &mut services);
+            HalfEdge::line_segment([[0., 0.], [1., 0.]], None, &mut services);
         let invalid = {
             let boundary = [Point::from([0.]); 2];
 
-            Edge::new(
+            HalfEdge::new(
                 valid.path(),
                 boundary,
                 valid.curve().clone(),

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::{
         assert_contains_err,
         objects::HalfEdge,
-        operations::BuildEdge,
+        operations::BuildHalfEdge,
         services::Services,
         validate::{EdgeValidationError, Validate, ValidationError},
     };

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -22,7 +22,7 @@ pub enum EdgeValidationError {
         "Vertices of `Edge` on curve are coincident\n\
         - Position of back vertex: {back_position:?}\n\
         - Position of front vertex: {front_position:?}\n\
-        - `Edge`: {edge:#?}"
+        - `Edge`: {half_edge:#?}"
     )]
     VerticesAreCoincident {
         /// The position of the back vertex
@@ -35,7 +35,7 @@ pub enum EdgeValidationError {
         distance: Scalar,
 
         /// The edge
-        edge: HalfEdge,
+        half_edge: HalfEdge,
     },
 }
 
@@ -54,7 +54,7 @@ impl EdgeValidationError {
                     back_position,
                     front_position,
                     distance,
-                    edge: edge.clone(),
+                    half_edge: edge.clone(),
                 }
                 .into(),
             );

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -38,7 +38,7 @@ pub enum FaceValidationError {
 
 impl FaceValidationError {
     fn check_interior_winding(face: &Face, errors: &mut Vec<ValidationError>) {
-        if face.region().exterior().edges().is_empty() {
+        if face.region().exterior().half_edges().is_empty() {
             // Can't determine winding, if the cycle has no edges. Sounds like a
             // job for a different validation check.
             return;
@@ -47,7 +47,7 @@ impl FaceValidationError {
         let exterior_winding = face.region().exterior().winding();
 
         for interior in face.region().interiors() {
-            if interior.edges().is_empty() {
+            if interior.half_edges().is_empty() {
                 // Can't determine winding, if the cycle has no edges. Sounds
                 // like a job for a different validation check.
                 continue;

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -376,8 +376,8 @@ mod tests {
         assert_contains_err,
         objects::{Curve, Shell},
         operations::{
-            BuildShell, Insert, Reverse, UpdateCycle, UpdateEdge, UpdateFace,
-            UpdateRegion, UpdateShell,
+            BuildShell, Insert, Reverse, UpdateCycle, UpdateFace,
+            UpdateHalfEdge, UpdateRegion, UpdateShell,
         },
         services::Services,
         validate::{shell::ShellValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -298,7 +298,7 @@ impl ShellValidationError {
 
         for face in shell.faces() {
             for cycle in face.region().all_cycles() {
-                for edge in cycle.edges() {
+                for edge in cycle.half_edges() {
                     let curve = HandleWrapper::from(edge.curve().clone());
 
                     let unmatched_edges = unmatched_edges_by_curve
@@ -327,7 +327,7 @@ impl ShellValidationError {
 
         for face in shell.faces() {
             for cycle in face.region().all_cycles() {
-                for edge in cycle.edges() {
+                for edge in cycle.half_edges() {
                     let curve = HandleWrapper::from(edge.curve().clone());
                     let boundary = cycle
                         .bounding_vertices_of_edge(edge)
@@ -397,7 +397,7 @@ mod tests {
                     .update_exterior(|cycle| {
                         cycle
                             .update_edge(
-                                cycle.edges().nth_circular(0),
+                                cycle.half_edges().nth_circular(0),
                                 |edge| {
                                     edge.update_path(|path| path.reverse())
                                         .update_boundary(|boundary| {
@@ -438,7 +438,7 @@ mod tests {
                     .update_exterior(|cycle| {
                         cycle
                             .update_edge(
-                                cycle.edges().nth_circular(0),
+                                cycle.half_edges().nth_circular(0),
                                 |edge| {
                                     edge.update_curve(|_| {
                                         Curve::new().insert(&mut services)

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -164,7 +164,7 @@ impl ShellValidationError {
 
                         if distance > config.identical_max_distance {
                             mismatches.push(CurveCoordinateSystemMismatch {
-                                edge_a: edge_a.clone(),
+                                half_edge_a: edge_a.clone(),
                                 edge_b: edge_b.clone(),
                                 point_curve,
                                 point_a: a_global,
@@ -362,7 +362,7 @@ impl ShellValidationError {
 
 #[derive(Clone, Debug)]
 pub struct CurveCoordinateSystemMismatch {
-    pub edge_a: Handle<HalfEdge>,
+    pub half_edge_a: Handle<HalfEdge>,
     pub edge_b: Handle<HalfEdge>,
     pub point_curve: Point<1>,
     pub point_a: Point<3>,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -4,7 +4,7 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     geometry::{CurveBoundaries, SurfaceGeometry},
-    objects::{Edge, Shell, Surface},
+    objects::{HalfEdge, Shell, Surface},
     queries::{AllEdgesWithSurface, BoundingVerticesOfEdge},
     storage::{Handle, HandleWrapper},
 };
@@ -46,7 +46,7 @@ pub enum ShellValidationError {
         Edge 1: {0:#?}\n\
         Edge 2: {1:#?}"
     )]
-    CoincidentEdgesNotIdentical(Handle<Edge>, Handle<Edge>),
+    CoincidentEdgesNotIdentical(Handle<HalfEdge>, Handle<HalfEdge>),
 
     /// [`Shell`] contains edges that are identical, but do not coincide
     #[error(
@@ -58,13 +58,13 @@ pub enum ShellValidationError {
     )]
     IdenticalEdgesNotCoincident {
         /// The first edge
-        edge_a: Handle<Edge>,
+        edge_a: Handle<HalfEdge>,
 
         /// The surface that the first edge is on
         surface_a: Handle<Surface>,
 
         /// The second edge
-        edge_b: Handle<Edge>,
+        edge_b: Handle<HalfEdge>,
 
         /// The surface that the second edge is on
         surface_b: Handle<Surface>,
@@ -79,14 +79,14 @@ pub enum ShellValidationError {
 ///
 /// Returns an [`Iterator`] of the distance at each sample.
 fn distances(
-    edge_a: Handle<Edge>,
+    edge_a: Handle<HalfEdge>,
     surface_a: Handle<Surface>,
-    edge_b: Handle<Edge>,
+    edge_b: Handle<HalfEdge>,
     surface_b: Handle<Surface>,
 ) -> impl Iterator<Item = Scalar> {
     fn sample(
         percent: f64,
-        (edge, surface): (&Handle<Edge>, SurfaceGeometry),
+        (edge, surface): (&Handle<HalfEdge>, SurfaceGeometry),
     ) -> Point<3> {
         let [start, end] = edge.boundary().inner;
         let path_coords = start + (end - start) * percent;
@@ -132,9 +132,9 @@ impl ShellValidationError {
                 }
 
                 fn compare_curve_coords(
-                    edge_a: &Handle<Edge>,
+                    edge_a: &Handle<HalfEdge>,
                     surface_a: &Handle<Surface>,
-                    edge_b: &Handle<Edge>,
+                    edge_b: &Handle<HalfEdge>,
                     surface_b: &Handle<Surface>,
                     config: &ValidationConfig,
                     mismatches: &mut Vec<CurveCoordinateSystemMismatch>,
@@ -362,8 +362,8 @@ impl ShellValidationError {
 
 #[derive(Clone, Debug)]
 pub struct CurveCoordinateSystemMismatch {
-    pub edge_a: Handle<Edge>,
-    pub edge_b: Handle<Edge>,
+    pub edge_a: Handle<HalfEdge>,
+    pub edge_b: Handle<HalfEdge>,
     pub point_curve: Point<1>,
     pub point_a: Point<3>,
     pub point_b: Point<3>,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -165,7 +165,7 @@ impl ShellValidationError {
                         if distance > config.identical_max_distance {
                             mismatches.push(CurveCoordinateSystemMismatch {
                                 half_edge_a: edge_a.clone(),
-                                edge_b: edge_b.clone(),
+                                half_edge_b: edge_b.clone(),
                                 point_curve,
                                 point_a: a_global,
                                 point_b: b_global,
@@ -363,7 +363,7 @@ impl ShellValidationError {
 #[derive(Clone, Debug)]
 pub struct CurveCoordinateSystemMismatch {
     pub half_edge_a: Handle<HalfEdge>,
-    pub edge_b: Handle<HalfEdge>,
+    pub half_edge_b: Handle<HalfEdge>,
     pub point_curve: Point<1>,
     pub point_a: Point<3>,
     pub point_b: Point<3>,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -396,7 +396,7 @@ mod tests {
                 region
                     .update_exterior(|cycle| {
                         cycle
-                            .update_edge(
+                            .update_half_edge(
                                 cycle.half_edges().nth_circular(0),
                                 |edge| {
                                     edge.update_path(|path| path.reverse())
@@ -437,7 +437,7 @@ mod tests {
                 region
                     .update_exterior(|cycle| {
                         cycle
-                            .update_edge(
+                            .update_half_edge(
                                 cycle.half_edges().nth_circular(0),
                                 |edge| {
                                     edge.update_curve(|_| {

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -53,7 +53,7 @@ pub enum ShellValidationError {
         "Shell contains `Edge`s that are identical but do not coincide\n\
         Edge 1: {half_edge_a:#?}\n\
         Surface for edge 1: {surface_a:#?}\n\
-        Edge 2: {edge_b:#?}\n\
+        Edge 2: {half_edge_b:#?}\n\
         Surface for edge 2: {surface_b:#?}"
     )]
     IdenticalEdgesNotCoincident {
@@ -64,7 +64,7 @@ pub enum ShellValidationError {
         surface_a: Handle<Surface>,
 
         /// The second edge
-        edge_b: Handle<HalfEdge>,
+        half_edge_b: Handle<HalfEdge>,
 
         /// The surface that the second edge is on
         surface_b: Handle<Surface>,
@@ -257,7 +257,7 @@ impl ShellValidationError {
                                 Self::IdenticalEdgesNotCoincident {
                                     half_edge_a: edge_a.clone(),
                                     surface_a: surface_a.clone(),
-                                    edge_b: edge_b.clone(),
+                                    half_edge_b: edge_b.clone(),
                                     surface_b: surface_b.clone(),
                                 }
                                 .into(),

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -51,14 +51,14 @@ pub enum ShellValidationError {
     /// [`Shell`] contains edges that are identical, but do not coincide
     #[error(
         "Shell contains `Edge`s that are identical but do not coincide\n\
-        Edge 1: {edge_a:#?}\n\
+        Edge 1: {half_edge_a:#?}\n\
         Surface for edge 1: {surface_a:#?}\n\
         Edge 2: {edge_b:#?}\n\
         Surface for edge 2: {surface_b:#?}"
     )]
     IdenticalEdgesNotCoincident {
         /// The first edge
-        edge_a: Handle<HalfEdge>,
+        half_edge_a: Handle<HalfEdge>,
 
         /// The surface that the first edge is on
         surface_a: Handle<Surface>,
@@ -255,7 +255,7 @@ impl ShellValidationError {
                         {
                             errors.push(
                                 Self::IdenticalEdgesNotCoincident {
-                                    edge_a: edge_a.clone(),
+                                    half_edge_a: edge_a.clone(),
                                     surface_a: surface_a.clone(),
                                     edge_b: edge_b.clone(),
                                     surface_b: surface_b.clone(),

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -75,7 +75,7 @@ impl SolidValidationError {
             .flat_map(|face| {
                 face.region()
                     .all_cycles()
-                    .flat_map(|cycle| cycle.edges().iter().cloned())
+                    .flat_map(|cycle| cycle.half_edges().iter().cloned())
                     .zip(repeat(face.surface().geometry()))
             })
             .map(|(h, s)| {


### PR DESCRIPTION
From the main commit:

> This reverts a decision made some time ago, after `GlobalEdge` had been removed and the name `Edge` became free.
>
> While `Edge` is shorter and thus nicer, it's also less clear. I found that it's easy to forget that this object is not actually "the edge", but only, well, a half-edge that always had an equal but opposite sibling.
>
> And that's despite me working on this almost daily, so I guess it's potentially even more confusing for someone less active in the code base.

I also renamed quite a few things that refer to `HalfEdge`, but didn't go through the effort of updating every single argument and variable name. That can happen piece-meal, as that code gets touched for other reasons.