### PR TITLE
Clean up edge approximation code

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -1,0 +1,58 @@
+//! Curve approximation
+
+use std::collections::BTreeMap;
+
+use fj_math::Point;
+
+use crate::{
+    geometry::CurveBoundary,
+    objects::Curve,
+    storage::{Handle, HandleWrapper},
+};
+
+use super::ApproxPoint;
+
+/// Cache for curve approximations
+#[derive(Default)]
+pub struct CurveApproxCache {
+    inner: BTreeMap<
+        (HandleWrapper<Curve>, CurveBoundary<Point<1>>),
+        Vec<ApproxPoint<1>>,
+    >,
+}
+
+impl CurveApproxCache {
+    /// Get an approximated curve from the cache
+    pub fn get(
+        &self,
+        handle: &Handle<Curve>,
+        boundary: CurveBoundary<Point<1>>,
+    ) -> Option<Vec<ApproxPoint<1>>> {
+        let handle = HandleWrapper::from(handle.clone());
+
+        if let Some(approx) = self.inner.get(&(handle.clone(), boundary)) {
+            return Some(approx.clone());
+        }
+        if let Some(approx) = self.inner.get(&(handle, boundary.reverse())) {
+            let mut approx = approx.clone();
+            approx.reverse();
+
+            return Some(approx);
+        }
+
+        None
+    }
+
+    /// Insert an approximated curve into the cache
+    pub fn insert(
+        &mut self,
+        handle: Handle<Curve>,
+        boundary: CurveBoundary<Point<1>>,
+        approx: Vec<ApproxPoint<1>>,
+    ) -> Vec<ApproxPoint<1>> {
+        let handle = HandleWrapper::from(handle);
+        self.inner
+            .insert((handle, boundary), approx.clone())
+            .unwrap_or(approx)
+    }
+}

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -42,7 +42,7 @@ impl Approx
     }
 }
 
