### PR TITLE
Update link to Matrix room

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,6 @@ The commit message as a whole ideally follows these guidelines:
 
 
 [issues]: https://github.com/hannobraun/Fornjot/issues
-[Matrix]: https://matrix.to/#/#fornjot:braun-odw.eu
+[Matrix]: https://matrix.to/#/#fornjot:pub.solar
 [Discussions]: https://github.com/hannobraun/Fornjot/discussions
 [@hannobraun]: https://github.com/hannobraun


### PR DESCRIPTION
My homeserver will shut down in a few weeks, which means the old link will no longer work.