### PR TITLE
Return bare objects from model functions

### DIFF
--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -1,4 +1,4 @@
-use std::{error::Error as _, fmt, mem, ops::Deref};
+use std::{error::Error as _, fmt, mem};
 
 use fj_core::{
     algorithms::{
@@ -23,10 +23,7 @@ use crate::Args;
 ///
 /// This function is used by Fornjot's own testing infrastructure, but is useful
 /// beyond that, when using Fornjot directly to define a model.
-pub fn handle_model<M>(
-    model: impl Deref<Target = M>,
-    services: Services,
-) -> Result
+pub fn handle_model<M>(model: &M, services: Services) -> Result
 where
     for<'r> (&'r M, Tolerance): Triangulate,
     M: BoundingVolume<3>,
@@ -68,7 +65,7 @@ where
         Some(user_defined_tolerance) => user_defined_tolerance,
     };
 
-    let mesh = (model.deref(), tolerance).triangulate();
+    let mesh = (model, tolerance).triangulate();
 
     if let Some(path) = args.export {
         crate::export::export(&mesh, &path)?;

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -1,16 +1,13 @@
 use fj::{
     core::{
         objects::Solid,
-        operations::{
-            insert::Insert, merge::Merge, transform::TransformObject,
-        },
+        operations::{merge::Merge, transform::TransformObject},
         services::Services,
-        storage::Handle,
     },
     math::{Scalar, Vector},
 };
 
-pub fn model(services: &mut Services) -> Handle<Solid> {
+pub fn model(services: &mut Services) -> Solid {
     // Just combine all the other models using offsets/rotations that won't
     // result in neat vertex positions or axis-aligned edges/faces. This is
     // useful for testing.
@@ -40,5 +37,4 @@ pub fn model(services: &mut Services) -> Handle<Solid> {
         .merge(&star)
         .merge(&split)
         .merge(&holes)
-        .insert(services)
 }

--- a/models/all/src/main.rs
+++ b/models/all/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = all::model(&mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/all/src/main.rs
+++ b/models/all/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = all::model(&mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -7,40 +7,37 @@ use fj::core::{
         update::{UpdateFace, UpdateShell, UpdateSolid},
     },
     services::Services,
-    storage::Handle,
 };
 
-pub fn model(services: &mut Services) -> Handle<Solid> {
+pub fn model(services: &mut Services) -> Solid {
     let size = 1.;
     let cuboid = cuboid::model([size, size, size], services);
 
-    cuboid
-        .update_shell(cuboid.shells().only(), |shell| {
-            let shell = shell.update_face(shell.faces().first(), |face| {
-                face.update_region(|region| {
-                    region.set_color([0., 1., 0.]).insert(services)
-                })
-                .insert(services)
-            });
+    cuboid.update_shell(cuboid.shells().only(), |shell| {
+        let shell = shell.update_face(shell.faces().first(), |face| {
+            face.update_region(|region| {
+                region.set_color([0., 1., 0.]).insert(services)
+            })
+            .insert(services)
+        });
 
-            // Split colored face, to make sure the same color is applied to the
-            // two derived faces.
-            let shell = {
-                let face = shell.faces().first();
-                let line = {
-                    let cycle = face.region().exterior();
+        // Split colored face, to make sure the same color is applied to the
+        // two derived faces.
+        let shell = {
+            let face = shell.faces().first();
+            let line = {
+                let cycle = face.region().exterior();
 
-                    [
-                        (cycle.half_edges().nth(0).unwrap(), [0.2]),
-                        (cycle.half_edges().nth(2).unwrap(), [0.2]),
-                    ]
-                };
-
-                let (shell, _) = shell.split_face(face, line, services);
-                shell
+                [
+                    (cycle.half_edges().nth(0).unwrap(), [0.2]),
+                    (cycle.half_edges().nth(2).unwrap(), [0.2]),
+                ]
             };
 
-            shell.insert(services)
-        })
-        .insert(services)
+            let (shell, _) = shell.split_face(face, line, services);
+            shell
+        };
+
+        shell.insert(services)
+    })
 }

--- a/models/color/src/main.rs
+++ b/models/color/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = color::model(&mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/color/src/main.rs
+++ b/models/color/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = color::model(&mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -8,15 +8,11 @@ use fj::{
             update::UpdateSketch,
         },
         services::Services,
-        storage::Handle,
     },
     math::{Scalar, Vector},
 };
 
-pub fn model(
-    size: impl Into<Vector<3>>,
-    services: &mut Services,
-) -> Handle<Solid> {
+pub fn model(size: impl Into<Vector<3>>, services: &mut Services) -> Solid {
     let [x, y, z] = size.into().components;
 
     let bottom_surface = services.objects.surfaces.xy_plane();
@@ -36,5 +32,4 @@ pub fn model(
             .insert(services),
         )
         .sweep_sketch(bottom_surface, sweep_path, services)
-        .insert(services)
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = cuboid::model([3., 2., 1.], &mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = cuboid::model([3., 2., 1.], &mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/holes/src/lib.rs
+++ b/models/holes/src/lib.rs
@@ -7,58 +7,52 @@ use fj::{
             update::UpdateSolid,
         },
         services::Services,
-        storage::Handle,
     },
     math::Scalar,
 };
 
-pub fn model(
-    radius: impl Into<Scalar>,
-    services: &mut Services,
-) -> Handle<Solid> {
+pub fn model(radius: impl Into<Scalar>, services: &mut Services) -> Solid {
     let radius = radius.into();
 
     let size = radius * 4.;
     let cuboid = cuboid::model([size * 2., size, size], services);
 
-    cuboid
-        .update_shell(cuboid.shells().only(), |shell| {
-            let bottom_face = shell.faces().first();
-            let offset = size / 2.;
-            let depth = size / 2.;
+    cuboid.update_shell(cuboid.shells().only(), |shell| {
+        let bottom_face = shell.faces().first();
+        let offset = size / 2.;
+        let depth = size / 2.;
 
-            let shell = shell.add_blind_hole(
-                HoleLocation {
-                    face: bottom_face,
-                    position: [-offset, Scalar::ZERO].into(),
-                },
+        let shell = shell.add_blind_hole(
+            HoleLocation {
+                face: bottom_face,
+                position: [-offset, Scalar::ZERO].into(),
+            },
+            radius,
+            [Scalar::ZERO, Scalar::ZERO, depth],
+            services,
+        );
+
+        let bottom_face = shell.faces().first();
+        let top_face = shell
+            .faces()
+            .nth(5)
+            .expect("Expected shell to have top face");
+
+        shell
+            .add_through_hole(
+                [
+                    HoleLocation {
+                        face: bottom_face,
+                        position: [offset, Scalar::ZERO].into(),
+                    },
+                    HoleLocation {
+                        face: top_face,
+                        position: [offset, Scalar::ZERO].into(),
+                    },
+                ],
                 radius,
-                [Scalar::ZERO, Scalar::ZERO, depth],
                 services,
-            );
-
-            let bottom_face = shell.faces().first();
-            let top_face = shell
-                .faces()
-                .nth(5)
-                .expect("Expected shell to have top face");
-
-            shell
-                .add_through_hole(
-                    [
-                        HoleLocation {
-                            face: bottom_face,
-                            position: [offset, Scalar::ZERO].into(),
-                        },
-                        HoleLocation {
-                            face: top_face,
-                            position: [offset, Scalar::ZERO].into(),
-                        },
-                    ],
-                    radius,
-                    services,
-                )
-                .insert(services)
-        })
-        .insert(services)
+            )
+            .insert(services)
+    })
 }

--- a/models/holes/src/main.rs
+++ b/models/holes/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = holes::model(0.25, &mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/holes/src/main.rs
+++ b/models/holes/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = holes::model(0.25, &mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -9,7 +9,6 @@ use fj::{
             update::{UpdateRegion, UpdateSketch},
         },
         services::Services,
-        storage::Handle,
     },
     math::{Point, Vector},
 };
@@ -19,7 +18,7 @@ pub fn model(
     inner: f64,
     height: f64,
     services: &mut Services,
-) -> Handle<Solid> {
+) -> Solid {
     let bottom_surface = services.objects.surfaces.xy_plane();
     let sweep_path = Vector::from([0., 0., height]);
 
@@ -36,5 +35,4 @@ pub fn model(
                 .insert(services),
         )
         .sweep_sketch(bottom_surface, sweep_path, services)
-        .insert(services)
 }

--- a/models/spacer/src/main.rs
+++ b/models/spacer/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = spacer::model(1., 0.5, 1., &mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/spacer/src/main.rs
+++ b/models/spacer/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = spacer::model(1., 0.5, 1., &mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -5,31 +5,24 @@ use fj::core::{
         update::UpdateSolid,
     },
     services::Services,
-    storage::Handle,
 };
 
-pub fn model(
-    size: f64,
-    split_pos: f64,
-    services: &mut Services,
-) -> Handle<Solid> {
+pub fn model(size: f64, split_pos: f64, services: &mut Services) -> Solid {
     let cuboid = cuboid::model([size, size, size], services);
 
-    cuboid
-        .update_shell(cuboid.shells().only(), |shell| {
-            let face = shell.faces().first();
-            let cycle = face.region().exterior();
+    cuboid.update_shell(cuboid.shells().only(), |shell| {
+        let face = shell.faces().first();
+        let cycle = face.region().exterior();
 
-            let line = [
-                (cycle.half_edges().nth(0).unwrap(), [split_pos]),
-                (cycle.half_edges().nth(2).unwrap(), [split_pos]),
-            ];
+        let line = [
+            (cycle.half_edges().nth(0).unwrap(), [split_pos]),
+            (cycle.half_edges().nth(2).unwrap(), [split_pos]),
+        ];
 
-            let (shell, [face, _]) = shell.split_face(face, line, services);
+        let (shell, [face, _]) = shell.split_face(face, line, services);
 
-            shell
-                .sweep_face_of_shell(face, [0., 0., -size / 2.], services)
-                .insert(services)
-        })
-        .insert(services)
+        shell
+            .sweep_face_of_shell(face, [0., 0., -size / 2.], services)
+            .insert(services)
+    })
 }

--- a/models/split/src/main.rs
+++ b/models/split/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = split::model(1.0, 0.2, &mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/split/src/main.rs
+++ b/models/split/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = split::model(1.0, 0.2, &mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -11,7 +11,6 @@ use fj::{
             update::{UpdateRegion, UpdateSketch},
         },
         services::Services,
-        storage::Handle,
     },
     math::Vector,
 };
@@ -22,7 +21,7 @@ pub fn model(
     r2: f64,
     h: f64,
     services: &mut Services,
-) -> Handle<Solid> {
+) -> Solid {
     let num_vertices = num_points * 2;
     let vertex_iter = (0..num_vertices).map(|i| {
         let angle_rad = 2. * PI / num_vertices as f64 * i as f64;
@@ -55,5 +54,4 @@ pub fn model(
                 .insert(services),
         )
         .sweep_sketch(bottom_surface, sweep_path, services)
-        .insert(services)
 }

--- a/models/star/src/main.rs
+++ b/models/star/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = star::model(5, 1., 2., 1., &mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/star/src/main.rs
+++ b/models/star/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = star::model(5, 1., 2., 1., &mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }

--- a/models/vertices-indices/src/lib.rs
+++ b/models/vertices-indices/src/lib.rs
@@ -6,16 +6,13 @@ use fj::core::{
         update::UpdateSolid,
     },
     services::Services,
-    storage::Handle,
 };
 
-pub fn model(services: &mut Services) -> Handle<Solid> {
-    Solid::empty()
-        .add_shells([Shell::from_vertices_and_indices(
-            [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
-            [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
-            services,
-        )
-        .insert(services)])
-        .insert(services)
+pub fn model(services: &mut Services) -> Solid {
+    Solid::empty().add_shells([Shell::from_vertices_and_indices(
+        [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
+        [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
+        services,
+    )
+    .insert(services)])
 }

--- a/models/vertices-indices/src/main.rs
+++ b/models/vertices-indices/src/main.rs
@@ -1,10 +1,8 @@
-use std::ops::Deref;
-
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = vertices_indices::model(&mut services);
-    handle_model(model.deref(), services)?;
+    handle_model(&model, services)?;
     Ok(())
 }

--- a/models/vertices-indices/src/main.rs
+++ b/models/vertices-indices/src/main.rs
@@ -1,8 +1,10 @@
+use std::ops::Deref;
+
 use fj::{core::services::Services, handle_model};
 
 fn main() -> fj::Result {
     let mut services = Services::new();
     let model = vertices_indices::model(&mut services);
-    handle_model(model, services)?;
+    handle_model(model.deref(), services)?;
     Ok(())
 }


### PR DESCRIPTION
Turns out, returning an object behind a `Handle` isn't necessary in this case. This simplifies the models, as well as the infrastructure handling them slightly.