-pub(super) fn approx_curve(
+fn approx_curve(
     path: &SurfacePath,
     surface: &Surface,
     boundary: CurveBoundary<Point<1>>,

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -5,12 +5,88 @@ use std::collections::BTreeMap;
 use fj_math::Point;
 
 use crate::{
-    geometry::CurveBoundary,
-    objects::Curve,
+    geometry::{CurveBoundary, GlobalPath, SurfacePath},
+    objects::{Curve, Surface},
     storage::{Handle, HandleWrapper},
 };
 
-use super::ApproxPoint;
+use super::{Approx, ApproxPoint, Tolerance};
+
+pub(super) fn approx_curve(
+    path: &SurfacePath,
+    surface: &Surface,
+    boundary: CurveBoundary<Point<1>>,
+    tolerance: impl Into<Tolerance>,
+) -> CurveApprox {
+    // There are different cases of varying complexity. Circles are the hard
+    // part here, as they need to be approximated, while lines don't need to be.
+    //
+    // This will probably all be unified eventually, as `SurfacePath` and
+    // `GlobalPath` grow APIs that are better suited to implementing this code
+    // in a more abstract way.
+    let points = match (path, surface.geometry().u) {
+        (SurfacePath::Circle(_), GlobalPath::Circle(_)) => {
+            todo!(
+                "Approximating a circle on a curved surface not supported yet."
+            )
+        }
+        (SurfacePath::Circle(_), GlobalPath::Line(_)) => {
+            (path, boundary)
+                .approx_with_cache(tolerance, &mut ())
+                .into_iter()
+                .map(|(point_curve, point_surface)| {
+                    // We're throwing away `point_surface` here, which is a bit
+                    // weird, as we're recomputing it later (outside of this
+                    // function).
+                    //
+                    // It should be fine though:
+                    //
+                    // 1. We're throwing this version away, so there's no danger
+                    //    of inconsistency between this and the later version.
+                    // 2. This version should have been computed using the same
+                    //    path and parameters and the later version will be, so
+                    //    they should be the same anyway.
+                    // 3. Not all other cases handled in this function have a
+                    //    surface point available, so it needs to be computed
+                    //    later anyway, in the general case.
+
+                    let point_global = surface
+                        .geometry()
+                        .point_from_surface_coords(point_surface);
+                    (point_curve, point_global)
+                })
+                .collect()
+        }
+        (SurfacePath::Line(line), _) => {
+            let range_u =
+                CurveBoundary::from(boundary.inner.map(|point_curve| {
+                    [path.point_from_path_coords(point_curve).u]
+                }));
+
+            let approx_u = (surface.geometry().u, range_u)
+                .approx_with_cache(tolerance, &mut ());
+
+            let mut points = Vec::new();
+            for (u, _) in approx_u {
+                let t = (u.t - line.origin().u) / line.direction().u;
+                let point_surface = path.point_from_path_coords([t]);
+                let point_global =
+                    surface.geometry().point_from_surface_coords(point_surface);
+                points.push((u, point_global));
+            }
+
+            points
+        }
+    };
+
+    let points = points
+        .into_iter()
+        .map(|(point_curve, point_global)| {
+            ApproxPoint::new(point_curve, point_global)
+        })
+        .collect();
+    CurveApprox { points }
+}
 
 /// Approximation of [`Curve`], within a specific boundary
 #[derive(Clone)]

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -12,6 +12,36 @@ use crate::{
 
 use super::{Approx, ApproxPoint, Tolerance};
 
+impl Approx
+    for (
+        &Handle<Curve>,
+        SurfacePath,
+        &Surface,
+        CurveBoundary<Point<1>>,
+    )
+{
+    type Approximation = CurveApprox;
+    type Cache = CurveApproxCache;
+
+    fn approx_with_cache(
+        self,
+        tolerance: impl Into<Tolerance>,
+        cache: &mut Self::Cache,
+    ) -> Self::Approximation {
+        let (curve, surface_path, surface, boundary) = self;
+
+        match cache.get(curve, boundary) {
+            Some(approx) => approx,
+            None => {
+                let approx =
+                    approx_curve(&surface_path, surface, boundary, tolerance);
+
+                cache.insert(curve.clone(), boundary, approx)
+            }
+        }
+    }
+}
+
 pub(super) fn approx_curve(
     path: &SurfacePath,
     surface: &Surface,

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -19,6 +19,13 @@ pub struct CurveApprox {
     pub points: Vec<ApproxPoint<1>>,
 }
 
+impl CurveApprox {
+    fn reverse(mut self) -> Self {
+        self.points.reverse();
+        self
+    }
+}
+
 /// Cache for curve approximations
 #[derive(Default)]
 pub struct CurveApproxCache {
@@ -39,10 +46,7 @@ impl CurveApproxCache {
             return Some(approx.clone());
         }
         if let Some(approx) = self.inner.get(&(handle, boundary.reverse())) {
-            let mut approx = approx.clone();
-            approx.points.reverse();
-
-            return Some(approx);
+            return Some(approx.clone().reverse());
         }
 
         None

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -12,13 +12,18 @@ use crate::{
 
 use super::ApproxPoint;
 
+/// Approximation of [`Curve`], within a specific boundary
+#[derive(Clone)]
+pub struct CurveApprox {
+    /// The points that approximate the curve within the boundary
+    pub points: Vec<ApproxPoint<1>>,
+}
+
 /// Cache for curve approximations
 #[derive(Default)]
 pub struct CurveApproxCache {
-    inner: BTreeMap<
-        (HandleWrapper<Curve>, CurveBoundary<Point<1>>),
-        Vec<ApproxPoint<1>>,
-    >,
+    inner:
+        BTreeMap<(HandleWrapper<Curve>, CurveBoundary<Point<1>>), CurveApprox>,
 }
 
 impl CurveApproxCache {
@@ -27,7 +32,7 @@ impl CurveApproxCache {
         &self,
         handle: &Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,
-    ) -> Option<Vec<ApproxPoint<1>>> {
+    ) -> Option<CurveApprox> {
         let handle = HandleWrapper::from(handle.clone());
 
         if let Some(approx) = self.inner.get(&(handle.clone(), boundary)) {
@@ -35,7 +40,7 @@ impl CurveApproxCache {
         }
         if let Some(approx) = self.inner.get(&(handle, boundary.reverse())) {
             let mut approx = approx.clone();
-            approx.reverse();
+            approx.points.reverse();
 
             return Some(approx);
         }
@@ -48,8 +53,8 @@ impl CurveApproxCache {
         &mut self,
         handle: Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,
-        approx: Vec<ApproxPoint<1>>,
-    ) -> Vec<ApproxPoint<1>> {
+        approx: CurveApprox,
+    ) -> CurveApprox {
         let handle = HandleWrapper::from(handle);
         self.inner
             .insert((handle, boundary), approx.clone())

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -140,8 +140,7 @@ pub struct CurveApproxCache {
 }
 
 impl CurveApproxCache {
-    /// Get an approximated curve from the cache
-    pub fn get(
+    fn get(
         &self,
         handle: &Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,
@@ -158,8 +157,7 @@ impl CurveApproxCache {
         None
     }
 
-    /// Insert an approximated curve into the cache
-    pub fn insert(
+    fn insert(
         &mut self,
         handle: Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,

--- a/crates/fj-core/src/algorithms/approx/cycle.rs
+++ b/crates/fj-core/src/algorithms/approx/cycle.rs
@@ -9,13 +9,13 @@ use fj_math::Segment;
 use crate::objects::{Cycle, Surface};
 
 use super::{
-    edge::{EdgeApproxCache, HalfEdgeApprox},
+    edge::{HalfEdgeApprox, HalfEdgeApproxCache},
     Approx, ApproxPoint, Tolerance,
 };
 
 impl Approx for (&Cycle, &Surface) {
     type Approximation = CycleApprox;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -15,7 +15,7 @@ use crate::{
     storage::{Handle, HandleWrapper},
 };
 
-use super::{Approx, ApproxPoint, Tolerance};
+use super::{vertex::VertexApproxCache, Approx, ApproxPoint, Tolerance};
 
 impl Approx for (&HalfEdge, &Surface) {
     type Approximation = HalfEdgeApprox;
@@ -170,7 +170,7 @@ fn approx_curve(
 /// Cache for edge approximations
 #[derive(Default)]
 pub struct EdgeApproxCache {
-    start_position_approx: BTreeMap<HandleWrapper<Vertex>, Point<3>>,
+    start_position_approx: VertexApproxCache,
     curve_approx: BTreeMap<
         (HandleWrapper<Curve>, CurveBoundary<Point<1>>),
         Vec<ApproxPoint<1>>,
@@ -182,9 +182,7 @@ impl EdgeApproxCache {
         &self,
         handle: &Handle<Vertex>,
     ) -> Option<Point<3>> {
-        self.start_position_approx
-            .get(&handle.clone().into())
-            .cloned()
+        self.start_position_approx.get(handle)
     }
 
     fn insert_start_position_approx(
@@ -192,9 +190,7 @@ impl EdgeApproxCache {
         handle: &Handle<Vertex>,
         position: Point<3>,
     ) -> Point<3> {
-        self.start_position_approx
-            .insert(handle.clone().into(), position)
-            .unwrap_or(position)
+        self.start_position_approx.insert(handle.clone(), position)
     }
 
     fn get_curve_approx(

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -5,15 +5,10 @@
 //! approximations are usually used to build cycle approximations, and this way,
 //! the caller doesn't have to deal with duplicate vertices.
 
-use fj_math::Point;
-
-use crate::{
-    geometry::{CurveBoundary, GlobalPath, SurfacePath},
-    objects::{HalfEdge, Surface},
-};
+use crate::objects::{HalfEdge, Surface};
 
 use super::{
-    curve::{CurveApprox, CurveApproxCache},
+    curve::{approx_curve, CurveApproxCache},
     vertex::VertexApproxCache,
     Approx, ApproxPoint, Tolerance,
 };
@@ -88,82 +83,6 @@ impl Approx for (&HalfEdge, &Surface) {
 pub struct HalfEdgeApprox {
     /// The points that approximate the half-edge
     pub points: Vec<ApproxPoint<2>>,
-}
-
-fn approx_curve(
-    path: &SurfacePath,
-    surface: &Surface,
-    boundary: CurveBoundary<Point<1>>,
-    tolerance: impl Into<Tolerance>,
-) -> CurveApprox {
-    // There are different cases of varying complexity. Circles are the hard
-    // part here, as they need to be approximated, while lines don't need to be.
-    //
-    // This will probably all be unified eventually, as `SurfacePath` and
-    // `GlobalPath` grow APIs that are better suited to implementing this code
-    // in a more abstract way.
-    let points = match (path, surface.geometry().u) {
-        (SurfacePath::Circle(_), GlobalPath::Circle(_)) => {
-            todo!(
-                "Approximating a circle on a curved surface not supported yet."
-            )
-        }
-        (SurfacePath::Circle(_), GlobalPath::Line(_)) => {
-            (path, boundary)
-                .approx_with_cache(tolerance, &mut ())
-                .into_iter()
-                .map(|(point_curve, point_surface)| {
-                    // We're throwing away `point_surface` here, which is a bit
-                    // weird, as we're recomputing it later (outside of this
-                    // function).
-                    //
-                    // It should be fine though:
-                    //
-                    // 1. We're throwing this version away, so there's no danger
-                    //    of inconsistency between this and the later version.
-                    // 2. This version should have been computed using the same
-                    //    path and parameters and the later version will be, so
-                    //    they should be the same anyway.
-                    // 3. Not all other cases handled in this function have a
-                    //    surface point available, so it needs to be computed
-                    //    later anyway, in the general case.
-
-                    let point_global = surface
-                        .geometry()
-                        .point_from_surface_coords(point_surface);
-                    (point_curve, point_global)
-                })
-                .collect()
-        }
-        (SurfacePath::Line(line), _) => {
-            let range_u =
-                CurveBoundary::from(boundary.inner.map(|point_curve| {
-                    [path.point_from_path_coords(point_curve).u]
-                }));
-
-            let approx_u = (surface.geometry().u, range_u)
-                .approx_with_cache(tolerance, &mut ());
-
-            let mut points = Vec::new();
-            for (u, _) in approx_u {
-                let t = (u.t - line.origin().u) / line.direction().u;
-                let point_surface = path.point_from_path_coords([t]);
-                let point_global =
-                    surface.geometry().point_from_surface_coords(point_surface);
-                points.push((u, point_global));
-            }
-
-            points
-        }
-    };
-
-    let points = points
-        .into_iter()
-        .map(|(point_curve, point_global)| {
-            ApproxPoint::new(point_curve, point_global)
-        })
-        .collect();
-    CurveApprox { points }
 }
 
 /// Cache for edge approximations

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -30,19 +30,19 @@ impl Approx for (&HalfEdge, &Surface) {
         let tolerance = tolerance.into();
 
         let start_position_surface = edge.start_position();
-        let start_position =
-            match cache.get_start_position_approx(edge.start_vertex()) {
-                Some(position) => position,
-                None => {
-                    let position_global = surface
-                        .geometry()
-                        .point_from_surface_coords(start_position_surface);
-                    cache.insert_start_position_approx(
-                        edge.start_vertex(),
-                        position_global,
-                    )
-                }
-            };
+        let start_position = match cache.start_position.get(edge.start_vertex())
+        {
+            Some(position) => position,
+            None => {
+                let position_global = surface
+                    .geometry()
+                    .point_from_surface_coords(start_position_surface);
+                cache.insert_start_position_approx(
+                    edge.start_vertex(),
+                    position_global,
+                )
+            }
+        };
 
         let first = ApproxPoint::new(start_position_surface, start_position);
 
@@ -178,13 +178,6 @@ pub struct EdgeApproxCache {
 }
 
 impl EdgeApproxCache {
-    fn get_start_position_approx(
-        &self,
-        handle: &Handle<Vertex>,
-    ) -> Option<Point<3>> {
-        self.start_position.get(handle)
-    }
-
     fn insert_start_position_approx(
         &mut self,
         handle: &Handle<Vertex>,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -171,7 +171,7 @@ fn approx_curve(
 #[derive(Default)]
 pub struct EdgeApproxCache {
     start_position: VertexApproxCache,
-    curve_approx: CurveApproxCache,
+    curve: CurveApproxCache,
 }
 
 impl EdgeApproxCache {
@@ -180,7 +180,7 @@ impl EdgeApproxCache {
         handle: Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,
     ) -> Option<Vec<ApproxPoint<1>>> {
-        self.curve_approx.get(&handle, boundary)
+        self.curve.get(&handle, boundary)
     }
 
     fn insert_curve_approx(
@@ -189,7 +189,7 @@ impl EdgeApproxCache {
         boundary: CurveBoundary<Point<1>>,
         approx: Vec<ApproxPoint<1>>,
     ) {
-        self.curve_approx.insert(handle, boundary, approx);
+        self.curve.insert(handle, boundary, approx);
     }
 }
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -9,8 +9,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::{CurveBoundary, GlobalPath, SurfacePath},
-    objects::{Curve, HalfEdge, Surface},
-    storage::Handle,
+    objects::{HalfEdge, Surface},
 };
 
 use super::{
@@ -60,7 +59,7 @@ impl Approx for (&HalfEdge, &Surface) {
                         tolerance,
                     );
 
-                    cache.insert_curve_approx(
+                    cache.curve.insert(
                         edge.curve().clone(),
                         edge.boundary(),
                         approx.clone(),
@@ -172,17 +171,6 @@ fn approx_curve(
 pub struct EdgeApproxCache {
     start_position: VertexApproxCache,
     curve: CurveApproxCache,
-}
-
-impl EdgeApproxCache {
-    fn insert_curve_approx(
-        &mut self,
-        handle: Handle<Curve>,
-        boundary: CurveBoundary<Point<1>>,
-        approx: Vec<ApproxPoint<1>>,
-    ) {
-        self.curve.insert(handle, boundary, approx);
-    }
 }
 
 #[cfg(test)]

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -62,10 +62,8 @@ impl Approx for (&HalfEdge, &Surface) {
                     cache.curve.insert(
                         edge.curve().clone(),
                         edge.boundary(),
-                        approx.clone(),
-                    );
-
-                    approx
+                        approx,
+                    )
                 }
             };
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -14,7 +14,7 @@ use super::{
 
 impl Approx for (&HalfEdge, &Surface) {
     type Approximation = HalfEdgeApprox;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,
@@ -68,7 +68,7 @@ pub struct HalfEdgeApprox {
 
 /// Cache for edge approximations
 #[derive(Default)]
-pub struct EdgeApproxCache {
+pub struct HalfEdgeApproxCache {
     start_position: VertexApproxCache,
     curve: CurveApproxCache,
 }

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -1,7 +1,7 @@
 //! Edge approximation
 //!
 //! The approximation of a curve is its first vertex, combined with the
-//! approximation of its curve. The second vertex is left off, as edge
+//! approximation of its curve. The second vertex is left out, as edge
 //! approximations are usually used to build cycle approximations, and this way,
 //! the caller doesn't have to deal with duplicate vertices.
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -170,7 +170,7 @@ fn approx_curve(
 /// Cache for edge approximations
 #[derive(Default)]
 pub struct EdgeApproxCache {
-    start_position_approx: VertexApproxCache,
+    start_position: VertexApproxCache,
     curve_approx: BTreeMap<
         (HandleWrapper<Curve>, CurveBoundary<Point<1>>),
         Vec<ApproxPoint<1>>,
@@ -182,7 +182,7 @@ impl EdgeApproxCache {
         &self,
         handle: &Handle<Vertex>,
     ) -> Option<Point<3>> {
-        self.start_position_approx.get(handle)
+        self.start_position.get(handle)
     }
 
     fn insert_start_position_approx(
@@ -190,7 +190,7 @@ impl EdgeApproxCache {
         handle: &Handle<Vertex>,
         position: Point<3>,
     ) -> Point<3> {
-        self.start_position_approx.insert(handle.clone(), position)
+        self.start_position.insert(handle.clone(), position)
     }
 
     fn get_curve_approx(

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -48,7 +48,7 @@ impl Approx for (&HalfEdge, &Surface) {
 
         let rest = {
             let cached =
-                cache.get_curve_approx(edge.curve().clone(), edge.boundary());
+                cache.curve.get(&edge.curve().clone(), edge.boundary());
 
             let approx = match cached {
                 Some(approx) => approx,
@@ -175,14 +175,6 @@ pub struct EdgeApproxCache {
 }
 
 impl EdgeApproxCache {
-    fn get_curve_approx(
-        &self,
-        handle: Handle<Curve>,
-        boundary: CurveBoundary<Point<1>>,
-    ) -> Option<Vec<ApproxPoint<1>>> {
-        self.curve.get(&handle, boundary)
-    }
-
     fn insert_curve_approx(
         &mut self,
         handle: Handle<Curve>,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -8,9 +8,8 @@
 use crate::objects::{HalfEdge, Surface};
 
 use super::{
-    curve::{approx_curve, CurveApproxCache},
-    vertex::VertexApproxCache,
-    Approx, ApproxPoint, Tolerance,
+    curve::CurveApproxCache, vertex::VertexApproxCache, Approx, ApproxPoint,
+    Tolerance,
 };
 
 impl Approx for (&HalfEdge, &Surface) {
@@ -42,26 +41,8 @@ impl Approx for (&HalfEdge, &Surface) {
         let first = ApproxPoint::new(start_position_surface, start_position);
 
         let rest = {
-            let cached =
-                cache.curve.get(&edge.curve().clone(), edge.boundary());
-
-            let approx = match cached {
-                Some(approx) => approx,
-                None => {
-                    let approx = approx_curve(
-                        &edge.path(),
-                        surface,
-                        edge.boundary(),
-                        tolerance,
-                    );
-
-                    cache.curve.insert(
-                        edge.curve().clone(),
-                        edge.boundary(),
-                        approx,
-                    )
-                }
-            };
+            let approx = (edge.curve(), edge.path(), surface, edge.boundary())
+                .approx_with_cache(tolerance, &mut cache.curve);
 
             approx.points.into_iter().map(|point| {
                 let point_surface =

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -66,7 +66,7 @@ pub struct HalfEdgeApprox {
     pub points: Vec<ApproxPoint<2>>,
 }
 
-/// Cache for edge approximations
+/// Cache for half-edge approximations
 #[derive(Default)]
 pub struct HalfEdgeApproxCache {
     start_position: VertexApproxCache,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 
 use super::{
-    curve::CurveApproxCache, vertex::VertexApproxCache, Approx, ApproxPoint,
-    Tolerance,
+    curve::{CurveApprox, CurveApproxCache},
+    vertex::VertexApproxCache,
+    Approx, ApproxPoint, Tolerance,
 };
 
 impl Approx for (&HalfEdge, &Surface) {
@@ -67,7 +68,7 @@ impl Approx for (&HalfEdge, &Surface) {
                 }
             };
 
-            approx.into_iter().map(|point| {
+            approx.points.into_iter().map(|point| {
                 let point_surface =
                     edge.path().point_from_path_coords(point.local_form);
 
@@ -94,7 +95,7 @@ fn approx_curve(
     surface: &Surface,
     boundary: CurveBoundary<Point<1>>,
     tolerance: impl Into<Tolerance>,
-) -> Vec<ApproxPoint<1>> {
+) -> CurveApprox {
     // There are different cases of varying complexity. Circles are the hard
     // part here, as they need to be approximated, while lines don't need to be.
     //
@@ -156,12 +157,13 @@ fn approx_curve(
         }
     };
 
-    points
+    let points = points
         .into_iter()
         .map(|(point_curve, point_global)| {
             ApproxPoint::new(point_curve, point_global)
         })
-        .collect()
+        .collect();
+    CurveApprox { points }
 }
 
 /// Cache for edge approximations

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -11,7 +11,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::{CurveBoundary, GlobalPath, SurfacePath},
-    objects::{Curve, HalfEdge, Surface, Vertex},
+    objects::{Curve, HalfEdge, Surface},
     storage::{Handle, HandleWrapper},
 };
 
@@ -37,10 +37,9 @@ impl Approx for (&HalfEdge, &Surface) {
                 let position_global = surface
                     .geometry()
                     .point_from_surface_coords(start_position_surface);
-                cache.insert_start_position_approx(
-                    edge.start_vertex(),
-                    position_global,
-                )
+                cache
+                    .start_position
+                    .insert(edge.start_vertex().clone(), position_global)
             }
         };
 
@@ -178,14 +177,6 @@ pub struct EdgeApproxCache {
 }
 
 impl EdgeApproxCache {
-    fn insert_start_position_approx(
-        &mut self,
-        handle: &Handle<Vertex>,
-        position: Point<3>,
-    ) -> Point<3> {
-        self.start_position.insert(handle.clone(), position)
-    }
-
     fn get_curve_approx(
         &self,
         handle: Handle<Curve>,

--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -12,12 +12,13 @@ use crate::{
 };
 
 use super::{
-    cycle::CycleApprox, edge::EdgeApproxCache, Approx, ApproxPoint, Tolerance,
+    cycle::CycleApprox, edge::HalfEdgeApproxCache, Approx, ApproxPoint,
+    Tolerance,
 };
 
 impl Approx for &Handles<Face> {
     type Approximation = BTreeSet<FaceApprox>;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,
@@ -63,7 +64,7 @@ impl Approx for &Handles<Face> {
 
 impl Approx for &Face {
     type Approximation = FaceApprox;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,

--- a/crates/fj-core/src/algorithms/approx/mod.rs
+++ b/crates/fj-core/src/algorithms/approx/mod.rs
@@ -1,5 +1,6 @@
 //! Approximation of objects
 
+pub mod curve;
 pub mod cycle;
 pub mod edge;
 pub mod face;

--- a/crates/fj-core/src/algorithms/approx/mod.rs
+++ b/crates/fj-core/src/algorithms/approx/mod.rs
@@ -8,6 +8,7 @@ pub mod shell;
 pub mod sketch;
 pub mod solid;
 pub mod tolerance;
+pub mod vertex;
 
 use std::{
     cmp::Ordering,

--- a/crates/fj-core/src/algorithms/approx/shell.rs
+++ b/crates/fj-core/src/algorithms/approx/shell.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeSet;
 
 use crate::objects::Shell;
 
-use super::{edge::EdgeApproxCache, face::FaceApprox, Approx, Tolerance};
+use super::{edge::HalfEdgeApproxCache, face::FaceApprox, Approx, Tolerance};
 
 impl Approx for &Shell {
     type Approximation = BTreeSet<FaceApprox>;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,

--- a/crates/fj-core/src/algorithms/approx/sketch.rs
+++ b/crates/fj-core/src/algorithms/approx/sketch.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeSet;
 
 use crate::objects::Sketch;
 
-use super::{edge::EdgeApproxCache, face::FaceApprox, Approx, Tolerance};
+use super::{edge::HalfEdgeApproxCache, face::FaceApprox, Approx, Tolerance};
 
 impl Approx for &Sketch {
     type Approximation = BTreeSet<FaceApprox>;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,

--- a/crates/fj-core/src/algorithms/approx/solid.rs
+++ b/crates/fj-core/src/algorithms/approx/solid.rs
@@ -4,11 +4,11 @@ use std::collections::BTreeSet;
 
 use crate::objects::Solid;
 
-use super::{edge::EdgeApproxCache, face::FaceApprox, Approx, Tolerance};
+use super::{edge::HalfEdgeApproxCache, face::FaceApprox, Approx, Tolerance};
 
 impl Approx for &Solid {
     type Approximation = BTreeSet<FaceApprox>;
-    type Cache = EdgeApproxCache;
+    type Cache = HalfEdgeApproxCache;
 
     fn approx_with_cache(
         self,

--- a/crates/fj-core/src/algorithms/approx/vertex.rs
+++ b/crates/fj-core/src/algorithms/approx/vertex.rs
@@ -1,0 +1,34 @@
+//! Vertex approximation
+
+use std::collections::BTreeMap;
+
+use fj_math::Point;
+
+use crate::{
+    objects::Vertex,
+    storage::{Handle, HandleWrapper},
+};
+
+/// Cache for vertex approximations
+#[derive(Default)]
+pub struct VertexApproxCache {
+    inner: BTreeMap<HandleWrapper<Vertex>, Point<3>>,
+}
+
+impl VertexApproxCache {
+    /// Get an approximated vertex from the cache
+    pub fn get(&self, handle: &Handle<Vertex>) -> Option<Point<3>> {
+        self.inner.get(&handle.clone().into()).cloned()
+    }
+
+    /// Insert an approximated vertex into the cache
+    pub fn insert(
+        &mut self,
+        handle: Handle<Vertex>,
+        position: Point<3>,
+    ) -> Point<3> {
+        self.inner
+            .insert(handle.clone().into(), position)
+            .unwrap_or(position)
+    }
+}


### PR DESCRIPTION
Make the edge approximation code a bit lighter, by moving the vertex and curve approximation code into their own dedicated modules.