### PR TITLE
Add `IsObject` trait

### DIFF
--- a/crates/fj-core/src/objects/is_object.rs
+++ b/crates/fj-core/src/objects/is_object.rs
@@ -1,3 +1,9 @@
+use crate::storage::Handle;
+
+use super::{
+    Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid, Surface, Vertex,
+};
+
 /// A trait implemented for all object types
 ///
 /// This trait is implemented for both `T` and `Handle<T>`, where `T` is the
@@ -10,4 +16,44 @@
 pub trait IsObject {
     /// The type of the bare object
     type BareObject;
+}
+
+impl IsObject for Handle<Curve> {
+    type BareObject = Curve;
+}
+
+impl IsObject for Handle<Cycle> {
+    type BareObject = Cycle;
+}
+
+impl IsObject for Handle<Face> {
+    type BareObject = Face;
+}
+
+impl IsObject for Handle<HalfEdge> {
+    type BareObject = HalfEdge;
+}
+
+impl IsObject for Handle<Region> {
+    type BareObject = Region;
+}
+
+impl IsObject for Handle<Shell> {
+    type BareObject = Shell;
+}
+
+impl IsObject for Handle<Sketch> {
+    type BareObject = Sketch;
+}
+
+impl IsObject for Handle<Solid> {
+    type BareObject = Solid;
+}
+
+impl IsObject for Handle<Surface> {
+    type BareObject = Surface;
+}
+
+impl IsObject for Handle<Vertex> {
+    type BareObject = Vertex;
 }

--- a/crates/fj-core/src/objects/is_object.rs
+++ b/crates/fj-core/src/objects/is_object.rs
@@ -1,0 +1,13 @@
+/// A trait implemented for all object types
+///
+/// This trait is implemented for both `T` and `Handle<T>`, where `T` is the
+/// type of any bare object. The `BareObject` associated type provides access to
+/// the bare object type.
+///
+/// This is a piece of infrastructure that is useful for other traits, which
+/// would otherwise have to duplicate its functionality. Users are unlikely to
+/// be affected by this trait.
+pub trait IsObject {
+    /// The type of the bare object
+    type BareObject;
+}

--- a/crates/fj-core/src/objects/is_object.rs
+++ b/crates/fj-core/src/objects/is_object.rs
@@ -18,6 +18,46 @@ pub trait IsObject {
     type BareObject;
 }
 
+impl IsObject for Curve {
+    type BareObject = Curve;
+}
+
+impl IsObject for Cycle {
+    type BareObject = Cycle;
+}
+
+impl IsObject for Face {
+    type BareObject = Face;
+}
+
+impl IsObject for HalfEdge {
+    type BareObject = HalfEdge;
+}
+
+impl IsObject for Region {
+    type BareObject = Region;
+}
+
+impl IsObject for Shell {
+    type BareObject = Shell;
+}
+
+impl IsObject for Sketch {
+    type BareObject = Sketch;
+}
+
+impl IsObject for Solid {
+    type BareObject = Solid;
+}
+
+impl IsObject for Surface {
+    type BareObject = Surface;
+}
+
+impl IsObject for Vertex {
+    type BareObject = Vertex;
+}
+
 impl IsObject for Handle<Curve> {
     type BareObject = Curve;
 }

--- a/crates/fj-core/src/objects/mod.rs
+++ b/crates/fj-core/src/objects/mod.rs
@@ -39,12 +39,14 @@
 //!
 //! [`Handle`]: crate::storage::Handle
 
