### PR TITLE
Implement `operations::replace` traits for bare objects

### DIFF
--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -1,6 +1,6 @@
 use crate::{
     objects::{Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
-    operations::update::UpdateHalfEdge,
+    operations::{insert::Insert, update::UpdateHalfEdge},
     services::Services,
     storage::Handle,
 };
@@ -62,7 +62,11 @@ impl ReplaceCurve for Handle<Cycle> {
                 services,
             );
             replacement_happened |= half_edge.was_updated();
-            half_edges.push(half_edge.into_inner(services));
+            half_edges.push(
+                half_edge
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
@@ -96,12 +100,18 @@ impl ReplaceCurve for Handle<Region> {
             let cycle =
                 cycle.replace_curve(original, replacement.clone(), services);
             replacement_happened |= cycle.was_updated();
-            interiors.push(cycle.into_inner(services));
+            interiors.push(
+                cycle
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
             ReplaceOutput::Updated(Region::new(
-                exterior.into_inner(services),
+                exterior
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
                 interiors,
                 self.color(),
             ))
@@ -127,7 +137,11 @@ impl ReplaceCurve for Handle<Sketch> {
             let region =
                 region.replace_curve(original, replacement.clone(), services);
             replacement_happened |= region.was_updated();
-            regions.push(region.into_inner(services));
+            regions.push(
+                region
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
@@ -153,7 +167,9 @@ impl ReplaceCurve for Handle<Face> {
         if region.was_updated() {
             ReplaceOutput::Updated(Face::new(
                 self.surface().clone(),
-                region.into_inner(services),
+                region
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
             ))
         } else {
             ReplaceOutput::Original(self.clone())
@@ -177,7 +193,10 @@ impl ReplaceCurve for Handle<Shell> {
             let face =
                 face.replace_curve(original, replacement.clone(), services);
             replacement_happened |= face.was_updated();
-            faces.push(face.into_inner(services));
+            faces.push(
+                face.map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
@@ -204,7 +223,11 @@ impl ReplaceCurve for Handle<Solid> {
             let shell =
                 shell.replace_curve(original, replacement.clone(), services);
             replacement_happened |= shell.was_updated();
-            shells.push(shell.into_inner(services));
+            shells.push(
+                shell
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -23,7 +23,7 @@ pub trait ReplaceCurve: Sized {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject>;
+    ) -> ReplaceOutput<Self, Self::BareObject>;
 }
 
 impl ReplaceCurve for Handle<HalfEdge> {
@@ -34,7 +34,7 @@ impl ReplaceCurve for Handle<HalfEdge> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         _: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         if original.id() == self.curve().id() {
             ReplaceOutput::Updated(self.update_curve(|_| replacement))
         } else {
@@ -51,7 +51,7 @@ impl ReplaceCurve for Handle<Cycle> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut half_edges = Vec::new();
@@ -81,7 +81,7 @@ impl ReplaceCurve for Handle<Region> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let exterior = self.exterior().replace_curve(
@@ -119,7 +119,7 @@ impl ReplaceCurve for Handle<Sketch> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
@@ -146,7 +146,7 @@ impl ReplaceCurve for Handle<Face> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let region =
             self.region().replace_curve(original, replacement, services);
 
@@ -169,7 +169,7 @@ impl ReplaceCurve for Handle<Shell> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
@@ -196,7 +196,7 @@ impl ReplaceCurve for Handle<Solid> {
         original: &Handle<Curve>,
         replacement: Handle<Curve>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{
     objects::{Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
     operations::{insert::Insert, update::UpdateHalfEdge},
@@ -26,8 +28,8 @@ pub trait ReplaceCurve: Sized {
     ) -> ReplaceOutput<Self, Self::BareObject>;
 }
 
-impl ReplaceCurve for Handle<HalfEdge> {
-    type BareObject = HalfEdge;
+impl ReplaceCurve for HalfEdge {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -43,8 +45,8 @@ impl ReplaceCurve for Handle<HalfEdge> {
     }
 }
 
-impl ReplaceCurve for Handle<Cycle> {
-    type BareObject = Cycle;
+impl ReplaceCurve for Cycle {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -77,8 +79,8 @@ impl ReplaceCurve for Handle<Cycle> {
     }
 }
 
-impl ReplaceCurve for Handle<Region> {
-    type BareObject = Region;
+impl ReplaceCurve for Region {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -121,8 +123,8 @@ impl ReplaceCurve for Handle<Region> {
     }
 }
 
-impl ReplaceCurve for Handle<Sketch> {
-    type BareObject = Sketch;
+impl ReplaceCurve for Sketch {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -152,8 +154,8 @@ impl ReplaceCurve for Handle<Sketch> {
     }
 }
 
-impl ReplaceCurve for Handle<Face> {
-    type BareObject = Face;
+impl ReplaceCurve for Face {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -177,8 +179,8 @@ impl ReplaceCurve for Handle<Face> {
     }
 }
 
-impl ReplaceCurve for Handle<Shell> {
-    type BareObject = Shell;
+impl ReplaceCurve for Shell {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -207,8 +209,8 @@ impl ReplaceCurve for Handle<Shell> {
     }
 }
 
-impl ReplaceCurve for Handle<Solid> {
-    type BareObject = Solid;
+impl ReplaceCurve for Solid {
+    type BareObject = Self;
 
     fn replace_curve(
         &self,
@@ -235,5 +237,110 @@ impl ReplaceCurve for Handle<Solid> {
         } else {
             ReplaceOutput::Original(self.clone())
         }
+    }
+}
+
+impl ReplaceCurve for Handle<HalfEdge> {
+    type BareObject = HalfEdge;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceCurve for Handle<Cycle> {
+    type BareObject = Cycle;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceCurve for Handle<Region> {
+    type BareObject = Region;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceCurve for Handle<Sketch> {
+    type BareObject = Sketch;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceCurve for Handle<Face> {
+    type BareObject = Face;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceCurve for Handle<Shell> {
+    type BareObject = Shell;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceCurve for Handle<Solid> {
+    type BareObject = Solid;
+
+    fn replace_curve(
+        &self,
+        original: &Handle<Curve>,
+        replacement: Handle<Curve>,
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_curve(original, replacement, services)
+            .map_original(|_| self.clone())
     }
 }

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -22,7 +22,7 @@ pub trait ReplaceHalfEdge: Sized {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject>;
+    ) -> ReplaceOutput<Self, Self::BareObject>;
 }
 
 impl ReplaceHalfEdge for Handle<Cycle> {
@@ -33,7 +33,7 @@ impl ReplaceHalfEdge for Handle<Cycle> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         _: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         if let Some(half_edges) =
             self.half_edges().replace(original, replacements)
         {
@@ -52,7 +52,7 @@ impl ReplaceHalfEdge for Handle<Region> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let exterior = self.exterior().replace_half_edge(
@@ -93,7 +93,7 @@ impl ReplaceHalfEdge for Handle<Sketch> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
@@ -123,7 +123,7 @@ impl ReplaceHalfEdge for Handle<Face> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let region =
             self.region()
                 .replace_half_edge(original, replacements, services);
@@ -147,7 +147,7 @@ impl ReplaceHalfEdge for Handle<Shell> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
@@ -177,7 +177,7 @@ impl ReplaceHalfEdge for Handle<Solid> {
         original: &Handle<HalfEdge>,
         replacements: [Handle<HalfEdge>; N],
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -1,5 +1,6 @@
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
+    operations::insert::Insert,
     services::Services,
     storage::Handle,
 };
@@ -70,12 +71,18 @@ impl ReplaceHalfEdge for Handle<Region> {
                 services,
             );
             replacement_happened |= cycle.was_updated();
-            interiors.push(cycle.into_inner(services));
+            interiors.push(
+                cycle
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
             ReplaceOutput::Updated(Region::new(
-                exterior.into_inner(services),
+                exterior
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
                 interiors,
                 self.color(),
             ))
@@ -104,7 +111,11 @@ impl ReplaceHalfEdge for Handle<Sketch> {
                 services,
             );
             replacement_happened |= region.was_updated();
-            regions.push(region.into_inner(services));
+            regions.push(
+                region
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
@@ -131,7 +142,9 @@ impl ReplaceHalfEdge for Handle<Face> {
         if region.was_updated() {
             ReplaceOutput::Updated(Face::new(
                 self.surface().clone(),
-                region.into_inner(services),
+                region
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
             ))
         } else {
             ReplaceOutput::Original(self.clone())
@@ -158,7 +171,10 @@ impl ReplaceHalfEdge for Handle<Shell> {
                 services,
             );
             replacement_happened |= face.was_updated();
-            faces.push(face.into_inner(services));
+            faces.push(
+                face.map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {
@@ -188,7 +204,11 @@ impl ReplaceHalfEdge for Handle<Solid> {
                 services,
             );
             replacement_happened |= shell.was_updated();
-            shells.push(shell.into_inner(services));
+            shells.push(
+                shell
+                    .map_updated(|updated| updated.insert(services))
+                    .into_inner(),
+            );
         }
 
         if replacement_happened {

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
     operations::insert::Insert,
@@ -26,8 +28,8 @@ pub trait ReplaceHalfEdge: Sized {
     ) -> ReplaceOutput<Self, Self::BareObject>;
 }
 
-impl ReplaceHalfEdge for Handle<Cycle> {
-    type BareObject = Cycle;
+impl ReplaceHalfEdge for Cycle {
+    type BareObject = Self;
 
     fn replace_half_edge<const N: usize>(
         &self,
@@ -45,8 +47,8 @@ impl ReplaceHalfEdge for Handle<Cycle> {
     }
 }
 
-impl ReplaceHalfEdge for Handle<Region> {
-    type BareObject = Region;
+impl ReplaceHalfEdge for Region {
+    type BareObject = Self;
 
     fn replace_half_edge<const N: usize>(
         &self,
@@ -92,8 +94,8 @@ impl ReplaceHalfEdge for Handle<Region> {
     }
 }
 
-impl ReplaceHalfEdge for Handle<Sketch> {
-    type BareObject = Sketch;
+impl ReplaceHalfEdge for Sketch {
+    type BareObject = Self;
 
     fn replace_half_edge<const N: usize>(
         &self,
@@ -126,8 +128,8 @@ impl ReplaceHalfEdge for Handle<Sketch> {
     }
 }
 
-impl ReplaceHalfEdge for Handle<Face> {
-    type BareObject = Face;
+impl ReplaceHalfEdge for Face {
+    type BareObject = Self;
 
     fn replace_half_edge<const N: usize>(
         &self,
@@ -152,8 +154,8 @@ impl ReplaceHalfEdge for Handle<Face> {
     }
 }
 
-impl ReplaceHalfEdge for Handle<Shell> {
-    type BareObject = Shell;
+impl ReplaceHalfEdge for Shell {
+    type BareObject = Self;
 
     fn replace_half_edge<const N: usize>(
         &self,
@@ -185,8 +187,8 @@ impl ReplaceHalfEdge for Handle<Shell> {
     }
 }
 
-impl ReplaceHalfEdge for Handle<Solid> {
-    type BareObject = Solid;
+impl ReplaceHalfEdge for Solid {
+    type BareObject = Self;
 
     fn replace_half_edge<const N: usize>(
         &self,
@@ -216,5 +218,95 @@ impl ReplaceHalfEdge for Handle<Solid> {
         } else {
             ReplaceOutput::Original(self.clone())
         }
+    }
+}
+
+impl ReplaceHalfEdge for Handle<Cycle> {
+    type BareObject = Cycle;
+
+    fn replace_half_edge<const N: usize>(
+        &self,
+        original: &Handle<HalfEdge>,
+        replacements: [Handle<HalfEdge>; N],
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_half_edge(original, replacements, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceHalfEdge for Handle<Region> {
+    type BareObject = Region;
+
+    fn replace_half_edge<const N: usize>(
+        &self,
+        original: &Handle<HalfEdge>,
+        replacements: [Handle<HalfEdge>; N],
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_half_edge(original, replacements, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceHalfEdge for Handle<Sketch> {
+    type BareObject = Sketch;
+
+    fn replace_half_edge<const N: usize>(
+        &self,
+        original: &Handle<HalfEdge>,
+        replacements: [Handle<HalfEdge>; N],
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_half_edge(original, replacements, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceHalfEdge for Handle<Face> {
+    type BareObject = Face;
+
+    fn replace_half_edge<const N: usize>(
+        &self,
+        original: &Handle<HalfEdge>,
+        replacements: [Handle<HalfEdge>; N],
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_half_edge(original, replacements, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceHalfEdge for Handle<Shell> {
+    type BareObject = Shell;
+
+    fn replace_half_edge<const N: usize>(
+        &self,
+        original: &Handle<HalfEdge>,
+        replacements: [Handle<HalfEdge>; N],
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_half_edge(original, replacements, services)
+            .map_original(|_| self.clone())
+    }
+}
+
+impl ReplaceHalfEdge for Handle<Solid> {
+    type BareObject = Solid;
+
+    fn replace_half_edge<const N: usize>(
+        &self,
+        original: &Handle<HalfEdge>,
+        replacements: [Handle<HalfEdge>; N],
+        services: &mut Services,
+    ) -> ReplaceOutput<Self, Self::BareObject> {
+        self.deref()
+            .replace_half_edge(original, replacements, services)
+            .map_original(|_| self.clone())
     }
 }

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -98,10 +98,6 @@ pub use self::{
     curve::ReplaceCurve, half_edge::ReplaceHalfEdge, vertex::ReplaceVertex,
 };
 
-use crate::{services::Services, storage::Handle};
-
-use super::insert::Insert;
-
 /// The output of a replace operation
 ///
 /// See [module documentation] for more information.
@@ -146,15 +142,12 @@ impl<Original, Updated> ReplaceOutput<Original, Updated> {
     }
 }
 
-impl<T> ReplaceOutput<Handle<T>, T> {
+impl<T> ReplaceOutput<T, T> {
     /// Return the original object, or insert the updated on and return handle
-    pub fn into_inner(self, services: &mut Services) -> Handle<T>
-    where
-        T: Insert<Inserted = Handle<T>>,
-    {
+    pub fn into_inner(self) -> T {
         match self {
             Self::Original(inner) => inner,
-            Self::Updated(inner) => inner.insert(services),
+            Self::Updated(inner) => inner,
         }
     }
 }

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -107,12 +107,12 @@ use super::insert::Insert;
 /// See [module documentation] for more information.
 ///
 /// [module documentation]: self
-pub enum ReplaceOutput<T> {
+pub enum ReplaceOutput<Original, Updated> {
     /// The original object that the replace operation was called on
     ///
     /// If this variant is returned, the object to be replaced was not
     /// referenced, and no replacement happened.
-    Original(Handle<T>),
+    Original(Original),
 
     /// The updated version of the object that the operation was called on
     ///
@@ -125,15 +125,17 @@ pub enum ReplaceOutput<T> {
     /// modeling process. The validation infrastructure currently provides no
     /// good ways to deal with invalid intermediate results, even if the end
     /// result ends up valid.
-    Updated(T),
+    Updated(Updated),
 }
 
-impl<T> ReplaceOutput<T> {
+impl<Original, Updated> ReplaceOutput<Original, Updated> {
     /// Indicate whether the original object was updated
     pub fn was_updated(&self) -> bool {
         matches!(self, ReplaceOutput::Updated(_))
     }
+}
 
+impl<T> ReplaceOutput<Handle<T>, T> {
     /// Return the original object, or insert the updated on and return handle
     pub fn into_inner(self, services: &mut Services) -> Handle<T>
     where

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -130,6 +130,17 @@ impl<Original, Updated> ReplaceOutput<Original, Updated> {
         matches!(self, ReplaceOutput::Updated(_))
     }
 
+    /// Map the `Original` variant using the provided function
+    pub fn map_original<T>(
+        self,
+        f: impl FnOnce(Original) -> T,
+    ) -> ReplaceOutput<T, Updated> {
+        match self {
+            Self::Original(original) => ReplaceOutput::Original(f(original)),
+            Self::Updated(updated) => ReplaceOutput::Updated(updated),
+        }
+    }
+
     /// Map the `Updated` variant using the provided function
     pub fn map_updated<T>(
         self,

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -153,8 +153,8 @@ impl<T> ReplaceOutput<Handle<T>, T> {
         T: Insert<Inserted = Handle<T>>,
     {
         match self {
-            ReplaceOutput::Original(inner) => inner,
-            ReplaceOutput::Updated(inner) => inner.insert(services),
+            Self::Original(inner) => inner,
+            Self::Updated(inner) => inner.insert(services),
         }
     }
 }

--- a/crates/fj-core/src/operations/replace/mod.rs
+++ b/crates/fj-core/src/operations/replace/mod.rs
@@ -133,6 +133,17 @@ impl<Original, Updated> ReplaceOutput<Original, Updated> {
     pub fn was_updated(&self) -> bool {
         matches!(self, ReplaceOutput::Updated(_))
     }
+
+    /// Map the `Updated` variant using the provided function
+    pub fn map_updated<T>(
+        self,
+        f: impl FnOnce(Updated) -> T,
+    ) -> ReplaceOutput<Original, T> {
+        match self {
+            Self::Original(original) => ReplaceOutput::Original(original),
+            Self::Updated(updated) => ReplaceOutput::Updated(f(updated)),
+        }
+    }
 }
 
 impl<T> ReplaceOutput<Handle<T>, T> {

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -23,7 +23,7 @@ pub trait ReplaceVertex: Sized {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject>;
+    ) -> ReplaceOutput<Self, Self::BareObject>;
 }
 
 impl ReplaceVertex for Handle<HalfEdge> {
@@ -34,7 +34,7 @@ impl ReplaceVertex for Handle<HalfEdge> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         _: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         if original.id() == self.start_vertex().id() {
             ReplaceOutput::Updated(self.update_start_vertex(|_| replacement))
         } else {
@@ -51,7 +51,7 @@ impl ReplaceVertex for Handle<Cycle> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut half_edges = Vec::new();
@@ -81,7 +81,7 @@ impl ReplaceVertex for Handle<Region> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let exterior = self.exterior().replace_vertex(
@@ -119,7 +119,7 @@ impl ReplaceVertex for Handle<Sketch> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
@@ -146,7 +146,7 @@ impl ReplaceVertex for Handle<Face> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let region =
             self.region()
                 .replace_vertex(original, replacement, services);
@@ -170,7 +170,7 @@ impl ReplaceVertex for Handle<Shell> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
@@ -197,7 +197,7 @@ impl ReplaceVertex for Handle<Solid> {
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
         services: &mut Services,
-    ) -> ReplaceOutput<Self::BareObject> {
+    ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();


### PR DESCRIPTION
Update the implementations for `Handle`s to use the bare object implementations. This change provides much more flexibility for the replace operations:

- It makes the replace operations available in more places; specifically other operations that are themselves implemented for bare objects.
- It makes it possibly to use the operations in more places. Previously, when chaining multiple replace operations, the caller was forced to `insert` the intermediate object, which caused issues, if the intermediate object was invalid. Now the insertion is no longer required, making it possible to make the object valid using the chained replaced operation, before inserting it.

The `Handle` implementations are still provided, as they are also required in some situation, specifically, some of the replace operations themselves. Maybe this can be addressed, I'm not sure.

This is needed to make further progress on https://github.com/hannobraun/fornjot/issues/2023.