### PR TITLE
Return more information from `SplitEdge::split_edge`

### DIFF
--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -49,16 +49,12 @@ impl SplitEdge for Shell {
                 sibling.split_half_edge(point, services);
             let sibling_b = sibling_b
                 .update_start_vertex(|_| half_edge_b.start_vertex().clone());
-            [sibling_a, sibling_b]
+            [sibling_a, sibling_b].map(|half_edge| half_edge.insert(services))
         };
 
         self.replace_half_edge(half_edge, [half_edge_a, half_edge_b], services)
             .into_inner()
-            .replace_half_edge(
-                &sibling,
-                siblings.map(|half_edge| half_edge.insert(services)),
-                services,
-            )
+            .replace_half_edge(&sibling, siblings, services)
             .into_inner()
     }
 }

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -44,16 +44,19 @@ impl SplitEdge for Shell {
             .split_half_edge(point, services)
             .map(|half_edge| half_edge.insert(services));
 
-        let [sibling_a, sibling_b] = sibling.split_half_edge(point, services);
-        let sibling_b = sibling_b
-            .update_start_vertex(|_| half_edge_b.start_vertex().clone());
+        let siblings = {
+            let [sibling_a, sibling_b] =
+                sibling.split_half_edge(point, services);
+            let sibling_b = sibling_b
+                .update_start_vertex(|_| half_edge_b.start_vertex().clone());
+            [sibling_a, sibling_b]
+        };
 
         self.replace_half_edge(half_edge, [half_edge_a, half_edge_b], services)
             .into_inner()
             .replace_half_edge(
                 &sibling,
-                [sibling_a, sibling_b]
-                    .map(|half_edge| half_edge.insert(services)),
+                siblings.map(|half_edge| half_edge.insert(services)),
                 services,
             )
             .into_inner()

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Split a pair of [`HalfEdge`]s into two
-pub trait SplitEdge {
+pub trait SplitEdge: Sized {
     /// Split the provided [`HalfEdge`], as well as its sibling, into two
     ///
     /// # Panics

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -24,7 +24,7 @@ pub trait SplitEdge: Sized {
         half_edge: &Handle<HalfEdge>,
         point: impl Into<Point<1>>,
         services: &mut Services,
-    ) -> Self;
+    ) -> (Self, [[Handle<HalfEdge>; 2]; 2]);
 }
 
 impl SplitEdge for Shell {
@@ -33,7 +33,7 @@ impl SplitEdge for Shell {
         half_edge: &Handle<HalfEdge>,
         point: impl Into<Point<1>>,
         services: &mut Services,
-    ) -> Self {
+    ) -> (Self, [[Handle<HalfEdge>; 2]; 2]) {
         let point = point.into();
 
         let sibling = self
@@ -52,9 +52,16 @@ impl SplitEdge for Shell {
             [sibling_a, sibling_b].map(|half_edge| half_edge.insert(services))
         };
 
-        self.replace_half_edge(half_edge, [half_edge_a, half_edge_b], services)
+        let shell = self
+            .replace_half_edge(
+                half_edge,
+                [half_edge_a.clone(), half_edge_b.clone()],
+                services,
+            )
             .into_inner()
-            .replace_half_edge(&sibling, siblings, services)
-            .into_inner()
+            .replace_half_edge(&sibling, siblings.clone(), services)
+            .into_inner();
+
+        (shell, [[half_edge_a, half_edge_b], siblings])
     }
 }

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -52,6 +52,7 @@ pub fn model(
                     [split_pos],
                     services,
                 )
+                .0
                 .insert(services)
         })
         .insert(services)


### PR DESCRIPTION
Make the operation usable in more scenarios. This came out of my work on https://github.com/hannobraun/fornjot/issues/2023.