### PR TITLE
Rename `Object` to `AnyObject`

### DIFF
--- a/crates/fj-core/src/objects/mod.rs
+++ b/crates/fj-core/src/objects/mod.rs
@@ -59,7 +59,7 @@ pub use self::{
         surface::Surface,
         vertex::Vertex,
     },
-    object::{Bare, BehindHandle, Form, Object, WithHandle},
+    object::{AnyObject, Bare, BehindHandle, Form, WithHandle},
     object_set::ObjectSet,
     stores::{Objects, Surfaces},
 };

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -9,11 +9,11 @@ use crate::{
 
 macro_rules! object {
     ($($ty:ident, $name:expr, $store:ident;)*) => {
-        /// An object
+        /// An enum that can hold object
         ///
         /// This enum is generic over the form that the object takes. An
-        /// `Object<Bare>` contains bare objects, like `Curve`. An
-        /// `Object<BehindHandle>` contains handles, like `Handle<Curve>`.
+        /// `AnyObject<Bare>` contains bare objects, like `Curve`. An
+        /// `AnyObject<BehindHandle>` contains handles, like `Handle<Curve>`.
         #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
         pub enum AnyObject<F: Form> {
             $(

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -7,7 +7,7 @@ use crate::{
     validate::{Validate, ValidationConfig, ValidationError},
 };
 
-macro_rules! object {
+macro_rules! any_object {
     ($($ty:ident, $name:expr, $store:ident;)*) => {
         /// An enum that can hold object
         ///
@@ -101,7 +101,7 @@ macro_rules! object {
     };
 }
 
-object!(
+any_object!(
     Curve, "curve", curves;
     Cycle, "cycle", cycles;
     Face, "face", faces;

--- a/crates/fj-core/src/objects/object.rs
+++ b/crates/fj-core/src/objects/object.rs
@@ -15,14 +15,14 @@ macro_rules! object {
         /// `Object<Bare>` contains bare objects, like `Curve`. An
         /// `Object<BehindHandle>` contains handles, like `Handle<Curve>`.
         #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-        pub enum Object<F: Form> {
+        pub enum AnyObject<F: Form> {
             $(
                 #[doc = concat!("A ", $name)]
                 $ty(F::Form<$ty>),
             )*
         }
 
-        impl Object<BehindHandle> {
+        impl AnyObject<BehindHandle> {
             /// Access the ID of the object
             pub fn id(&self) -> ObjectId {
                 match self {
@@ -51,9 +51,11 @@ macro_rules! object {
             }
         }
 
-        impl Object<WithHandle> {
+        impl AnyObject<WithHandle> {
             /// Insert the object into its respective store
-            pub fn insert(self, objects: &mut Objects) -> Object<BehindHandle> {
+            pub fn insert(self, objects: &mut Objects) ->
+                AnyObject<BehindHandle>
+            {
                 match self {
                     $(
                         Self::$ty((handle, object)) => {
@@ -67,30 +69,30 @@ macro_rules! object {
             }
         }
 
-        impl From<Object<WithHandle>> for Object<BehindHandle> {
-            fn from(object: Object<WithHandle>) -> Self {
+        impl From<AnyObject<WithHandle>> for AnyObject<BehindHandle> {
+            fn from(object: AnyObject<WithHandle>) -> Self {
                 match object {
                     $(
-                        Object::$ty((handle, _)) => Self::$ty(handle.into()),
+                        AnyObject::$ty((handle, _)) => Self::$ty(handle.into()),
                     )*
                 }
             }
         }
 
         $(
-            impl From<$ty> for Object<Bare> {
+            impl From<$ty> for AnyObject<Bare> {
                 fn from(object: $ty) -> Self {
                     Self::$ty(object)
                 }
             }
 
-            impl From<Handle<$ty>> for Object<BehindHandle> {
+            impl From<Handle<$ty>> for AnyObject<BehindHandle> {
                 fn from(object: Handle<$ty>) -> Self {
                     Self::$ty(object.into())
                 }
             }
 
-            impl From<(Handle<$ty>, $ty)> for Object<WithHandle> {
+            impl From<(Handle<$ty>, $ty)> for AnyObject<WithHandle> {
                 fn from((handle, object): (Handle<$ty>, $ty)) -> Self {
                     Self::$ty((handle.into(), object))
                 }

--- a/crates/fj-core/src/services/mod.rs
+++ b/crates/fj-core/src/services/mod.rs
@@ -7,7 +7,7 @@ mod service;
 mod validation;
 
 use crate::{
-    objects::{Object, Objects, WithHandle},
+    objects::{AnyObject, Objects, WithHandle},
     validate::{ValidationConfig, ValidationErrors},
 };
 
@@ -54,7 +54,7 @@ impl Services {
     }
 
     /// Insert an object into the stores
-    pub fn insert_object(&mut self, object: Object<WithHandle>) {
+    pub fn insert_object(&mut self, object: AnyObject<WithHandle>) {
         let mut object_events = Vec::new();
         self.objects
             .execute(Operation::InsertObject { object }, &mut object_events);

--- a/crates/fj-core/src/services/objects.rs
+++ b/crates/fj-core/src/services/objects.rs
@@ -1,4 +1,4 @@
-use crate::objects::{Object, Objects, WithHandle};
+use crate::objects::{AnyObject, Objects, WithHandle};
 
 use super::State;
 
@@ -25,7 +25,7 @@ pub enum Operation {
     /// upon.
     InsertObject {
         /// The object to insert
-        object: Object<WithHandle>,
+        object: AnyObject<WithHandle>,
     },
 }
 
@@ -33,5 +33,5 @@ pub enum Operation {
 #[derive(Clone, Debug)]
 pub struct InsertObject {
     /// The object to insert
-    pub object: Object<WithHandle>,
+    pub object: AnyObject<WithHandle>,
 }

--- a/crates/fj-core/src/services/validation.rs
+++ b/crates/fj-core/src/services/validation.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, error::Error, thread};
 
 use crate::{
-    objects::{BehindHandle, Object},
+    objects::{AnyObject, BehindHandle},
     storage::ObjectId,
     validate::{ValidationConfig, ValidationError},
 };
@@ -97,7 +97,7 @@ pub enum ValidationCommand {
     /// Validate the provided object
     ValidateObject {
         /// The object to validate
-        object: Object<BehindHandle>,
+        object: AnyObject<BehindHandle>,
     },
 }
 
@@ -107,7 +107,7 @@ pub enum ValidationEvent {
     /// Validation of an object failed
     ValidationFailed {
         /// The object for which validation failed
-        object: Object<BehindHandle>,
+        object: AnyObject<BehindHandle>,
 
         /// The validation error
         err: ValidationError,


### PR DESCRIPTION
I'd like to free up some of that prime real estate in the namespace. I also think that the new name is more fitting.