### PR TITLE
Fix models seemingly not reacting to input

### DIFF
--- a/crates/fj-window/src/display.rs
+++ b/crates/fj-window/src/display.rs
@@ -98,6 +98,9 @@ pub fn display(model: Model, invert_zoom: bool) -> Result<(), Error> {
                 event: WindowEvent::MouseWheel { .. },
                 ..
             } => viewer.add_focus_point(),
+            Event::AboutToWait => {
+                window.window().request_redraw();
+            }
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..


### PR DESCRIPTION
They were actually handling the input fine, but the model wasn't redrawn afterwards. This bug must have snuck in with the recent winit upgrade.