### PR TITLE
Replace `Sweep` with object-specific traits

### DIFF
--- a/crates/fj-core/src/operations/sweep/face.rs
+++ b/crates/fj-core/src/operations/sweep/face.rs
@@ -12,17 +12,30 @@ use crate::{
     services::Services,
 };
 
-use super::{Sweep, SweepCache, SweepHalfEdge};
+use super::{SweepCache, SweepHalfEdge};
 
-impl Sweep for &Face {
-    type Swept = Shell;
-
-    fn sweep_with_cache(
-        self,
+/// # Sweep a [`Face`]
+///
+/// See [module documentation] for more information.
+///
+/// [module documentation]: super
+pub trait SweepFace {
+    /// # Sweep the [`Face`]
+    fn sweep_face(
+        &self,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         services: &mut Services,
-    ) -> Self::Swept {
+    ) -> Shell;
+}
+
+impl SweepFace for Face {
+    fn sweep_face(
+        &self,
+        path: impl Into<Vector<3>>,
+        cache: &mut SweepCache,
+        services: &mut Services,
+    ) -> Shell {
         // Please note that this function uses the words "bottom" and "top" in a
         // specific sense:
         //

--- a/crates/fj-core/src/operations/sweep/face.rs
+++ b/crates/fj-core/src/operations/sweep/face.rs
@@ -12,7 +12,7 @@ use crate::{
     services::Services,
 };
 
-use super::{Sweep, SweepCache};
+use super::{Sweep, SweepCache, SweepHalfEdge};
 
 impl Sweep for &Face {
     type Swept = Shell;
@@ -62,13 +62,14 @@ impl Sweep for &Face {
                 let (bottom_half_edge, bottom_half_edge_next) =
                     bottom_half_edge_pair;
 
-                let (side_face, top_edge) = (
-                    bottom_half_edge.deref(),
+                let (side_face, top_edge) = bottom_half_edge.sweep_half_edge(
                     bottom_half_edge_next.start_vertex().clone(),
                     bottom_face.surface().deref(),
                     bottom_face.region().color(),
-                )
-                    .sweep_with_cache(path, cache, services);
+                    path,
+                    cache,
+                    services,
+                );
 
                 let side_face = side_face.insert(services);
 

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -12,7 +12,7 @@ use crate::{
     storage::Handle,
 };
 
-use super::{Sweep, SweepCache};
+use super::{vertex::SweepVertex, Sweep, SweepCache};
 
 impl Sweep for (&HalfEdge, Handle<Vertex>, &Surface, Option<Color>) {
     type Swept = (Face, Handle<HalfEdge>);
@@ -34,10 +34,8 @@ impl Sweep for (&HalfEdge, Handle<Vertex>, &Surface, Option<Color>) {
         // the global vertices and edges.
         let (vertices, curves) = {
             let [a, b] = [edge.start_vertex().clone(), end_vertex];
-            let (curve_up, c) =
-                b.clone().sweep_with_cache(path, cache, services);
-            let (curve_down, d) =
-                a.clone().sweep_with_cache(path, cache, services);
+            let (curve_up, c) = b.clone().sweep_vertex(cache, services);
+            let (curve_down, d) = a.clone().sweep_vertex(cache, services);
 
             (
                 [a, b, c, d],

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -12,7 +12,7 @@ use crate::{
     storage::Handle,
 };
 
-use super::{vertex::SweepVertex, Sweep, SweepCache};
+use super::{vertex::SweepVertex, Sweep, SweepCache, SweepSurfacePath};
 
 impl Sweep for (&HalfEdge, Handle<Vertex>, &Surface, Option<Color>) {
     type Swept = (Face, Handle<HalfEdge>);
@@ -26,8 +26,9 @@ impl Sweep for (&HalfEdge, Handle<Vertex>, &Surface, Option<Color>) {
         let (edge, end_vertex, surface, color) = self;
         let path = path.into();
 
-        let surface = (edge.path(), surface)
-            .sweep_with_cache(path, cache, services)
+        let surface = edge
+            .path()
+            .sweep_surface_path(surface, path)
             .insert(services);
 
         // Next, we need to define the boundaries of the face. Let's start with

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -13,41 +13,12 @@ pub use self::{
 
 use std::collections::BTreeMap;
 
-use fj_math::Vector;
-
 use crate::{
     objects::{Curve, Vertex},
-    services::Services,
     storage::{Handle, ObjectId},
 };
 
-/// Sweep an object along a path to create another object
-pub trait Sweep: Sized {
-    /// The object that is created by sweeping the implementing object
-    type Swept;
-
-    /// Sweep the object along the given path
-    fn sweep(
-        self,
-        path: impl Into<Vector<3>>,
-        services: &mut Services,
-    ) -> Self::Swept {
-        let mut cache = SweepCache::default();
-        self.sweep_with_cache(path, &mut cache, services)
-    }
-
-    /// Sweep the object along the given path, using the provided cache
-    fn sweep_with_cache(
-        self,
-        path: impl Into<Vector<3>>,
-        cache: &mut SweepCache,
-        services: &mut Services,
-    ) -> Self::Swept;
-}
-
 /// A cache used for sweeping
-///
-/// See [`Sweep`].
 #[derive(Default)]
 pub struct SweepCache {
     /// Cache for curves

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -7,7 +7,8 @@ mod sketch;
 mod vertex;
 
 pub use self::{
-    half_edge::SweepHalfEdge, path::SweepSurfacePath, vertex::SweepVertex,
+    face::SweepFace, half_edge::SweepHalfEdge, path::SweepSurfacePath,
+    vertex::SweepVertex,
 };
 
 use std::collections::BTreeMap;

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -6,7 +6,9 @@ mod path;
 mod sketch;
 mod vertex;
 
-pub use self::{path::SweepSurfacePath, vertex::SweepVertex};
+pub use self::{
+    half_edge::SweepHalfEdge, path::SweepSurfacePath, vertex::SweepVertex,
+};
 
 use std::collections::BTreeMap;
 

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -1,4 +1,7 @@
-//! Sweeping objects along a path to create new objects
+//! Sweep objects along a path to create new objects
+//!
+//! Sweeps 1D or 2D objects along a straight path, creating a 2D or 3D object,
+//! respectively.
 
 mod face;
 mod half_edge;

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -6,7 +6,7 @@ mod path;
 mod sketch;
 mod vertex;
 
-pub use self::vertex::SweepVertex;
+pub use self::{path::SweepSurfacePath, vertex::SweepVertex};
 
 use std::collections::BTreeMap;
 

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -6,6 +6,8 @@ mod path;
 mod sketch;
 mod vertex;
 
+pub use self::vertex::SweepVertex;
+
 use std::collections::BTreeMap;
 
 use fj_math::Vector;

--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -8,7 +8,7 @@ mod vertex;
 
 pub use self::{
     face::SweepFace, half_edge::SweepHalfEdge, path::SweepSurfacePath,
-    vertex::SweepVertex,
+    sketch::SweepSketch, vertex::SweepVertex,
 };
 
 use std::collections::BTreeMap;

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -3,22 +3,37 @@ use fj_math::{Circle, Line, Vector};
 use crate::{
     geometry::{GlobalPath, SurfaceGeometry, SurfacePath},
     objects::Surface,
-    services::Services,
 };
 
-use super::{Sweep, SweepCache};
-
-impl Sweep for (SurfacePath, &Surface) {
-    type Swept = Surface;
-
-    fn sweep_with_cache(
-        self,
+/// # Sweep a [`SurfacePath`]
+///
+/// See [module documentation] for more information.
+///
+/// [module documentation]: super
+pub trait SweepSurfacePath {
+    /// # Sweep the surface path
+    ///
+    /// Requires a reference to the surface that the path is defined on.
+    ///
+    ///
+    /// ## Implementation Note
+    ///
+    /// Sweeping a `SurfacePath` that is defined on a curved surface is
+    /// currently not supported:
+    /// <https://github.com/hannobraun/fornjot/issues/1112>
+    fn sweep_surface_path(
+        &self,
+        surface: &Surface,
         path: impl Into<Vector<3>>,
-        _: &mut SweepCache,
-        _: &mut Services,
-    ) -> Self::Swept {
-        let (curve, surface) = self;
+    ) -> Surface;
+}
 
+impl SweepSurfacePath for SurfacePath {
+    fn sweep_surface_path(
+        &self,
+        surface: &Surface,
+        path: impl Into<Vector<3>>,
+    ) -> Surface {
         match surface.geometry().u {
             GlobalPath::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
@@ -43,7 +58,7 @@ impl Sweep for (SurfacePath, &Surface) {
             }
         }
 
-        let u = match curve {
+        let u = match self {
             SurfacePath::Circle(circle) => {
                 let center = surface
                     .geometry()

--- a/crates/fj-core/src/operations/sweep/sketch.rs
+++ b/crates/fj-core/src/operations/sweep/sketch.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::Handle,
 };
 
-use super::{Sweep, SweepCache};
+use super::{face::SweepFace, Sweep, SweepCache};
 
 impl Sweep for (&Sketch, Handle<Surface>) {
     type Swept = Solid;
@@ -25,9 +25,7 @@ impl Sweep for (&Sketch, Handle<Surface>) {
         for region in sketch.regions() {
             let face =
                 Face::new(surface.clone(), region.clone()).insert(services);
-            let shell = face
-                .sweep_with_cache(path, cache, services)
-                .insert(services);
+            let shell = face.sweep_face(path, cache, services).insert(services);
             shells.push(shell);
         }
 

--- a/crates/fj-core/src/operations/sweep/sketch.rs
+++ b/crates/fj-core/src/operations/sweep/sketch.rs
@@ -7,25 +7,39 @@ use crate::{
     storage::Handle,
 };
 
-use super::{face::SweepFace, Sweep, SweepCache};
+use super::{face::SweepFace, SweepCache};
 
-impl Sweep for (&Sketch, Handle<Surface>) {
-    type Swept = Solid;
-
-    fn sweep_with_cache(
-        self,
+/// # Sweep a [`Sketch`]
+///
+/// See [module documentation] for more information.
+///
+/// [module documentation]: super
+pub trait SweepSketch {
+    /// # Sweep the [`Sketch`]
+    fn sweep_sketch(
+        &self,
+        surface: Handle<Surface>,
         path: impl Into<Vector<3>>,
-        cache: &mut SweepCache,
         services: &mut Services,
-    ) -> Self::Swept {
-        let (sketch, surface) = self;
+    ) -> Solid;
+}
+
+impl SweepSketch for Sketch {
+    fn sweep_sketch(
+        &self,
+        surface: Handle<Surface>,
+        path: impl Into<Vector<3>>,
+        services: &mut Services,
+    ) -> Solid {
         let path = path.into();
+        let mut cache = SweepCache::default();
 
         let mut shells = Vec::new();
-        for region in sketch.regions() {
+        for region in self.regions() {
             let face =
                 Face::new(surface.clone(), region.clone()).insert(services);
-            let shell = face.sweep_face(path, cache, services).insert(services);
+            let shell =
+                face.sweep_face(path, &mut cache, services).insert(services);
             shells.push(shell);
         }
 

--- a/crates/fj-core/src/operations/sweep/vertex.rs
+++ b/crates/fj-core/src/operations/sweep/vertex.rs
@@ -1,5 +1,3 @@
-use fj_math::Vector;
-
 use crate::{
     objects::{Curve, Vertex},
     operations::insert::Insert,
@@ -7,17 +5,45 @@ use crate::{
     storage::Handle,
 };
 
-use super::{Sweep, SweepCache};
+use super::SweepCache;
 
-impl Sweep for Handle<Vertex> {
-    type Swept = (Handle<Curve>, Self);
-
-    fn sweep_with_cache(
-        self,
-        _: impl Into<Vector<3>>,
+/// # Sweep a [`Vertex`]
+///
+/// See [module documentation] for more information.
+///
+/// [module documentation]: super
+pub trait SweepVertex: Sized {
+    /// # Sweep the vertex
+    ///
+    /// Returns the curve that the vertex was swept along, as well as a new
+    /// vertex to represent the point at the end of the sweep.
+    ///
+    ///
+    /// ## Comparison to Other Sweep Operations
+    ///
+    /// This method is a bit weird, compared to most other sweep operations, in
+    /// that it doesn't actually do any sweeping. That is because because both
+    /// [`Vertex`] and [`Curve`] do not define any geometry (please refer to
+    /// their respective documentation). Because of that, this method doesn't
+    /// even take the sweep path as an argument.
+    ///
+    /// The reason this code still exists as part of the sweep infrastructure,
+    /// is to make sure that sweeping the same vertex multiple times always
+    /// results in the same curve. This is also the reason that this trait is
+    /// only implemented for `Handle<Vertex>` and produces a `Handle<Curve>`.
+    fn sweep_vertex(
+        &self,
         cache: &mut SweepCache,
         services: &mut Services,
-    ) -> Self::Swept {
+    ) -> (Handle<Curve>, Handle<Vertex>);
+}
+
+impl SweepVertex for Handle<Vertex> {
+    fn sweep_vertex(
+        &self,
+        cache: &mut SweepCache,
+        services: &mut Services,
+    ) -> (Handle<Curve>, Handle<Vertex>) {
         let curve = cache
             .curves
             .entry(self.id())

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -4,7 +4,7 @@ use fj::{
         operations::{
             build::{BuildRegion, BuildSketch},
             insert::Insert,
-            sweep::Sweep,
+            sweep::SweepSketch,
             update::UpdateSketch,
         },
         services::Services,
@@ -29,5 +29,7 @@ pub fn model(x: f64, y: f64, z: f64, services: &mut Services) -> Handle<Solid> {
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., z]);
-    (&sketch, surface).sweep(path, services).insert(services)
+    sketch
+        .sweep_sketch(surface, path, services)
+        .insert(services)
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -5,7 +5,7 @@ use fj::{
             build::{BuildCycle, BuildRegion, BuildSketch},
             insert::Insert,
             reverse::Reverse,
-            sweep::Sweep,
+            sweep::SweepSketch,
             update::{UpdateRegion, UpdateSketch},
         },
         services::Services,
@@ -30,5 +30,7 @@ pub fn model(
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., height]);
-    (&sketch, surface).sweep(path, services).insert(services)
+    sketch
+        .sweep_sketch(surface, path, services)
+        .insert(services)
 }

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -5,7 +5,7 @@ use fj::{
             build::{BuildRegion, BuildSketch},
             insert::Insert,
             split::SplitFace,
-            sweep::Sweep,
+            sweep::SweepSketch,
             update::{UpdateSketch, UpdateSolid},
         },
         services::Services,
@@ -34,7 +34,7 @@ pub fn model(
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., size]);
-    let solid = (&sketch, surface).sweep(path, services);
+    let solid = sketch.sweep_sketch(surface, path, services);
 
     solid
         .update_shell(solid.shells().only(), |shell| {

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -7,7 +7,7 @@ use fj::{
             build::{BuildCycle, BuildRegion, BuildSketch},
             insert::Insert,
             reverse::Reverse,
-            sweep::Sweep,
+            sweep::SweepSketch,
             update::{UpdateRegion, UpdateSketch},
         },
         services::Services,
@@ -53,5 +53,7 @@ pub fn model(
 
     let surface = services.objects.surfaces.xy_plane();
     let path = Vector::from([0., 0., h]);
-    (&sketch, surface).sweep(path, services).insert(services)
+    sketch
+        .sweep_sketch(surface, path, services)
+        .insert(services)
 }


### PR DESCRIPTION
The old `Sweep` trait was over-generalized. There was no code that actually used it to abstract over multiple of its implementations, and I don't think it would have been practical to do so. Those implementations, on the other hand, were partially implemented not for single types, but tuples of them (thereby effectively adding arguments that the trait didn't have), while at the same time ignoring argument the trait *did* have.

Overall, this was both messy and unnecessary. In this pull request, I've replaced those `Sweep` implementations with object-specific sweep traits that are more targeted to the needs of the object they're sweeping. This also provides a place for object-specific sweep *documentation*, some of which I've added.

Lastly, this brings `operations::sweep` more in line with other operations modules, which function in a similar way.

This came out of my work on https://github.com/hannobraun/fornjot/issues/2098.