### PR TITLE
Require `&mut Instance` in `Insert::insert`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -188,7 +188,7 @@ mod tests {
     fn approx_line_on_flat_surface() {
         let mut core = Instance::new();
 
-        let curve = Curve::new().insert(&mut core.services);
+        let curve = Curve::new().insert(&mut core);
         let (surface_path, boundary) =
             SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
@@ -205,7 +205,7 @@ mod tests {
     fn approx_line_on_curved_surface_but_not_along_curve() {
         let mut core = Instance::new();
 
-        let curve = Curve::new().insert(&mut core.services);
+        let curve = Curve::new().insert(&mut core);
         let (surface_path, boundary) =
             SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
@@ -226,7 +226,7 @@ mod tests {
         let mut core = Instance::new();
 
         let global_path = GlobalPath::circle_from_radius(1.);
-        let curve = Curve::new().insert(&mut core.services);
+        let curve = Curve::new().insert(&mut core);
         let surface_path = SurfacePath::line_from_points_with_coords([
             ([0.], [0., 1.]),
             ([TAU], [TAU, 1.]),
@@ -259,7 +259,7 @@ mod tests {
     fn approx_circle_on_flat_surface() {
         let mut core = Instance::new();
 
-        let curve = Curve::new().insert(&mut core.services);
+        let curve = Curve::new().insert(&mut core);
         let surface_path =
             SurfacePath::circle_from_center_and_radius([0., 0.], 1.);
         let boundary = CurveBoundary::from([[0.], [TAU]]);

--- a/crates/fj-core/src/operations/build/cycle.rs
+++ b/crates/fj-core/src/operations/build/cycle.rs
@@ -40,8 +40,7 @@ pub trait BuildCycle {
             .map(Into::into)
             .circular_tuple_windows()
             .map(|(start, end)| {
-                HalfEdge::line_segment([start, end], None, core)
-                    .insert(&mut core.services)
+                HalfEdge::line_segment([start, end], None, core).insert(core)
             });
 
         Cycle::new(edges)

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -21,8 +21,8 @@ use crate::{
 pub trait BuildFace {
     /// Build a face with an empty exterior, no interiors, and no color
     fn unbound(surface: Handle<Surface>, core: &mut Instance) -> Face {
-        let exterior = Cycle::empty().insert(&mut core.services);
-        let region = Region::new(exterior, [], None).insert(&mut core.services);
+        let exterior = Cycle::empty().insert(core);
+        let region = Region::new(exterior, [], None).insert(core);
         Face::new(surface, region)
     }
 
@@ -32,7 +32,7 @@ pub trait BuildFace {
         core: &mut Instance,
     ) -> Polygon<3> {
         let (surface, points_surface) = Surface::plane_from_points(points);
-        let surface = surface.insert(&mut core.services);
+        let surface = surface.insert(core);
 
         let face = Face::polygon(surface, points_surface, core);
 
@@ -70,7 +70,7 @@ pub trait BuildFace {
         Ps: IntoIterator<Item = P>,
         Ps::IntoIter: Clone + ExactSizeIterator,
     {
-        let region = Region::polygon(points, core).insert(&mut core.services);
+        let region = Region::polygon(points, core).insert(core);
         Face::new(surface, region)
     }
 }

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -21,8 +21,8 @@ pub trait BuildHalfEdge {
         boundary: impl Into<CurveBoundary<Point<1>>>,
         core: &mut Instance,
     ) -> HalfEdge {
-        let curve = Curve::new().insert(&mut core.services);
-        let start_vertex = Vertex::new().insert(&mut core.services);
+        let curve = Curve::new().insert(core);
+        let start_vertex = Vertex::new().insert(core);
 
         HalfEdge::new(path, boundary, curve, start_vertex)
     }

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -14,7 +14,7 @@ use crate::{
 pub trait BuildRegion {
     /// Build an empty region
     fn empty(core: &mut Instance) -> Region {
-        let exterior = Cycle::empty().insert(&mut core.services);
+        let exterior = Cycle::empty().insert(core);
         let interiors = [];
         let color = None;
 
@@ -27,8 +27,7 @@ pub trait BuildRegion {
         radius: impl Into<Scalar>,
         core: &mut Instance,
     ) -> Region {
-        let exterior =
-            Cycle::circle(center, radius, core).insert(&mut core.services);
+        let exterior = Cycle::circle(center, radius, core).insert(core);
         Region::new(exterior, [], None)
     }
 
@@ -39,7 +38,7 @@ pub trait BuildRegion {
         Ps: IntoIterator<Item = P>,
         Ps::IntoIter: Clone + ExactSizeIterator,
     {
-        let exterior = Cycle::polygon(points, core).insert(&mut core.services);
+        let exterior = Cycle::polygon(points, core).insert(core);
         Region::new(exterior, [], None)
     }
 }

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -39,7 +39,7 @@ pub trait BuildShell {
             .into_iter()
             .enumerate()
             .map(|(index, position)| {
-                let vertex = Vertex::new().insert(&mut core.services);
+                let vertex = Vertex::new().insert(core);
                 let position = position.into();
 
                 (index, (vertex, position))
@@ -57,7 +57,7 @@ pub trait BuildShell {
                 let (surface, _) = Surface::plane_from_points(
                     [a_pos, b_pos, c_pos].map(Clone::clone),
                 );
-                let surface = surface.insert(&mut core.services);
+                let surface = surface.insert(core);
 
                 let curves_and_boundaries =
                     [[a, b], [b, c], [c, a]].map(|vertices| {
@@ -68,8 +68,7 @@ pub trait BuildShell {
                             .get(&vertices.clone().reverse())
                             .cloned()
                             .unwrap_or_else(|| {
-                                let curve =
-                                    Curve::new().insert(&mut core.services);
+                                let curve = Curve::new().insert(core);
                                 let boundary =
                                     CurveBoundary::<Point<1>>::from([
                                         [0.],
@@ -262,8 +261,8 @@ pub trait BuildShell {
             core,
         );
 
-        let triangles = [abc, bad, dac, cbd]
-            .map(|triangle| triangle.insert(&mut core.services));
+        let triangles =
+            [abc, bad, dac, cbd].map(|triangle| triangle.insert(core));
         let shell =
             Shell::new(triangles.iter().map(|triangle| triangle.face.clone()));
 

--- a/crates/fj-core/src/operations/build/solid.rs
+++ b/crates/fj-core/src/operations/build/solid.rs
@@ -28,7 +28,7 @@ pub trait BuildSolid {
         points: [impl Into<Point<3>>; 4],
         core: &mut Instance,
     ) -> Tetrahedron {
-        let shell = Shell::tetrahedron(points, core).insert(&mut core.services);
+        let shell = Shell::tetrahedron(points, core).insert(core);
         let solid = Solid::empty().add_shells([shell.shell.clone()], core);
 
         Tetrahedron { solid, shell }

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -44,8 +44,8 @@ impl AddHole for Shell {
         path: impl Into<Vector<3>>,
         core: &mut Instance,
     ) -> Self {
-        let entry = HalfEdge::circle(location.position, radius, core)
-            .insert(&mut core.services);
+        let entry =
+            HalfEdge::circle(location.position, radius, core).insert(core);
         let hole = Region::empty(core)
             .update_exterior(
                 |_, core| Cycle::empty().add_half_edges([entry.clone()], core),
@@ -94,7 +94,7 @@ impl AddHole for Shell {
         let radius = radius.into();
 
         let entry = HalfEdge::circle(entry_location.position, radius, core)
-            .insert(&mut core.services);
+            .insert(core);
 
         let path = {
             let point = |location: &HoleLocation| {

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -58,7 +58,7 @@ impl ReplaceCurve for Cycle {
             replacement_happened |= half_edge.was_updated();
             half_edges.push(
                 half_edge
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -92,7 +92,7 @@ impl ReplaceCurve for Region {
             replacement_happened |= cycle.was_updated();
             interiors.push(
                 cycle
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -100,7 +100,7 @@ impl ReplaceCurve for Region {
         if replacement_happened {
             ReplaceOutput::Updated(Region::new(
                 exterior
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
                 interiors,
                 self.color(),
@@ -127,7 +127,7 @@ impl ReplaceCurve for Sketch {
             replacement_happened |= region.was_updated();
             regions.push(
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -153,7 +153,7 @@ impl ReplaceCurve for Face {
             ReplaceOutput::Updated(Face::new(
                 self.surface().clone(),
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             ))
         } else {
@@ -176,7 +176,7 @@ impl ReplaceCurve for Shell {
             let face = face.replace_curve(original, replacement.clone(), core);
             replacement_happened |= face.was_updated();
             faces.push(
-                face.map_updated(|updated| updated.insert(&mut core.services))
+                face.map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -205,7 +205,7 @@ impl ReplaceCurve for Solid {
             replacement_happened |= shell.was_updated();
             shells.push(
                 shell
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -65,7 +65,7 @@ impl ReplaceHalfEdge for Region {
             replacement_happened |= cycle.was_updated();
             interiors.push(
                 cycle
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -73,7 +73,7 @@ impl ReplaceHalfEdge for Region {
         if replacement_happened {
             ReplaceOutput::Updated(Region::new(
                 exterior
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
                 interiors,
                 self.color(),
@@ -100,7 +100,7 @@ impl ReplaceHalfEdge for Sketch {
             replacement_happened |= region.was_updated();
             regions.push(
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -128,7 +128,7 @@ impl ReplaceHalfEdge for Face {
             ReplaceOutput::Updated(Face::new(
                 self.surface().clone(),
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             ))
         } else {
@@ -152,7 +152,7 @@ impl ReplaceHalfEdge for Shell {
                 face.replace_half_edge(original, replacements.clone(), core);
             replacement_happened |= face.was_updated();
             faces.push(
-                face.map_updated(|updated| updated.insert(&mut core.services))
+                face.map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -181,7 +181,7 @@ impl ReplaceHalfEdge for Solid {
             replacement_happened |= shell.was_updated();
             shells.push(
                 shell
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -60,7 +60,7 @@ impl ReplaceVertex for Cycle {
             replacement_happened |= half_edge.was_updated();
             half_edges.push(
                 half_edge
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -94,7 +94,7 @@ impl ReplaceVertex for Region {
             replacement_happened |= cycle.was_updated();
             interiors.push(
                 cycle
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -102,7 +102,7 @@ impl ReplaceVertex for Region {
         if replacement_happened {
             ReplaceOutput::Updated(Region::new(
                 exterior
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
                 interiors,
                 self.color(),
@@ -129,7 +129,7 @@ impl ReplaceVertex for Sketch {
             replacement_happened |= region.was_updated();
             regions.push(
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -155,7 +155,7 @@ impl ReplaceVertex for Face {
             ReplaceOutput::Updated(Face::new(
                 self.surface().clone(),
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             ))
         } else {
@@ -178,7 +178,7 @@ impl ReplaceVertex for Shell {
             let face = face.replace_vertex(original, replacement.clone(), core);
             replacement_happened |= face.was_updated();
             faces.push(
-                face.map_updated(|updated| updated.insert(&mut core.services))
+                face.map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -207,7 +207,7 @@ impl ReplaceVertex for Solid {
             replacement_happened |= shell.was_updated();
             shells.push(
                 shell
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }
@@ -275,7 +275,7 @@ impl ReplaceVertex for Handle<Sketch> {
             replacement_happened |= region.was_updated();
             regions.push(
                 region
-                    .map_updated(|updated| updated.insert(&mut core.services))
+                    .map_updated(|updated| updated.insert(core))
                     .into_inner(),
             );
         }

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -18,7 +18,7 @@ impl Reverse for Cycle {
                     current.curve().clone(),
                     next.start_vertex().clone(),
                 )
-                .insert(&mut core.services)
+                .insert(core)
             })
             .collect::<Vec<_>>();
 
@@ -31,8 +31,7 @@ impl Reverse for Cycle {
 impl ReverseCurveCoordinateSystems for Cycle {
     fn reverse_curve_coordinate_systems(&self, core: &mut Instance) -> Self {
         let edges = self.half_edges().iter().map(|edge| {
-            edge.reverse_curve_coordinate_systems(core)
-                .insert(&mut core.services)
+            edge.reverse_curve_coordinate_systems(core).insert(core)
         });
 
         Cycle::new(edges)

--- a/crates/fj-core/src/operations/reverse/face.rs
+++ b/crates/fj-core/src/operations/reverse/face.rs
@@ -13,7 +13,7 @@ use super::{Reverse, ReverseCurveCoordinateSystems};
 
 impl Reverse for Face {
     fn reverse(&self, core: &mut Instance) -> Self {
-        let region = self.region().reverse(core).insert(&mut core.services);
+        let region = self.region().reverse(core).insert(core);
         Face::new(self.surface().clone(), region)
     }
 }
@@ -28,7 +28,7 @@ impl<const D: usize> Reverse for Polygon<D, IsInsertedNo> {
 impl<const D: usize> Reverse for Polygon<D, IsInsertedYes> {
     fn reverse(&self, core: &mut Instance) -> Self {
         let face: &Face = self.face.borrow();
-        let face = face.reverse(core).insert(&mut core.services);
+        let face = face.reverse(core).insert(core);
 
         self.replace_face(face)
     }
@@ -39,7 +39,7 @@ impl ReverseCurveCoordinateSystems for Face {
         let region = self
             .region()
             .reverse_curve_coordinate_systems(core)
-            .insert(&mut core.services);
+            .insert(core);
         Face::new(self.surface().clone(), region)
     }
 }
@@ -58,9 +58,7 @@ impl<const D: usize> ReverseCurveCoordinateSystems
 {
     fn reverse_curve_coordinate_systems(&self, core: &mut Instance) -> Self {
         let face: &Face = self.face.borrow();
-        let face = face
-            .reverse_curve_coordinate_systems(core)
-            .insert(&mut core.services);
+        let face = face.reverse_curve_coordinate_systems(core).insert(core);
 
         self.replace_face(face)
     }

--- a/crates/fj-core/src/operations/reverse/region.rs
+++ b/crates/fj-core/src/operations/reverse/region.rs
@@ -4,11 +4,11 @@ use super::{Reverse, ReverseCurveCoordinateSystems};
 
 impl Reverse for Region {
     fn reverse(&self, core: &mut Instance) -> Self {
-        let exterior = self.exterior().reverse(core).insert(&mut core.services);
+        let exterior = self.exterior().reverse(core).insert(core);
         let interiors = self
             .interiors()
             .iter()
-            .map(|cycle| cycle.reverse(core).insert(&mut core.services));
+            .map(|cycle| cycle.reverse(core).insert(core));
 
         Region::new(exterior, interiors, self.color())
     }
@@ -19,11 +19,9 @@ impl ReverseCurveCoordinateSystems for Region {
         let exterior = self
             .exterior()
             .reverse_curve_coordinate_systems(core)
-            .insert(&mut core.services);
+            .insert(core);
         let interiors = self.interiors().iter().map(|cycle| {
-            cycle
-                .reverse_curve_coordinate_systems(core)
-                .insert(&mut core.services)
+            cycle.reverse_curve_coordinate_systems(core).insert(core)
         });
 
         Region::new(exterior, interiors, self.color())

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -42,7 +42,7 @@ impl SplitEdge for Shell {
 
         let [half_edge_a, half_edge_b] = half_edge
             .split_half_edge(point, core)
-            .map(|half_edge| half_edge.insert(&mut core.services));
+            .map(|half_edge| half_edge.insert(core));
 
         let siblings = {
             let [sibling_a, sibling_b] = sibling.split_half_edge(point, core);
@@ -50,8 +50,7 @@ impl SplitEdge for Shell {
                 |_, _| half_edge_b.start_vertex().clone(),
                 core,
             );
-            [sibling_a, sibling_b]
-                .map(|half_edge| half_edge.insert(&mut core.services))
+            [sibling_a, sibling_b].map(|half_edge| half_edge.insert(core))
         };
 
         let shell = self

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -145,17 +145,17 @@ impl SplitFace for Shell {
                         },
                         core,
                     )
-                    .insert(&mut core.services);
+                    .insert(core);
 
                 if let Some(color) = face.region().color() {
-                    region = region.set_color(color).insert(&mut core.services);
+                    region = region.set_color(color).insert(core);
                 }
 
                 region
             },
             core,
         )
-        .insert(&mut core.services);
+        .insert(core);
 
         // The previous operation has moved the iterator along.
         let half_edges_of_face_starting_at_d = half_edges_of_face_starting_at_b;
@@ -183,17 +183,17 @@ impl SplitFace for Shell {
                         },
                         core,
                     )
-                    .insert(&mut core.services);
+                    .insert(core);
 
                 if let Some(color) = face.region().color() {
-                    region = region.set_color(color).insert(&mut core.services);
+                    region = region.set_color(color).insert(core);
                 }
 
                 region
             },
             core,
         )
-        .insert(&mut core.services);
+        .insert(core);
 
         let faces = [split_face_a, split_face_b];
         let self_ = self_.update_face(

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -51,7 +51,7 @@ impl SplitHalfEdge for HalfEdge {
             self.path(),
             [point, end],
             self.curve().clone(),
-            Vertex::new().insert(&mut core.services),
+            Vertex::new().insert(core),
         );
 
         [a, b]

--- a/crates/fj-core/src/operations/sweep/face.rs
+++ b/crates/fj-core/src/operations/sweep/face.rs
@@ -51,7 +51,7 @@ impl SweepFace for Handle<Face> {
             .region()
             .sweep_region(bottom_face.surface(), path, cache, core)
             .all_faces()
-            .map(|side_face| side_face.insert(&mut core.services));
+            .map(|side_face| side_face.insert(core));
 
         let mut faces = Vec::new();
         faces.push(bottom_face.clone());

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -56,10 +56,8 @@ impl SweepHalfEdge for HalfEdge {
     ) -> (Face, Handle<HalfEdge>) {
         let path = path.into();
 
-        let surface = self
-            .path()
-            .sweep_surface_path(surface, path)
-            .insert(&mut core.services);
+        let surface =
+            self.path().sweep_surface_path(surface, path).insert(core);
 
         // Next, we need to define the boundaries of the face. Let's start with
         // the global vertices and edges.
@@ -128,7 +126,7 @@ impl SweepHalfEdge for HalfEdge {
                         edge
                     };
 
-                    edge.insert(&mut core.services)
+                    edge.insert(core)
                 };
 
                 exterior = exterior.add_half_edges([edge.clone()], core);
@@ -136,9 +134,8 @@ impl SweepHalfEdge for HalfEdge {
                 edge
             });
 
-        let exterior = exterior.insert(&mut core.services);
-        let region =
-            Region::new(exterior, [], color).insert(&mut core.services);
+        let exterior = exterior.insert(core);
+        let region = Region::new(exterior, [], color).insert(core);
         let face = Face::new(surface, region);
 
         (face, edge_top)

--- a/crates/fj-core/src/operations/sweep/region.rs
+++ b/crates/fj-core/src/operations/sweep/region.rs
@@ -77,11 +77,10 @@ impl SweepRegion for Region {
             .collect::<Vec<_>>();
 
         let top_face = {
-            let top_surface =
-                surface.translate(path, core).insert(&mut core.services);
+            let top_surface = surface.translate(path, core).insert(core);
             let top_region =
                 Region::new(top_exterior, top_interiors, self.color())
-                    .insert(&mut core.services);
+                    .insert(core);
 
             Face::new(top_surface, top_region)
         };
@@ -112,7 +111,7 @@ fn sweep_cycle(
 
     faces.extend(swept_cycle.faces);
 
-    swept_cycle.top_cycle.insert(&mut core.services)
+    swept_cycle.top_cycle.insert(core)
 }
 
 /// The result of sweeping a [`Region`]

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -52,11 +52,7 @@ impl SweepFaceOfShell for Shell {
 
         let mut cache = SweepCache::default();
 
-        let exterior = face
-            .region()
-            .exterior()
-            .reverse(core)
-            .insert(&mut core.services);
+        let exterior = face.region().exterior().reverse(core).insert(core);
         let region = Region::new(exterior, [], face.region().color());
         let faces = region
             .sweep_region(face.surface(), path, &mut cache, core)

--- a/crates/fj-core/src/operations/sweep/sketch.rs
+++ b/crates/fj-core/src/operations/sweep/sketch.rs
@@ -60,15 +60,12 @@ impl SweepSketch for Sketch {
                 if is_negative_sweep {
                     region.clone()
                 } else {
-                    region.reverse(core).insert(&mut core.services)
+                    region.reverse(core).insert(core)
                 }
             };
 
-            let face = Face::new(surface.clone(), region.clone())
-                .insert(&mut core.services);
-            let shell = face
-                .sweep_face(path, &mut cache, core)
-                .insert(&mut core.services);
+            let face = Face::new(surface.clone(), region.clone()).insert(core);
+            let shell = face.sweep_face(path, &mut cache, core).insert(core);
             shells.push(shell);
         }
 

--- a/crates/fj-core/src/operations/sweep/vertex.rs
+++ b/crates/fj-core/src/operations/sweep/vertex.rs
@@ -47,13 +47,13 @@ impl SweepVertex for Handle<Vertex> {
         let curve = cache
             .curves
             .entry(self.id())
-            .or_insert_with(|| Curve::new().insert(&mut core.services))
+            .or_insert_with(|| Curve::new().insert(core))
             .clone();
 
         let vertex = cache
             .vertices
             .entry(self.id())
-            .or_insert_with(|| Vertex::new().insert(&mut core.services))
+            .or_insert_with(|| Vertex::new().insert(core))
             .clone();
 
         (curve, vertex)

--- a/crates/fj-core/src/operations/transform/mod.rs
+++ b/crates/fj-core/src/operations/transform/mod.rs
@@ -85,7 +85,7 @@ where
         let transformed = self
             .clone_object()
             .transform_with_cache(transform, core, cache)
-            .insert(&mut core.services);
+            .insert(core);
 
         cache.insert(self.clone(), transformed.clone());
 

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -46,7 +46,7 @@ impl UpdateCycle for Cycle {
     {
         let half_edges = half_edges
             .into_iter()
-            .map(|half_edge| half_edge.insert(&mut core.services));
+            .map(|half_edge| half_edge.insert(core));
         let half_edges = self.half_edges().iter().cloned().chain(half_edges);
         Cycle::new(half_edges)
     }
@@ -64,8 +64,7 @@ impl UpdateCycle for Cycle {
             .half_edges()
             .replace(
                 handle,
-                update(handle, core)
-                    .map(|object| object.insert(&mut core.services)),
+                update(handle, core).map(|object| object.insert(core)),
             )
             .expect("Half-edge not found");
         Cycle::new(edges)

--- a/crates/fj-core/src/operations/update/face.rs
+++ b/crates/fj-core/src/operations/update/face.rs
@@ -28,7 +28,7 @@ impl UpdateFace for Face {
         T: Insert<Inserted = Handle<Region>>,
     {
         let region = update(self.region(), core);
-        Face::new(self.surface().clone(), region.insert(&mut core.services))
+        Face::new(self.surface().clone(), region.insert(core))
     }
 }
 

--- a/crates/fj-core/src/operations/update/half_edge.rs
+++ b/crates/fj-core/src/operations/update/half_edge.rs
@@ -81,7 +81,7 @@ impl UpdateHalfEdge for HalfEdge {
         HalfEdge::new(
             self.path(),
             self.boundary(),
-            update(self.curve(), core).insert(&mut core.services),
+            update(self.curve(), core).insert(core),
             self.start_vertex().clone(),
         )
     }
@@ -98,7 +98,7 @@ impl UpdateHalfEdge for HalfEdge {
             self.path(),
             self.boundary(),
             self.curve().clone(),
-            update(self.start_vertex(), core).insert(&mut core.services),
+            update(self.start_vertex(), core).insert(core),
         )
     }
 }

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -54,7 +54,7 @@ impl UpdateRegion for Region {
     where
         T: Insert<Inserted = Handle<Cycle>>,
     {
-        let exterior = update(self.exterior(), core).insert(&mut core.services);
+        let exterior = update(self.exterior(), core).insert(core);
         Region::new(exterior, self.interiors().iter().cloned(), self.color())
     }
 
@@ -66,9 +66,7 @@ impl UpdateRegion for Region {
     where
         T: Insert<Inserted = Handle<Cycle>>,
     {
-        let interiors = interiors
-            .into_iter()
-            .map(|cycle| cycle.insert(&mut core.services));
+        let interiors = interiors.into_iter().map(|cycle| cycle.insert(core));
         let interiors = self.interiors().iter().cloned().chain(interiors);
         Region::new(self.exterior().clone(), interiors, self.color())
     }
@@ -86,8 +84,7 @@ impl UpdateRegion for Region {
             .interiors()
             .replace(
                 handle,
-                update(handle, core)
-                    .map(|object| object.insert(&mut core.services)),
+                update(handle, core).map(|object| object.insert(core)),
             )
             .expect("Cycle not found");
         Region::new(self.exterior().clone(), interiors, self.color())

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -48,9 +48,7 @@ impl UpdateShell for Shell {
     where
         T: Insert<Inserted = Handle<Face>>,
     {
-        let faces = faces
-            .into_iter()
-            .map(|face| face.insert(&mut core.services));
+        let faces = faces.into_iter().map(|face| face.insert(core));
         let faces = self.faces().iter().cloned().chain(faces);
         Shell::new(faces)
     }
@@ -68,8 +66,7 @@ impl UpdateShell for Shell {
             .faces()
             .replace(
                 handle,
-                update(handle, core)
-                    .map(|object| object.insert(&mut core.services)),
+                update(handle, core).map(|object| object.insert(core)),
             )
             .expect("Face not found");
         Shell::new(faces)

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -44,9 +44,7 @@ impl UpdateSketch for Sketch {
     where
         T: Insert<Inserted = Handle<Region>>,
     {
-        let regions = regions
-            .into_iter()
-            .map(|region| region.insert(&mut core.services));
+        let regions = regions.into_iter().map(|region| region.insert(core));
         let regions = self.regions().iter().cloned().chain(regions);
         Sketch::new(regions)
     }
@@ -64,8 +62,7 @@ impl UpdateSketch for Sketch {
             .regions()
             .replace(
                 handle,
-                update(handle, core)
-                    .map(|object| object.insert(&mut core.services)),
+                update(handle, core).map(|object| object.insert(core)),
             )
             .expect("Region not found");
         Sketch::new(regions)

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -44,9 +44,7 @@ impl UpdateSolid for Solid {
     where
         T: Insert<Inserted = Handle<Shell>>,
     {
-        let shells = shells
-            .into_iter()
-            .map(|shell| shell.insert(&mut core.services));
+        let shells = shells.into_iter().map(|shell| shell.insert(core));
         let shells = self.shells().iter().cloned().chain(shells);
         Solid::new(shells)
     }
@@ -64,8 +62,7 @@ impl UpdateSolid for Solid {
             .shells()
             .replace(
                 handle,
-                update(handle, core)
-                    .map(|object| object.insert(&mut core.services)),
+                update(handle, core).map(|object| object.insert(core)),
             )
             .expect("Shell not found");
         Solid::new(shells)

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -161,9 +161,7 @@ mod tests {
                 .interiors()
                 .iter()
                 .cloned()
-                .map(|cycle| {
-                    cycle.reverse(&mut core).insert(&mut core.services)
-                })
+                .map(|cycle| cycle.reverse(&mut core).insert(&mut core))
                 .collect::<Vec<_>>();
 
             let region = Region::new(
@@ -171,7 +169,7 @@ mod tests {
                 interiors,
                 valid.region().color(),
             )
-            .insert(&mut core.services);
+            .insert(&mut core);
 
             Face::new(valid.surface().clone(), region)
         };

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -66,16 +66,16 @@ mod tests {
     fn should_find_cycle_multiple_references() -> anyhow::Result<()> {
         let mut core = Instance::new();
 
-        let shared_cycle = Cycle::new(vec![]).insert(&mut core.services);
+        let shared_cycle = Cycle::new(vec![]).insert(&mut core);
 
         let invalid_sketch = Sketch::new(vec![
             Region::new(
-                Cycle::new(vec![]).insert(&mut core.services),
+                Cycle::new(vec![]).insert(&mut core),
                 vec![shared_cycle.clone()],
                 None,
             )
-            .insert(&mut core.services),
-            Region::new(shared_cycle, vec![], None).insert(&mut core.services),
+            .insert(&mut core),
+            Region::new(shared_cycle, vec![], None).insert(&mut core),
         ]);
         assert_contains_err!(
             invalid_sketch,
@@ -85,11 +85,11 @@ mod tests {
         );
 
         let valid_sketch = Sketch::new(vec![Region::new(
-            Cycle::new(vec![]).insert(&mut core.services),
+            Cycle::new(vec![]).insert(&mut core),
             vec![],
             None,
         )
-        .insert(&mut core.services)]);
+        .insert(&mut core)]);
         valid_sketch.validate_and_return_first_error()?;
 
         Ok(())
@@ -101,27 +101,25 @@ mod tests {
 
         let half_edge =
             HalfEdge::line_segment([[0., 0.], [1., 0.]], None, &mut core)
-                .insert(&mut core.services);
-        let sibling_edge = HalfEdge::from_sibling(
-            &half_edge,
-            Vertex::new().insert(&mut core.services),
-        )
-        .insert(&mut core.services);
+                .insert(&mut core);
+        let sibling_edge =
+            HalfEdge::from_sibling(&half_edge, Vertex::new().insert(&mut core))
+                .insert(&mut core);
 
         let exterior =
             Cycle::new(vec![half_edge.clone(), sibling_edge.clone()])
-                .insert(&mut core.services);
+                .insert(&mut core);
 
         let interior =
             Cycle::new(vec![half_edge.clone(), sibling_edge.clone()])
-                .insert(&mut core.services);
+                .insert(&mut core);
 
         let invalid_sketch = Sketch::new(vec![Region::new(
             exterior.clone(),
             vec![interior],
             None,
         )
-        .insert(&mut core.services)]);
+        .insert(&mut core)]);
         assert_contains_err!(
             invalid_sketch,
             ValidationError::Sketch(SketchValidationError::MultipleReferences(
@@ -131,7 +129,7 @@ mod tests {
 
         let valid_sketch =
             Sketch::new(vec![
-                Region::new(exterior, vec![], None).insert(&mut core.services)
+                Region::new(exterior, vec![], None).insert(&mut core)
             ]);
         valid_sketch.validate_and_return_first_error()?;
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -197,32 +197,33 @@ mod tests {
                 u: GlobalPath::circle_from_radius(1.),
                 v: [0., 1., 1.].into(),
             })
-            .insert(&mut core.services),
+            .insert(&mut core),
             Region::new(
-                Cycle::new(vec![HalfEdge::circle([0., 0.], 1., &mut core)
-                    .insert(&mut core.services)])
-                .insert(&mut core.services),
+                Cycle::new(vec![
+                    HalfEdge::circle([0., 0.], 1., &mut core).insert(&mut core)
+                ])
+                .insert(&mut core),
                 vec![],
                 None,
             )
-            .insert(&mut core.services),
+            .insert(&mut core),
         )
-        .insert(&mut core.services);
+        .insert(&mut core);
 
         let invalid_solid = Solid::new(vec![
-            Shell::new(vec![shared_face.clone()]).insert(&mut core.services),
+            Shell::new(vec![shared_face.clone()]).insert(&mut core),
             Shell::new(vec![
                 shared_face,
                 Face::triangle(
                     [[0., 0., 0.], [1., 0., 0.], [1., 1., 0.]],
                     &mut core,
                 )
-                .insert(&mut core.services)
+                .insert(&mut core)
                 .face,
             ])
-            .insert(&mut core.services),
+            .insert(&mut core),
         ])
-        .insert(&mut core.services);
+        .insert(&mut core);
 
         assert_contains_err!(
             invalid_solid,
@@ -231,7 +232,7 @@ mod tests {
             ))
         );
 
-        let valid_solid = Solid::new(vec![]).insert(&mut core.services);
+        let valid_solid = Solid::new(vec![]).insert(&mut core);
         valid_solid.validate_and_return_first_error()?;
 
         core.services.validation.errors.clear();
@@ -244,13 +245,14 @@ mod tests {
         let mut core = Instance::new();
 
         let shared_region = Region::new(
-            Cycle::new(vec![HalfEdge::circle([0., 0.], 1., &mut core)
-                .insert(&mut core.services)])
-            .insert(&mut core.services),
+            Cycle::new(vec![
+                HalfEdge::circle([0., 0.], 1., &mut core).insert(&mut core)
+            ])
+            .insert(&mut core),
             vec![],
             None,
         )
-        .insert(&mut core.services);
+        .insert(&mut core);
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![
             Face::new(
@@ -258,22 +260,22 @@ mod tests {
                     u: GlobalPath::circle_from_radius(1.),
                     v: [0., 1., 1.].into(),
                 })
-                .insert(&mut core.services),
+                .insert(&mut core),
                 shared_region.clone(),
             )
-            .insert(&mut core.services),
+            .insert(&mut core),
             Face::new(
                 Surface::new(SurfaceGeometry {
                     u: GlobalPath::circle_from_radius(1.),
                     v: [0., 0., 1.].into(),
                 })
-                .insert(&mut core.services),
+                .insert(&mut core),
                 shared_region.clone(),
             )
-            .insert(&mut core.services),
+            .insert(&mut core),
         ])
-        .insert(&mut core.services)])
-        .insert(&mut core.services);
+        .insert(&mut core)])
+        .insert(&mut core);
 
         assert_contains_err!(
             invalid_solid,
@@ -282,7 +284,7 @@ mod tests {
             ))
         );
 
-        let valid_solid = Solid::new(vec![]).insert(&mut core.services);
+        let valid_solid = Solid::new(vec![]).insert(&mut core);
         valid_solid.validate_and_return_first_error()?;
 
         core.services.validation.errors.clear();
@@ -295,9 +297,10 @@ mod tests {
         let mut core = Instance::new();
 
         let shared_cycle =
-            Cycle::new(vec![HalfEdge::circle([0., 0.], 1., &mut core)
-                .insert(&mut core.services)])
-            .insert(&mut core.services);
+            Cycle::new(vec![
+                HalfEdge::circle([0., 0.], 1., &mut core).insert(&mut core)
+            ])
+            .insert(&mut core);
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![
             Face::new(
@@ -305,24 +308,23 @@ mod tests {
                     u: GlobalPath::circle_from_radius(1.),
                     v: [0., 1., 1.].into(),
                 })
-                .insert(&mut core.services),
+                .insert(&mut core),
                 Region::new(shared_cycle.clone(), vec![], None)
-                    .insert(&mut core.services),
+                    .insert(&mut core),
             )
-            .insert(&mut core.services),
+            .insert(&mut core),
             Face::new(
                 Surface::new(SurfaceGeometry {
                     u: GlobalPath::circle_from_radius(1.),
                     v: [0., 0., 1.].into(),
                 })
-                .insert(&mut core.services),
-                Region::new(shared_cycle, vec![], None)
-                    .insert(&mut core.services),
+                .insert(&mut core),
+                Region::new(shared_cycle, vec![], None).insert(&mut core),
             )
-            .insert(&mut core.services),
+            .insert(&mut core),
         ])
-        .insert(&mut core.services)])
-        .insert(&mut core.services);
+        .insert(&mut core)])
+        .insert(&mut core);
 
         assert_contains_err!(
             invalid_solid,
@@ -331,7 +333,7 @@ mod tests {
             ))
         );
 
-        let valid_solid = Solid::new(vec![]).insert(&mut core.services);
+        let valid_solid = Solid::new(vec![]).insert(&mut core);
         valid_solid.validate_and_return_first_error()?;
 
         core.services.validation.errors.clear();
@@ -343,27 +345,25 @@ mod tests {
     fn should_find_half_edge_multiple_references() -> anyhow::Result<()> {
         let mut core = Instance::new();
 
-        let shared_edge = HalfEdge::circle([0., 0.], 1., &mut core)
-            .insert(&mut core.services);
+        let shared_edge =
+            HalfEdge::circle([0., 0.], 1., &mut core).insert(&mut core);
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![Face::new(
             Surface::new(SurfaceGeometry {
                 u: GlobalPath::circle_from_radius(1.),
                 v: [0., 0., 1.].into(),
             })
-            .insert(&mut core.services),
+            .insert(&mut core),
             Region::new(
-                Cycle::new(vec![shared_edge.clone()])
-                    .insert(&mut core.services),
-                vec![Cycle::new(vec![shared_edge.clone()])
-                    .insert(&mut core.services)],
+                Cycle::new(vec![shared_edge.clone()]).insert(&mut core),
+                vec![Cycle::new(vec![shared_edge.clone()]).insert(&mut core)],
                 None,
             )
-            .insert(&mut core.services),
+            .insert(&mut core),
         )
-        .insert(&mut core.services)])
-        .insert(&mut core.services)])
-        .insert(&mut core.services);
+        .insert(&mut core)])
+        .insert(&mut core)])
+        .insert(&mut core);
 
         assert_contains_err!(
             invalid_solid,
@@ -372,7 +372,7 @@ mod tests {
             ))
         );
 
-        let valid_solid = Solid::new(vec![]).insert(&mut core.services);
+        let valid_solid = Solid::new(vec![]).insert(&mut core);
         valid_solid.validate_and_return_first_error()?;
 
         core.services.validation.errors.clear();


### PR DESCRIPTION
This makes calling it more convenient (as all code already has a `&mut Instance` available directly, and with this change no longer has to access the field).

It also has the advantage of not exposing `Instance` internals to all code calling `insert`.

This comes out of my experimentation related to https://github.com/hannobraun/fornjot/issues/2117.