### PR TITLE
Make `add_*` methods of `update` operation more convenient to call

### DIFF
--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -195,11 +195,11 @@ mod tests {
                                 |_, core| Cycle::polygon(exterior_points, core),
                                 core,
                             )
-                            .add_interiors([Cycle::polygon(
-                                interior_points,
+                            .add_interiors(
+                                [Cycle::polygon(interior_points, core)
+                                    .insert(&mut core.services)],
                                 core,
                             )
-                            .insert(&mut core.services)])
                     },
                     &mut core,
                 );

--- a/crates/fj-core/src/algorithms/intersect/curve_face.rs
+++ b/crates/fj-core/src/algorithms/intersect/curve_face.rs
@@ -157,7 +157,6 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
         Instance,
@@ -196,8 +195,7 @@ mod tests {
                                 core,
                             )
                             .add_interiors(
-                                [Cycle::polygon(interior_points, core)
-                                    .insert(&mut core.services)],
+                                [Cycle::polygon(interior_points, core)],
                                 core,
                             )
                     },

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -149,8 +149,11 @@ mod tests {
                         |_, core| Cycle::polygon([a, b, c, d], core),
                         core,
                     )
-                    .add_interiors([Cycle::polygon([e, f, g, h], core)
-                        .insert(&mut core.services)])
+                    .add_interiors(
+                        [Cycle::polygon([e, f, g, h], core)
+                            .insert(&mut core.services)],
+                        core,
+                    )
             },
             &mut core,
         );

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -82,7 +82,6 @@ mod tests {
         objects::{Cycle, Face},
         operations::{
             build::{BuildCycle, BuildFace},
-            insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
         Instance,
@@ -149,11 +148,7 @@ mod tests {
                         |_, core| Cycle::polygon([a, b, c, d], core),
                         core,
                     )
-                    .add_interiors(
-                        [Cycle::polygon([e, f, g, h], core)
-                            .insert(&mut core.services)],
-                        core,
-                    )
+                    .add_interiors([Cycle::polygon([e, f, g, h], core)], core)
             },
             &mut core,
         );

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -26,7 +26,7 @@ pub trait BuildCycle {
     ) -> Cycle {
         let circle =
             HalfEdge::circle(center, radius, core).insert(&mut core.services);
-        Cycle::empty().add_half_edges([circle])
+        Cycle::empty().add_half_edges([circle], core)
     }
 
     /// Build a polygon

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -24,8 +24,7 @@ pub trait BuildCycle {
         radius: impl Into<Scalar>,
         core: &mut Instance,
     ) -> Cycle {
-        let circle =
-            HalfEdge::circle(center, radius, core).insert(&mut core.services);
+        let circle = HalfEdge::circle(center, radius, core);
         Cycle::empty().add_half_edges([circle], core)
     }
 

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -102,19 +102,17 @@ pub trait BuildShell {
                         })
                 };
 
-                Face::unbound(surface, core)
-                    .update_region(
-                        |region, core| {
-                            region.update_exterior(
-                                |cycle, core| {
-                                    cycle.add_half_edges(half_edges, core)
-                                },
-                                core,
-                            )
-                        },
-                        core,
-                    )
-                    .insert(&mut core.services)
+                Face::unbound(surface, core).update_region(
+                    |region, core| {
+                        region.update_exterior(
+                            |cycle, core| {
+                                cycle.add_half_edges(half_edges, core)
+                            },
+                            core,
+                        )
+                    },
+                    core,
+                )
             })
             .collect::<Vec<_>>();
 

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -118,7 +118,7 @@ pub trait BuildShell {
             })
             .collect::<Vec<_>>();
 
-        Shell::empty().add_faces(faces)
+        Shell::empty().add_faces(faces, core)
     }
 
     /// Build a tetrahedron from the provided points

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -99,7 +99,6 @@ pub trait BuildShell {
                             )
                             .update_start_vertex(|_, _| vertex, core)
                             .update_curve(|_, _| curve, core)
