### PR TITLE
Preserve color when splitting face

### DIFF
--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -7,6 +7,7 @@ use crate::{
     operations::{
         build::{BuildFace, BuildHalfEdge},
         insert::Insert,
+        presentation::SetColor,
         split::SplitEdge,
         update::{
             UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,
@@ -131,14 +132,18 @@ impl SplitFace for Shell {
             services,
         )
         .update_region(|region| {
-            region
-                .update_exterior(|cycle| {
-                    cycle
-                        .add_half_edges(half_edges_b_to_c_inclusive)
-                        .add_half_edges([dividing_half_edge_c_to_b])
-                        .insert(services)
-                })
-                .insert(services)
+            let mut region = region.update_exterior(|cycle| {
+                cycle
+                    .add_half_edges(half_edges_b_to_c_inclusive)
+                    .add_half_edges([dividing_half_edge_c_to_b])
+                    .insert(services)
+            });
+
+            if let Some(color) = face.region().color() {
+                region = region.set_color(color);
+            }
+
+            region.insert(services)
         })
         .insert(services);
 
@@ -152,14 +157,18 @@ impl SplitFace for Shell {
             services,
         )
         .update_region(|region| {
-            region
-                .update_exterior(|cycle| {
-                    cycle
-                        .add_half_edges(half_edges_d_to_a_inclusive)
-                        .add_half_edges([dividing_half_edge_a_to_d])
-                        .insert(services)
-                })
-                .insert(services)
+            let mut region = region.update_exterior(|cycle| {
+                cycle
+                    .add_half_edges(half_edges_d_to_a_inclusive)
+                    .add_half_edges([dividing_half_edge_a_to_d])
+                    .insert(services)
+            });
+
+            if let Some(color) = face.region().color() {
+                region = region.set_color(color);
+            }
+
+            region.insert(services)
         })
         .insert(services);
 

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -3,6 +3,7 @@ use fj::core::{
     operations::{
         insert::Insert,
         presentation::SetColor,
+        split::SplitFace,
         update::{UpdateFace, UpdateShell, UpdateSolid},
     },
     services::Services,
@@ -15,14 +16,31 @@ pub fn model(services: &mut Services) -> Handle<Solid> {
 
     cuboid
         .update_shell(cuboid.shells().only(), |shell| {
-            shell
-                .update_face(shell.faces().first(), |face| {
-                    face.update_region(|region| {
-                        region.set_color([0., 1., 0.]).insert(services)
-                    })
-                    .insert(services)
+            let shell = shell.update_face(shell.faces().first(), |face| {
+                face.update_region(|region| {
+                    region.set_color([0., 1., 0.]).insert(services)
                 })
                 .insert(services)
+            });
+
+            // Split colored face, to make sure the same color is applied to the
+            // two derived faces.
+            let shell = {
+                let face = shell.faces().first();
+                let line = {
+                    let cycle = face.region().exterior();
+
+                    [
+                        (cycle.half_edges().nth(0).unwrap(), [0.2]),
+                        (cycle.half_edges().nth(2).unwrap(), [0.2]),
+                    ]
+                };
+
+                let (shell, _) = shell.split_face(face, line, services);
+                shell
+            };
+
+            shell.insert(services)
         })
         .insert(services)
 }


### PR DESCRIPTION
Previously, the new faces were reset to the default color. I found this while working on https://github.com/hannobraun/fornjot/issues/2117.