### PR TITLE
Merge redundant methods of `update` operations

### DIFF
--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -152,8 +152,9 @@ pub trait BuildShell {
                         .update_half_edge(
                             cycle.half_edges().nth_circular(0),
                             |edge| {
-                                edge.reverse_curve_coordinate_systems(core)
-                                    .insert(&mut core.services)
+                                [edge
+                                    .reverse_curve_coordinate_systems(core)
+                                    .insert(&mut core.services)]
                             },
                         )
                         .join_to(
@@ -173,8 +174,9 @@ pub trait BuildShell {
                         .update_half_edge(
                             cycle.half_edges().nth_circular(1),
                             |edge| {
-                                edge.reverse_curve_coordinate_systems(core)
-                                    .insert(&mut core.services)
+                                [edge
+                                    .reverse_curve_coordinate_systems(core)
+                                    .insert(&mut core.services)]
                             },
                         )
                         .join_to(
@@ -186,8 +188,9 @@ pub trait BuildShell {
                         .update_half_edge(
                             cycle.half_edges().nth_circular(0),
                             |edge| {
-                                edge.reverse_curve_coordinate_systems(core)
-                                    .insert(&mut core.services)
+                                [edge
+                                    .reverse_curve_coordinate_systems(core)
+                                    .insert(&mut core.services)]
                             },
                         )
                         .join_to(
@@ -207,22 +210,25 @@ pub trait BuildShell {
                         .update_half_edge(
                             cycle.half_edges().nth_circular(0),
                             |edge| {
-                                edge.reverse_curve_coordinate_systems(core)
-                                    .insert(&mut core.services)
+                                [edge
+                                    .reverse_curve_coordinate_systems(core)
+                                    .insert(&mut core.services)]
                             },
                         )
                         .update_half_edge(
                             cycle.half_edges().nth_circular(1),
                             |edge| {
-                                edge.reverse_curve_coordinate_systems(core)
-                                    .insert(&mut core.services)
+                                [edge
+                                    .reverse_curve_coordinate_systems(core)
+                                    .insert(&mut core.services)]
                             },
                         )
                         .update_half_edge(
                             cycle.half_edges().nth_circular(2),
                             |edge| {
-                                edge.reverse_curve_coordinate_systems(core)
-                                    .insert(&mut core.services)
+                                [edge
+                                    .reverse_curve_coordinate_systems(core)
+                                    .insert(&mut core.services)]
                             },
                         )
                         .join_to(

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -63,17 +63,22 @@ impl AddHole for Shell {
             .collect::<Vec<_>>();
 
         self.update_face(location.face, |face| {
-            face.update_region(|region| {
-                region
-                    .add_interiors([Cycle::empty()
-                        .add_joined_edges(
-                            [(entry.clone(), entry.path(), entry.boundary())],
-                            core,
-                        )
-                        .insert(&mut core.services)])
-                    .insert(&mut core.services)
-            })
-            .insert(&mut core.services)
+            [face
+                .update_region(|region| {
+                    region
+                        .add_interiors([Cycle::empty()
+                            .add_joined_edges(
+                                [(
+                                    entry.clone(),
+                                    entry.path(),
+                                    entry.boundary(),
+                                )],
+                                core,
+                            )
+                            .insert(&mut core.services)])
+                        .insert(&mut core.services)
+                })
+                .insert(&mut core.services)]
         })
         .add_faces(hole)
     }
@@ -131,30 +136,36 @@ impl AddHole for Shell {
             .only();
 
         self.update_face(entry_location.face, |face| {
-            face.update_region(|region| {
-                region
-                    .add_interiors([Cycle::empty()
-                        .add_joined_edges(
-                            [(entry.clone(), entry.path(), entry.boundary())],
-                            core,
-                        )
-                        .insert(&mut core.services)])
-                    .insert(&mut core.services)
-            })
-            .insert(&mut core.services)
+            [face
+                .update_region(|region| {
+                    region
+                        .add_interiors([Cycle::empty()
+                            .add_joined_edges(
+                                [(
+                                    entry.clone(),
+                                    entry.path(),
+                                    entry.boundary(),
+                                )],
+                                core,
+                            )
+                            .insert(&mut core.services)])
+                        .insert(&mut core.services)
+                })
+                .insert(&mut core.services)]
         })
         .update_face(exit_location.face, |face| {
-            face.update_region(|region| {
-                region
-                    .add_interiors([Cycle::empty()
-                        .add_joined_edges(
-                            [(exit.clone(), exit.path(), exit.boundary())],
-                            core,
-                        )
-                        .insert(&mut core.services)])
-                    .insert(&mut core.services)
-            })
-            .insert(&mut core.services)
+            [face
+                .update_region(|region| {
+                    region
+                        .add_interiors([Cycle::empty()
+                            .add_joined_edges(
+                                [(exit.clone(), exit.path(), exit.boundary())],
+                                core,
+                            )
+                            .insert(&mut core.services)])
+                        .insert(&mut core.services)
+                })
+                .insert(&mut core.services)]
         })
         .add_faces(hole)
     }

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -119,7 +119,8 @@ impl JoinCycle for Cycle {
                     .update_half_edge(
                         self.half_edges().nth_circular(index),
                         |edge| {
-                            edge.update_curve(|_| edge_other.curve().clone())
+                            [edge
+                                .update_curve(|_| edge_other.curve().clone())
                                 .update_start_vertex(|_| {
                                     other
                                         .half_edges()
@@ -127,16 +128,17 @@ impl JoinCycle for Cycle {
                                         .start_vertex()
                                         .clone()
                                 })
-                                .insert(&mut core.services)
+                                .insert(&mut core.services)]
                         },
                     )
                     .update_half_edge(
                         self.half_edges().nth_circular(index + 1),
                         |edge| {
-                            edge.update_start_vertex(|_| {
-                                edge_other.start_vertex().clone()
-                            })
-                            .insert(&mut core.services)
+                            [edge
+                                .update_start_vertex(|_| {
+                                    edge_other.start_vertex().clone()
+                                })
+                                .insert(&mut core.services)]
                         },
                     )
             },

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -177,7 +177,7 @@ impl SplitFace for Shell {
 
         let faces = [split_face_a, split_face_b];
         let self_ = self_
-            .replace_face(updated_face_after_split_edges, |_| faces.clone());
+            .update_face(updated_face_after_split_edges, |_| faces.clone());
 
         (self_, faces)
     }

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -20,27 +20,10 @@ pub trait UpdateCycle {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_half_edge(
+    fn update_half_edge<const N: usize>(
         &self,
         handle: &Handle<HalfEdge>,
-        update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,
-    ) -> Self;
-
-    /// Replace an edge of the cycle
-    ///
-    /// This is a more general version of [`UpdateCycle::update_half_edge`]
-    /// which can replace a single edge with multiple others.
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the object can't be found.
-    ///
-    /// Panics, if the update results in a duplicate object.
-    #[must_use]
-    fn replace_half_edge<const N: usize>(
-        &self,
-        handle: &Handle<HalfEdge>,
-        replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
+        update: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
     ) -> Self;
 }
 
@@ -53,26 +36,14 @@ impl UpdateCycle for Cycle {
         Cycle::new(half_edges)
     }
 
-    fn update_half_edge(
+    fn update_half_edge<const N: usize>(
         &self,
         handle: &Handle<HalfEdge>,
-        update: impl FnOnce(&Handle<HalfEdge>) -> Handle<HalfEdge>,
+        update: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
     ) -> Self {
         let edges = self
             .half_edges()
-            .replace(handle, [update(handle)])
-            .expect("Half-edge not found");
-        Cycle::new(edges)
-    }
-
-    fn replace_half_edge<const N: usize>(
-        &self,
-        handle: &Handle<HalfEdge>,
-        replace: impl FnOnce(&Handle<HalfEdge>) -> [Handle<HalfEdge>; N],
-    ) -> Self {
-        let edges = self
-            .half_edges()
-            .replace(handle, replace(handle))
+            .replace(handle, update(handle))
             .expect("Half-edge not found");
         Cycle::new(edges)
     }

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -27,27 +27,10 @@ pub trait UpdateRegion {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_interior(
+    fn update_interior<const N: usize>(
         &self,
         handle: &Handle<Cycle>,
-        update: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
-    ) -> Self;
-
-    /// Replace an interior cycle of the region
-    ///
-    /// This is a more general version of [`UpdateRegion::update_interior`]
-    /// which can replace a single cycle with multiple others.
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the object can't be found.
-    ///
-    /// Panics, if the update results in a duplicate object.
-    #[must_use]
-    fn replace_interior<const N: usize>(
-        &self,
-        handle: &Handle<Cycle>,
-        replace: impl FnOnce(&Handle<Cycle>) -> [Handle<Cycle>; N],
+        update: impl FnOnce(&Handle<Cycle>) -> [Handle<Cycle>; N],
     ) -> Self;
 }
 
@@ -68,26 +51,14 @@ impl UpdateRegion for Region {
         Region::new(self.exterior().clone(), interiors, self.color())
     }
 
-    fn update_interior(
+    fn update_interior<const N: usize>(
         &self,
         handle: &Handle<Cycle>,
-        update: impl FnOnce(&Handle<Cycle>) -> Handle<Cycle>,
+        update: impl FnOnce(&Handle<Cycle>) -> [Handle<Cycle>; N],
     ) -> Self {
         let interiors = self
             .interiors()
-            .replace(handle, [update(handle)])
-            .expect("Cycle not found");
-        Region::new(self.exterior().clone(), interiors, self.color())
-    }
-
-    fn replace_interior<const N: usize>(
-        &self,
-        handle: &Handle<Cycle>,
-        replace: impl FnOnce(&Handle<Cycle>) -> [Handle<Cycle>; N],
-    ) -> Self {
-        let interiors = self
-            .interiors()
-            .replace(handle, replace(handle))
+            .replace(handle, update(handle))
             .expect("Cycle not found");
         Region::new(self.exterior().clone(), interiors, self.color())
     }

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -17,27 +17,10 @@ pub trait UpdateShell {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_face(
+    fn update_face<const N: usize>(
         &self,
         handle: &Handle<Face>,
-        update: impl FnOnce(&Handle<Face>) -> Handle<Face>,
-    ) -> Self;
-
-    /// Replace a face of the shell
-    ///
-    /// This is a more general version of [`UpdateShell::update_face`] which can
-    /// replace a single face with multiple others.
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the object can't be found.
-    ///
-    /// Panics, if the update results in a duplicate object.
-    #[must_use]
-    fn replace_face<const N: usize>(
-        &self,
-        handle: &Handle<Face>,
-        replace: impl FnOnce(&Handle<Face>) -> [Handle<Face>; N],
+        update: impl FnOnce(&Handle<Face>) -> [Handle<Face>; N],
     ) -> Self;
 
     /// Remove a face from the shell
@@ -51,26 +34,14 @@ impl UpdateShell for Shell {
         Shell::new(faces)
     }
 
-    fn update_face(
+    fn update_face<const N: usize>(
         &self,
         handle: &Handle<Face>,
-        update: impl FnOnce(&Handle<Face>) -> Handle<Face>,
+        update: impl FnOnce(&Handle<Face>) -> [Handle<Face>; N],
     ) -> Self {
         let faces = self
             .faces()
-            .replace(handle, [update(handle)])
-            .expect("Face not found");
-        Shell::new(faces)
-    }
-
-    fn replace_face<const N: usize>(
-        &self,
-        handle: &Handle<Face>,
-        replace: impl FnOnce(&Handle<Face>) -> [Handle<Face>; N],
-    ) -> Self {
-        let faces = self
-            .faces()
-            .replace(handle, replace(handle))
+            .replace(handle, update(handle))
             .expect("Face not found");
         Shell::new(faces)
     }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -17,27 +17,10 @@ pub trait UpdateSketch {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_region(
+    fn update_region<const N: usize>(
         &self,
         handle: &Handle<Region>,
-        update: impl FnOnce(&Handle<Region>) -> Handle<Region>,
-    ) -> Self;
-
-    /// Replace a region of the sketch
-    ///
-    /// This is a more general version of [`UpdateSketch::update_region`] which
-    /// can replace a single edge with multiple others.
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the object can't be found.
-    ///
-    /// Panics, if the update results in a duplicate object.
-    #[must_use]
-    fn replace_region<const N: usize>(
-        &self,
-        handle: &Handle<Region>,
-        replace: impl FnOnce(&Handle<Region>) -> [Handle<Region>; N],
+        update: impl FnOnce(&Handle<Region>) -> [Handle<Region>; N],
     ) -> Self;
 }
 
@@ -46,26 +29,14 @@ impl UpdateSketch for Sketch {
         Sketch::new(self.regions().iter().cloned().chain([region]))
     }
 
-    fn update_region(
+    fn update_region<const N: usize>(
         &self,
         handle: &Handle<Region>,
-        update: impl FnOnce(&Handle<Region>) -> Handle<Region>,
+        update: impl FnOnce(&Handle<Region>) -> [Handle<Region>; N],
     ) -> Self {
         let regions = self
             .regions()
-            .replace(handle, [update(handle)])
-            .expect("Region not found");
-        Sketch::new(regions)
-    }
-
-    fn replace_region<const N: usize>(
-        &self,
-        handle: &Handle<Region>,
-        replace: impl FnOnce(&Handle<Region>) -> [Handle<Region>; N],
-    ) -> Self {
-        let regions = self
-            .regions()
-            .replace(handle, replace(handle))
+            .replace(handle, update(handle))
             .expect("Region not found");
         Sketch::new(regions)
     }

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -20,27 +20,10 @@ pub trait UpdateSolid {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_shell(
+    fn update_shell<const N: usize>(
         &self,
         handle: &Handle<Shell>,
-        update: impl FnOnce(&Handle<Shell>) -> Handle<Shell>,
-    ) -> Self;
-
-    /// Replace a shell of the solid
-    ///
-    /// This is a more general version of [`UpdateSolid::update_shell`] which
-    /// can replace a single edge with multiple others.
-    ///
-    /// # Panics
-    ///
-    /// Panics, if the object can't be found.
-    ///
-    /// Panics, if the update results in a duplicate object.
-    #[must_use]
-    fn replace_shell<const N: usize>(
-        &self,
-        handle: &Handle<Shell>,
-        replace: impl FnOnce(&Handle<Shell>) -> [Handle<Shell>; N],
+        update: impl FnOnce(&Handle<Shell>) -> [Handle<Shell>; N],
     ) -> Self;
 }
 
@@ -53,26 +36,14 @@ impl UpdateSolid for Solid {
         Solid::new(shells)
     }
 
-    fn update_shell(
+    fn update_shell<const N: usize>(
         &self,
         handle: &Handle<Shell>,
-        update: impl FnOnce(&Handle<Shell>) -> Handle<Shell>,
+        update: impl FnOnce(&Handle<Shell>) -> [Handle<Shell>; N],
     ) -> Self {
         let shells = self
             .shells()
-            .replace(handle, [update(handle)])
-            .expect("Shell not found");
-        Solid::new(shells)
-    }
-
-    fn replace_shell<const N: usize>(
-        &self,
-        handle: &Handle<Shell>,
-        replace: impl FnOnce(&Handle<Shell>) -> [Handle<Shell>; N],
-    ) -> Self {
-        let shells = self
-            .shells()
-            .replace(handle, replace(handle))
+            .replace(handle, update(handle))
             .expect("Shell not found");
         Solid::new(shells)
     }

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -417,26 +417,27 @@ mod tests {
             &mut core,
         );
         let invalid = valid.shell.update_face(&valid.abc.face, |face| {
-            face.update_region(|region| {
-                region
-                    .update_exterior(|cycle| {
-                        cycle
-                            .update_half_edge(
-                                cycle.half_edges().nth_circular(0),
-                                |edge| {
-                                    [edge
-                                        .update_path(|path| path.reverse())
-                                        .update_boundary(|boundary| {
-                                            boundary.reverse()
-                                        })
-                                        .insert(&mut core.services)]
-                                },
-                            )
-                            .insert(&mut core.services)
-                    })
-                    .insert(&mut core.services)
-            })
-            .insert(&mut core.services)
+            [face
+                .update_region(|region| {
+                    region
+                        .update_exterior(|cycle| {
+                            cycle
+                                .update_half_edge(
+                                    cycle.half_edges().nth_circular(0),
+                                    |edge| {
+                                        [edge
+                                            .update_path(|path| path.reverse())
+                                            .update_boundary(|boundary| {
+                                                boundary.reverse()
+                                            })
+                                            .insert(&mut core.services)]
+                                    },
+                                )
+                                .insert(&mut core.services)
+                        })
+                        .insert(&mut core.services)
+                })
+                .insert(&mut core.services)]
         });
 
         valid.shell.validate_and_return_first_error()?;
@@ -480,26 +481,27 @@ mod tests {
             &mut core,
         );
         let invalid = valid.shell.update_face(&valid.abc.face, |face| {
-            face.update_region(|region| {
-                region
-                    .update_exterior(|cycle| {
-                        cycle
-                            .update_half_edge(
-                                cycle.half_edges().nth_circular(0),
-                                |edge| {
-                                    [edge
-                                        .update_curve(|_| {
-                                            Curve::new()
-                                                .insert(&mut core.services)
-                                        })
-                                        .insert(&mut core.services)]
-                                },
-                            )
-                            .insert(&mut core.services)
-                    })
-                    .insert(&mut core.services)
-            })
-            .insert(&mut core.services)
+            [face
+                .update_region(|region| {
+                    region
+                        .update_exterior(|cycle| {
+                            cycle
+                                .update_half_edge(
+                                    cycle.half_edges().nth_circular(0),
+                                    |edge| {
+                                        [edge
+                                            .update_curve(|_| {
+                                                Curve::new()
+                                                    .insert(&mut core.services)
+                                            })
+                                            .insert(&mut core.services)]
+                                    },
+                                )
+                                .insert(&mut core.services)
+                        })
+                        .insert(&mut core.services)
+                })
+                .insert(&mut core.services)]
         });
 
         valid.shell.validate_and_return_first_error()?;

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -424,11 +424,12 @@ mod tests {
                             .update_half_edge(
                                 cycle.half_edges().nth_circular(0),
                                 |edge| {
-                                    edge.update_path(|path| path.reverse())
+                                    [edge
+                                        .update_path(|path| path.reverse())
                                         .update_boundary(|boundary| {
                                             boundary.reverse()
                                         })
-                                        .insert(&mut core.services)
+                                        .insert(&mut core.services)]
                                 },
                             )
                             .insert(&mut core.services)
@@ -486,10 +487,12 @@ mod tests {
                             .update_half_edge(
                                 cycle.half_edges().nth_circular(0),
                                 |edge| {
-                                    edge.update_curve(|_| {
-                                        Curve::new().insert(&mut core.services)
-                                    })
-                                    .insert(&mut core.services)
+                                    [edge
+                                        .update_curve(|_| {
+                                            Curve::new()
+                                                .insert(&mut core.services)
+                                        })
+                                        .insert(&mut core.services)]
                                 },
                             )
                             .insert(&mut core.services)

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -38,6 +38,6 @@ pub fn model(core: &mut fj::core::Instance) -> Solid {
             shell
         };
 
-        shell.insert(&mut core.services)
+        [shell.insert(&mut core.services)]
     })
 }

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -14,10 +14,11 @@ pub fn model(core: &mut fj::core::Instance) -> Solid {
 
     cuboid.update_shell(cuboid.shells().only(), |shell| {
         let shell = shell.update_face(shell.faces().first(), |face| {
-            face.update_region(|region| {
-                region.set_color([0., 1., 0.]).insert(&mut core.services)
-            })
-            .insert(&mut core.services)
+            [face
+                .update_region(|region| {
+                    region.set_color([0., 1., 0.]).insert(&mut core.services)
+                })
+                .insert(&mut core.services)]
         });
 
         // Split colored face, to make sure the same color is applied to the

--- a/models/holes/src/lib.rs
+++ b/models/holes/src/lib.rs
@@ -40,7 +40,7 @@ pub fn model(
             .nth(5)
             .expect("Expected shell to have top face");
 
-        shell
+        [shell
             .add_through_hole(
                 [
                     HoleLocation {
@@ -55,6 +55,6 @@ pub fn model(
                 radius,
                 core,
             )
-            .insert(&mut core.services)
+            .insert(&mut core.services)]
     })
 }

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -24,8 +24,8 @@ pub fn model(
 
         let (shell, [face, _]) = shell.split_face(face, line, core);
 
-        shell
+        [shell
             .sweep_face_of_shell(face, [0., 0., -size / 2.], core)
-            .insert(&mut core.services)
+            .insert(&mut core.services)]
     })
 }


### PR DESCRIPTION
Update operations for all objects that reference multiple of another objects (for example cycles, which reference multiple half-edges) had two update methods per referenced type of object: The slightly more convenient `update_*` and the slightly more flexible `replace_*`.

I've decided this redundancy isn't worth it. I've merged all of those methods, taking the name from the `update_*` methods and the signature from the `replace_*` methods. This has resulted in slightly less convenient use sites, but more simplicity overall.

While not directly related to https://github.com/hannobraun/fornjot/issues/2117, this came out of my continued experimentation with solutions for the issues I'm facing there.