-                            .insert(&mut core.services)
                         })
                 };
 

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -107,7 +107,9 @@ pub trait BuildShell {
                     .update_region(
                         |region, core| {
                             region.update_exterior(
-                                |cycle, _| cycle.add_half_edges(half_edges),
+                                |cycle, core| {
+                                    cycle.add_half_edges(half_edges, core)
+                                },
                                 core,
                             )
                         },

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -29,7 +29,7 @@ pub trait BuildSolid {
         core: &mut Instance,
     ) -> Tetrahedron {
         let shell = Shell::tetrahedron(points, core).insert(&mut core.services);
-        let solid = Solid::empty().add_shells([shell.shell.clone()]);
+        let solid = Solid::empty().add_shells([shell.shell.clone()], core);
 
         Tetrahedron { solid, shell }
     }

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -48,7 +48,7 @@ impl AddHole for Shell {
             .insert(&mut core.services);
         let hole = Region::empty(core)
             .update_exterior(
-                |_, _| Cycle::empty().add_half_edges([entry.clone()]),
+                |_, core| Cycle::empty().add_half_edges([entry.clone()], core),
                 core,
             )
             .sweep_region(
@@ -113,7 +113,7 @@ impl AddHole for Shell {
 
         let swept_region = Region::empty(core)
             .update_exterior(
-                |_, _| Cycle::empty().add_half_edges([entry.clone()]),
+                |_, core| Cycle::empty().add_half_edges([entry.clone()], core),
                 core,
             )
             .sweep_region(

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -66,16 +66,19 @@ impl AddHole for Shell {
             |face, core| {
                 [face.update_region(
                     |region, core| {
-                        region.add_interiors([Cycle::empty()
-                            .add_joined_edges(
-                                [(
-                                    entry.clone(),
-                                    entry.path(),
-                                    entry.boundary(),
-                                )],
-                                core,
-                            )
-                            .insert(&mut core.services)])
+                        region.add_interiors(
+                            [Cycle::empty()
+                                .add_joined_edges(
+                                    [(
+                                        entry.clone(),
+                                        entry.path(),
+                                        entry.boundary(),
+                                    )],
+                                    core,
+                                )
+                                .insert(&mut core.services)],
+                            core,
+                        )
                     },
                     core,
                 )]
@@ -141,16 +144,19 @@ impl AddHole for Shell {
             |face, core| {
                 [face.update_region(
                     |region, core| {
-                        region.add_interiors([Cycle::empty()
-                            .add_joined_edges(
-                                [(
-                                    entry.clone(),
-                                    entry.path(),
-                                    entry.boundary(),
-                                )],
-                                core,
-                            )
-                            .insert(&mut core.services)])
+                        region.add_interiors(
+                            [Cycle::empty()
+                                .add_joined_edges(
+                                    [(
+                                        entry.clone(),
+                                        entry.path(),
+                                        entry.boundary(),
+                                    )],
+                                    core,
+                                )
+                                .insert(&mut core.services)],
+                            core,
+                        )
                     },
                     core,
                 )]
@@ -162,12 +168,19 @@ impl AddHole for Shell {
             |face, core| {
                 [face.update_region(
                     |region, core| {
-                        region.add_interiors([Cycle::empty()
-                            .add_joined_edges(
-                                [(exit.clone(), exit.path(), exit.boundary())],
-                                core,
-                            )
-                            .insert(&mut core.services)])
+                        region.add_interiors(
+                            [Cycle::empty()
+                                .add_joined_edges(
+                                    [(
+                                        exit.clone(),
+                                        exit.path(),
+                                        exit.boundary(),
+                                    )],
+                                    core,
+                                )
+                                .insert(&mut core.services)],
+                            core,
+                        )
                     },
                     core,
                 )]

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -58,7 +58,6 @@ impl AddHole for Shell {
                 core,
             )
             .all_faces()
-            .map(|face| face.insert(&mut core.services))
             .collect::<Vec<_>>();
 
         self.update_face(
@@ -124,11 +123,7 @@ impl AddHole for Shell {
                 core,
             );
 
-        let hole = swept_region
-            .side_faces
-            .into_iter()
-            .map(|face| face.insert(&mut core.services))
-            .collect::<Vec<_>>();
+        let hole = swept_region.side_faces.into_iter().collect::<Vec<_>>();
 
         let exit = swept_region
             .top_face

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -67,16 +67,14 @@ impl AddHole for Shell {
                 [face.update_region(
                     |region, core| {
                         region.add_interiors(
-                            [Cycle::empty()
-                                .add_joined_edges(
-                                    [(
-                                        entry.clone(),
-                                        entry.path(),
-                                        entry.boundary(),
-                                    )],
-                                    core,
-                                )
-                                .insert(&mut core.services)],
+                            [Cycle::empty().add_joined_edges(
+                                [(
+                                    entry.clone(),
+                                    entry.path(),
+                                    entry.boundary(),
+                                )],
+                                core,
+                            )],
                             core,
                         )
                     },
@@ -145,16 +143,14 @@ impl AddHole for Shell {
                 [face.update_region(
                     |region, core| {
                         region.add_interiors(
-                            [Cycle::empty()
-                                .add_joined_edges(
-                                    [(
-                                        entry.clone(),
-                                        entry.path(),
-                                        entry.boundary(),
-                                    )],
-                                    core,
-                                )
-                                .insert(&mut core.services)],
+                            [Cycle::empty().add_joined_edges(
+                                [(
+                                    entry.clone(),
+                                    entry.path(),
+                                    entry.boundary(),
+                                )],
+                                core,
+                            )],
                             core,
                         )
                     },
@@ -169,16 +165,10 @@ impl AddHole for Shell {
                 [face.update_region(
                     |region, core| {
                         region.add_interiors(
-                            [Cycle::empty()
-                                .add_joined_edges(
-                                    [(
-                                        exit.clone(),
-                                        exit.path(),
-                                        exit.boundary(),
-                                    )],
-                                    core,
-                                )
-                                .insert(&mut core.services)],
+                            [Cycle::empty().add_joined_edges(
+                                [(exit.clone(), exit.path(), exit.boundary())],
+                                core,
+                            )],
                             core,
                         )
                     },

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -83,7 +83,7 @@ impl AddHole for Shell {
             },
             core,
         )
-        .add_faces(hole)
+        .add_faces(hole, core)
     }
 
     fn add_through_hole(
@@ -177,7 +177,7 @@ impl AddHole for Shell {
             },
             core,
         )
-        .add_faces(hole)
+        .add_faces(hole, core)
     }
 }
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -85,8 +85,10 @@ impl JoinCycle for Cycle {
         >,
         Es::IntoIter: Clone + ExactSizeIterator,
     {
-        let half_edges = edges.into_iter().circular_tuple_windows().map(
-            |((prev_half_edge, _, _), (half_edge, curve, boundary))| {
+        let half_edges = edges
+            .into_iter()
+            .circular_tuple_windows()
+            .map(|((prev_half_edge, _, _), (half_edge, curve, boundary))| {
                 HalfEdge::unjoined(curve, boundary, core)
                     .update_curve(|_, _| half_edge.curve().clone(), core)
                     .update_start_vertex(
@@ -94,8 +96,8 @@ impl JoinCycle for Cycle {
                         core,
                     )
                     .insert(&mut core.services)
-            },
-        );
+            })
+            .collect::<Vec<_>>();
         self.add_half_edges(half_edges)
     }
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -85,7 +85,7 @@ impl JoinCycle for Cycle {
         >,
         Es::IntoIter: Clone + ExactSizeIterator,
     {
-        self.add_half_edges(edges.into_iter().circular_tuple_windows().map(
+        let half_edges = edges.into_iter().circular_tuple_windows().map(
             |((prev_half_edge, _, _), (half_edge, curve, boundary))| {
                 HalfEdge::unjoined(curve, boundary, core)
                     .update_curve(|_, _| half_edge.curve().clone(), core)
@@ -95,7 +95,8 @@ impl JoinCycle for Cycle {
                     )
                     .insert(&mut core.services)
             },
-        ))
+        );
+        self.add_half_edges(half_edges)
     }
 
     fn join_to(

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -8,7 +8,6 @@ use crate::{
     objects::{Cycle, HalfEdge},
     operations::{
         build::BuildHalfEdge,
-        insert::Insert,
         update::{UpdateCycle, UpdateHalfEdge},
     },
     storage::Handle,
@@ -95,7 +94,6 @@ impl JoinCycle for Cycle {
                         |_, _| prev_half_edge.start_vertex().clone(),
                         core,
                     )
-                    .insert(&mut core.services)
             })
             .collect::<Vec<_>>();
         self.add_half_edges(half_edges, core)

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -98,7 +98,7 @@ impl JoinCycle for Cycle {
                     .insert(&mut core.services)
             })
             .collect::<Vec<_>>();
-        self.add_half_edges(half_edges)
+        self.add_half_edges(half_edges, core)
     }
 
     fn join_to(

--- a/crates/fj-core/src/operations/merge.rs
+++ b/crates/fj-core/src/operations/merge.rs
@@ -15,7 +15,7 @@ pub trait Merge {
 }
 
 impl Merge for Solid {
-    fn merge(&self, other: &Self, _: &mut Instance) -> Self {
-        self.add_shells(other.shells().iter().cloned())
+    fn merge(&self, other: &Self, core: &mut Instance) -> Self {
+        self.add_shells(other.shells().iter().cloned(), core)
     }
 }

--- a/crates/fj-core/src/operations/merge.rs
+++ b/crates/fj-core/src/operations/merge.rs
@@ -3,7 +3,7 @@
 //! See [`Merge`], which is currently the only trait in this module, for more
 //! information.
 
-use crate::objects::Solid;
+use crate::{objects::Solid, Instance};
 
 use super::update::UpdateSolid;
 
@@ -11,11 +11,11 @@ use super::update::UpdateSolid;
 pub trait Merge {
     /// Merge this solid with another
     #[must_use]
-    fn merge(&self, other: &Self) -> Self;
+    fn merge(&self, other: &Self, core: &mut Instance) -> Self;
 }
 
 impl Merge for Solid {
-    fn merge(&self, other: &Self) -> Self {
+    fn merge(&self, other: &Self, _: &mut Instance) -> Self {
         self.add_shells(other.shells().iter().cloned())
     }
 }

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -106,13 +106,11 @@ impl SplitFace for Shell {
             None,
             core,
         )
-        .update_start_vertex(|_, _| b.start_vertex().clone(), core)
-        .insert(&mut core.services);
+        .update_start_vertex(|_, _| b.start_vertex().clone(), core);
         let dividing_half_edge_c_to_b = HalfEdge::from_sibling(
             &dividing_half_edge_a_to_d,
             d.start_vertex().clone(),
-        )
-        .insert(&mut core.services);
+        );
 
         let mut half_edges_of_face_starting_at_b =
             updated_face_after_split_edges

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -134,10 +134,16 @@ impl SplitFace for Shell {
             |region, core| {
                 let mut region = region
                     .update_exterior(
-                        |cycle, _| {
+                        |cycle, core| {
                             cycle
-                                .add_half_edges(half_edges_b_to_c_inclusive)
-                                .add_half_edges([dividing_half_edge_c_to_b])
+                                .add_half_edges(
+                                    half_edges_b_to_c_inclusive,
+                                    core,
+                                )
+                                .add_half_edges(
+                                    [dividing_half_edge_c_to_b],
+                                    core,
+                                )
                         },
                         core,
                     )
@@ -166,10 +172,16 @@ impl SplitFace for Shell {
             |region, core| {
                 let mut region = region
                     .update_exterior(
-                        |cycle, _| {
+                        |cycle, core| {
                             cycle
-                                .add_half_edges(half_edges_d_to_a_inclusive)
-                                .add_half_edges([dividing_half_edge_a_to_d])
+                                .add_half_edges(
+                                    half_edges_d_to_a_inclusive,
+                                    core,
+                                )
+                                .add_half_edges(
+                                    [dividing_half_edge_a_to_d],
+                                    core,
+                                )
                         },
                         core,
                     )

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -131,7 +131,7 @@ impl SweepHalfEdge for HalfEdge {
                     edge.insert(&mut core.services)
                 };
 
-                exterior = exterior.add_half_edges([edge.clone()]);
+                exterior = exterior.add_half_edges([edge.clone()], core);
 
                 edge
             });

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -64,6 +64,6 @@ impl SweepFaceOfShell for Shell {
             .map(|face| face.insert(&mut core.services))
             .collect::<Vec<_>>();
 
-        self.remove_face(&face).add_faces(faces)
+        self.remove_face(&face).add_faces(faces, core)
     }
 }

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -61,7 +61,8 @@ impl SweepFaceOfShell for Shell {
         let faces = region
             .sweep_region(face.surface(), path, &mut cache, core)
             .all_faces()
-            .map(|face| face.insert(&mut core.services));
+            .map(|face| face.insert(&mut core.services))
+            .collect::<Vec<_>>();
 
         self.remove_face(&face).add_faces(faces)
     }

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -61,7 +61,6 @@ impl SweepFaceOfShell for Shell {
         let faces = region
             .sweep_region(face.surface(), path, &mut cache, core)
             .all_faces()
-            .map(|face| face.insert(&mut core.services))
             .collect::<Vec<_>>();
 
         self.remove_face(&face).add_faces(faces, core)

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -12,6 +12,7 @@ pub trait UpdateCycle {
     fn add_half_edges(
         &self,
         half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
+        core: &mut Instance,
     ) -> Self;
 
     /// Update an edge of the cycle
@@ -36,6 +37,7 @@ impl UpdateCycle for Cycle {
     fn add_half_edges(
         &self,
         half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
+        _: &mut Instance,
     ) -> Self {
         let half_edges = self.half_edges().iter().cloned().chain(half_edges);
         Cycle::new(half_edges)

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -9,11 +9,13 @@ use crate::{
 pub trait UpdateCycle {
     /// Add edges to the cycle
     #[must_use]
-    fn add_half_edges(
+    fn add_half_edges<T>(
         &self,
-        half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
+        half_edges: impl IntoIterator<Item = T>,
         core: &mut Instance,
-    ) -> Self;
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<HalfEdge>>;
 
     /// Update an edge of the cycle
     ///
@@ -34,11 +36,17 @@ pub trait UpdateCycle {
 }
 
 impl UpdateCycle for Cycle {
-    fn add_half_edges(
+    fn add_half_edges<T>(
         &self,
-        half_edges: impl IntoIterator<Item = Handle<HalfEdge>>,
-        _: &mut Instance,
-    ) -> Self {
+        half_edges: impl IntoIterator<Item = T>,
+        core: &mut Instance,
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<HalfEdge>>,
+    {
+        let half_edges = half_edges
+            .into_iter()
+            .map(|half_edge| half_edge.insert(&mut core.services));
         let half_edges = self.half_edges().iter().cloned().chain(half_edges);
         Cycle::new(half_edges)
     }

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -22,6 +22,7 @@ pub trait UpdateRegion {
     fn add_interiors(
         &self,
         interiors: impl IntoIterator<Item = Handle<Cycle>>,
+        core: &mut Instance,
     ) -> Self;
 
     /// Update an interior cycle of the region
@@ -58,6 +59,7 @@ impl UpdateRegion for Region {
     fn add_interiors(
         &self,
         interiors: impl IntoIterator<Item = Handle<Cycle>>,
+        _: &mut Instance,
     ) -> Self {
         let interiors = self.interiors().iter().cloned().chain(interiors);
         Region::new(self.exterior().clone(), interiors, self.color())

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -19,11 +19,13 @@ pub trait UpdateRegion {
 
     /// Add the provided interiors to the region
     #[must_use]
-    fn add_interiors(
+    fn add_interiors<T>(
         &self,
-        interiors: impl IntoIterator<Item = Handle<Cycle>>,
+        interiors: impl IntoIterator<Item = T>,
         core: &mut Instance,
-    ) -> Self;
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Cycle>>;
 
     /// Update an interior cycle of the region
     ///
@@ -56,11 +58,17 @@ impl UpdateRegion for Region {
         Region::new(exterior, self.interiors().iter().cloned(), self.color())
     }
 
-    fn add_interiors(
+    fn add_interiors<T>(
         &self,
-        interiors: impl IntoIterator<Item = Handle<Cycle>>,
-        _: &mut Instance,
-    ) -> Self {
+        interiors: impl IntoIterator<Item = T>,
+        core: &mut Instance,
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Cycle>>,
+    {
+        let interiors = interiors
+            .into_iter()
+            .map(|cycle| cycle.insert(&mut core.services));
         let interiors = self.interiors().iter().cloned().chain(interiors);
         Region::new(self.exterior().clone(), interiors, self.color())
     }

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -9,7 +9,11 @@ use crate::{
 pub trait UpdateShell {
     /// Add faces to the shell
     #[must_use]
-    fn add_faces(&self, faces: impl IntoIterator<Item = Handle<Face>>) -> Self;
+    fn add_faces(
+        &self,
+        faces: impl IntoIterator<Item = Handle<Face>>,
+        core: &mut Instance,
+    ) -> Self;
 
     /// Update a face of the shell
     ///
@@ -34,7 +38,11 @@ pub trait UpdateShell {
 }
 
 impl UpdateShell for Shell {
-    fn add_faces(&self, faces: impl IntoIterator<Item = Handle<Face>>) -> Self {
+    fn add_faces(
+        &self,
+        faces: impl IntoIterator<Item = Handle<Face>>,
+        _: &mut Instance,
+    ) -> Self {
         let faces = self.faces().iter().cloned().chain(faces);
         Shell::new(faces)
     }

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -9,11 +9,13 @@ use crate::{
 pub trait UpdateShell {
     /// Add faces to the shell
     #[must_use]
-    fn add_faces(
+    fn add_faces<T>(
         &self,
-        faces: impl IntoIterator<Item = Handle<Face>>,
+        faces: impl IntoIterator<Item = T>,
         core: &mut Instance,
-    ) -> Self;
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Face>>;
 
     /// Update a face of the shell
     ///
@@ -38,11 +40,17 @@ pub trait UpdateShell {
 }
 
 impl UpdateShell for Shell {
-    fn add_faces(
+    fn add_faces<T>(
         &self,
-        faces: impl IntoIterator<Item = Handle<Face>>,
-        _: &mut Instance,
-    ) -> Self {
+        faces: impl IntoIterator<Item = T>,
+        core: &mut Instance,
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Face>>,
+    {
+        let faces = faces
+            .into_iter()
+            .map(|face| face.insert(&mut core.services));
         let faces = self.faces().iter().cloned().chain(faces);
         Shell::new(faces)
     }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -12,6 +12,7 @@ pub trait UpdateSketch {
     fn add_regions(
         &self,
         regions: impl IntoIterator<Item = Handle<Region>>,
+        core: &mut Instance,
     ) -> Self;
 
     /// Update a region of the sketch
@@ -36,6 +37,7 @@ impl UpdateSketch for Sketch {
     fn add_regions(
         &self,
         regions: impl IntoIterator<Item = Handle<Region>>,
+        _: &mut Instance,
     ) -> Self {
         Sketch::new(self.regions().iter().cloned().chain(regions))
     }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -9,11 +9,13 @@ use crate::{
 pub trait UpdateSketch {
     /// Add a region to the sketch
     #[must_use]
-    fn add_regions(
+    fn add_regions<T>(
         &self,
-        regions: impl IntoIterator<Item = Handle<Region>>,
+        regions: impl IntoIterator<Item = T>,
         core: &mut Instance,
-    ) -> Self;
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Region>>;
 
     /// Update a region of the sketch
     ///
@@ -34,11 +36,17 @@ pub trait UpdateSketch {
 }
 
 impl UpdateSketch for Sketch {
-    fn add_regions(
+    fn add_regions<T>(
         &self,
-        regions: impl IntoIterator<Item = Handle<Region>>,
-        _: &mut Instance,
-    ) -> Self {
+        regions: impl IntoIterator<Item = T>,
+        core: &mut Instance,
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Region>>,
+    {
+        let regions = regions
+            .into_iter()
+            .map(|region| region.insert(&mut core.services));
         let regions = self.regions().iter().cloned().chain(regions);
         Sketch::new(regions)
     }

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -39,7 +39,8 @@ impl UpdateSketch for Sketch {
         regions: impl IntoIterator<Item = Handle<Region>>,
         _: &mut Instance,
     ) -> Self {
-        Sketch::new(self.regions().iter().cloned().chain(regions))
+        let regions = self.regions().iter().cloned().chain(regions);
+        Sketch::new(regions)
     }
 
     fn update_region<T, const N: usize>(

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -9,11 +9,13 @@ use crate::{
 pub trait UpdateSolid {
     /// Add a shell to the solid
     #[must_use]
-    fn add_shells(
+    fn add_shells<T>(
         &self,
-        shells: impl IntoIterator<Item = Handle<Shell>>,
+        shells: impl IntoIterator<Item = T>,
         core: &mut Instance,
-    ) -> Self;
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Shell>>;
 
     /// Update a shell of the solid
     ///
@@ -34,11 +36,17 @@ pub trait UpdateSolid {
 }
 
 impl UpdateSolid for Solid {
-    fn add_shells(
+    fn add_shells<T>(
         &self,
-        shells: impl IntoIterator<Item = Handle<Shell>>,
-        _: &mut Instance,
-    ) -> Self {
+        shells: impl IntoIterator<Item = T>,
+        core: &mut Instance,
+    ) -> Self
+    where
+        T: Insert<Inserted = Handle<Shell>>,
+    {
+        let shells = shells
+            .into_iter()
+            .map(|shell| shell.insert(&mut core.services));
         let shells = self.shells().iter().cloned().chain(shells);
         Solid::new(shells)
     }

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -12,6 +12,7 @@ pub trait UpdateSolid {
     fn add_shells(
         &self,
         shells: impl IntoIterator<Item = Handle<Shell>>,
+        core: &mut Instance,
     ) -> Self;
 
     /// Update a shell of the solid
@@ -36,6 +37,7 @@ impl UpdateSolid for Solid {
     fn add_shells(
         &self,
         shells: impl IntoIterator<Item = Handle<Shell>>,
+        _: &mut Instance,
     ) -> Self {
         let shells = self.shells().iter().cloned().chain(shells);
         Solid::new(shells)

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -104,7 +104,7 @@ mod tests {
             ];
             let edges = edges.map(|edge| edge.insert(&mut core.services));
 
-            Cycle::empty().add_half_edges(edges)
+            Cycle::empty().add_half_edges(edges, &mut core)
         };
 
         assert_contains_err!(

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -81,7 +81,6 @@ mod tests {
         objects::{Cycle, HalfEdge},
         operations::{
             build::{BuildCycle, BuildHalfEdge},
-            insert::Insert,
             update::UpdateCycle,
         },
         validate::{cycle::CycleValidationError, Validate, ValidationError},
@@ -102,7 +101,6 @@ mod tests {
                 HalfEdge::line_segment([[0., 0.], [1., 0.]], None, &mut core),
                 HalfEdge::line_segment([[0., 0.], [1., 0.]], None, &mut core),
             ];
-            let edges = edges.map(|edge| edge.insert(&mut core.services));
 
             Cycle::empty().add_half_edges(edges, &mut core)
         };

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -107,12 +107,11 @@ mod tests {
             |region, core| {
                 region.update_exterior(
                     |cycle, core| {
-                        cycle.add_half_edges([HalfEdge::circle(
-                            [0., 0.],
-                            1.,
+                        cycle.add_half_edges(
+                            [HalfEdge::circle([0., 0.], 1., core)
+                                .insert(&mut core.services)],
                             core,
                         )
-                        .insert(&mut core.services)])
                     },
                     core,
                 )

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -149,8 +149,7 @@ mod tests {
                                 [Cycle::polygon(
                                     [[1., 1.], [1., 2.], [2., 1.]],
                                     core,
-                                )
-                                .insert(&mut core.services)],
+                                )],
                                 core,
                             )
                     },

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -145,11 +145,14 @@ mod tests {
                                 },
                                 core,
                             )
-                            .add_interiors([Cycle::polygon(
-                                [[1., 1.], [1., 2.], [2., 1.]],
+                            .add_interiors(
+                                [Cycle::polygon(
+                                    [[1., 1.], [1., 2.], [2., 1.]],
+                                    core,
+                                )
+                                .insert(&mut core.services)],
                                 core,
                             )
-                            .insert(&mut core.services)])
                     },
                     &mut core,
                 );

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -108,8 +108,7 @@ mod tests {
                 region.update_exterior(
                     |cycle, core| {
                         cycle.add_half_edges(
-                            [HalfEdge::circle([0., 0.], 1., core)
-                                .insert(&mut core.services)],
+                            [HalfEdge::circle([0., 0.], 1., core)],
                             core,
                         )
                     },

--- a/models/all/src/lib.rs
+++ b/models/all/src/lib.rs
@@ -36,7 +36,7 @@ pub fn model(core: &mut fj::core::Instance) -> Solid {
             .translate(offset * f, core)
             .rotate(axis * angle_rad * f, core);
 
-        all = all.merge(&model);
+        all = all.merge(&model, core);
     }
 
     all

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -21,15 +21,18 @@ pub fn model(
     let sweep_path = Vector::from([Scalar::ZERO, Scalar::ZERO, z]);
 
     Sketch::empty()
-        .add_regions([Region::polygon(
-            [
-                [-x / 2., -y / 2.],
-                [x / 2., -y / 2.],
-                [x / 2., y / 2.],
-                [-x / 2., y / 2.],
-            ],
+        .add_regions(
+            [Region::polygon(
+                [
+                    [-x / 2., -y / 2.],
+                    [x / 2., -y / 2.],
+                    [x / 2., y / 2.],
+                    [-x / 2., y / 2.],
+                ],
+                core,
+            )
+            .insert(&mut core.services)],
             core,
         )
-        .insert(&mut core.services)])
         .sweep_sketch(bottom_surface, sweep_path, core)
 }

--- a/models/cuboid/src/lib.rs
+++ b/models/cuboid/src/lib.rs
@@ -3,7 +3,6 @@ use fj::{
         objects::{Region, Sketch, Solid},
         operations::{
             build::{BuildRegion, BuildSketch},
-            insert::Insert,
             sweep::SweepSketch,
             update::UpdateSketch,
         },
@@ -30,8 +29,7 @@ pub fn model(
                     [-x / 2., y / 2.],
                 ],
                 core,
-            )
-            .insert(&mut core.services)],
+            )],
             core,
         )
         .sweep_sketch(bottom_surface, sweep_path, core)

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -24,9 +24,7 @@ pub fn model(
     Sketch::empty()
         .add_regions([Region::circle(Point::origin(), outer, core)
             .add_interiors(
-                [Cycle::circle(Point::origin(), inner, core)
-                    .reverse(core)
-                    .insert(&mut core.services)],
+                [Cycle::circle(Point::origin(), inner, core).reverse(core)],
                 core,
             )
             .insert(&mut core.services)])

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -23,9 +23,12 @@ pub fn model(
 
     Sketch::empty()
         .add_regions([Region::circle(Point::origin(), outer, core)
-            .add_interiors([Cycle::circle(Point::origin(), inner, core)
-                .reverse(core)
-                .insert(&mut core.services)])
+            .add_interiors(
+                [Cycle::circle(Point::origin(), inner, core)
+                    .reverse(core)
+                    .insert(&mut core.services)],
+                core,
+            )
             .insert(&mut core.services)])
         .sweep_sketch(bottom_surface, sweep_path, core)
 }

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -3,7 +3,6 @@ use fj::{
         objects::{Cycle, Region, Sketch, Solid},
         operations::{
             build::{BuildCycle, BuildRegion, BuildSketch},
-            insert::Insert,
             reverse::Reverse,
             sweep::SweepSketch,
             update::{UpdateRegion, UpdateSketch},
@@ -23,12 +22,10 @@ pub fn model(
 
     Sketch::empty()
         .add_regions(
-            [Region::circle(Point::origin(), outer, core)
-                .add_interiors(
-                    [Cycle::circle(Point::origin(), inner, core).reverse(core)],
-                    core,
-                )
-                .insert(&mut core.services)],
+            [Region::circle(Point::origin(), outer, core).add_interiors(
+                [Cycle::circle(Point::origin(), inner, core).reverse(core)],
+                core,
+            )],
             core,
         )
         .sweep_sketch(bottom_surface, sweep_path, core)

--- a/models/spacer/src/lib.rs
+++ b/models/spacer/src/lib.rs
@@ -22,11 +22,14 @@ pub fn model(
     let sweep_path = Vector::from([0., 0., height]);
 
     Sketch::empty()
-        .add_regions([Region::circle(Point::origin(), outer, core)
-            .add_interiors(
-                [Cycle::circle(Point::origin(), inner, core).reverse(core)],
-                core,
-            )
-            .insert(&mut core.services)])
+        .add_regions(
+            [Region::circle(Point::origin(), outer, core)
+                .add_interiors(
+                    [Cycle::circle(Point::origin(), inner, core).reverse(core)],
+                    core,
+                )
+                .insert(&mut core.services)],
+            core,
+        )
         .sweep_sketch(bottom_surface, sweep_path, core)
 }

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -46,9 +46,12 @@ pub fn model(
 
     Sketch::empty()
         .add_regions([Region::polygon(outer_points, core)
-            .add_interiors([Cycle::polygon(inner_points, core)
-                .reverse(core)
-                .insert(&mut core.services)])
+            .add_interiors(
+                [Cycle::polygon(inner_points, core)
+                    .reverse(core)
+                    .insert(&mut core.services)],
+                core,
+            )
             .insert(&mut core.services)])
         .sweep_sketch(bottom_surface, sweep_path, core)
 }

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -47,9 +47,7 @@ pub fn model(
     Sketch::empty()
         .add_regions([Region::polygon(outer_points, core)
             .add_interiors(
-                [Cycle::polygon(inner_points, core)
-                    .reverse(core)
-                    .insert(&mut core.services)],
+                [Cycle::polygon(inner_points, core).reverse(core)],
                 core,
             )
             .insert(&mut core.services)])

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -5,7 +5,6 @@ use fj::{
         objects::{Cycle, Region, Sketch, Solid},
         operations::{
             build::{BuildCycle, BuildRegion, BuildSketch},
-            insert::Insert,
             reverse::Reverse,
             sweep::SweepSketch,
             update::{UpdateRegion, UpdateSketch},
@@ -46,12 +45,10 @@ pub fn model(
 
     Sketch::empty()
         .add_regions(
-            [Region::polygon(outer_points, core)
-                .add_interiors(
-                    [Cycle::polygon(inner_points, core).reverse(core)],
-                    core,
-                )
-                .insert(&mut core.services)],
+            [Region::polygon(outer_points, core).add_interiors(
+                [Cycle::polygon(inner_points, core).reverse(core)],
+                core,
+            )],
             core,
         )
         .sweep_sketch(bottom_surface, sweep_path, core)

--- a/models/star/src/lib.rs
+++ b/models/star/src/lib.rs
@@ -45,11 +45,14 @@ pub fn model(
     let sweep_path = Vector::from([0., 0., h]);
 
     Sketch::empty()
-        .add_regions([Region::polygon(outer_points, core)
-            .add_interiors(
-                [Cycle::polygon(inner_points, core).reverse(core)],
-                core,
-            )
-            .insert(&mut core.services)])
+        .add_regions(
+            [Region::polygon(outer_points, core)
+                .add_interiors(
+                    [Cycle::polygon(inner_points, core).reverse(core)],
+                    core,
+                )
+                .insert(&mut core.services)],
+            core,
+        )
         .sweep_sketch(bottom_surface, sweep_path, core)
 }

--- a/models/vertices-indices/src/lib.rs
+++ b/models/vertices-indices/src/lib.rs
@@ -8,10 +8,13 @@ use fj::core::{
 };
 
 pub fn model(core: &mut fj::core::Instance) -> Solid {
-    Solid::empty().add_shells([Shell::from_vertices_and_indices(
-        [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
-        [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
+    Solid::empty().add_shells(
+        [Shell::from_vertices_and_indices(
+            [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
+            [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
+            core,
+        )
+        .insert(&mut core.services)],
         core,
     )
-    .insert(&mut core.services)])
 }

--- a/models/vertices-indices/src/lib.rs
+++ b/models/vertices-indices/src/lib.rs
@@ -2,7 +2,6 @@ use fj::core::{
     objects::{Shell, Solid},
     operations::{
         build::{BuildShell, BuildSolid},
-        insert::Insert,
         update::UpdateSolid,
     },
 };
@@ -13,8 +12,7 @@ pub fn model(core: &mut fj::core::Instance) -> Solid {
             [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
             [[2, 1, 0], [0, 1, 3], [1, 2, 3], [2, 0, 3]],
             core,
-        )
-        .insert(&mut core.services)],
+        )],
         core,
     )
 }


### PR DESCRIPTION
Gives the same treatment that the `update_*` methods already got in https://github.com/hannobraun/fornjot/pull/2205 to the `add_*` methods. This removes more reasons to use `insert` in model code, and like https://github.com/hannobraun/fornjot/pull/2205, further reduces sources of potential errors regarding the changes I'm working on for https://github.com/hannobraun/fornjot/issues/2117. 