### PR TITLE
Add operation for creating shell from vertices and indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vertices-indices"
+version = "0.1.0"
+dependencies = [
+ "fj",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "models/spacer",
     "models/split",
     "models/star",
+    "models/vertices-indices",
 
     "tools/autolib",
     "tools/automator",

--- a/models/vertices-indices/Cargo.toml
+++ b/models/vertices-indices/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vertices-indices"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.fj]
+path = "../../crates/fj"

--- a/models/vertices-indices/src/lib.rs
+++ b/models/vertices-indices/src/lib.rs
@@ -1,0 +1,21 @@
+use fj::core::{
+    objects::{Shell, Solid},
+    operations::{
+        build::{BuildShell, BuildSolid},
+        insert::Insert,
+        update::UpdateSolid,
+    },
+    services::Services,
+    storage::Handle,
+};
+
+pub fn model(services: &mut Services) -> Handle<Solid> {
+    Solid::empty()
+        .add_shells([Shell::from_vertices_and_indices(
+            [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
+            [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
+            services,
+        )
+        .insert(services)])
+        .insert(services)
+}

--- a/models/vertices-indices/src/main.rs
+++ b/models/vertices-indices/src/main.rs
@@ -1,0 +1,8 @@
+use fj::{core::services::Services, handle_model};
+
+fn main() -> fj::Result {
+    let mut services = Services::new();
+    let model = vertices_indices::model(&mut services);
+    handle_model(model, services)?;
+    Ok(())
+}


### PR DESCRIPTION
This is a way to create models that is rather quick-and-dirty, doesn't scale well to more complex models, but is extremely flexible and well-suited for some simpler models.