+mod is_object;
 mod kinds;
 mod object;
 mod object_set;
 mod stores;
 
 pub use self::{
+    is_object::IsObject,
     kinds::{
         curve::Curve,
         cycle::Cycle,

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -1,7 +1,9 @@
 use std::ops::Deref;
 
 use crate::{
-    objects::{Curve, Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
+    objects::{
+        Curve, Cycle, Face, HalfEdge, IsObject, Region, Shell, Sketch, Solid,
+    },
     operations::{insert::Insert, update::UpdateHalfEdge},
     services::Services,
     storage::Handle,
@@ -14,10 +16,7 @@ use super::ReplaceOutput;
 /// See [module documentation] for more information.
 ///
 /// [module documentation]: super
-pub trait ReplaceCurve: Sized {
-    /// The bare object type that this trait is implemented for
-    type BareObject;
-
+pub trait ReplaceCurve: IsObject + Sized {
     /// Replace the curve
     #[must_use]
     fn replace_curve(
@@ -29,8 +28,6 @@ pub trait ReplaceCurve: Sized {
 }
 
 impl ReplaceCurve for HalfEdge {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -46,8 +43,6 @@ impl ReplaceCurve for HalfEdge {
 }
 
 impl ReplaceCurve for Cycle {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -80,8 +75,6 @@ impl ReplaceCurve for Cycle {
 }
 
 impl ReplaceCurve for Region {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -124,8 +117,6 @@ impl ReplaceCurve for Region {
 }
 
 impl ReplaceCurve for Sketch {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -155,8 +146,6 @@ impl ReplaceCurve for Sketch {
 }
 
 impl ReplaceCurve for Face {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -180,8 +169,6 @@ impl ReplaceCurve for Face {
 }
 
 impl ReplaceCurve for Shell {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -210,8 +197,6 @@ impl ReplaceCurve for Shell {
 }
 
 impl ReplaceCurve for Solid {
-    type BareObject = Self;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -241,8 +226,6 @@ impl ReplaceCurve for Solid {
 }
 
 impl ReplaceCurve for Handle<HalfEdge> {
-    type BareObject = HalfEdge;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -256,8 +239,6 @@ impl ReplaceCurve for Handle<HalfEdge> {
 }
 
 impl ReplaceCurve for Handle<Cycle> {
-    type BareObject = Cycle;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -271,8 +252,6 @@ impl ReplaceCurve for Handle<Cycle> {
 }
 
 impl ReplaceCurve for Handle<Region> {
-    type BareObject = Region;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -286,8 +265,6 @@ impl ReplaceCurve for Handle<Region> {
 }
 
 impl ReplaceCurve for Handle<Sketch> {
-    type BareObject = Sketch;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -301,8 +278,6 @@ impl ReplaceCurve for Handle<Sketch> {
 }
 
 impl ReplaceCurve for Handle<Face> {
-    type BareObject = Face;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -316,8 +291,6 @@ impl ReplaceCurve for Handle<Face> {
 }
 
 impl ReplaceCurve for Handle<Shell> {
-    type BareObject = Shell;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,
@@ -331,8 +304,6 @@ impl ReplaceCurve for Handle<Shell> {
 }
 
 impl ReplaceCurve for Handle<Solid> {
-    type BareObject = Solid;
-
     fn replace_curve(
         &self,
         original: &Handle<Curve>,

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::{
-    objects::{Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid},
+    objects::{Cycle, Face, HalfEdge, IsObject, Region, Shell, Sketch, Solid},
     operations::insert::Insert,
     services::Services,
     storage::Handle,
@@ -14,10 +14,7 @@ use super::ReplaceOutput;
 /// See [module documentation] for more information.
 ///
 /// [module documentation]: super
-pub trait ReplaceHalfEdge: Sized {
-    /// The bare object type that this trait is implemented for
-    type BareObject;
-
+pub trait ReplaceHalfEdge: IsObject + Sized {
     /// Replace the half-edge
     #[must_use]
     fn replace_half_edge<const N: usize>(
@@ -29,8 +26,6 @@ pub trait ReplaceHalfEdge: Sized {
 }
 
 impl ReplaceHalfEdge for Cycle {
-    type BareObject = Self;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -48,8 +43,6 @@ impl ReplaceHalfEdge for Cycle {
 }
 
 impl ReplaceHalfEdge for Region {
-    type BareObject = Self;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -95,8 +88,6 @@ impl ReplaceHalfEdge for Region {
 }
 
 impl ReplaceHalfEdge for Sketch {
-    type BareObject = Self;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -129,8 +120,6 @@ impl ReplaceHalfEdge for Sketch {
 }
 
 impl ReplaceHalfEdge for Face {
-    type BareObject = Self;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -155,8 +144,6 @@ impl ReplaceHalfEdge for Face {
 }
 
 impl ReplaceHalfEdge for Shell {
-    type BareObject = Self;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -188,8 +175,6 @@ impl ReplaceHalfEdge for Shell {
 }
 
 impl ReplaceHalfEdge for Solid {
-    type BareObject = Self;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -222,8 +207,6 @@ impl ReplaceHalfEdge for Solid {
 }
 
 impl ReplaceHalfEdge for Handle<Cycle> {
-    type BareObject = Cycle;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -237,8 +220,6 @@ impl ReplaceHalfEdge for Handle<Cycle> {
 }
 
 impl ReplaceHalfEdge for Handle<Region> {
-    type BareObject = Region;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -252,8 +233,6 @@ impl ReplaceHalfEdge for Handle<Region> {
 }
 
 impl ReplaceHalfEdge for Handle<Sketch> {
-    type BareObject = Sketch;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -267,8 +246,6 @@ impl ReplaceHalfEdge for Handle<Sketch> {
 }
 
 impl ReplaceHalfEdge for Handle<Face> {
-    type BareObject = Face;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -282,8 +259,6 @@ impl ReplaceHalfEdge for Handle<Face> {
 }
 
 impl ReplaceHalfEdge for Handle<Shell> {
-    type BareObject = Shell;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,
@@ -297,8 +272,6 @@ impl ReplaceHalfEdge for Handle<Shell> {
 }
 
 impl ReplaceHalfEdge for Handle<Solid> {
-    type BareObject = Solid;
-
     fn replace_half_edge<const N: usize>(
         &self,
         original: &Handle<HalfEdge>,

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -1,7 +1,9 @@
 use std::ops::Deref;
 
 use crate::{
-    objects::{Cycle, Face, HalfEdge, Region, Shell, Sketch, Solid, Vertex},
+    objects::{
+        Cycle, Face, HalfEdge, IsObject, Region, Shell, Sketch, Solid, Vertex,
+    },
     operations::{insert::Insert, update::UpdateHalfEdge},
     services::Services,
     storage::Handle,
@@ -14,10 +16,7 @@ use super::ReplaceOutput;
 /// See [module documentation] for more information.
 ///
 /// [module documentation]: super
-pub trait ReplaceVertex: Sized {
-    /// The bare object type that this trait is implemented for
-    type BareObject;
-
+pub trait ReplaceVertex: IsObject + Sized {
     /// Replace the vertex
     #[must_use]
     fn replace_vertex(
@@ -29,8 +28,6 @@ pub trait ReplaceVertex: Sized {
 }
 
 impl ReplaceVertex for HalfEdge {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -46,8 +43,6 @@ impl ReplaceVertex for HalfEdge {
 }
 
 impl ReplaceVertex for Cycle {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -80,8 +75,6 @@ impl ReplaceVertex for Cycle {
 }
 
 impl ReplaceVertex for Region {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -124,8 +117,6 @@ impl ReplaceVertex for Region {
 }
 
 impl ReplaceVertex for Sketch {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -155,8 +146,6 @@ impl ReplaceVertex for Sketch {
 }
 
 impl ReplaceVertex for Face {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -181,8 +170,6 @@ impl ReplaceVertex for Face {
 }
 
 impl ReplaceVertex for Shell {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -211,8 +198,6 @@ impl ReplaceVertex for Shell {
 }
 
 impl ReplaceVertex for Solid {
-    type BareObject = Self;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -242,8 +227,6 @@ impl ReplaceVertex for Solid {
 }
 
 impl ReplaceVertex for Handle<HalfEdge> {
-    type BareObject = HalfEdge;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -257,8 +240,6 @@ impl ReplaceVertex for Handle<HalfEdge> {
 }
 
 impl ReplaceVertex for Handle<Cycle> {
-    type BareObject = Cycle;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -272,8 +253,6 @@ impl ReplaceVertex for Handle<Cycle> {
 }
 
 impl ReplaceVertex for Handle<Region> {
-    type BareObject = Region;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -287,8 +266,6 @@ impl ReplaceVertex for Handle<Region> {
 }
 
 impl ReplaceVertex for Handle<Sketch> {
-    type BareObject = Sketch;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -318,8 +295,6 @@ impl ReplaceVertex for Handle<Sketch> {
 }
 
 impl ReplaceVertex for Handle<Face> {
-    type BareObject = Face;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -333,8 +308,6 @@ impl ReplaceVertex for Handle<Face> {
 }
 
 impl ReplaceVertex for Handle<Shell> {
-    type BareObject = Shell;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,
@@ -348,8 +321,6 @@ impl ReplaceVertex for Handle<Shell> {
 }
 
 impl ReplaceVertex for Handle<Solid> {
-    type BareObject = Solid;
-
     fn replace_vertex(
         &self,
         original: &Handle<Vertex>,


### PR DESCRIPTION
The new trait is a piece of infrastructure that is useful for defining some other traits. I'm using it in this pull request to clean up the `replace` traits a bit.

I'm also going to need this for https://github.com/hannobraun/fornjot/issues/2117.