### PR TITLE
Add edge splitting operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "split"
+version = "0.1.0"
+dependencies = [
+ "fj",
+]
+
+[[package]]
 name = "star"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "cuboid",
  "fj",
  "spacer",
+ "split",
  "star",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "models/all",
     "models/cuboid",
     "models/spacer",
+    "models/split",
     "models/star",
 
     "tools/autolib",

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -1,0 +1,61 @@
+use fj_math::Point;
+
+use crate::{
+    objects::{HalfEdge, Shell},
+    operations::{
+        insert::Insert, replace::ReplaceHalfEdge, split::SplitHalfEdge,
+        update::UpdateHalfEdge,
+    },
+    queries::SiblingOfHalfEdge,
+    services::Services,
+    storage::Handle,
+};
+
+/// Split a pair of [`HalfEdge`]s into two
+pub trait SplitEdge {
+    /// Split the provided [`HalfEdge`], as well as its sibling, into two
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the provided half-edge is not a part of this shell.
+    #[must_use]
+    fn split_edge(
+        &self,
+        half_edge: &Handle<HalfEdge>,
+        point: impl Into<Point<1>>,
+        services: &mut Services,
+    ) -> Self;
+}
+
+impl SplitEdge for Shell {
+    fn split_edge(
+        &self,
+        half_edge: &Handle<HalfEdge>,
+        point: impl Into<Point<1>>,
+        services: &mut Services,
+    ) -> Self {
+        let point = point.into();
+
+        let sibling = self
+            .get_sibling_of(half_edge)
+            .expect("Expected half-edge and its sibling to be part of shell");
+
+        let [half_edge_a, half_edge_b] = half_edge
+            .split_half_edge(point, services)
+            .map(|half_edge| half_edge.insert(services));
+
+        let [sibling_a, sibling_b] = sibling.split_half_edge(point, services);
+        let sibling_b = sibling_b
+            .update_start_vertex(|_| half_edge_b.start_vertex().clone());
+
+        self.replace_half_edge(half_edge, [half_edge_a, half_edge_b], services)
+            .into_inner()
+            .replace_half_edge(
+                &sibling,
+                [sibling_a, sibling_b]
+                    .map(|half_edge| half_edge.insert(services)),
+                services,
+            )
+            .into_inner()
+    }
+}

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -7,6 +7,11 @@ use crate::{
 };
 
 /// Split a [`HalfEdge`] into two
+///
+/// This is a low-level operation that, by itself, leaves the containing shell
+/// in an invalid state. You probably want to use [`SplitEdge`] instead.
+///
+/// [`SplitEdge`]: super::SplitEdge
 pub trait SplitHalfEdge {
     /// Split the half-edge into two
     ///

--- a/crates/fj-core/src/operations/split/mod.rs
+++ b/crates/fj-core/src/operations/split/mod.rs
@@ -3,6 +3,7 @@
 //! See [`SplitHalfEdge`], which is currently the only trait in this module, for
 //! more information.
 
+mod edge;
 mod half_edge;
 
-pub use self::half_edge::SplitHalfEdge;
+pub use self::{edge::SplitEdge, half_edge::SplitHalfEdge};

--- a/crates/fj-core/src/operations/split/mod.rs
+++ b/crates/fj-core/src/operations/split/mod.rs
@@ -1,7 +1,9 @@
 //! # Operations to split objects
 //!
-//! See [`SplitHalfEdge`], which is currently the only trait in this module, for
-//! more information.
+//! Splitting means removing an object, replacing it with to new ones that fill
+//! the same space. This often makes sense, when you want to modify only part of
+//! an object. In such a case, you can split off the part you want to modify,
+//! leaving the rest unchanged.
 
 mod edge;
 mod half_edge;

--- a/models/all/Cargo.toml
+++ b/models/all/Cargo.toml
@@ -12,5 +12,8 @@ path = "../cuboid"
 [dependencies.spacer]
 path = "../spacer"
 
+[dependencies.split]
+path = "../split"
+
 [dependencies.star]
 path = "../star"

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -27,6 +27,13 @@ pub fn model(services: &mut Services) -> Handle<Solid> {
     let star = star::model(5, 2., 1., 1., services)
         .translate(offset * 3., services)
         .rotate(axis * angle_rad * 3., services);
+    let split = split::model(1., 0.5, services)
+        .translate(offset * 4., services)
+        .rotate(axis * angle_rad * 4., services);
 
-    cuboid.merge(&spacer).merge(&star).insert(services)
+    cuboid
+        .merge(&spacer)
+        .merge(&star)
+        .merge(&split)
+        .insert(services)
 }

--- a/models/split/Cargo.toml
+++ b/models/split/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "split"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.fj]
+path = "../../crates/fj"

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -1,0 +1,58 @@
+use fj::{
+    core::{
+        algorithms::sweep::Sweep,
+        objects::{Region, Sketch, Solid},
+        operations::{
+            build::{BuildRegion, BuildSketch},
+            insert::Insert,
+            split::SplitEdge,
+            update::{UpdateSketch, UpdateSolid},
+        },
+        services::Services,
+        storage::Handle,
+    },
+    math::Vector,
+};
+
+pub fn model(
+    size: f64,
+    split_pos: f64,
+    services: &mut Services,
+) -> Handle<Solid> {
+    let sketch = Sketch::empty()
+        .add_region(
+            Region::polygon(
+                [
+                    [-size / 2., -size / 2.],
+                    [size / 2., -size / 2.],
+                    [size / 2., size / 2.],
+                    [-size / 2., size / 2.],
+                ],
+                services,
+            )
+            .insert(services),
+        )
+        .insert(services);
+
+    let surface = services.objects.surfaces.xy_plane();
+    let path = Vector::from([0., 0., size]);
+    let solid = (sketch, surface).sweep(path, services);
+
+    solid
+        .update_shell(solid.shells().only(), |shell| {
+            shell
+                .split_edge(
+                    shell
+                        .faces()
+                        .first()
+                        .region()
+                        .exterior()
+                        .half_edges()
+                        .first(),
+                    [split_pos],
+                    services,
+                )
+                .insert(services)
+        })
+        .insert(services)
+}

--- a/models/split/src/main.rs
+++ b/models/split/src/main.rs
@@ -1,0 +1,8 @@
+use fj::{core::services::Services, handle_model};
+
+fn main() -> fj::Result {
+    let mut services = Services::new();
+    let model = split::model(1.0, 0.5, &mut services);
+    handle_model(model, services)?;
+    Ok(())
+}


### PR DESCRIPTION
Builds on the previously added half-edge splitting operation to build an operation that splits the full edge, leaving the shell that contains it valid throughout. Also added an example model that tests and demonstrates this capability.

This is a big step towards providing an operation to split faces (#2023).