### PR TITLE
Don't insert updated replacement result 

### DIFF
--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -13,6 +13,9 @@ use super::ReplaceOutput;
 ///
 /// [module documentation]: super
 pub trait ReplaceCurve: Sized {
+    /// The bare object type that this trait is implemented for
+    type BareObject;
+
     /// Replace the curve
     #[must_use]
     fn replace_curve(
@@ -24,6 +27,8 @@ pub trait ReplaceCurve: Sized {
 }
 
 impl ReplaceCurve for Handle<HalfEdge> {
+    type BareObject = HalfEdge;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,
@@ -41,6 +46,8 @@ impl ReplaceCurve for Handle<HalfEdge> {
 }
 
 impl ReplaceCurve for Handle<Cycle> {
+    type BareObject = Cycle;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,
@@ -69,6 +76,8 @@ impl ReplaceCurve for Handle<Cycle> {
 }
 
 impl ReplaceCurve for Handle<Region> {
+    type BareObject = Region;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,
@@ -107,6 +116,8 @@ impl ReplaceCurve for Handle<Region> {
 }
 
 impl ReplaceCurve for Handle<Sketch> {
+    type BareObject = Sketch;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,
@@ -135,6 +146,8 @@ impl ReplaceCurve for Handle<Sketch> {
 }
 
 impl ReplaceCurve for Handle<Face> {
+    type BareObject = Face;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,
@@ -159,6 +172,8 @@ impl ReplaceCurve for Handle<Face> {
 }
 
 impl ReplaceCurve for Handle<Shell> {
+    type BareObject = Shell;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,
@@ -187,6 +202,8 @@ impl ReplaceCurve for Handle<Shell> {
 }
 
 impl ReplaceCurve for Handle<Solid> {
+    type BareObject = Solid;
+
     fn replace_curve(
         self,
         original: &Handle<Curve>,

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
-    operations::{insert::Insert, update::UpdateHalfEdge},
+    operations::update::UpdateHalfEdge,
     services::Services,
     storage::Handle,
 };
@@ -33,12 +33,10 @@ impl ReplaceCurve for Handle<HalfEdge> {
         self,
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
-        services: &mut Services,
+        _: &mut Services,
     ) -> ReplaceOutput<Self::BareObject> {
         if original.id() == self.curve().id() {
-            ReplaceOutput::Updated(
-                self.update_curve(|_| replacement).insert(services),
-            )
+            ReplaceOutput::Updated(self.update_curve(|_| replacement))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -68,7 +66,7 @@ impl ReplaceCurve for Handle<Cycle> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Cycle::new(half_edges).insert(services))
+            ReplaceOutput::Updated(Cycle::new(half_edges))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -105,14 +103,11 @@ impl ReplaceCurve for Handle<Region> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(
-                Region::new(
-                    exterior.into_inner(services),
-                    interiors,
-                    self.color(),
-                )
-                .insert(services),
-            )
+            ReplaceOutput::Updated(Region::new(
+                exterior.into_inner(services),
+                interiors,
+                self.color(),
+            ))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -142,7 +137,7 @@ impl ReplaceCurve for Handle<Sketch> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Sketch::new(regions).insert(services))
+            ReplaceOutput::Updated(Sketch::new(regions))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -165,10 +160,10 @@ impl ReplaceCurve for Handle<Face> {
         );
 
         if region.was_updated() {
-            ReplaceOutput::Updated(
-                Face::new(self.surface().clone(), region.into_inner(services))
-                    .insert(services),
-            )
+            ReplaceOutput::Updated(Face::new(
+                self.surface().clone(),
+                region.into_inner(services),
+            ))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -198,7 +193,7 @@ impl ReplaceCurve for Handle<Shell> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Shell::new(faces).insert(services))
+            ReplaceOutput::Updated(Shell::new(faces))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -228,7 +223,7 @@ impl ReplaceCurve for Handle<Solid> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Solid::new(shells).insert(services))
+            ReplaceOutput::Updated(Solid::new(shells))
         } else {
             ReplaceOutput::Original(self)
         }

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -64,7 +64,7 @@ impl ReplaceCurve for Handle<Cycle> {
                 services,
             );
             replacement_happened |= half_edge.was_updated();
-            half_edges.push(half_edge.into_inner());
+            half_edges.push(half_edge.into_inner(services));
         }
 
         if replacement_happened {
@@ -101,13 +101,17 @@ impl ReplaceCurve for Handle<Region> {
                 services,
             );
             replacement_happened |= cycle.was_updated();
-            interiors.push(cycle.into_inner());
+            interiors.push(cycle.into_inner(services));
         }
 
         if replacement_happened {
             ReplaceOutput::Updated(
-                Region::new(exterior.into_inner(), interiors, self.color())
-                    .insert(services),
+                Region::new(
+                    exterior.into_inner(services),
+                    interiors,
+                    self.color(),
+                )
+                .insert(services),
             )
         } else {
             ReplaceOutput::Original(self)
@@ -134,7 +138,7 @@ impl ReplaceCurve for Handle<Sketch> {
                 services,
             );
             replacement_happened |= region.was_updated();
-            regions.push(region.into_inner());
+            regions.push(region.into_inner(services));
         }
 
         if replacement_happened {
@@ -162,7 +166,7 @@ impl ReplaceCurve for Handle<Face> {
 
         if region.was_updated() {
             ReplaceOutput::Updated(
-                Face::new(self.surface().clone(), region.into_inner())
+                Face::new(self.surface().clone(), region.into_inner(services))
                     .insert(services),
             )
         } else {
@@ -190,7 +194,7 @@ impl ReplaceCurve for Handle<Shell> {
                 services,
             );
             replacement_happened |= face.was_updated();
-            faces.push(face.into_inner());
+            faces.push(face.into_inner(services));
         }
 
         if replacement_happened {
@@ -220,7 +224,7 @@ impl ReplaceCurve for Handle<Solid> {
                 services,
             );
             replacement_happened |= shell.was_updated();
-            shells.push(shell.into_inner());
+            shells.push(shell.into_inner(services));
         }
 
         if replacement_happened {

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -23,7 +23,7 @@ pub trait ReplaceCurve: Sized {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self>;
+    ) -> ReplaceOutput<Self::BareObject>;
 }
 
 impl ReplaceCurve for Handle<HalfEdge> {
@@ -34,7 +34,7 @@ impl ReplaceCurve for Handle<HalfEdge> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         if original.id() == self.curve().id() {
             ReplaceOutput::Updated(
                 self.update_curve(|_| replacement).insert(services),
@@ -53,7 +53,7 @@ impl ReplaceCurve for Handle<Cycle> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut half_edges = Vec::new();
@@ -83,7 +83,7 @@ impl ReplaceCurve for Handle<Region> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let exterior = self.exterior().clone().replace_curve(
@@ -123,7 +123,7 @@ impl ReplaceCurve for Handle<Sketch> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
@@ -153,7 +153,7 @@ impl ReplaceCurve for Handle<Face> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let region = self.region().clone().replace_curve(
             original,
             replacement,
@@ -179,7 +179,7 @@ impl ReplaceCurve for Handle<Shell> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
@@ -209,7 +209,7 @@ impl ReplaceCurve for Handle<Solid> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -1,6 +1,5 @@
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
-    operations::insert::Insert,
     services::Services,
     storage::Handle,
 };
@@ -33,12 +32,12 @@ impl ReplaceHalfEdge for Handle<Cycle> {
         self,
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
-        services: &mut Services,
+        _: &mut Services,
     ) -> ReplaceOutput<Self::BareObject> {
         if let Some(half_edges) =
             self.half_edges().replace(original, replacements)
         {
-            ReplaceOutput::Updated(Cycle::new(half_edges).insert(services))
+            ReplaceOutput::Updated(Cycle::new(half_edges))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -75,14 +74,11 @@ impl ReplaceHalfEdge for Handle<Region> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(
-                Region::new(
-                    exterior.into_inner(services),
-                    interiors,
-                    self.color(),
-                )
-                .insert(services),
-            )
+            ReplaceOutput::Updated(Region::new(
+                exterior.into_inner(services),
+                interiors,
+                self.color(),
+            ))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -112,7 +108,7 @@ impl ReplaceHalfEdge for Handle<Sketch> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Sketch::new(regions).insert(services))
+            ReplaceOutput::Updated(Sketch::new(regions))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -135,10 +131,10 @@ impl ReplaceHalfEdge for Handle<Face> {
         );
 
         if region.was_updated() {
-            ReplaceOutput::Updated(
-                Face::new(self.surface().clone(), region.into_inner(services))
-                    .insert(services),
-            )
+            ReplaceOutput::Updated(Face::new(
+                self.surface().clone(),
+                region.into_inner(services),
+            ))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -168,7 +164,7 @@ impl ReplaceHalfEdge for Handle<Shell> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Shell::new(faces).insert(services))
+            ReplaceOutput::Updated(Shell::new(faces))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -198,7 +194,7 @@ impl ReplaceHalfEdge for Handle<Solid> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Solid::new(shells).insert(services))
+            ReplaceOutput::Updated(Solid::new(shells))
         } else {
             ReplaceOutput::Original(self)
         }

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -23,7 +23,7 @@ pub trait ReplaceHalfEdge: Sized {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self>;
+    ) -> ReplaceOutput<Self::BareObject>;
 }
 
 impl ReplaceHalfEdge for Handle<Cycle> {
@@ -34,7 +34,7 @@ impl ReplaceHalfEdge for Handle<Cycle> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         if let Some(half_edges) =
             self.half_edges().replace(original, replacements)
         {
@@ -53,7 +53,7 @@ impl ReplaceHalfEdge for Handle<Region> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let exterior = self.exterior().clone().replace_half_edge(
@@ -93,7 +93,7 @@ impl ReplaceHalfEdge for Handle<Sketch> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
@@ -123,7 +123,7 @@ impl ReplaceHalfEdge for Handle<Face> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let region = self.region().clone().replace_half_edge(
             original,
             replacements,
@@ -149,7 +149,7 @@ impl ReplaceHalfEdge for Handle<Shell> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
@@ -179,7 +179,7 @@ impl ReplaceHalfEdge for Handle<Solid> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -13,6 +13,9 @@ use super::ReplaceOutput;
 ///
 /// [module documentation]: super
 pub trait ReplaceHalfEdge: Sized {
+    /// The bare object type that this trait is implemented for
+    type BareObject;
+
     /// Replace the half-edge
     #[must_use]
     fn replace_half_edge<const N: usize>(
@@ -24,6 +27,8 @@ pub trait ReplaceHalfEdge: Sized {
 }
 
 impl ReplaceHalfEdge for Handle<Cycle> {
+    type BareObject = Cycle;
+
     fn replace_half_edge<const N: usize>(
         self,
         original: &Handle<HalfEdge>,
@@ -41,6 +46,8 @@ impl ReplaceHalfEdge for Handle<Cycle> {
 }
 
 impl ReplaceHalfEdge for Handle<Region> {
+    type BareObject = Region;
+
     fn replace_half_edge<const N: usize>(
         self,
         original: &Handle<HalfEdge>,
@@ -79,6 +86,8 @@ impl ReplaceHalfEdge for Handle<Region> {
 }
 
 impl ReplaceHalfEdge for Handle<Sketch> {
+    type BareObject = Sketch;
+
     fn replace_half_edge<const N: usize>(
         self,
         original: &Handle<HalfEdge>,
@@ -107,6 +116,8 @@ impl ReplaceHalfEdge for Handle<Sketch> {
 }
 
 impl ReplaceHalfEdge for Handle<Face> {
+    type BareObject = Face;
+
     fn replace_half_edge<const N: usize>(
         self,
         original: &Handle<HalfEdge>,
@@ -131,6 +142,8 @@ impl ReplaceHalfEdge for Handle<Face> {
 }
 
 impl ReplaceHalfEdge for Handle<Shell> {
+    type BareObject = Shell;
+
     fn replace_half_edge<const N: usize>(
         self,
         original: &Handle<HalfEdge>,
@@ -159,6 +172,8 @@ impl ReplaceHalfEdge for Handle<Shell> {
 }
 
 impl ReplaceHalfEdge for Handle<Solid> {
+    type BareObject = Solid;
+
     fn replace_half_edge<const N: usize>(
         self,
         original: &Handle<HalfEdge>,

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -71,13 +71,17 @@ impl ReplaceHalfEdge for Handle<Region> {
                 services,
             );
             replacement_happened |= cycle.was_updated();
-            interiors.push(cycle.into_inner());
+            interiors.push(cycle.into_inner(services));
         }
 
         if replacement_happened {
             ReplaceOutput::Updated(
-                Region::new(exterior.into_inner(), interiors, self.color())
-                    .insert(services),
+                Region::new(
+                    exterior.into_inner(services),
+                    interiors,
+                    self.color(),
+                )
+                .insert(services),
             )
         } else {
             ReplaceOutput::Original(self)
@@ -104,7 +108,7 @@ impl ReplaceHalfEdge for Handle<Sketch> {
                 services,
             );
             replacement_happened |= region.was_updated();
-            regions.push(region.into_inner());
+            regions.push(region.into_inner(services));
         }
 
         if replacement_happened {
@@ -132,7 +136,7 @@ impl ReplaceHalfEdge for Handle<Face> {
 
         if region.was_updated() {
             ReplaceOutput::Updated(
-                Face::new(self.surface().clone(), region.into_inner())
+                Face::new(self.surface().clone(), region.into_inner(services))
                     .insert(services),
             )
         } else {
@@ -160,7 +164,7 @@ impl ReplaceHalfEdge for Handle<Shell> {
                 services,
             );
             replacement_happened |= face.was_updated();
-            faces.push(face.into_inner());
+            faces.push(face.into_inner(services));
         }
 
         if replacement_happened {
@@ -190,7 +194,7 @@ impl ReplaceHalfEdge for Handle<Solid> {
                 services,
             );
             replacement_happened |= shell.was_updated();
-            shells.push(shell.into_inner());
+            shells.push(shell.into_inner(services));
         }
 
         if replacement_happened {

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -87,7 +87,7 @@ pub use self::{
     curve::ReplaceCurve, half_edge::ReplaceHalfEdge, vertex::ReplaceVertex,
 };
 
-use crate::storage::Handle;
+use crate::{services::Services, storage::Handle};
 
 /// The output of a replace operation
 ///
@@ -115,7 +115,7 @@ impl<T> ReplaceOutput<T> {
     }
 
     /// Convert `self` into a `T`, regardless of variant
-    pub fn into_inner(self) -> Handle<T> {
+    pub fn into_inner(self, _: &mut Services) -> Handle<T> {
         match self {
             ReplaceOutput::Original(inner) => inner,
             ReplaceOutput::Updated(inner) => inner,

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -62,7 +62,7 @@
 //! Only a few replace operations are implemented so far. More can be added, as
 //! the need arises.
 //!
-//! As of this writing, replace operations are generally implemented in a most
+//! As of this writing, replace operations are generally implemented in the most
 //! simple and naive way possible: Iterating over all referenced objects and
 //! calling the replace operation recursively. This might have performance
 //! implications for large object graphs.

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -107,7 +107,7 @@ pub enum ReplaceOutput<T> {
     ///
     /// If this variant is returned, a replacement happened, and this is the new
     /// version of the object that reflects that.
-    Updated(Handle<T>),
+    Updated(T),
 }
 
 impl<T> ReplaceOutput<T> {
@@ -117,13 +117,13 @@ impl<T> ReplaceOutput<T> {
     }
 
     /// Convert `self` into a `T`, regardless of variant
-    pub fn into_inner(self, _: &mut Services) -> Handle<T>
+    pub fn into_inner(self, services: &mut Services) -> Handle<T>
     where
         T: Insert<Inserted = Handle<T>>,
     {
         match self {
             ReplaceOutput::Original(inner) => inner,
-            ReplaceOutput::Updated(inner) => inner,
+            ReplaceOutput::Updated(inner) => inner.insert(services),
         }
     }
 }

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -87,6 +87,8 @@ pub use self::{
     curve::ReplaceCurve, half_edge::ReplaceHalfEdge, vertex::ReplaceVertex,
 };
 
+use crate::storage::Handle;
+
 /// The output of a replace operation
 ///
 /// See [module documentation] for more information.
@@ -97,13 +99,13 @@ pub enum ReplaceOutput<T> {
     ///
     /// If this variant is returned, the object to be replaced was not
     /// referenced, and no replacement happened.
-    Original(T),
+    Original(Handle<T>),
 
     /// The updated version of the object that the operation was called on
     ///
     /// If this variant is returned, a replacement happened, and this is the new
     /// version of the object that reflects that.
-    Updated(T),
+    Updated(Handle<T>),
 }
 
 impl<T> ReplaceOutput<T> {
@@ -113,7 +115,7 @@ impl<T> ReplaceOutput<T> {
     }
 
     /// Convert `self` into a `T`, regardless of variant
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(self) -> Handle<T> {
         match self {
             ReplaceOutput::Original(inner) => inner,
             ReplaceOutput::Updated(inner) => inner,

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -89,6 +89,8 @@ pub use self::{
 
 use crate::{services::Services, storage::Handle};
 
+use super::insert::Insert;
+
 /// The output of a replace operation
 ///
 /// See [module documentation] for more information.
@@ -115,7 +117,10 @@ impl<T> ReplaceOutput<T> {
     }
 
     /// Convert `self` into a `T`, regardless of variant
-    pub fn into_inner(self, _: &mut Services) -> Handle<T> {
+    pub fn into_inner(self, _: &mut Services) -> Handle<T>
+    where
+        T: Insert<Inserted = Handle<T>>,
+    {
         match self {
             ReplaceOutput::Original(inner) => inner,
             ReplaceOutput::Updated(inner) => inner,

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -70,10 +70,10 @@
 //! There are some update operations that are straight-up redundant with what
 //! replace operations are doing. Some of the methods even have the same names.
 //! Those haven't been removed yet, as update operations generally require a
-//! reference to an object, while replace operations require a `Handle`. There
-//! are some open questions about how operations in general should deal with
-//! objects being inserted or not, so it's probably not worth to address this
-//! before doing a general revamp of how operations deal with inserting.
+//! reference to a bare object, while replace operations require a `Handle`.
+//! There are some open questions about how operations in general should deal
+//! with objects being inserted or not, so it's probably not worth addressing
+//! this before doing a general revamp of how operations deal with inserting.
 //!
 //!
 //! [`Handle`]: crate::storage::Handle

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -64,7 +64,7 @@ impl ReplaceVertex for Handle<Cycle> {
                 services,
             );
             replacement_happened |= half_edge.was_updated();
-            half_edges.push(half_edge.into_inner());
+            half_edges.push(half_edge.into_inner(services));
         }
 
         if replacement_happened {
@@ -101,13 +101,17 @@ impl ReplaceVertex for Handle<Region> {
                 services,
             );
             replacement_happened |= cycle.was_updated();
-            interiors.push(cycle.into_inner());
+            interiors.push(cycle.into_inner(services));
         }
 
         if replacement_happened {
             ReplaceOutput::Updated(
-                Region::new(exterior.into_inner(), interiors, self.color())
-                    .insert(services),
+                Region::new(
+                    exterior.into_inner(services),
+                    interiors,
+                    self.color(),
+                )
+                .insert(services),
             )
         } else {
             ReplaceOutput::Original(self)
@@ -134,7 +138,7 @@ impl ReplaceVertex for Handle<Sketch> {
                 services,
             );
             replacement_happened |= region.was_updated();
-            regions.push(region.into_inner());
+            regions.push(region.into_inner(services));
         }
 
         if replacement_happened {
@@ -162,7 +166,7 @@ impl ReplaceVertex for Handle<Face> {
 
         if region.was_updated() {
             ReplaceOutput::Updated(
-                Face::new(self.surface().clone(), region.into_inner())
+                Face::new(self.surface().clone(), region.into_inner(services))
                     .insert(services),
             )
         } else {
@@ -190,7 +194,7 @@ impl ReplaceVertex for Handle<Shell> {
                 services,
             );
             replacement_happened |= face.was_updated();
-            faces.push(face.into_inner());
+            faces.push(face.into_inner(services));
         }
 
         if replacement_happened {
@@ -220,7 +224,7 @@ impl ReplaceVertex for Handle<Solid> {
                 services,
             );
             replacement_happened |= shell.was_updated();
-            shells.push(shell.into_inner());
+            shells.push(shell.into_inner(services));
         }
 
         if replacement_happened {

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid, Vertex},
-    operations::{insert::Insert, update::UpdateHalfEdge},
+    operations::update::UpdateHalfEdge,
     services::Services,
     storage::Handle,
 };
@@ -33,12 +33,10 @@ impl ReplaceVertex for Handle<HalfEdge> {
         self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        _: &mut Services,
     ) -> ReplaceOutput<Self::BareObject> {
         if original.id() == self.start_vertex().id() {
-            ReplaceOutput::Updated(
-                self.update_start_vertex(|_| replacement).insert(services),
-            )
+            ReplaceOutput::Updated(self.update_start_vertex(|_| replacement))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -68,7 +66,7 @@ impl ReplaceVertex for Handle<Cycle> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Cycle::new(half_edges).insert(services))
+            ReplaceOutput::Updated(Cycle::new(half_edges))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -105,14 +103,11 @@ impl ReplaceVertex for Handle<Region> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(
-                Region::new(
-                    exterior.into_inner(services),
-                    interiors,
-                    self.color(),
-                )
-                .insert(services),
-            )
+            ReplaceOutput::Updated(Region::new(
+                exterior.into_inner(services),
+                interiors,
+                self.color(),
+            ))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -142,7 +137,7 @@ impl ReplaceVertex for Handle<Sketch> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Sketch::new(regions).insert(services))
+            ReplaceOutput::Updated(Sketch::new(regions))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -165,10 +160,10 @@ impl ReplaceVertex for Handle<Face> {
         );
 
         if region.was_updated() {
-            ReplaceOutput::Updated(
-                Face::new(self.surface().clone(), region.into_inner(services))
-                    .insert(services),
-            )
+            ReplaceOutput::Updated(Face::new(
+                self.surface().clone(),
+                region.into_inner(services),
+            ))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -198,7 +193,7 @@ impl ReplaceVertex for Handle<Shell> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Shell::new(faces).insert(services))
+            ReplaceOutput::Updated(Shell::new(faces))
         } else {
             ReplaceOutput::Original(self)
         }
@@ -228,7 +223,7 @@ impl ReplaceVertex for Handle<Solid> {
         }
 
         if replacement_happened {
-            ReplaceOutput::Updated(Solid::new(shells).insert(services))
+            ReplaceOutput::Updated(Solid::new(shells))
         } else {
             ReplaceOutput::Original(self)
         }

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -13,6 +13,9 @@ use super::ReplaceOutput;
 ///
 /// [module documentation]: super
 pub trait ReplaceVertex: Sized {
+    /// The bare object type that this trait is implemented for
+    type BareObject;
+
     /// Replace the vertex
     #[must_use]
     fn replace_vertex(
@@ -24,6 +27,8 @@ pub trait ReplaceVertex: Sized {
 }
 
 impl ReplaceVertex for Handle<HalfEdge> {
+    type BareObject = HalfEdge;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,
@@ -41,6 +46,8 @@ impl ReplaceVertex for Handle<HalfEdge> {
 }
 
 impl ReplaceVertex for Handle<Cycle> {
+    type BareObject = Cycle;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,
@@ -69,6 +76,8 @@ impl ReplaceVertex for Handle<Cycle> {
 }
 
 impl ReplaceVertex for Handle<Region> {
+    type BareObject = Region;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,
@@ -107,6 +116,8 @@ impl ReplaceVertex for Handle<Region> {
 }
 
 impl ReplaceVertex for Handle<Sketch> {
+    type BareObject = Sketch;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,
@@ -135,6 +146,8 @@ impl ReplaceVertex for Handle<Sketch> {
 }
 
 impl ReplaceVertex for Handle<Face> {
+    type BareObject = Face;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,
@@ -159,6 +172,8 @@ impl ReplaceVertex for Handle<Face> {
 }
 
 impl ReplaceVertex for Handle<Shell> {
+    type BareObject = Shell;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,
@@ -187,6 +202,8 @@ impl ReplaceVertex for Handle<Shell> {
 }
 
 impl ReplaceVertex for Handle<Solid> {
+    type BareObject = Solid;
+
     fn replace_vertex(
         self,
         original: &Handle<Vertex>,

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -23,7 +23,7 @@ pub trait ReplaceVertex: Sized {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self>;
+    ) -> ReplaceOutput<Self::BareObject>;
 }
 
 impl ReplaceVertex for Handle<HalfEdge> {
@@ -34,7 +34,7 @@ impl ReplaceVertex for Handle<HalfEdge> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         if original.id() == self.start_vertex().id() {
             ReplaceOutput::Updated(
                 self.update_start_vertex(|_| replacement).insert(services),
@@ -53,7 +53,7 @@ impl ReplaceVertex for Handle<Cycle> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut half_edges = Vec::new();
@@ -83,7 +83,7 @@ impl ReplaceVertex for Handle<Region> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let exterior = self.exterior().clone().replace_vertex(
@@ -123,7 +123,7 @@ impl ReplaceVertex for Handle<Sketch> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
@@ -153,7 +153,7 @@ impl ReplaceVertex for Handle<Face> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let region = self.region().clone().replace_vertex(
             original,
             replacement,
@@ -179,7 +179,7 @@ impl ReplaceVertex for Handle<Shell> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
@@ -209,7 +209,7 @@ impl ReplaceVertex for Handle<Solid> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self> {
+    ) -> ReplaceOutput<Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();


### PR DESCRIPTION
From a commit message:

> This makes replace operations more flexible, as it gives control over insertion to the caller. This is especially relevant, if the replacement produces an invalid intermediate step. Currently, everything that is inserted is validated, and validation provides no good mechanism to deal with invalid intermediate objects, even if the final object ends up being valid.

This is required for making the next steps on https://github.com/hannobraun/fornjot/issues/2023.