### PR TITLE
Add missing models to `all` model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
 name = "all"
 version = "0.1.0"
 dependencies = [
+ "color",
  "cuboid",
  "fj",
  "holes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "spacer",
  "split",
  "star",
+ "vertices-indices",
 ]
 
 [[package]]

--- a/models/all/Cargo.toml
+++ b/models/all/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies.fj]
 path = "../../crates/fj"
 
+[dependencies.color]
+path = "../color"
+
 [dependencies.cuboid]
 path = "../cuboid"
 

--- a/models/all/Cargo.toml
+++ b/models/all/Cargo.toml
@@ -23,3 +23,6 @@ path = "../split"
 
 [dependencies.star]
 path = "../star"
+
+[dependencies.vertices-indices]
+path = "../vertices-indices"

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -1,7 +1,9 @@
 use fj::{
     core::{
         objects::Solid,
-        operations::{merge::Merge, transform::TransformObject},
+        operations::{
+            build::BuildSolid, merge::Merge, transform::TransformObject,
+        },
         services::Services,
     },
     math::{Scalar, Vector},
@@ -16,25 +18,25 @@ pub fn model(services: &mut Services) -> Solid {
     let axis = Vector::from([1., 1., 1.]).normalize();
     let angle_rad = Scalar::PI / 6.;
 
-    let cuboid = cuboid::model([1., 2., 3.], services)
-        .translate(offset * 1., services)
-        .rotate(axis * angle_rad * 1., services);
-    let spacer = spacer::model(2., 1., 1., services)
-        .translate(offset * 2., services)
-        .rotate(axis * angle_rad * 2., services);
-    let star = star::model(5, 2., 1., 1., services)
-        .translate(offset * 3., services)
-        .rotate(axis * angle_rad * 3., services);
-    let split = split::model(1., 0.2, services)
-        .translate(offset * 4., services)
-        .rotate(axis * angle_rad * 4., services);
-    let holes = holes::model(0.5, services)
-        .translate(offset * 5., services)
-        .rotate(axis * angle_rad * 5., services);
+    let models = [
+        cuboid::model([1., 2., 3.], services),
+        spacer::model(2., 1., 1., services),
+        star::model(5, 2., 1., 1., services),
+        split::model(1., 0.2, services),
+        holes::model(0.5, services),
+    ];
 
-    cuboid
-        .merge(&spacer)
-        .merge(&star)
-        .merge(&split)
-        .merge(&holes)
+    let mut all = Solid::empty();
+
+    for (i, model) in models.into_iter().enumerate() {
+        let f = i as f64;
+
+        let model = model
+            .translate(offset * f, services)
+            .rotate(axis * angle_rad * f, services);
+
+        all = all.merge(&model);
+    }
+
+    all
 }

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -20,10 +20,10 @@ pub fn model(services: &mut Services) -> Solid {
 
     let models = [
         cuboid::model([1., 2., 3.], services),
-        spacer::model(2., 1., 1., services),
-        star::model(5, 2., 1., 1., services),
-        split::model(1., 0.2, services),
         holes::model(0.5, services),
+        spacer::model(2., 1., 1., services),
+        split::model(1., 0.2, services),
+        star::model(5, 2., 1., 1., services),
     ];
 
     let mut all = Solid::empty();

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -19,6 +19,7 @@ pub fn model(services: &mut Services) -> Solid {
     let angle_rad = Scalar::PI / 6.;
 
     let models = [
+        color::model(services),
         cuboid::model([1., 2., 3.], services),
         holes::model(0.5, services),
         spacer::model(2., 1., 1., services),

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -25,6 +25,7 @@ pub fn model(services: &mut Services) -> Solid {
         spacer::model(2., 1., 1., services),
         split::model(1., 0.2, services),
         star::model(5, 2., 1., 1., services),
+        vertices_indices::model(services),
     ];
 
     let mut all = Solid::empty();


### PR DESCRIPTION
I had added more models, but forgot to include them in the `all` model. This pull request cleans up `all` a bit, and includes all the missing models, making it more useful for testing an CI.