### PR TITLE
Improve documentation of `operations` module

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -180,7 +180,7 @@ mod tests {
         algorithms::approx::{Approx, ApproxPoint},
         geometry::{CurveBoundary, GlobalPath, SurfaceGeometry, SurfacePath},
         objects::{Curve, Surface},
-        operations::Insert,
+        operations::insert::Insert,
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_edge.rs
@@ -72,8 +72,8 @@ mod tests {
     use fj_math::Point;
 
     use crate::{
-        geometry::SurfacePath, objects::HalfEdge, operations::BuildHalfEdge,
-        services::Services,
+        geometry::SurfacePath, objects::HalfEdge,
+        operations::build::BuildHalfEdge, services::Services,
     };
 
     use super::CurveEdgeIntersection;

--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -157,7 +157,8 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            Insert, UpdateFace, UpdateRegion,
+            insert::Insert,
+            UpdateFace, UpdateRegion,
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -158,7 +158,7 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildFace},
             insert::Insert,
-            UpdateFace, UpdateRegion,
+            update::{UpdateFace, UpdateRegion},
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -155,7 +155,10 @@ mod tests {
     use crate::{
         geometry::SurfacePath,
         objects::{Cycle, Face},
-        operations::{BuildCycle, BuildFace, Insert, UpdateFace, UpdateRegion},
+        operations::{
+            build::{BuildCycle, BuildFace},
+            Insert, UpdateFace, UpdateRegion,
+        },
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_face.rs
@@ -67,7 +67,7 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildFace},
             insert::Insert,
-            UpdateFace, UpdateRegion,
+            update::{UpdateFace, UpdateRegion},
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_face.rs
@@ -64,7 +64,10 @@ mod tests {
         algorithms::intersect::CurveFaceIntersection,
         geometry::SurfacePath,
         objects::{Cycle, Face},
-        operations::{BuildCycle, BuildFace, Insert, UpdateFace, UpdateRegion},
+        operations::{
+            build::{BuildCycle, BuildFace},
+            Insert, UpdateFace, UpdateRegion,
+        },
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_face.rs
@@ -66,7 +66,8 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            Insert, UpdateFace, UpdateRegion,
+            insert::Insert,
+            UpdateFace, UpdateRegion,
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -138,7 +138,8 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            Insert, UpdateFace, UpdateRegion,
+            insert::Insert,
+            UpdateFace, UpdateRegion,
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -139,7 +139,7 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildFace},
             insert::Insert,
-            UpdateFace, UpdateRegion,
+            update::{UpdateFace, UpdateRegion},
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -136,7 +136,10 @@ mod tests {
     use crate::{
         algorithms::intersect::{face_point::FacePointIntersection, Intersect},
         objects::{Cycle, Face},
-        operations::{BuildCycle, BuildFace, Insert, UpdateFace, UpdateRegion},
+        operations::{
+            build::{BuildCycle, BuildFace},
+            Insert, UpdateFace, UpdateRegion,
+        },
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_face.rs
@@ -156,7 +156,7 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildFace},
             insert::Insert,
-            UpdateFace, UpdateRegion,
+            update::{UpdateFace, UpdateRegion},
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_face.rs
@@ -155,7 +155,8 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            Insert, UpdateFace, UpdateRegion,
+            insert::Insert,
+            UpdateFace, UpdateRegion,
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_face.rs
@@ -153,7 +153,10 @@ mod tests {
             transform::TransformObject,
         },
         objects::{Cycle, Face},
-        operations::{BuildCycle, BuildFace, Insert, UpdateFace, UpdateRegion},
+        operations::{
+            build::{BuildCycle, BuildFace},
+            Insert, UpdateFace, UpdateRegion,
+        },
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -3,7 +3,7 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
-    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
+    operations::{build::BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -4,7 +4,9 @@ use fj_math::{Point, Scalar, Vector};
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
     operations::{
-        build::BuildHalfEdge, insert::Insert, UpdateCycle, UpdateHalfEdge,
+        build::BuildHalfEdge,
+        insert::Insert,
+        update::{UpdateCycle, UpdateHalfEdge},
     },
     services::Services,
     storage::Handle,

--- a/crates/fj-core/src/algorithms/sweep/edge.rs
+++ b/crates/fj-core/src/algorithms/sweep/edge.rs
@@ -3,7 +3,9 @@ use fj_math::{Point, Scalar, Vector};
 
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
-    operations::{build::BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
+    operations::{
+        build::BuildHalfEdge, insert::Insert, UpdateCycle, UpdateHalfEdge,
+    },
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -6,7 +6,9 @@ use crate::{
     algorithms::transform::TransformObject,
     geometry::GlobalPath,
     objects::{Cycle, Face, Region, Shell},
-    operations::{build::BuildCycle, insert::Insert, join::JoinCycle, Reverse},
+    operations::{
+        build::BuildCycle, insert::Insert, join::JoinCycle, reverse::Reverse,
+    },
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -6,7 +6,7 @@ use crate::{
     algorithms::transform::TransformObject,
     geometry::GlobalPath,
     objects::{Cycle, Face, Region, Shell},
-    operations::{build::BuildCycle, Insert, JoinCycle, Reverse},
+    operations::{build::BuildCycle, insert::Insert, JoinCycle, Reverse},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -6,7 +6,7 @@ use crate::{
     algorithms::transform::TransformObject,
     geometry::GlobalPath,
     objects::{Cycle, Face, Region, Shell},
-    operations::{BuildCycle, Insert, JoinCycle, Reverse},
+    operations::{build::BuildCycle, Insert, JoinCycle, Reverse},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/face.rs
+++ b/crates/fj-core/src/algorithms/sweep/face.rs
@@ -6,7 +6,7 @@ use crate::{
     algorithms::transform::TransformObject,
     geometry::GlobalPath,
     objects::{Cycle, Face, Region, Shell},
-    operations::{build::BuildCycle, insert::Insert, JoinCycle, Reverse},
+    operations::{build::BuildCycle, insert::Insert, join::JoinCycle, Reverse},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/path.rs
+++ b/crates/fj-core/src/algorithms/sweep/path.rs
@@ -3,7 +3,7 @@ use fj_math::{Circle, Line, Vector};
 use crate::{
     geometry::{GlobalPath, SurfaceGeometry, SurfacePath},
     objects::Surface,
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/sketch.rs
+++ b/crates/fj-core/src/algorithms/sweep/sketch.rs
@@ -2,7 +2,7 @@ use fj_math::Vector;
 
 use crate::{
     objects::{Face, Sketch, Solid, Surface},
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/sweep/vertex.rs
+++ b/crates/fj-core/src/algorithms/sweep/vertex.rs
@@ -2,7 +2,7 @@ use fj_math::Vector;
 
 use crate::{
     objects::{Curve, Vertex},
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/algorithms/transform/face.rs
+++ b/crates/fj-core/src/algorithms/transform/face.rs
@@ -2,7 +2,7 @@ use fj_math::Transform;
 
 use crate::{
     objects::{Face, Region},
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
 };
 

--- a/crates/fj-core/src/algorithms/transform/mod.rs
+++ b/crates/fj-core/src/algorithms/transform/mod.rs
@@ -15,7 +15,7 @@ use fj_math::{Transform, Vector};
 use type_map::TypeMap;
 
 use crate::{
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
     storage::{Handle, ObjectId},
 };

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -82,7 +82,8 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            Insert, UpdateFace, UpdateRegion,
+            insert::Insert,
+            UpdateFace, UpdateRegion,
         },
         services::Services,
     };

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -80,7 +80,10 @@ mod tests {
     use crate::{
         algorithms::approx::{Approx, Tolerance},
         objects::{Cycle, Face},
-        operations::{BuildCycle, BuildFace, Insert, UpdateFace, UpdateRegion},
+        operations::{
+            build::{BuildCycle, BuildFace},
+            Insert, UpdateFace, UpdateRegion,
+        },
         services::Services,
     };
 

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -83,7 +83,7 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildFace},
             insert::Insert,
-            UpdateFace, UpdateRegion,
+            update::{UpdateFace, UpdateRegion},
         },
         services::Services,
     };

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::{
     objects::{Cycle, HalfEdge},
-    operations::{BuildHalfEdge, Insert, UpdateCycle},
+    operations::{build::BuildHalfEdge, Insert, UpdateCycle},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::{
     objects::{Cycle, HalfEdge},
-    operations::{build::BuildHalfEdge, insert::Insert, UpdateCycle},
+    operations::{build::BuildHalfEdge, insert::Insert, update::UpdateCycle},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::{
     objects::{Cycle, HalfEdge},
-    operations::{build::BuildHalfEdge, Insert, UpdateCycle},
+    operations::{build::BuildHalfEdge, insert::Insert, UpdateCycle},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -8,6 +8,10 @@ use crate::{
 };
 
 /// Build a [`Cycle`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildCycle {
     /// Build an empty cycle
     fn empty() -> Cycle {

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -9,6 +9,10 @@ use crate::{
 };
 
 /// Build a [`HalfEdge`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildHalfEdge {
     /// Create a half-edge that is not joined to a sibling
     fn unjoined(

--- a/crates/fj-core/src/operations/build/edge.rs
+++ b/crates/fj-core/src/operations/build/edge.rs
@@ -4,7 +4,7 @@ use fj_math::{Arc, Point, Scalar};
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
     objects::{Curve, HalfEdge, Vertex},
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -13,6 +13,10 @@ use crate::{
 };
 
 /// Build a [`Face`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildFace {
     /// Build a face with an empty exterior, no interiors, and no color
     fn unbound(surface: Handle<Surface>, services: &mut Services) -> Face {

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -7,7 +7,7 @@ use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
     operations::{
         build::{BuildCycle, BuildRegion, BuildSurface},
-        Insert, IsInserted, IsInsertedNo,
+        insert::{Insert, IsInserted, IsInsertedNo},
     },
     services::Services,
     storage::Handle,

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -6,7 +6,8 @@ use fj_math::Point;
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Surface, Vertex},
     operations::{
-        BuildCycle, BuildRegion, BuildSurface, Insert, IsInserted, IsInsertedNo,
+        build::{BuildCycle, BuildRegion, BuildSurface},
+        Insert, IsInserted, IsInsertedNo,
     },
     services::Services,
     storage::Handle,

--- a/crates/fj-core/src/operations/build/mod.rs
+++ b/crates/fj-core/src/operations/build/mod.rs
@@ -1,8 +1,19 @@
-pub mod cycle;
-pub mod edge;
-pub mod face;
-pub mod region;
-pub mod shell;
-pub mod sketch;
-pub mod solid;
-pub mod surface;
+mod cycle;
+mod edge;
+mod face;
+mod region;
+mod shell;
+mod sketch;
+mod solid;
+mod surface;
+
+pub use self::{
+    cycle::BuildCycle,
+    edge::BuildHalfEdge,
+    face::{BuildFace, Polygon},
+    region::BuildRegion,
+    shell::{BuildShell, TetrahedronShell},
+    sketch::BuildSketch,
+    solid::{BuildSolid, Tetrahedron},
+    surface::BuildSurface,
+};

--- a/crates/fj-core/src/operations/build/mod.rs
+++ b/crates/fj-core/src/operations/build/mod.rs
@@ -1,3 +1,22 @@
+//! # Operations to build objects
+//!
+//! All object structs have constructors, but building even simple shapes by
+//! just using those is pretty difficult. This is why the traits in this module
+//! exist. They build on top of those low-level constructors, providing a more
+//! rich set of operations to build geometry.
+//!
+//!
+//! ## Wrapper Structs
+//!
+//! Many of the the trait methods return the object that is being built
+//! directly, but others return a wrapper struct. An example of this is
+//! [`BuildFace::triangle`], which returns [`Polygon`] instead of returning the
+//! face directly.
+//!
+//! These wrapper structs are designed to provide convenient access not only to
+//! the top-level object itself, but also to the other objects that make up its
+//! components.
+
 mod cycle;
 mod edge;
 mod face;

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -7,6 +7,10 @@ use crate::{
 };
 
 /// Build a [`Region`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildRegion {
     /// Build an empty region
     fn empty(services: &mut Services) -> Region {

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -2,7 +2,7 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{Cycle, Region},
-    operations::{build::BuildCycle, Insert},
+    operations::{build::BuildCycle, insert::Insert},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -2,7 +2,7 @@ use fj_math::{Point, Scalar};
 
 use crate::{
     objects::{Cycle, Region},
-    operations::{BuildCycle, Insert},
+    operations::{build::BuildCycle, Insert},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -7,7 +7,7 @@ use crate::{
         insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
         join::JoinCycle,
         reverse::ReverseCurveCoordinateSystems,
-        UpdateCycle, UpdateFace, UpdateRegion,
+        update::{UpdateCycle, UpdateFace, UpdateRegion},
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -3,9 +3,10 @@ use fj_math::Point;
 use crate::{
     objects::{Face, Shell},
     operations::{
-        reverse::ReverseCurveCoordinateSystems, BuildFace, Insert, IsInserted,
-        IsInsertedNo, IsInsertedYes, JoinCycle, Polygon, UpdateCycle,
-        UpdateFace, UpdateRegion,
+        build::{BuildFace, Polygon},
+        reverse::ReverseCurveCoordinateSystems,
+        Insert, IsInserted, IsInsertedNo, IsInsertedYes, JoinCycle,
+        UpdateCycle, UpdateFace, UpdateRegion,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -3,9 +3,9 @@ use fj_math::Point;
 use crate::{
     objects::{Face, Shell},
     operations::{
-        reverse::ReverseCurveCoordinateSystems, update::region::UpdateRegion,
-        BuildFace, Insert, IsInserted, IsInsertedNo, IsInsertedYes, JoinCycle,
-        Polygon, UpdateCycle, UpdateFace,
+        reverse::ReverseCurveCoordinateSystems, BuildFace, Insert, IsInserted,
+        IsInsertedNo, IsInsertedYes, JoinCycle, Polygon, UpdateCycle,
+        UpdateFace, UpdateRegion,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -4,9 +4,9 @@ use crate::{
     objects::{Face, Shell},
     operations::{
         build::{BuildFace, Polygon},
+        insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
         reverse::ReverseCurveCoordinateSystems,
-        Insert, IsInserted, IsInsertedNo, IsInsertedYes, JoinCycle,
-        UpdateCycle, UpdateFace, UpdateRegion,
+        JoinCycle, UpdateCycle, UpdateFace, UpdateRegion,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -5,8 +5,9 @@ use crate::{
     operations::{
         build::{BuildFace, Polygon},
         insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
+        join::JoinCycle,
         reverse::ReverseCurveCoordinateSystems,
-        JoinCycle, UpdateCycle, UpdateFace, UpdateRegion,
+        UpdateCycle, UpdateFace, UpdateRegion,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -11,6 +11,10 @@ use crate::{
 };
 
 /// Build a [`Shell`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildShell {
     /// Build an empty shell
     fn empty() -> Shell {

--- a/crates/fj-core/src/operations/build/sketch.rs
+++ b/crates/fj-core/src/operations/build/sketch.rs
@@ -1,6 +1,10 @@
 use crate::objects::Sketch;
 
 /// Build a [`Sketch`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildSketch {
     /// Create a sketch with no regions
     fn empty() -> Sketch {

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -3,7 +3,8 @@ use fj_math::Point;
 use crate::{
     objects::{Shell, Solid},
     operations::{
-        build::BuildShell, Insert, IsInsertedYes, TetrahedronShell, UpdateSolid,
+        build::{BuildShell, TetrahedronShell},
+        Insert, IsInsertedYes, UpdateSolid,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -3,8 +3,7 @@ use fj_math::Point;
 use crate::{
     objects::{Shell, Solid},
     operations::{
-        build::shell::BuildShell, Insert, IsInsertedYes, TetrahedronShell,
-        UpdateSolid,
+        build::BuildShell, Insert, IsInsertedYes, TetrahedronShell, UpdateSolid,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -4,7 +4,8 @@ use crate::{
     objects::{Shell, Solid},
     operations::{
         build::{BuildShell, TetrahedronShell},
-        Insert, IsInsertedYes, UpdateSolid,
+        insert::{Insert, IsInsertedYes},
+        UpdateSolid,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -10,6 +10,10 @@ use crate::{
 };
 
 /// Build a [`Solid`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildSolid {
     /// Build an empty solid
     fn empty() -> Solid {

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -5,7 +5,7 @@ use crate::{
     operations::{
         build::{BuildShell, TetrahedronShell},
         insert::{Insert, IsInsertedYes},
-        UpdateSolid,
+        update::UpdateSolid,
     },
     services::Services,
 };

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -6,6 +6,10 @@ use crate::{
 };
 
 /// Build a [`Surface`]
+///
+/// See [module-level documentation] for context.
+///
+/// [module-level documentation]: super
 pub trait BuildSurface {
     /// Build a plane from the provided points
     fn plane_from_points(

--- a/crates/fj-core/src/operations/insert/insert_trait.rs
+++ b/crates/fj-core/src/operations/insert/insert_trait.rs
@@ -3,7 +3,7 @@ use crate::{
         Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid, Surface,
         Vertex,
     },
-    operations::{Polygon, TetrahedronShell},
+    operations::build::{Polygon, TetrahedronShell},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/operations/insert/mod.rs
+++ b/crates/fj-core/src/operations/insert/mod.rs
@@ -1,3 +1,5 @@
+//! Insert objects into their respective store
+
 mod insert_trait;
 mod is_inserted;
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -6,7 +6,9 @@ use itertools::Itertools;
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
     objects::{Cycle, HalfEdge},
-    operations::{build::BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
+    operations::{
+        build::BuildHalfEdge, insert::Insert, UpdateCycle, UpdateHalfEdge,
+    },
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use crate::{
     geometry::{CurveBoundary, SurfacePath},
     objects::{Cycle, HalfEdge},
-    operations::{BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
+    operations::{build::BuildHalfEdge, Insert, UpdateCycle, UpdateHalfEdge},
     services::Services,
     storage::Handle,
 };

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -7,7 +7,9 @@ use crate::{
     geometry::{CurveBoundary, SurfacePath},
     objects::{Cycle, HalfEdge},
     operations::{
-        build::BuildHalfEdge, insert::Insert, UpdateCycle, UpdateHalfEdge,
+        build::BuildHalfEdge,
+        insert::Insert,
+        update::{UpdateCycle, UpdateHalfEdge},
     },
     services::Services,
     storage::Handle,

--- a/crates/fj-core/src/operations/join/mod.rs
+++ b/crates/fj-core/src/operations/join/mod.rs
@@ -1,1 +1,3 @@
-pub mod cycle;
+mod cycle;
+
+pub use self::cycle::JoinCycle;

--- a/crates/fj-core/src/operations/join/mod.rs
+++ b/crates/fj-core/src/operations/join/mod.rs
@@ -1,3 +1,8 @@
+//! # Operations to join objects together
+//!
+//! See [`JoinCycle`], which is currently the only trait in this module, for
+//! more information.
+
 mod cycle;
 
 pub use self::cycle::JoinCycle;

--- a/crates/fj-core/src/operations/merge.rs
+++ b/crates/fj-core/src/operations/merge.rs
@@ -1,3 +1,8 @@
+//! # Operations to merge objects
+//!
+//! See [`Merge`], which is currently the only trait in this module, for more
+//! information.
+
 use crate::objects::Solid;
 
 use super::UpdateSolid;

--- a/crates/fj-core/src/operations/merge.rs
+++ b/crates/fj-core/src/operations/merge.rs
@@ -5,7 +5,7 @@
 
 use crate::objects::Solid;
 
-use super::UpdateSolid;
+use super::update::UpdateSolid;
 
 /// Merge two [`Solid`]s
 pub trait Merge {

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -8,10 +8,7 @@ pub mod reverse;
 pub mod split;
 mod update;
 
-pub use self::{
-    split::SplitHalfEdge,
-    update::{
-        UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,
-        UpdateSketch, UpdateSolid,
-    },
+pub use self::update::{
+    UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,
+    UpdateSketch, UpdateSolid,
 };

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -9,11 +9,6 @@ mod split;
 mod update;
 
 pub use self::{
-    build::{
-        BuildCycle, BuildFace, BuildHalfEdge, BuildRegion, BuildShell,
-        BuildSketch, BuildSolid, BuildSurface, Polygon, Tetrahedron,
-        TetrahedronShell,
-    },
     insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
     join::JoinCycle,
     merge::Merge,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod build;
 pub mod insert;
-mod join;
+pub mod join;
 mod merge;
 mod reverse;
 mod split;

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -9,7 +9,6 @@ mod split;
 mod update;
 
 pub use self::{
-    reverse::Reverse,
     split::SplitHalfEdge,
     update::{
         UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     join::JoinCycle,
     merge::Merge,
     reverse::Reverse,
-    split::edge::SplitHalfEdge,
+    split::SplitHalfEdge,
     update::{
         cycle::UpdateCycle, edge::UpdateHalfEdge, face::UpdateFace,
         region::UpdateRegion, shell::UpdateShell, sketch::UpdateSketch,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -1,6 +1,6 @@
 //! Operations to update shapes
 
-mod build;
+pub mod build;
 mod insert;
 mod join;
 mod merge;

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -7,8 +7,3 @@ pub mod merge;
 pub mod reverse;
 pub mod split;
 pub mod update;
-
-pub use self::update::{
-    UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,
-    UpdateSketch, UpdateSolid,
-};

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -20,8 +20,7 @@ pub use self::{
     reverse::Reverse,
     split::SplitHalfEdge,
     update::{
-        cycle::UpdateCycle, edge::UpdateHalfEdge, face::UpdateFace,
-        region::UpdateRegion, shell::UpdateShell, sketch::UpdateSketch,
-        solid::UpdateSolid,
+        UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,
+        UpdateSketch, UpdateSolid,
     },
 };

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -1,7 +1,7 @@
 //! Operations to update shapes
 
 pub mod build;
-mod insert;
+pub mod insert;
 mod join;
 mod merge;
 mod reverse;

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -6,7 +6,7 @@ pub mod join;
 pub mod merge;
 pub mod reverse;
 pub mod split;
-mod update;
+pub mod update;
 
 pub use self::update::{
     UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -4,7 +4,7 @@ pub mod build;
 pub mod insert;
 pub mod join;
 pub mod merge;
-mod reverse;
+pub mod reverse;
 mod split;
 mod update;
 

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -3,7 +3,7 @@
 pub mod build;
 pub mod insert;
 pub mod join;
-mod merge;
+pub mod merge;
 mod reverse;
 mod split;
 mod update;

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -9,7 +9,6 @@ mod split;
 mod update;
 
 pub use self::{
-    join::JoinCycle,
     merge::Merge,
     reverse::Reverse,
     split::SplitHalfEdge,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -9,7 +9,6 @@ mod split;
 mod update;
 
 pub use self::{
-    insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
     join::JoinCycle,
     merge::Merge,
     reverse::Reverse,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -9,7 +9,6 @@ mod split;
 mod update;
 
 pub use self::{
-    merge::Merge,
     reverse::Reverse,
     split::SplitHalfEdge,
     update::{

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -15,7 +15,7 @@ pub use self::{
         TetrahedronShell,
     },
     insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
-    join::cycle::JoinCycle,
+    join::JoinCycle,
     merge::Merge,
     reverse::Reverse,
     split::edge::SplitHalfEdge,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -10,14 +10,9 @@ mod update;
 
 pub use self::{
     build::{
-        cycle::BuildCycle,
-        edge::BuildHalfEdge,
-        face::{BuildFace, Polygon},
-        region::BuildRegion,
-        shell::{BuildShell, TetrahedronShell},
-        sketch::BuildSketch,
-        solid::{BuildSolid, Tetrahedron},
-        surface::BuildSurface,
+        BuildCycle, BuildFace, BuildHalfEdge, BuildRegion, BuildShell,
+        BuildSketch, BuildSolid, BuildSurface, Polygon, Tetrahedron,
+        TetrahedronShell,
     },
     insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
     join::cycle::JoinCycle,

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -5,7 +5,7 @@ pub mod insert;
 pub mod join;
 pub mod merge;
 pub mod reverse;
-mod split;
+pub mod split;
 mod update;
 
 pub use self::{

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Cycle, HalfEdge},
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/reverse/face.rs
+++ b/crates/fj-core/src/operations/reverse/face.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 
 use crate::{
     objects::Face,
-    operations::{Insert, IsInsertedNo, IsInsertedYes, Polygon},
+    operations::{Insert, IsInsertedNo, IsInsertedYes, build::Polygon},
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/reverse/face.rs
+++ b/crates/fj-core/src/operations/reverse/face.rs
@@ -2,7 +2,10 @@ use std::borrow::Borrow;
 
 use crate::{
     objects::Face,
-    operations::{Insert, IsInsertedNo, IsInsertedYes, build::Polygon},
+    operations::{
+        build::Polygon,
+        insert::{Insert, IsInsertedNo, IsInsertedYes},
+    },
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/reverse/region.rs
+++ b/crates/fj-core/src/operations/reverse/region.rs
@@ -1,4 +1,4 @@
-use crate::{objects::Region, operations::Insert, services::Services};
+use crate::{objects::Region, operations::insert::Insert, services::Services};
 
 use super::{Reverse, ReverseCurveCoordinateSystems};
 

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -2,7 +2,7 @@ use fj_math::Point;
 
 use crate::{
     objects::{HalfEdge, Vertex},
-    operations::Insert,
+    operations::insert::Insert,
     services::Services,
 };
 

--- a/crates/fj-core/src/operations/split/mod.rs
+++ b/crates/fj-core/src/operations/split/mod.rs
@@ -1,1 +1,3 @@
-pub mod edge;
+mod edge;
+
+pub use self::edge::SplitHalfEdge;

--- a/crates/fj-core/src/operations/split/mod.rs
+++ b/crates/fj-core/src/operations/split/mod.rs
@@ -1,3 +1,8 @@
+//! # Operations to split objects
+//!
+//! See [`SplitHalfEdge`], which is currently the only trait in this module, for
+//! more information.
+
 mod edge;
 
 pub use self::edge::SplitHalfEdge;

--- a/crates/fj-core/src/operations/update/face.rs
+++ b/crates/fj-core/src/operations/update/face.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Face, Region},
-    operations::Polygon,
+    operations::build::Polygon,
     storage::Handle,
 };
 

--- a/crates/fj-core/src/operations/update/mod.rs
+++ b/crates/fj-core/src/operations/update/mod.rs
@@ -1,7 +1,13 @@
-pub mod cycle;
-pub mod edge;
-pub mod face;
-pub mod region;
-pub mod shell;
-pub mod sketch;
-pub mod solid;
+mod cycle;
+mod edge;
+mod face;
+mod region;
+mod shell;
+mod sketch;
+mod solid;
+
+pub use self::{
+    cycle::UpdateCycle, edge::UpdateHalfEdge, face::UpdateFace,
+    region::UpdateRegion, shell::UpdateShell, sketch::UpdateSketch,
+    solid::UpdateSolid,
+};

--- a/crates/fj-core/src/operations/update/mod.rs
+++ b/crates/fj-core/src/operations/update/mod.rs
@@ -1,3 +1,5 @@
+//! Operations to update objects
+
 mod cycle;
 mod edge;
 mod face;

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -97,7 +97,7 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildHalfEdge},
             insert::Insert,
-            UpdateCycle,
+            update::UpdateCycle,
         },
         services::Services,
         validate::{cycle::CycleValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -96,7 +96,8 @@ mod tests {
         objects::{Cycle, HalfEdge},
         operations::{
             build::{BuildCycle, BuildHalfEdge},
-            Insert, UpdateCycle,
+            insert::Insert,
+            UpdateCycle,
         },
         services::Services,
         validate::{cycle::CycleValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -94,7 +94,10 @@ mod tests {
     use crate::{
         assert_contains_err,
         objects::{Cycle, HalfEdge},
-        operations::{BuildCycle, BuildHalfEdge, Insert, UpdateCycle},
+        operations::{
+            build::{BuildCycle, BuildHalfEdge},
+            Insert, UpdateCycle,
+        },
         services::Services,
         validate::{cycle::CycleValidationError, Validate, ValidationError},
     };

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::{
         assert_contains_err,
         objects::HalfEdge,
-        operations::BuildHalfEdge,
+        operations::build::BuildHalfEdge,
         services::Services,
         validate::{EdgeValidationError, Validate, ValidationError},
     };

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -74,7 +74,8 @@ mod tests {
         assert_contains_err,
         objects::{Cycle, Face, Region},
         operations::{
-            BuildCycle, BuildFace, Insert, Reverse, UpdateFace, UpdateRegion,
+            build::{BuildCycle, BuildFace},
+            Insert, Reverse, UpdateFace, UpdateRegion,
         },
         services::Services,
         validate::{FaceValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -75,7 +75,8 @@ mod tests {
         objects::{Cycle, Face, Region},
         operations::{
             build::{BuildCycle, BuildFace},
-            Insert, Reverse, UpdateFace, UpdateRegion,
+            insert::Insert,
+            Reverse, UpdateFace, UpdateRegion,
         },
         services::Services,
         validate::{FaceValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -76,7 +76,8 @@ mod tests {
         operations::{
             build::{BuildCycle, BuildFace},
             insert::Insert,
-            Reverse, UpdateFace, UpdateRegion,
+            reverse::Reverse,
+            UpdateFace, UpdateRegion,
         },
         services::Services,
         validate::{FaceValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -77,7 +77,7 @@ mod tests {
             build::{BuildCycle, BuildFace},
             insert::Insert,
             reverse::Reverse,
-            UpdateFace, UpdateRegion,
+            update::{UpdateFace, UpdateRegion},
         },
         services::Services,
         validate::{FaceValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -289,7 +289,7 @@ mod tests {
         assert_contains_err,
         objects::{Curve, Shell},
         operations::{
-            BuildShell, Insert, UpdateCycle, UpdateFace, UpdateHalfEdge,
+            build::BuildShell, Insert, UpdateCycle, UpdateFace, UpdateHalfEdge,
             UpdateRegion, UpdateShell,
         },
         services::Services,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -289,8 +289,8 @@ mod tests {
         assert_contains_err,
         objects::{Curve, Shell},
         operations::{
-            build::BuildShell, Insert, UpdateCycle, UpdateFace, UpdateHalfEdge,
-            UpdateRegion, UpdateShell,
+            build::BuildShell, insert::Insert, UpdateCycle, UpdateFace,
+            UpdateHalfEdge, UpdateRegion, UpdateShell,
         },
         services::Services,
         validate::{shell::ShellValidationError, Validate, ValidationError},

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -289,8 +289,12 @@ mod tests {
         assert_contains_err,
         objects::{Curve, Shell},
         operations::{
-            build::BuildShell, insert::Insert, UpdateCycle, UpdateFace,
-            UpdateHalfEdge, UpdateRegion, UpdateShell,
+            build::BuildShell,
+            insert::Insert,
+            update::{
+                UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion,
+                UpdateShell,
+            },
         },
         services::Services,
         validate::{shell::ShellValidationError, Validate, ValidationError},

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -2,7 +2,7 @@ use fj::{
     core::{
         algorithms::transform::TransformObject,
         objects::Solid,
-        operations::{insert::Insert, Merge},
+        operations::{insert::Insert, merge::Merge},
         services::Services,
         storage::Handle,
     },

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -2,7 +2,7 @@ use fj::{
     core::{
         algorithms::transform::TransformObject,
         objects::Solid,
-        operations::{Insert, Merge},
+        operations::{insert::Insert, Merge},
         services::Services,
         storage::Handle,
     },

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -4,7 +4,8 @@ use fj::{
         objects::{Region, Sketch, Solid},
         operations::{
             build::{BuildRegion, BuildSketch},
-            Insert, UpdateSketch,
+            insert::Insert,
+            UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -2,7 +2,10 @@ use fj::{
     core::{
         algorithms::sweep::Sweep,
         objects::{Region, Sketch, Solid},
-        operations::{BuildRegion, BuildSketch, Insert, UpdateSketch},
+        operations::{
+            build::{BuildRegion, BuildSketch},
+            Insert, UpdateSketch,
+        },
         services::Services,
         storage::Handle,
     },

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -5,7 +5,7 @@ use fj::{
         operations::{
             build::{BuildRegion, BuildSketch},
             insert::Insert,
-            UpdateSketch,
+            update::UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -6,7 +6,7 @@ use fj::{
             build::{BuildCycle, BuildRegion, BuildSketch},
             insert::Insert,
             reverse::Reverse,
-            UpdateRegion, UpdateSketch,
+            update::{UpdateRegion, UpdateSketch},
         },
         services::Services,
         storage::Handle,

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -4,7 +4,8 @@ use fj::{
         objects::{Cycle, Region, Sketch, Solid},
         operations::{
             build::{BuildCycle, BuildRegion, BuildSketch},
-            Insert, Reverse, UpdateRegion, UpdateSketch,
+            insert::Insert,
+            Reverse, UpdateRegion, UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -5,7 +5,8 @@ use fj::{
         operations::{
             build::{BuildCycle, BuildRegion, BuildSketch},
             insert::Insert,
-            Reverse, UpdateRegion, UpdateSketch,
+            reverse::Reverse,
+            UpdateRegion, UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -3,8 +3,8 @@ use fj::{
         algorithms::sweep::Sweep,
         objects::{Cycle, Region, Sketch, Solid},
         operations::{
-            BuildCycle, BuildRegion, BuildSketch, Insert, Reverse,
-            UpdateRegion, UpdateSketch,
+            build::{BuildCycle, BuildRegion, BuildSketch},
+            Insert, Reverse, UpdateRegion, UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -8,7 +8,7 @@ use fj::{
             build::{BuildCycle, BuildRegion, BuildSketch},
             insert::Insert,
             reverse::Reverse,
-            UpdateRegion, UpdateSketch,
+            update::{UpdateRegion, UpdateSketch},
         },
         services::Services,
         storage::Handle,

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -7,7 +7,8 @@ use fj::{
         operations::{
             build::{BuildCycle, BuildRegion, BuildSketch},
             insert::Insert,
-            Reverse, UpdateRegion, UpdateSketch,
+            reverse::Reverse,
+            UpdateRegion, UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -5,8 +5,8 @@ use fj::{
         algorithms::sweep::Sweep,
         objects::{Cycle, Region, Sketch, Solid},
         operations::{
-            BuildCycle, BuildRegion, BuildSketch, Insert, Reverse,
-            UpdateRegion, UpdateSketch,
+            build::{BuildCycle, BuildRegion, BuildSketch},
+            Insert, Reverse, UpdateRegion, UpdateSketch,
         },
         services::Services,
         storage::Handle,

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -6,7 +6,8 @@ use fj::{
         objects::{Cycle, Region, Sketch, Solid},
         operations::{
             build::{BuildCycle, BuildRegion, BuildSketch},
-            Insert, Reverse, UpdateRegion, UpdateSketch,
+            insert::Insert,
+            Reverse, UpdateRegion, UpdateSketch,
         },
         services::Services,
         storage::Handle,


### PR DESCRIPTION
Restructure the `operations` module, making its sub-modules public and adding documentation for each. The only module that is getting some "proper" documentation out of this so far is `build`, as all others are either fairly small or probably won't survive in their current form for much longer. However, this new structure provides the opportunity for improving the documentation of the other modules too in the future.