### PR TITLE
Add `fj_core::Instance`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -181,18 +181,18 @@ mod tests {
         geometry::{CurveBoundary, GlobalPath, SurfaceGeometry, SurfacePath},
         objects::{Curve, Surface},
         operations::insert::Insert,
-        services::Services,
+        Instance,
     };
 
     #[test]
     fn approx_line_on_flat_surface() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let curve = Curve::new().insert(&mut services);
+        let curve = Curve::new().insert(&mut core.services);
         let (surface_path, boundary) =
             SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
-        let surface = services.objects.surfaces.xz_plane();
+        let surface = core.services.objects.surfaces.xz_plane();
 
         let tolerance = 1.;
         let approx =
@@ -203,9 +203,9 @@ mod tests {
 
     #[test]
     fn approx_line_on_curved_surface_but_not_along_curve() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let curve = Curve::new().insert(&mut services);
+        let curve = Curve::new().insert(&mut core.services);
         let (surface_path, boundary) =
             SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
@@ -223,10 +223,10 @@ mod tests {
 
     #[test]
     fn approx_line_on_curved_surface_along_curve() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let global_path = GlobalPath::circle_from_radius(1.);
-        let curve = Curve::new().insert(&mut services);
+        let curve = Curve::new().insert(&mut core.services);
         let surface_path = SurfacePath::line_from_points_with_coords([
             ([0.], [0., 1.]),
             ([TAU], [TAU, 1.]),
@@ -257,13 +257,13 @@ mod tests {
 
     #[test]
     fn approx_circle_on_flat_surface() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let curve = Curve::new().insert(&mut services);
+        let curve = Curve::new().insert(&mut core.services);
         let surface_path =
             SurfacePath::circle_from_center_and_radius([0., 0.], 1.);
         let boundary = CurveBoundary::from([[0.], [TAU]]);
-        let surface = services.objects.surfaces.xz_plane();
+        let surface = core.services.objects.surfaces.xz_plane();
 
         let tolerance = 1.;
         let approx =

--- a/crates/fj-core/src/algorithms/intersect/curve_edge.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_edge.rs
@@ -73,18 +73,21 @@ mod tests {
 
     use crate::{
         geometry::SurfacePath, objects::HalfEdge,
-        operations::build::BuildHalfEdge, services::Services,
+        operations::build::BuildHalfEdge, Instance,
     };
 
     use super::CurveEdgeIntersection;
 
     #[test]
     fn compute_edge_in_front_of_curve_origin() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let path = SurfacePath::u_axis();
-        let edge =
-            HalfEdge::line_segment([[1., -1.], [1., 1.]], None, &mut services);
+        let edge = HalfEdge::line_segment(
+            [[1., -1.], [1., 1.]],
+            None,
+            &mut core.services,
+        );
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
 
@@ -98,13 +101,13 @@ mod tests {
 
     #[test]
     fn compute_edge_behind_curve_origin() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let path = SurfacePath::u_axis();
         let edge = HalfEdge::line_segment(
             [[-1., -1.], [-1., 1.]],
             None,
-            &mut services,
+            &mut core.services,
         );
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
@@ -119,13 +122,13 @@ mod tests {
 
     #[test]
     fn compute_edge_parallel_to_curve() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let path = SurfacePath::u_axis();
         let edge = HalfEdge::line_segment(
             [[-1., -1.], [1., -1.]],
             None,
-            &mut services,
+            &mut core.services,
         );
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
@@ -135,11 +138,14 @@ mod tests {
 
     #[test]
     fn compute_edge_on_curve() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let path = SurfacePath::u_axis();
-        let edge =
-            HalfEdge::line_segment([[-1., 0.], [1., 0.]], None, &mut services);
+        let edge = HalfEdge::line_segment(
+            [[-1., 0.], [1., 0.]],
+            None,
+            &mut core.services,
+        );
 
         let intersection = CurveEdgeIntersection::compute(&path, &edge);
 

--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -160,14 +160,14 @@ mod tests {
             insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
-        services::Services,
+        Instance,
     };
 
     use super::CurveFaceIntersection;
 
     #[test]
     fn compute() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let (path, _) = SurfacePath::line_from_points([[-3., 0.], [-2., 0.]]);
 
@@ -186,21 +186,23 @@ mod tests {
             [ 1., -1.],
         ];
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(exterior_points, &mut services)
-                                .insert(&mut services)
-                        })
-                        .add_interiors([Cycle::polygon(
-                            interior_points,
-                            &mut services,
-                        )
-                        .insert(&mut services)])
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(exterior_points, &mut core.services)
+                        .insert(&mut core.services)
+                })
+                .add_interiors([Cycle::polygon(
+                    interior_points,
+                    &mut core.services,
+                )
+                .insert(&mut core.services)])
+                .insert(&mut core.services)
+        });
 
         let expected =
             CurveFaceIntersection::from_intervals([[[1.], [2.]], [[4.], [5.]]]);

--- a/crates/fj-core/src/algorithms/intersect/face_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_face.rs
@@ -69,14 +69,14 @@ mod tests {
             insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
-        services::Services,
+        Instance,
     };
 
     use super::FaceFaceIntersection;
 
     #[test]
     fn compute_no_intersection() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         #[rustfmt::skip]
         let points = [
@@ -86,17 +86,17 @@ mod tests {
             [1., 2.],
         ];
         let [a, b] = [
-            services.objects.surfaces.xy_plane(),
-            services.objects.surfaces.xz_plane(),
+            core.services.objects.surfaces.xy_plane(),
+            core.services.objects.surfaces.xz_plane(),
         ]
         .map(|surface| {
-            Face::unbound(surface, &mut services).update_region(|region| {
+            Face::unbound(surface, &mut core.services).update_region(|region| {
                 region
                     .update_exterior(|_| {
-                        Cycle::polygon(points, &mut services)
-                            .insert(&mut services)
+                        Cycle::polygon(points, &mut core.services)
+                            .insert(&mut core.services)
                     })
-                    .insert(&mut services)
+                    .insert(&mut core.services)
             })
         });
 
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn compute_one_intersection() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         #[rustfmt::skip]
         let points = [
@@ -116,17 +116,17 @@ mod tests {
             [-1.,  1.],
         ];
         let surfaces = [
-            services.objects.surfaces.xy_plane(),
-            services.objects.surfaces.xz_plane(),
+            core.services.objects.surfaces.xy_plane(),
+            core.services.objects.surfaces.xz_plane(),
         ];
         let [a, b] = surfaces.clone().map(|surface| {
-            Face::unbound(surface, &mut services).update_region(|region| {
+            Face::unbound(surface, &mut core.services).update_region(|region| {
                 region
                     .update_exterior(|_| {
-                        Cycle::polygon(points, &mut services)
-                            .insert(&mut services)
+                        Cycle::polygon(points, &mut core.services)
+                            .insert(&mut core.services)
                     })
-                    .insert(&mut services)
+                    .insert(&mut core.services)
             })
         });
 

--- a/crates/fj-core/src/algorithms/intersect/face_point.rs
+++ b/crates/fj-core/src/algorithms/intersect/face_point.rs
@@ -141,26 +141,28 @@ mod tests {
             insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
-        services::Services,
+        Instance,
     };
 
     #[test]
     fn point_is_outside_face() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[0., 0.], [1., 1.], [0., 2.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [1., 1.], [0., 2.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([2., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -169,21 +171,23 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_while_passing_outside() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[0., 0.], [2., 1.], [0., 2.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [2., 1.], [0., 2.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -195,21 +199,23 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_at_cycle_seam() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[4., 2.], [0., 4.], [0., 0.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[4., 2.], [0., 4.], [0., 0.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 2.]);
 
         let intersection = (&face, &point).intersect();
@@ -221,21 +227,23 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex_while_staying_inside() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [2., 1.], [3., 0.], [3., 4.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -247,21 +255,23 @@ mod tests {
 
     #[test]
     fn ray_hits_parallel_edge_and_leaves_face_at_vertex() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [2., 1.], [3., 1.], [0., 2.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -273,27 +283,23 @@ mod tests {
 
     #[test]
     fn ray_hits_parallel_edge_and_does_not_leave_face_there() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [
-                                    [0., 0.],
-                                    [2., 1.],
-                                    [3., 1.],
-                                    [4., 0.],
-                                    [4., 5.],
-                                ],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [2., 1.], [3., 1.], [4., 0.], [4., 5.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 1.]);
 
         let intersection = (&face, &point).intersect();
@@ -305,21 +311,23 @@ mod tests {
 
     #[test]
     fn point_is_coincident_with_edge() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[0., 0.], [2., 0.], [0., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [2., 0.], [0., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();
@@ -339,21 +347,23 @@ mod tests {
 
     #[test]
     fn point_is_coincident_with_vertex() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[0., 0.], [1., 0.], [0., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[0., 0.], [1., 0.], [0., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
         let point = Point::from([1., 0.]);
 
         let intersection = (&face, &point).intersect();

--- a/crates/fj-core/src/algorithms/intersect/ray_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/ray_face.rs
@@ -155,53 +155,57 @@ mod tests {
             transform::TransformObject,
             update::{UpdateFace, UpdateRegion},
         },
-        services::Services,
+        Instance,
     };
 
     #[test]
     fn ray_misses_whole_surface() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.yz_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
-        let face = face.translate([-1., 0., 0.], &mut services);
+        let face = Face::unbound(
+            core.services.objects.surfaces.yz_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
+        let face = face.translate([-1., 0., 0.], &mut core.services);
 
         assert_eq!((&ray, &face).intersect(), None);
     }
 
     #[test]
     fn ray_hits_face() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.yz_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
-        let face = face.translate([1., 0., 0.], &mut services);
+        let face = Face::unbound(
+            core.services.objects.surfaces.yz_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
+        let face = face.translate([1., 0., 0.], &mut core.services);
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -211,48 +215,52 @@ mod tests {
 
     #[test]
     fn ray_hits_surface_but_misses_face() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.yz_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
-        let face = face.translate([0., 0., 2.], &mut services);
+        let face = Face::unbound(
+            core.services.objects.surfaces.yz_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
+        let face = face.translate([0., 0., 2.], &mut core.services);
 
         assert_eq!((&ray, &face).intersect(), None);
     }
 
     #[test]
     fn ray_hits_edge() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.yz_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
-        let face = face.translate([1., 1., 0.], &mut services);
+        let face = Face::unbound(
+            core.services.objects.surfaces.yz_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
+        let face = face.translate([1., 1., 0.], &mut core.services);
 
         let edge = face
             .region()
@@ -269,24 +277,26 @@ mod tests {
 
     #[test]
     fn ray_hits_vertex() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.yz_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
-        let face = face.translate([1., 1., 1.], &mut services);
+        let face = Face::unbound(
+            core.services.objects.surfaces.yz_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
+        let face = face.translate([1., 1., 1.], &mut core.services);
 
         let vertex = face
             .region()
@@ -304,23 +314,25 @@ mod tests {
 
     #[test]
     fn ray_is_parallel_to_surface_and_hits() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
 
         assert_eq!(
             (&ray, &face).intersect(),
@@ -330,24 +342,26 @@ mod tests {
 
     #[test]
     fn ray_is_parallel_to_surface_and_misses() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let ray = HorizontalRayToTheRight::from([0., 0., 0.]);
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon(
-                                [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
-                                &mut services,
-                            )
-                            .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
-        let face = face.translate([0., 0., 1.], &mut services);
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon(
+                        [[-1., -1.], [1., -1.], [1., 1.], [-1., 1.]],
+                        &mut core.services,
+                    )
+                    .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
+        let face = face.translate([0., 0., 1.], &mut core.services);
 
         assert_eq!((&ray, &face).intersect(), None);
     }

--- a/crates/fj-core/src/algorithms/intersect/surface_surface.rs
+++ b/crates/fj-core/src/algorithms/intersect/surface_surface.rs
@@ -76,18 +76,17 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::{
-        geometry::SurfacePath, operations::transform::TransformObject,
-        services::Services,
+        geometry::SurfacePath, operations::transform::TransformObject, Instance,
     };
 
     use super::SurfaceSurfaceIntersection;
 
     #[test]
     fn plane_plane() {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let xy = services.objects.surfaces.xy_plane();
-        let xz = services.objects.surfaces.xz_plane();
+        let xy = core.services.objects.surfaces.xy_plane();
+        let xz = core.services.objects.surfaces.xz_plane();
 
         // Coincident and parallel planes don't have an intersection curve.
         assert_eq!(
@@ -95,7 +94,7 @@ mod tests {
                 xy.clone(),
                 xy.clone().transform(
                     &Transform::translation([0., 0., 1.],),
-                    &mut services
+                    &mut core.services
                 )
             ],),
             None,

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -85,30 +85,32 @@ mod tests {
             insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
-        services::Services,
+        Instance,
     };
 
     use super::Triangulate;
 
     #[test]
     fn simple() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let a = [0., 0.];
         let b = [2., 0.];
         let c = [2., 2.];
         let d = [0., 1.];
 
-        let face =
-            Face::unbound(services.objects.surfaces.xy_plane(), &mut services)
-                .update_region(|region| {
-                    region
-                        .update_exterior(|_| {
-                            Cycle::polygon([a, b, c, d], &mut services)
-                                .insert(&mut services)
-                        })
-                        .insert(&mut services)
-                });
+        let face = Face::unbound(
+            core.services.objects.surfaces.xy_plane(),
+            &mut core.services,
+        )
+        .update_region(|region| {
+            region
+                .update_exterior(|_| {
+                    Cycle::polygon([a, b, c, d], &mut core.services)
+                        .insert(&mut core.services)
+                })
+                .insert(&mut core.services)
+        });
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
@@ -127,7 +129,7 @@ mod tests {
 
     #[test]
     fn simple_hole() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let a = [0., 0.];
         let b = [4., 0.];
@@ -139,23 +141,22 @@ mod tests {
         let g = [3., 3.];
         let h = [3., 1.];
 
-        let surface = services.objects.surfaces.xy_plane();
+        let surface = core.services.objects.surfaces.xy_plane();
 
-        let face = Face::unbound(surface.clone(), &mut services).update_region(
-            |region| {
+        let face = Face::unbound(surface.clone(), &mut core.services)
+            .update_region(|region| {
                 region
                     .update_exterior(|_| {
-                        Cycle::polygon([a, b, c, d], &mut services)
-                            .insert(&mut services)
+                        Cycle::polygon([a, b, c, d], &mut core.services)
+                            .insert(&mut core.services)
                     })
                     .add_interiors([Cycle::polygon(
                         [e, f, g, h],
-                        &mut services,
+                        &mut core.services,
                     )
-                    .insert(&mut services)])
-                    .insert(&mut services)
-            },
-        );
+                    .insert(&mut core.services)])
+                    .insert(&mut core.services)
+            });
 
         let triangles = triangulate(face)?;
 
@@ -189,7 +190,7 @@ mod tests {
 
     #[test]
     fn sharp_concave_shape() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         //   e       c
         //   |\     /|
@@ -208,18 +209,17 @@ mod tests {
         let d = [1., 1.];
         let e = [0., 9.];
 
-        let surface = services.objects.surfaces.xy_plane();
+        let surface = core.services.objects.surfaces.xy_plane();
 
-        let face = Face::unbound(surface.clone(), &mut services).update_region(
-            |region| {
+        let face = Face::unbound(surface.clone(), &mut core.services)
+            .update_region(|region| {
                 region
                     .update_exterior(|_| {
-                        Cycle::polygon([a, b, c, d, e], &mut services)
-                            .insert(&mut services)
+                        Cycle::polygon([a, b, c, d, e], &mut core.services)
+                            .insert(&mut core.services)
                     })
-                    .insert(&mut services)
-            },
-        );
+                    .insert(&mut core.services)
+            });
 
         let triangles = triangulate(face)?;
 

--- a/crates/fj-core/src/instance.rs
+++ b/crates/fj-core/src/instance.rs
@@ -2,7 +2,12 @@
 //!
 //! See [`Instance`].
 
+use crate::services::Services;
+
 /// An instance of the Fornjot core
 ///
 /// This is the main entry point to the Fornjot API.
-pub struct Instance {}
+pub struct Instance {
+    /// Event-sourced background services
+    pub services: Services,
+}

--- a/crates/fj-core/src/instance.rs
+++ b/crates/fj-core/src/instance.rs
@@ -1,0 +1,8 @@
+//! Main entry point to the `fj-core` API
+//!
+//! See [`Instance`].
+
+/// An instance of the Fornjot core
+///
+/// This is the main entry point to the Fornjot API.
+pub struct Instance {}

--- a/crates/fj-core/src/instance.rs
+++ b/crates/fj-core/src/instance.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`Instance`].
 
-use crate::services::Services;
+use crate::{services::Services, validate::ValidationConfig};
 
 /// An instance of the Fornjot core
 ///
@@ -10,4 +10,24 @@ use crate::services::Services;
 pub struct Instance {
     /// Event-sourced background services
     pub services: Services,
+}
+
+impl Instance {
+    /// Construct an instance of `Instance`
+    pub fn new() -> Self {
+        let services = Services::new();
+        Self { services }
+    }
+
+    /// Construct an instance of `Instance`, using the provided configuration
+    pub fn with_validation_config(config: ValidationConfig) -> Self {
+        let services = Services::with_validation_config(config);
+        Self { services }
+    }
+}
+
+impl Default for Instance {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/crates/fj-core/src/lib.rs
+++ b/crates/fj-core/src/lib.rs
@@ -89,3 +89,7 @@ pub mod queries;
 pub mod services;
 pub mod storage;
 pub mod validate;
+
+mod instance;
+
+pub use self::instance::Instance;

--- a/crates/fj-core/src/services/mod.rs
+++ b/crates/fj-core/src/services/mod.rs
@@ -42,7 +42,7 @@ impl Services {
         }
     }
 
-    /// Construct an instance of `Services` with a pre-defined configuration for the validation service
+    /// Construct an instance of `Services`, using the provided configuration
     pub fn with_validation_config(config: ValidationConfig) -> Self {
         let objects = Service::<Objects>::default();
         let validation =

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -84,16 +84,18 @@ mod tests {
             insert::Insert,
             update::UpdateCycle,
         },
-        services::Services,
         validate::{cycle::CycleValidationError, Validate, ValidationError},
+        Instance,
     };
 
     #[test]
     fn edges_connected() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let valid =
-            Cycle::polygon([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]], &mut services);
+        let valid = Cycle::polygon(
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+            &mut core.services,
+        );
 
         valid.validate_and_return_first_error()?;
 
@@ -102,15 +104,15 @@ mod tests {
                 HalfEdge::line_segment(
                     [[0., 0.], [1., 0.]],
                     None,
-                    &mut services,
+                    &mut core.services,
                 ),
                 HalfEdge::line_segment(
                     [[0., 0.], [1., 0.]],
                     None,
-                    &mut services,
+                    &mut core.services,
                 ),
             ];
-            let edges = edges.map(|edge| edge.insert(&mut services));
+            let edges = edges.map(|edge| edge.insert(&mut core.services));
 
             Cycle::empty().add_half_edges(edges)
         };

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -70,16 +70,19 @@ mod tests {
         assert_contains_err,
         objects::HalfEdge,
         operations::build::BuildHalfEdge,
-        services::Services,
         validate::{EdgeValidationError, Validate, ValidationError},
+        Instance,
     };
 
     #[test]
     fn edge_vertices_are_coincident() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
-        let valid =
-            HalfEdge::line_segment([[0., 0.], [1., 0.]], None, &mut services);
+        let valid = HalfEdge::line_segment(
+            [[0., 0.], [1., 0.]],
+            None,
+            &mut core.services,
+        );
         let invalid = {
             let boundary = [Point::from([0.]); 2];
 

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -404,17 +404,17 @@ mod tests {
                 UpdateShell,
             },
         },
-        services::Services,
         validate::{shell::ShellValidationError, Validate, ValidationError},
+        Instance,
     };
 
     #[test]
     fn curve_coordinate_system_mismatch() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let valid = Shell::tetrahedron(
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
-            &mut services,
+            &mut core.services,
         );
         let invalid = valid.shell.update_face(&valid.abc.face, |face| {
             face.update_region(|region| {
@@ -428,14 +428,14 @@ mod tests {
                                         .update_boundary(|boundary| {
                                             boundary.reverse()
                                         })
-                                        .insert(&mut services)
+                                        .insert(&mut core.services)
                                 },
                             )
-                            .insert(&mut services)
+                            .insert(&mut core.services)
                     })
-                    .insert(&mut services)
+                    .insert(&mut core.services)
             })
-            .insert(&mut services)
+            .insert(&mut core.services)
         });
 
         valid.shell.validate_and_return_first_error()?;
@@ -451,11 +451,11 @@ mod tests {
 
     #[test]
     fn half_edge_has_no_sibling() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let valid = Shell::tetrahedron(
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
-            &mut services,
+            &mut core.services,
         );
         let invalid = valid.shell.remove_face(&valid.abc.face);
 
@@ -472,11 +472,11 @@ mod tests {
 
     #[test]
     fn coincident_half_edges_are_not_siblings() -> anyhow::Result<()> {
-        let mut services = Services::new();
+        let mut core = Instance::new();
 
         let valid = Shell::tetrahedron(
             [[0., 0., 0.], [0., 1., 0.], [1., 0., 0.], [0., 0., 1.]],
-            &mut services,
+            &mut core.services,
         );
         let invalid = valid.shell.update_face(&valid.abc.face, |face| {
             face.update_region(|region| {
@@ -487,16 +487,16 @@ mod tests {
                                 cycle.half_edges().nth_circular(0),
                                 |edge| {
                                     edge.update_curve(|_| {
-                                        Curve::new().insert(&mut services)
+                                        Curve::new().insert(&mut core.services)
                                     })
-                                    .insert(&mut services)
+                                    .insert(&mut core.services)
                                 },
                             )
-                            .insert(&mut services)
+                            .insert(&mut core.services)
                     })
-                    .insert(&mut services)
+                    .insert(&mut core.services)
             })
-            .insert(&mut services)
+            .insert(&mut core.services)
         });
 
         valid.shell.validate_and_return_first_error()?;

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -4,12 +4,11 @@ use fj::{
         operations::{
             build::BuildSolid, merge::Merge, transform::TransformObject,
         },
-        services::Services,
     },
     math::{Scalar, Vector},
 };
 
-pub fn model(services: &mut Services) -> Solid {
+pub fn model(core: &mut fj::core::Instance) -> Solid {
     // Just combine all the other models using offsets/rotations that won't
     // result in neat vertex positions or axis-aligned edges/faces. This is
     // useful for testing.
@@ -19,13 +18,13 @@ pub fn model(services: &mut Services) -> Solid {
     let angle_rad = Scalar::PI / 6.;
 
     let models = [
-        color::model(services),
-        cuboid::model([1., 2., 3.], services),
-        holes::model(0.5, services),
-        spacer::model(2., 1., 1., services),
-        split::model(1., 0.2, services),
-        star::model(5, 2., 1., 1., services),
-        vertices_indices::model(services),
+        color::model(core),
+        cuboid::model([1., 2., 3.], core),
+        holes::model(0.5, core),
+        spacer::model(2., 1., 1., core),
+        split::model(1., 0.2, core),
+        star::model(5, 2., 1., 1., core),
+        vertices_indices::model(core),
     ];
 
     let mut all = Solid::empty();
@@ -34,8 +33,8 @@ pub fn model(services: &mut Services) -> Solid {
         let f = i as f64;
 
         let model = model
-            .translate(offset * f, services)
-            .rotate(axis * angle_rad * f, services);
+            .translate(offset * f, &mut core.services)
+            .rotate(axis * angle_rad * f, &mut core.services);
 
         all = all.merge(&model);
     }

--- a/models/all/src/main.rs
+++ b/models/all/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = all::model(&mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = all::model(&mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/all/src/main.rs
+++ b/models/all/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = all::model(&mut core.services);
+    let model = all::model(&mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -6,19 +6,18 @@ use fj::core::{
         split::SplitFace,
         update::{UpdateFace, UpdateShell, UpdateSolid},
     },
-    services::Services,
 };
 
-pub fn model(services: &mut Services) -> Solid {
+pub fn model(core: &mut fj::core::Instance) -> Solid {
     let size = 1.;
-    let cuboid = cuboid::model([size, size, size], services);
+    let cuboid = cuboid::model([size, size, size], core);
 
     cuboid.update_shell(cuboid.shells().only(), |shell| {
         let shell = shell.update_face(shell.faces().first(), |face| {
             face.update_region(|region| {
-                region.set_color([0., 1., 0.]).insert(services)
+                region.set_color([0., 1., 0.]).insert(&mut core.services)
             })
-            .insert(services)
+            .insert(&mut core.services)
         });
 
         // Split colored face, to make sure the same color is applied to the
@@ -34,10 +33,10 @@ pub fn model(services: &mut Services) -> Solid {
                 ]
             };
 
-            let (shell, _) = shell.split_face(face, line, services);
+            let (shell, _) = shell.split_face(face, line, &mut core.services);
             shell
         };
 
-        shell.insert(services)
+        shell.insert(&mut core.services)
     })
 }

--- a/models/color/src/main.rs
+++ b/models/color/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = color::model(&mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = color::model(&mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/color/src/main.rs
+++ b/models/color/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = color::model(&mut core.services);
+    let model = color::model(&mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -7,15 +7,17 @@ use fj::{
             sweep::SweepSketch,
             update::UpdateSketch,
         },
-        services::Services,
     },
     math::{Scalar, Vector},
 };
 
-pub fn model(size: impl Into<Vector<3>>, services: &mut Services) -> Solid {
+pub fn model(
+    size: impl Into<Vector<3>>,
+    core: &mut fj::core::Instance,
+) -> Solid {
     let [x, y, z] = size.into().components;
 
-    let bottom_surface = services.objects.surfaces.xy_plane();
+    let bottom_surface = core.services.objects.surfaces.xy_plane();
     let sweep_path = Vector::from([Scalar::ZERO, Scalar::ZERO, z]);
 
     Sketch::empty()
@@ -27,9 +29,9 @@ pub fn model(size: impl Into<Vector<3>>, services: &mut Services) -> Solid {
                     [x / 2., y / 2.],
                     [-x / 2., y / 2.],
                 ],
-                services,
+                &mut core.services,
             )
-            .insert(services),
+            .insert(&mut core.services),
         )
-        .sweep_sketch(bottom_surface, sweep_path, services)
+        .sweep_sketch(bottom_surface, sweep_path, &mut core.services)
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = cuboid::model([3., 2., 1.], &mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = cuboid::model([3., 2., 1.], &mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/cuboid/src/main.rs
+++ b/models/cuboid/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = cuboid::model([3., 2., 1.], &mut core.services);
+    let model = cuboid::model([3., 2., 1.], &mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/holes/src/lib.rs
+++ b/models/holes/src/lib.rs
@@ -6,16 +6,18 @@ use fj::{
             insert::Insert,
             update::UpdateSolid,
         },
-        services::Services,
     },
     math::Scalar,
 };
 
-pub fn model(radius: impl Into<Scalar>, services: &mut Services) -> Solid {
+pub fn model(
+    radius: impl Into<Scalar>,
+    core: &mut fj::core::Instance,
+) -> Solid {
     let radius = radius.into();
 
     let size = radius * 4.;
-    let cuboid = cuboid::model([size * 2., size, size], services);
+    let cuboid = cuboid::model([size * 2., size, size], core);
 
     cuboid.update_shell(cuboid.shells().only(), |shell| {
         let bottom_face = shell.faces().first();
@@ -29,7 +31,7 @@ pub fn model(radius: impl Into<Scalar>, services: &mut Services) -> Solid {
             },
             radius,
             [Scalar::ZERO, Scalar::ZERO, depth],
-            services,
+            &mut core.services,
         );
 
         let bottom_face = shell.faces().first();
@@ -51,8 +53,8 @@ pub fn model(radius: impl Into<Scalar>, services: &mut Services) -> Solid {
                     },
                 ],
                 radius,
-                services,
+                &mut core.services,
             )
-            .insert(services)
+            .insert(&mut core.services)
     })
 }

--- a/models/holes/src/main.rs
+++ b/models/holes/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = holes::model(0.25, &mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = holes::model(0.25, &mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/holes/src/main.rs
+++ b/models/holes/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = holes::model(0.25, &mut core.services);
+    let model = holes::model(0.25, &mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -8,7 +8,6 @@ use fj::{
             sweep::SweepSketch,
             update::{UpdateRegion, UpdateSketch},
         },
-        services::Services,
     },
     math::{Point, Vector},
 };
@@ -17,22 +16,22 @@ pub fn model(
     outer: f64,
     inner: f64,
     height: f64,
-    services: &mut Services,
+    core: &mut fj::core::Instance,
 ) -> Solid {
-    let bottom_surface = services.objects.surfaces.xy_plane();
+    let bottom_surface = core.services.objects.surfaces.xy_plane();
     let sweep_path = Vector::from([0., 0., height]);
 
     Sketch::empty()
         .add_region(
-            Region::circle(Point::origin(), outer, services)
+            Region::circle(Point::origin(), outer, &mut core.services)
                 .add_interiors([Cycle::circle(
                     Point::origin(),
                     inner,
-                    services,
+                    &mut core.services,
                 )
-                .reverse(services)
-                .insert(services)])
-                .insert(services),
+                .reverse(&mut core.services)
+                .insert(&mut core.services)])
+                .insert(&mut core.services),
         )
-        .sweep_sketch(bottom_surface, sweep_path, services)
+        .sweep_sketch(bottom_surface, sweep_path, &mut core.services)
 }

--- a/models/spacer/src/main.rs
+++ b/models/spacer/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = spacer::model(1., 0.5, 1., &mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = spacer::model(1., 0.5, 1., &mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/spacer/src/main.rs
+++ b/models/spacer/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = spacer::model(1., 0.5, 1., &mut core.services);
+    let model = spacer::model(1., 0.5, 1., &mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -4,11 +4,14 @@ use fj::core::{
         insert::Insert, split::SplitFace, sweep::SweepFaceOfShell,
         update::UpdateSolid,
     },
-    services::Services,
 };
 
-pub fn model(size: f64, split_pos: f64, services: &mut Services) -> Solid {
-    let cuboid = cuboid::model([size, size, size], services);
+pub fn model(
+    size: f64,
+    split_pos: f64,
+    core: &mut fj::core::Instance,
+) -> Solid {
+    let cuboid = cuboid::model([size, size, size], core);
 
     cuboid.update_shell(cuboid.shells().only(), |shell| {
         let face = shell.faces().first();
@@ -19,10 +22,11 @@ pub fn model(size: f64, split_pos: f64, services: &mut Services) -> Solid {
             (cycle.half_edges().nth(2).unwrap(), [split_pos]),
         ];
 
-        let (shell, [face, _]) = shell.split_face(face, line, services);
+        let (shell, [face, _]) =
+            shell.split_face(face, line, &mut core.services);
 
         shell
-            .sweep_face_of_shell(face, [0., 0., -size / 2.], services)
-            .insert(services)
+            .sweep_face_of_shell(face, [0., 0., -size / 2.], &mut core.services)
+            .insert(&mut core.services)
     })
 }

--- a/models/split/src/main.rs
+++ b/models/split/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = split::model(1.0, 0.2, &mut core.services);
+    let model = split::model(1.0, 0.2, &mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/split/src/main.rs
+++ b/models/split/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = split::model(1.0, 0.2, &mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = split::model(1.0, 0.2, &mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -10,7 +10,6 @@ use fj::{
             sweep::SweepSketch,
             update::{UpdateRegion, UpdateSketch},
         },
-        services::Services,
     },
     math::Vector,
 };
@@ -20,7 +19,7 @@ pub fn model(
     r1: f64,
     r2: f64,
     h: f64,
-    services: &mut Services,
+    core: &mut fj::core::Instance,
 ) -> Solid {
     let num_vertices = num_points * 2;
     let vertex_iter = (0..num_vertices).map(|i| {
@@ -42,16 +41,19 @@ pub fn model(
         inner_points.push([x / 2., y / 2.]);
     }
 
-    let bottom_surface = services.objects.surfaces.xy_plane();
+    let bottom_surface = core.services.objects.surfaces.xy_plane();
     let sweep_path = Vector::from([0., 0., h]);
 
     Sketch::empty()
         .add_region(
-            Region::polygon(outer_points, services)
-                .add_interiors([Cycle::polygon(inner_points, services)
-                    .reverse(services)
-                    .insert(services)])
-                .insert(services),
+            Region::polygon(outer_points, &mut core.services)
+                .add_interiors([Cycle::polygon(
+                    inner_points,
+                    &mut core.services,
+                )
+                .reverse(&mut core.services)
+                .insert(&mut core.services)])
+                .insert(&mut core.services),
         )
-        .sweep_sketch(bottom_surface, sweep_path, services)
+        .sweep_sketch(bottom_surface, sweep_path, &mut core.services)
 }

--- a/models/star/src/main.rs
+++ b/models/star/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = star::model(5, 1., 2., 1., &mut core.services);
+    let model = star::model(5, 1., 2., 1., &mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/star/src/main.rs
+++ b/models/star/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = star::model(5, 1., 2., 1., &mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = star::model(5, 1., 2., 1., &mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/vertices-indices/src/lib.rs
+++ b/models/vertices-indices/src/lib.rs
@@ -5,14 +5,13 @@ use fj::core::{
         insert::Insert,
         update::UpdateSolid,
     },
-    services::Services,
 };
 
-pub fn model(services: &mut Services) -> Solid {
+pub fn model(core: &mut fj::core::Instance) -> Solid {
     Solid::empty().add_shells([Shell::from_vertices_and_indices(
         [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
         [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
-        services,
+        &mut core.services,
     )
-    .insert(services)])
+    .insert(&mut core.services)])
 }

--- a/models/vertices-indices/src/main.rs
+++ b/models/vertices-indices/src/main.rs
@@ -2,7 +2,7 @@ use fj::handle_model;
 
 fn main() -> fj::Result {
     let mut core = fj::core::Instance::new();
-    let model = vertices_indices::model(&mut core.services);
+    let model = vertices_indices::model(&mut core);
     handle_model(&model, core.services)?;
     Ok(())
 }

--- a/models/vertices-indices/src/main.rs
+++ b/models/vertices-indices/src/main.rs
@@ -1,8 +1,8 @@
-use fj::{core::services::Services, handle_model};
+use fj::handle_model;
 
 fn main() -> fj::Result {
-    let mut services = Services::new();
-    let model = vertices_indices::model(&mut services);
-    handle_model(&model, services)?;
+    let mut core = fj::core::Instance::new();
+    let model = vertices_indices::model(&mut core.services);
+    handle_model(&model, core.services)?;
     Ok(())
 }


### PR DESCRIPTION
This adds a new entry point to the `fj_core` create, `fj_core::Instance`. It doesn't do a whole lot right now, but I already found this to be a nice improvement. Creating something called `Services` and using that for everything is much less obvious than what this pull request adds.

In the future, this will contain more stuff. For example, when there will be external layers for presentation, geometry, and possibly other things (https://github.com/hannobraun/fornjot/issues/2116, https://github.com/hannobraun/fornjot/issues/2117). I'm also experimenting with new APIs (to solve my problems in https://github.com/hannobraun/fornjot/issues/2117), which could be added to the new `Instance`.