### PR TITLE
Merge `Handles::replace_with_multiple` into `Handles::replace`

### DIFF
--- a/crates/fj-core/src/objects/handles.rs
+++ b/crates/fj-core/src/objects/handles.rs
@@ -143,29 +143,7 @@ impl<T> Handles<T> {
     ///
     /// Panics, if the update results in a duplicate item.
     #[must_use]
-    pub fn replace(
-        &self,
-        original: &Handle<T>,
-        replacement: Handle<T>,
-    ) -> Option<Self>
-    where
-        T: Debug + Ord,
-    {
-        self.replace_with_multiple(original, [replacement])
-    }
-
-    /// Create a new instance in which the provided item has been replaced
-    ///
-    /// Returns `None`, if the provided item is not present.
-    ///
-    /// This is a more general version of [`Handles::replace`] which can replace
-    /// a single item with multiple others.
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the replacement results in a duplicate item.
-    #[must_use]
-    pub fn replace_with_multiple<const N: usize>(
+    pub fn replace<const N: usize>(
         &self,
         original: &Handle<T>,
         replacements: [Handle<T>; N],

--- a/crates/fj-core/src/objects/handles.rs
+++ b/crates/fj-core/src/objects/handles.rs
@@ -168,7 +168,7 @@ impl<T> Handles<T> {
     pub fn replace_with_multiple<const N: usize>(
         &self,
         original: &Handle<T>,
-        replacement: [Handle<T>; N],
+        replacements: [Handle<T>; N],
     ) -> Option<Self>
     where
         T: Debug + Ord,
@@ -198,7 +198,13 @@ impl<T> Handles<T> {
         // Let's make that a bit more explicit by renaming the variable.
         let after = iter;
 
-        Some(before.into_iter().chain(replacement).chain(after).collect())
+        Some(
+            before
+                .into_iter()
+                .chain(replacements)
+                .chain(after)
+                .collect(),
+        )
     }
 }
 

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -60,7 +60,7 @@ impl UpdateCycle for Cycle {
     ) -> Self {
         let edges = self
             .half_edges()
-            .replace(handle, update(handle))
+            .replace(handle, [update(handle)])
             .expect("Half-edge not found");
         Cycle::new(edges)
     }
@@ -72,7 +72,7 @@ impl UpdateCycle for Cycle {
     ) -> Self {
         let edges = self
             .half_edges()
-            .replace_with_multiple(handle, replace(handle))
+            .replace(handle, replace(handle))
             .expect("Half-edge not found");
         Cycle::new(edges)
     }

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -75,7 +75,7 @@ impl UpdateRegion for Region {
     ) -> Self {
         let interiors = self
             .interiors()
-            .replace(handle, update(handle))
+            .replace(handle, [update(handle)])
             .expect("Cycle not found");
         Region::new(self.exterior().clone(), interiors, self.color())
     }
@@ -87,7 +87,7 @@ impl UpdateRegion for Region {
     ) -> Self {
         let interiors = self
             .interiors()
-            .replace_with_multiple(handle, replace(handle))
+            .replace(handle, replace(handle))
             .expect("Cycle not found");
         Region::new(self.exterior().clone(), interiors, self.color())
     }

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -58,7 +58,7 @@ impl UpdateShell for Shell {
     ) -> Self {
         let faces = self
             .faces()
-            .replace(handle, update(handle))
+            .replace(handle, [update(handle)])
             .expect("Face not found");
         Shell::new(faces)
     }
@@ -70,7 +70,7 @@ impl UpdateShell for Shell {
     ) -> Self {
         let faces = self
             .faces()
-            .replace_with_multiple(handle, replace(handle))
+            .replace(handle, replace(handle))
             .expect("Face not found");
         Shell::new(faces)
     }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -53,7 +53,7 @@ impl UpdateSketch for Sketch {
     ) -> Self {
         let regions = self
             .regions()
-            .replace(handle, update(handle))
+            .replace(handle, [update(handle)])
             .expect("Region not found");
         Sketch::new(regions)
     }
@@ -65,7 +65,7 @@ impl UpdateSketch for Sketch {
     ) -> Self {
         let regions = self
             .regions()
-            .replace_with_multiple(handle, replace(handle))
+            .replace(handle, replace(handle))
             .expect("Region not found");
         Sketch::new(regions)
     }

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -60,7 +60,7 @@ impl UpdateSolid for Solid {
     ) -> Self {
         let shells = self
             .shells()
-            .replace(handle, update(handle))
+            .replace(handle, [update(handle)])
             .expect("Shell not found");
         Solid::new(shells)
     }
@@ -72,7 +72,7 @@ impl UpdateSolid for Solid {
     ) -> Self {
         let shells = self
             .shells()
-            .replace_with_multiple(handle, replace(handle))
+            .replace(handle, replace(handle))
             .expect("Shell not found");
         Solid::new(shells)
     }


### PR DESCRIPTION
From the message of the main commit:

> Having two different versions of the same method is not justified, in my opinion:
>
> - The convenience of having a single-replacement special version is so minimal, it doesn't justify any additional complexity.
> - The minimal win in convenience is more than made up for by the inconvenience of a longer name for the general version.
>
> Having a single, general `replace` method is much better.

This is a follow-up to https://github.com/hannobraun/fornjot/pull/2083, and also came out of my work on https://github.com/hannobraun/fornjot/issues/2023.