### PR TITLE
Add READMEs for `tools/` and all subdirectories

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,1 @@
+This is a collection of tools that are used for the build process and release automation. Nothing here is relevant for *users* of Fornjot.

--- a/tools/cross-compiler/README.md
+++ b/tools/cross-compiler/README.md
@@ -1,0 +1,4 @@
+# `cross-compiler`
+
+CLI tool that is used by Fornjot's build process to compile the Fornjot crates for various targets.
+


### PR DESCRIPTION
Most of the tools already had READMEs, but now they all have one.