### PR TITLE
Require `&mut Instance` in `replace` traits

### DIFF
--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -5,8 +5,8 @@ use crate::{
         Cycle, Face, HalfEdge, IsObject, Region, Shell, Sketch, Solid, Vertex,
     },
     operations::{insert::Insert, update::UpdateHalfEdge},
-    services::Services,
     storage::Handle,
+    Instance,
 };
 
 use super::ReplaceOutput;
@@ -23,7 +23,7 @@ pub trait ReplaceVertex: IsObject + Sized {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject>;
 }
 
@@ -32,7 +32,7 @@ impl ReplaceVertex for HalfEdge {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        _: &mut Services,
+        _: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         if original.id() == self.start_vertex().id() {
             ReplaceOutput::Updated(self.update_start_vertex(|_| replacement))
@@ -47,21 +47,18 @@ impl ReplaceVertex for Cycle {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut half_edges = Vec::new();
         for half_edge in self.half_edges() {
-            let half_edge = half_edge.replace_vertex(
-                original,
-                replacement.clone(),
-                services,
-            );
+            let half_edge =
+                half_edge.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= half_edge.was_updated();
             half_edges.push(
                 half_edge
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             );
         }
@@ -79,25 +76,23 @@ impl ReplaceVertex for Region {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
-        let exterior = self.exterior().replace_vertex(
-            original,
-            replacement.clone(),
-            services,
-        );
+        let exterior =
+            self.exterior()
+                .replace_vertex(original, replacement.clone(), core);
         replacement_happened |= exterior.was_updated();
 
         let mut interiors = Vec::new();
         for cycle in self.interiors() {
             let cycle =
-                cycle.replace_vertex(original, replacement.clone(), services);
+                cycle.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= cycle.was_updated();
             interiors.push(
                 cycle
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             );
         }
@@ -105,7 +100,7 @@ impl ReplaceVertex for Region {
         if replacement_happened {
             ReplaceOutput::Updated(Region::new(
                 exterior
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
                 interiors,
                 self.color(),
@@ -121,18 +116,18 @@ impl ReplaceVertex for Sketch {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
         for region in self.regions() {
             let region =
-                region.replace_vertex(original, replacement.clone(), services);
+                region.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= region.was_updated();
             regions.push(
                 region
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             );
         }
@@ -150,17 +145,15 @@ impl ReplaceVertex for Face {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
-        let region =
-            self.region()
-                .replace_vertex(original, replacement, services);
+        let region = self.region().replace_vertex(original, replacement, core);
 
         if region.was_updated() {
             ReplaceOutput::Updated(Face::new(
                 self.surface().clone(),
                 region
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             ))
         } else {
@@ -174,17 +167,16 @@ impl ReplaceVertex for Shell {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut faces = Vec::new();
         for face in self.faces() {
-            let face =
-                face.replace_vertex(original, replacement.clone(), services);
+            let face = face.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= face.was_updated();
             faces.push(
-                face.map_updated(|updated| updated.insert(services))
+                face.map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             );
         }
@@ -202,18 +194,18 @@ impl ReplaceVertex for Solid {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut shells = Vec::new();
         for shell in self.shells() {
             let shell =
-                shell.replace_vertex(original, replacement.clone(), services);
+                shell.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= shell.was_updated();
             shells.push(
                 shell
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             );
         }
@@ -231,10 +223,10 @@ impl ReplaceVertex for Handle<HalfEdge> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         self.deref()
-            .replace_vertex(original, replacement, services)
+            .replace_vertex(original, replacement, core)
             .map_original(|_| self.clone())
     }
 }
@@ -244,10 +236,10 @@ impl ReplaceVertex for Handle<Cycle> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         self.deref()
-            .replace_vertex(original, replacement, services)
+            .replace_vertex(original, replacement, core)
             .map_original(|_| self.clone())
     }
 }
@@ -257,10 +249,10 @@ impl ReplaceVertex for Handle<Region> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         self.deref()
-            .replace_vertex(original, replacement, services)
+            .replace_vertex(original, replacement, core)
             .map_original(|_| self.clone())
     }
 }
@@ -270,18 +262,18 @@ impl ReplaceVertex for Handle<Sketch> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         let mut replacement_happened = false;
 
         let mut regions = Vec::new();
         for region in self.regions() {
             let region =
-                region.replace_vertex(original, replacement.clone(), services);
+                region.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= region.was_updated();
             regions.push(
                 region
-                    .map_updated(|updated| updated.insert(services))
+                    .map_updated(|updated| updated.insert(&mut core.services))
                     .into_inner(),
             );
         }
@@ -299,10 +291,10 @@ impl ReplaceVertex for Handle<Face> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         self.deref()
-            .replace_vertex(original, replacement, services)
+            .replace_vertex(original, replacement, core)
             .map_original(|_| self.clone())
     }
 }
@@ -312,10 +304,10 @@ impl ReplaceVertex for Handle<Shell> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         self.deref()
-            .replace_vertex(original, replacement, services)
+            .replace_vertex(original, replacement, core)
             .map_original(|_| self.clone())
     }
 }
@@ -325,10 +317,10 @@ impl ReplaceVertex for Handle<Solid> {
         &self,
         original: &Handle<Vertex>,
         replacement: Handle<Vertex>,
-        services: &mut Services,
+        core: &mut Instance,
     ) -> ReplaceOutput<Self, Self::BareObject> {
         self.deref()
-            .replace_vertex(original, replacement, services)
+            .replace_vertex(original, replacement, core)
             .map_original(|_| self.clone())
     }
 }

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -56,10 +56,10 @@ impl SplitEdge for Shell {
             .replace_half_edge(
                 half_edge,
                 [half_edge_a.clone(), half_edge_b.clone()],
-                &mut core.services,
+                core,
             )
             .into_inner()
-            .replace_half_edge(&sibling, siblings.clone(), &mut core.services)
+            .replace_half_edge(&sibling, siblings.clone(), core)
             .into_inner();
 
         (shell, [[half_edge_a, half_edge_b], siblings])


### PR DESCRIPTION
This is a follow-up to https://github.com/hannobraun/fornjot/pull/2192 and https://github.com/hannobraun/fornjot/pull/2196, coming out of the same experimentation I'm doing for https://github.com/hannobraun/fornjot/issues/2117.