### PR TITLE
Further clean up layers code

### DIFF
--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -67,7 +67,7 @@ where
 /// the consumer of this trait's API.
 ///
 /// See [`Layer`] for a more detailed explanation.
-pub trait State {
+pub trait State: Sized {
     /// A command that encodes a request to update the state
     ///
     /// Commands are processed by [`State::decide`].

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -30,11 +30,10 @@ impl<S: State> Layer<S> {
     ///
     /// The command is processed synchronously. When this method returns, the
     /// state has been updated.
-    pub fn process(
-        &mut self,
-        command: S::Command,
-        events: &mut Vec<<S::Command as Command<S>>::Event>,
-    ) {
+    pub fn process<C>(&mut self, command: C, events: &mut Vec<C::Event>)
+    where
+        C: Command<S>,
+    {
         command.decide(&self.state, events);
 
         for event in events {

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -70,12 +70,7 @@ where
 /// the consumer of this trait's API.
 ///
 /// See [`Layer`] for a more detailed explanation.
-pub trait State: Sized {
-    /// A command that encodes a request to update the state
-    ///
-    /// Commands are processed by [`Command::decide`].
-    type Command: Command<Self>;
-}
+pub trait State: Sized {}
 
 /// A command that encodes a request to update a layer's state
 pub trait Command<S: State> {

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -34,7 +34,7 @@ impl<S: State> Layer<S> {
         self.state.decide(command, events);
 
         for event in events {
-            self.state.evolve(event);
+            event.evolve(&mut self.state);
         }
     }
 
@@ -76,7 +76,7 @@ pub trait State: Sized {
     /// An event that encodes a change to the state
     ///
     /// Events are produced by [`State::decide`] and processed by
-    /// [`State::evolve`].
+    /// [`Event::evolve`].
     type Event: Event<Self>;
 
     /// Decide how to react to the provided command
@@ -84,8 +84,11 @@ pub trait State: Sized {
     /// If the command must result in changes to the state, any number of events
     /// that describe these state changes can be produced.
     fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>);
+}
 
-    /// Evolve the state according to the provided event
+/// An event that encodes a change to a layer's state
+pub trait Event<S> {
+    /// Evolve the provided state
     ///
     /// This is the only method that gets mutable access to the state, making
     /// sure that all changes to the state are captured as events.
@@ -93,8 +96,5 @@ pub trait State: Sized {
     /// Implementations of this method are supposed to be relatively dumb. Any
     /// decisions that go into updating the state should be made in
     /// [`State::decide`], and encoded into the event.
-    fn evolve(&mut self, event: &Self::Event);
+    fn evolve(&self, state: &mut S);
 }
-
-/// An event that encodes a change to a layer's state
-pub trait Event<S> {}

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -80,8 +80,8 @@ pub trait Command<S> {
 pub trait Event<S> {
     /// Evolve the provided state
     ///
-    /// This is the only method that gets mutable access to the state, making
-    /// sure that all changes to the state are captured as events.
+    /// This is the only method that [`Layer`] gives mutable access to the
+    /// state, making sure that all changes to the state are captured as events.
     ///
     /// Implementations of this method are supposed to be relatively dumb. Any
     /// decisions that go into updating the state should be made in

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -95,3 +95,6 @@ pub trait State {
     /// [`State::decide`], and encoded into the event.
     fn evolve(&mut self, event: &Self::Event);
 }
+
+/// An event that encodes a change to a layer's state
+pub trait Event<S> {}

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -71,7 +71,7 @@ pub trait State: Sized {
     /// A command that encodes a request to update the state
     ///
     /// Commands are processed by [`State::decide`].
-    type Command;
+    type Command: Command<Self>;
 
     /// An event that encodes a change to the state
     ///

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -16,11 +16,11 @@ use std::ops::Deref;
 /// This design takes inspiration from, and uses the nomenclature of, this
 /// article:
 /// <https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider>
-pub struct Layer<S: State> {
+pub struct Layer<S> {
     state: S,
 }
 
-impl<S: State> Layer<S> {
+impl<S> Layer<S> {
     /// Create an instance of `Layer`
     pub fn new(state: S) -> Self {
         Self { state }
@@ -47,7 +47,7 @@ impl<S: State> Layer<S> {
     }
 }
 
-impl<S: State> Deref for Layer<S> {
+impl<S> Deref for Layer<S> {
     type Target = S;
 
     fn deref(&self) -> &Self::Target {
@@ -55,7 +55,7 @@ impl<S: State> Deref for Layer<S> {
     }
 }
 
-impl<S: State> Default for Layer<S>
+impl<S> Default for Layer<S>
 where
     S: Default,
 {

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -10,9 +10,6 @@ use std::ops::Deref;
 /// processed by [`Layer::process`]. Processing a command can result in any
 /// number of events, which can then be used as commands for other layers.
 ///
-/// All of this is mediated through [`State`], which the wrapped state must
-/// implement.
-///
 /// This design takes inspiration from, and uses the nomenclature of, this
 /// article:
 /// <https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider>
@@ -63,14 +60,6 @@ where
         Self::new(S::default())
     }
 }
-
-/// The state of a specific layer
-///
-/// Implementations of this trait are wrapped by the generic [`Layer`], which is
-/// the consumer of this trait's API.
-///
-/// See [`Layer`] for a more detailed explanation.
-pub trait State: Sized {}
 
 /// A command that encodes a request to update a layer's state
 pub trait Command<S> {

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -86,6 +86,9 @@ pub trait State: Sized {
     fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>);
 }
 
+/// A command that encodes a request to update a layer's state
+pub trait Command<S: State> {}
+
 /// An event that encodes a change to a layer's state
 pub trait Event<S> {
     /// Evolve the provided state

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -73,7 +73,7 @@ where
 pub trait State: Sized {}
 
 /// A command that encodes a request to update a layer's state
-pub trait Command<S: State> {
+pub trait Command<S> {
     /// An event that encodes a change to the state
     ///
     /// Events are produced by [`Command::decide`] and processed by

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -77,7 +77,7 @@ pub trait State: Sized {
     ///
     /// Events are produced by [`State::decide`] and processed by
     /// [`State::evolve`].
-    type Event;
+    type Event: Event<Self>;
 
     /// Decide how to react to the provided command
     ///

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -30,7 +30,11 @@ impl<S: State> Layer<S> {
     ///
     /// The command is processed synchronously. When this method returns, the
     /// state has been updated.
-    pub fn process(&mut self, command: S::Command, events: &mut Vec<S::Event>) {
+    pub fn process(
+        &mut self,
+        command: S::Command,
+        events: &mut Vec<<S::Command as Command<S>>::Event>,
+    ) {
         command.decide(&self.state, events);
 
         for event in events {
@@ -72,21 +76,21 @@ pub trait State: Sized {
     ///
     /// Commands are processed by [`Command::decide`].
     type Command: Command<Self>;
-
-    /// An event that encodes a change to the state
-    ///
-    /// Events are produced by [`Command::decide`] and processed by
-    /// [`Event::evolve`].
-    type Event: Event<Self>;
 }
 
 /// A command that encodes a request to update a layer's state
 pub trait Command<S: State> {
+    /// An event that encodes a change to the state
+    ///
+    /// Events are produced by [`Command::decide`] and processed by
+    /// [`Event::evolve`].
+    type Event: Event<S>;
+
     /// Decide which events to produce, given the command and provided state
     ///
     /// If the command must result in changes to the state, any number of events
     /// that describe these state changes can be produced.
-    fn decide(self, state: &S, events: &mut Vec<S::Event>);
+    fn decide(self, state: &S, events: &mut Vec<Self::Event>);
 }
 
 /// An event that encodes a change to a layer's state

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -21,7 +21,7 @@ use super::Layer;
 /// That can be changed, once necessary.
 #[derive(Default)]
 pub struct Layers {
-    /// The objects layers
+    /// The objects layer
     ///
     /// Manages the stores of topological and geometric objects that make up
     /// shapes.

--- a/crates/fj-core/src/layers/mod.rs
+++ b/crates/fj-core/src/layers/mod.rs
@@ -9,6 +9,6 @@ mod layer;
 mod layers;
 
 pub use self::{
-    layer::{Command, Event, Layer, State},
+    layer::{Command, Event, Layer},
     layers::Layers,
 };

--- a/crates/fj-core/src/layers/mod.rs
+++ b/crates/fj-core/src/layers/mod.rs
@@ -9,6 +9,6 @@ mod layer;
 mod layers;
 
 pub use self::{
-    layer::{Event, Layer, State},
+    layer::{Command, Event, Layer, State},
     layers::Layers,
 };

--- a/crates/fj-core/src/layers/mod.rs
+++ b/crates/fj-core/src/layers/mod.rs
@@ -9,6 +9,6 @@ mod layer;
 mod layers;
 
 pub use self::{
-    layer::{Layer, State},
+    layer::{Event, Layer, State},
     layers::Layers,
 };

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -5,7 +5,7 @@ use crate::{
     validate::Validation,
 };
 
-use super::{Event, Layer, State};
+use super::{Command, Event, Layer, State};
 
 impl Layer<Objects> {
     /// Insert and object into the stores
@@ -45,6 +45,8 @@ pub enum ObjectsCommand {
         object: AnyObject<AboutToBeStored>,
     },
 }
+
+impl Command<Objects> for ObjectsCommand {}
 
 /// Insert an object into the stores
 ///

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -31,11 +31,6 @@ impl State for Objects {
         let ObjectsCommand::InsertObject { object } = command;
         events.push(ObjectsEvent::InsertObject { object });
     }
-
-    fn evolve(&mut self, event: &Self::Event) {
-        let ObjectsEvent::InsertObject { object } = event;
-        object.clone().insert(self);
-    }
 }
 
 /// Command for `Layer<Objects>`
@@ -61,4 +56,9 @@ pub enum ObjectsEvent {
     },
 }
 
-impl Event<Objects> for ObjectsEvent {}
+impl Event<Objects> for ObjectsEvent {
+    fn evolve(&self, state: &mut Objects) {
+        let ObjectsEvent::InsertObject { object } = self;
+        object.clone().insert(state);
+    }
+}

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -26,11 +26,6 @@ impl Layer<Objects> {
 impl State for Objects {
     type Command = ObjectsCommand;
     type Event = InsertObject;
-
-    fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>) {
-        let ObjectsCommand::InsertObject { object } = command;
-        events.push(InsertObject { object });
-    }
 }
 
 /// Command for `Layer<Objects>`
@@ -46,7 +41,12 @@ pub enum ObjectsCommand {
     },
 }
 
-impl Command<Objects> for ObjectsCommand {}
+impl Command<Objects> for ObjectsCommand {
+    fn decide(self, _: &Objects, events: &mut Vec<<Objects as State>::Event>) {
+        let ObjectsCommand::InsertObject { object } = self;
+        events.push(InsertObject { object });
+    }
+}
 
 /// Insert an object into the stores
 ///

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -15,33 +15,11 @@ impl Layer<Objects> {
         validation: &mut Layer<Validation>,
     ) {
         let mut events = Vec::new();
-        self.process(ObjectsCommand::InsertObject { object }, &mut events);
+        self.process(InsertObject { object }, &mut events);
 
         for event in events {
             validation.process(event, &mut Vec::new());
         }
-    }
-}
-
-/// Command for `Layer<Objects>`
-#[derive(Debug)]
-pub enum ObjectsCommand {
-    /// Insert an object into the stores
-    ///
-    /// This is the one primitive operation that all other operations are built
-    /// upon.
-    InsertObject {
-        /// The object to insert
-        object: AnyObject<AboutToBeStored>,
-    },
-}
-
-impl Command<Objects> for ObjectsCommand {
-    type Event = InsertObject;
-
-    fn decide(self, _: &Objects, events: &mut Vec<Self::Event>) {
-        let ObjectsCommand::InsertObject { object } = self;
-        events.push(InsertObject { object });
     }
 }
 
@@ -52,6 +30,14 @@ impl Command<Objects> for ObjectsCommand {
 pub struct InsertObject {
     /// The object to insert
     pub object: AnyObject<AboutToBeStored>,
+}
+
+impl Command<Objects> for InsertObject {
+    type Event = InsertObject;
+
+    fn decide(self, _: &Objects, events: &mut Vec<Self::Event>) {
+        events.push(self);
+    }
 }
 
 impl Event<Objects> for InsertObject {

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -18,7 +18,7 @@ impl Layer<Objects> {
         self.process(ObjectsCommand::InsertObject { object }, &mut events);
 
         for event in events {
-            validation.on_objects_event(event);
+            validation.on_insert_object(event);
         }
     }
 }

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -29,7 +29,7 @@ impl State for Objects {
 
     fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>) {
         let ObjectsCommand::InsertObject { object } = command;
-        events.push(ObjectsEvent::InsertObject { object });
+        events.push(ObjectsEvent { object });
     }
 }
 
@@ -48,17 +48,13 @@ pub enum ObjectsCommand {
 
 /// Event produced by `Layer<Objects>`
 #[derive(Clone, Debug)]
-pub enum ObjectsEvent {
-    /// Insert an object into the stores
-    InsertObject {
-        /// The object to insert
-        object: AnyObject<AboutToBeStored>,
-    },
+pub struct ObjectsEvent {
+    /// The object to insert
+    pub object: AnyObject<AboutToBeStored>,
 }
 
 impl Event<Objects> for ObjectsEvent {
     fn evolve(&self, state: &mut Objects) {
-        let ObjectsEvent::InsertObject { object } = self;
-        object.clone().insert(state);
+        self.object.clone().insert(state);
     }
 }

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -5,7 +5,7 @@ use crate::{
     validate::Validation,
 };
 
-use super::{Command, Event, Layer, State};
+use super::{Command, Event, Layer};
 
 impl Layer<Objects> {
     /// Insert and object into the stores
@@ -22,8 +22,6 @@ impl Layer<Objects> {
         }
     }
 }
-
-impl State for Objects {}
 
 /// Command for `Layer<Objects>`
 #[derive(Debug)]

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -25,7 +25,6 @@ impl Layer<Objects> {
 
 impl State for Objects {
     type Command = ObjectsCommand;
-    type Event = InsertObject;
 }
 
 /// Command for `Layer<Objects>`
@@ -42,7 +41,9 @@ pub enum ObjectsCommand {
 }
 
 impl Command<Objects> for ObjectsCommand {
-    fn decide(self, _: &Objects, events: &mut Vec<<Objects as State>::Event>) {
+    type Event = InsertObject;
+
+    fn decide(self, _: &Objects, events: &mut Vec<Self::Event>) {
         let ObjectsCommand::InsertObject { object } = self;
         events.push(InsertObject { object });
     }

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -23,9 +23,7 @@ impl Layer<Objects> {
     }
 }
 
-impl State for Objects {
-    type Command = ObjectsCommand;
-}
+impl State for Objects {}
 
 /// Command for `Layer<Objects>`
 #[derive(Debug)]

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -25,11 +25,11 @@ impl Layer<Objects> {
 
 impl State for Objects {
     type Command = ObjectsCommand;
-    type Event = ObjectsEvent;
+    type Event = InsertObject;
 
     fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>) {
         let ObjectsCommand::InsertObject { object } = command;
-        events.push(ObjectsEvent { object });
+        events.push(InsertObject { object });
     }
 }
 
@@ -50,12 +50,12 @@ pub enum ObjectsCommand {
 ///
 /// Event produced by `Layer<Objects>`.
 #[derive(Clone, Debug)]
-pub struct ObjectsEvent {
+pub struct InsertObject {
     /// The object to insert
     pub object: AnyObject<AboutToBeStored>,
 }
 
-impl Event<Objects> for ObjectsEvent {
+impl Event<Objects> for InsertObject {
     fn evolve(&self, state: &mut Objects) {
         self.object.clone().insert(state);
     }

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -18,7 +18,7 @@ impl Layer<Objects> {
         self.process(ObjectsCommand::InsertObject { object }, &mut events);
 
         for event in events {
-            validation.on_insert_object(event);
+            validation.process(event, &mut Vec::new());
         }
     }
 }

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -5,7 +5,7 @@ use crate::{
     validate::Validation,
 };
 
-use super::{Layer, State};
+use super::{Event, Layer, State};
 
 impl Layer<Objects> {
     /// Insert and object into the stores
@@ -60,3 +60,5 @@ pub enum ObjectsEvent {
         object: AnyObject<AboutToBeStored>,
     },
 }
+
+impl Event<Objects> for ObjectsEvent {}

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -46,7 +46,9 @@ pub enum ObjectsCommand {
     },
 }
 
-/// Event produced by `Layer<Objects>`
+/// Insert an object into the stores
+///
+/// Event produced by `Layer<Objects>`.
 #[derive(Clone, Debug)]
 pub struct ObjectsEvent {
     /// The object to insert

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -8,7 +8,9 @@ use crate::{
 use super::{Command, Event, Layer};
 
 impl Layer<Objects> {
-    /// Insert and object into the stores
+    /// Insert an object into the stores
+    ///
+    /// Passes any events produced to the validation layer.
     pub fn insert(
         &mut self,
         object: AnyObject<AboutToBeStored>,
@@ -25,7 +27,8 @@ impl Layer<Objects> {
 
 /// Insert an object into the stores
 ///
-/// Event produced by `Layer<Objects>`.
+/// This struct serves as both event and command for `Layer<Objects>`, as well
+/// as a command for `Layer<Validation>`.
 #[derive(Clone, Debug)]
 pub struct InsertObject {
     /// The object to insert

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -10,8 +10,7 @@ use super::{objects::InsertObject, Command, Event, Layer};
 impl Layer<Validation> {
     /// Handler for [`InsertObject`]
     pub fn on_insert_object(&mut self, event: InsertObject) {
-        let command = event;
-        self.process(command, &mut Vec::new());
+        self.process(event, &mut Vec::new());
     }
 
     /// Consume the validation layer, returning any validation errors

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -43,17 +43,15 @@ impl Command<Validation> for ValidationCommand {
     fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
 
-        match self {
-            ValidationCommand::ValidateObject { object } => {
-                object.validate_with_config(&state.config, &mut errors);
+        let ValidationCommand::ValidateObject { object } = self;
 
-                for err in errors {
-                    events.push(ValidationFailed {
-                        object: object.clone(),
-                        err,
-                    });
-                }
-            }
+        object.validate_with_config(&state.config, &mut errors);
+
+        for err in errors {
+            events.push(ValidationFailed {
+                object: object.clone(),
+                err,
+            });
         }
     }
 }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -10,9 +10,7 @@ use super::{objects::InsertObject, Command, Event, Layer};
 impl Layer<Validation> {
     /// Handler for [`InsertObject`]
     pub fn on_insert_object(&mut self, event: InsertObject) {
-        let command = ValidationCommand::ValidateObject {
-            object: event.object.into(),
-        };
+        let command = event;
         self.process(command, &mut Vec::new());
     }
 
@@ -28,23 +26,13 @@ impl Layer<Validation> {
     }
 }
 
-/// Command for `Layer<Validation>`
-pub enum ValidationCommand {
-    /// Validate the provided object
-    ValidateObject {
-        /// The object to validate
-        object: AnyObject<Stored>,
-    },
-}
-
-impl Command<Validation> for ValidationCommand {
+impl Command<Validation> for InsertObject {
     type Event = ValidationFailed;
 
     fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
 
-        let ValidationCommand::ValidateObject { object } = self;
-
+        let object: AnyObject<Stored> = self.object.into();
         object.validate_with_config(&state.config, &mut errors);
 
         for err in errors {

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -75,10 +75,7 @@ pub enum ValidationEvent {
 
 impl Event<Validation> for ValidationEvent {
     fn evolve(&self, state: &mut Validation) {
-        match self {
-            ValidationEvent::ValidationFailed { object, err } => {
-                state.errors.insert(object.id(), err.clone());
-            }
-        }
+        let ValidationEvent::ValidationFailed { object, err } = self;
+        state.errors.insert(object.id(), err.clone());
     }
 }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -10,9 +10,8 @@ use super::{objects::ObjectsEvent, Event, Layer, State};
 impl Layer<Validation> {
     /// Handler for [`ObjectsEvent`]
     pub fn on_objects_event(&mut self, event: ObjectsEvent) {
-        let ObjectsEvent::InsertObject { object } = event;
         let command = ValidationCommand::ValidateObject {
-            object: object.into(),
+            object: event.object.into(),
         };
         self.process(command, &mut Vec::new());
     }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -60,7 +60,9 @@ pub enum ValidationCommand {
     },
 }
 
-/// Event produced by `Layer<Validation>`
+/// Validation of an object failed
+///
+/// Event produced by `Layer<Validation>`.
 #[derive(Clone)]
 pub struct ValidationEvent {
     /// The object for which validation failed

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -41,7 +41,7 @@ impl State for Validation {
                 object.validate_with_config(&self.config, &mut errors);
 
                 for err in errors {
-                    events.push(ValidationEvent::ValidationFailed {
+                    events.push(ValidationEvent {
                         object: object.clone(),
                         err,
                     });
@@ -62,20 +62,16 @@ pub enum ValidationCommand {
 
 /// Event produced by `Layer<Validation>`
 #[derive(Clone)]
-pub enum ValidationEvent {
-    /// Validation of an object failed
-    ValidationFailed {
-        /// The object for which validation failed
-        object: AnyObject<Stored>,
+pub struct ValidationEvent {
+    /// The object for which validation failed
+    pub object: AnyObject<Stored>,
 
-        /// The validation error
-        err: ValidationError,
-    },
+    /// The validation error
+    pub err: ValidationError,
 }
 
 impl Event<Validation> for ValidationEvent {
     fn evolve(&self, state: &mut Validation) {
-        let ValidationEvent::ValidationFailed { object, err } = self;
-        state.errors.insert(object.id(), err.clone());
+        state.errors.insert(self.object.id(), self.err.clone());
     }
 }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -8,11 +8,6 @@ use crate::{
 use super::{objects::InsertObject, Command, Event, Layer};
 
 impl Layer<Validation> {
-    /// Handler for [`InsertObject`]
-    pub fn on_insert_object(&mut self, event: InsertObject) {
-        self.process(event, &mut Vec::new());
-    }
-
     /// Consume the validation layer, returning any validation errors
     pub fn into_result(self) -> Result<(), ValidationErrors> {
         let errors = self.into_state().into_errors();

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -5,7 +5,7 @@ use crate::{
     validate::{Validation, ValidationError, ValidationErrors},
 };
 
-use super::{objects::InsertObject, Event, Layer, State};
+use super::{objects::InsertObject, Command, Event, Layer, State};
 
 impl Layer<Validation> {
     /// Handler for [`InsertObject`]
@@ -58,6 +58,8 @@ pub enum ValidationCommand {
         object: AnyObject<Stored>,
     },
 }
+
+impl Command<Validation> for ValidationCommand {}
 
 /// Validation of an object failed
 ///

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -5,7 +5,7 @@ use crate::{
     validate::{Validation, ValidationError, ValidationErrors},
 };
 
-use super::{objects::InsertObject, Command, Event, Layer, State};
+use super::{objects::InsertObject, Command, Event, Layer};
 
 impl Layer<Validation> {
     /// Handler for [`InsertObject`]
@@ -27,8 +27,6 @@ impl Layer<Validation> {
         }
     }
 }
-
-impl State for Validation {}
 
 /// Command for `Layer<Validation>`
 pub enum ValidationCommand {

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -9,7 +9,7 @@ use super::{objects::InsertObject, Event, Layer, State};
 
 impl Layer<Validation> {
     /// Handler for [`InsertObject`]
-    pub fn on_objects_event(&mut self, event: InsertObject) {
+    pub fn on_insert_object(&mut self, event: InsertObject) {
         let command = ValidationCommand::ValidateObject {
             object: event.object.into(),
         };

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -49,14 +49,6 @@ impl State for Validation {
             }
         }
     }
-
-    fn evolve(&mut self, event: &Self::Event) {
-        match event {
-            ValidationEvent::ValidationFailed { object, err } => {
-                self.errors.insert(object.id(), err.clone());
-            }
-        }
-    }
 }
 
 /// Command for `Layer<Validation>`
@@ -81,4 +73,12 @@ pub enum ValidationEvent {
     },
 }
 
-impl Event<Validation> for ValidationEvent {}
+impl Event<Validation> for ValidationEvent {
+    fn evolve(&self, state: &mut Validation) {
+        match self {
+            ValidationEvent::ValidationFailed { object, err } => {
+                state.errors.insert(object.id(), err.clone());
+            }
+        }
+    }
+}

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -31,7 +31,7 @@ impl Layer<Validation> {
 
 impl State for Validation {
     type Command = ValidationCommand;
-    type Event = ValidationEvent;
+    type Event = ValidationFailed;
 
     fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
@@ -41,7 +41,7 @@ impl State for Validation {
                 object.validate_with_config(&self.config, &mut errors);
 
                 for err in errors {
-                    events.push(ValidationEvent {
+                    events.push(ValidationFailed {
                         object: object.clone(),
                         err,
                     });
@@ -64,7 +64,7 @@ pub enum ValidationCommand {
 ///
 /// Event produced by `Layer<Validation>`.
 #[derive(Clone)]
-pub struct ValidationEvent {
+pub struct ValidationFailed {
     /// The object for which validation failed
     pub object: AnyObject<Stored>,
 
@@ -72,7 +72,7 @@ pub struct ValidationEvent {
     pub err: ValidationError,
 }
 
-impl Event<Validation> for ValidationEvent {
+impl Event<Validation> for ValidationFailed {
     fn evolve(&self, state: &mut Validation) {
         state.errors.insert(self.object.id(), self.err.clone());
     }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -28,9 +28,7 @@ impl Layer<Validation> {
     }
 }
 
-impl State for Validation {
-    type Command = ValidationCommand;
-}
+impl State for Validation {}
 
 /// Command for `Layer<Validation>`
 pub enum ValidationCommand {

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -30,7 +30,6 @@ impl Layer<Validation> {
 
 impl State for Validation {
     type Command = ValidationCommand;
-    type Event = ValidationFailed;
 }
 
 /// Command for `Layer<Validation>`
@@ -43,11 +42,9 @@ pub enum ValidationCommand {
 }
 
 impl Command<Validation> for ValidationCommand {
-    fn decide(
-        self,
-        state: &Validation,
-        events: &mut Vec<<Validation as State>::Event>,
-    ) {
+    type Event = ValidationFailed;
+
+    fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
 
         match self {

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -5,7 +5,7 @@ use crate::{
     validate::{Validation, ValidationError, ValidationErrors},
 };
 
-use super::{objects::ObjectsEvent, Layer, State};
+use super::{objects::ObjectsEvent, Event, Layer, State};
 
 impl Layer<Validation> {
     /// Handler for [`ObjectsEvent`]
@@ -80,3 +80,5 @@ pub enum ValidationEvent {
         err: ValidationError,
     },
 }
+
+impl Event<Validation> for ValidationEvent {}

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -5,11 +5,11 @@ use crate::{
     validate::{Validation, ValidationError, ValidationErrors},
 };
 
-use super::{objects::ObjectsEvent, Event, Layer, State};
+use super::{objects::InsertObject, Event, Layer, State};
 
 impl Layer<Validation> {
-    /// Handler for [`ObjectsEvent`]
-    pub fn on_objects_event(&mut self, event: ObjectsEvent) {
+    /// Handler for [`InsertObject`]
+    pub fn on_objects_event(&mut self, event: InsertObject) {
         let command = ValidationCommand::ValidateObject {
             object: event.object.into(),
         };

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -31,23 +31,6 @@ impl Layer<Validation> {
 impl State for Validation {
     type Command = ValidationCommand;
     type Event = ValidationFailed;
-
-    fn decide(&self, command: Self::Command, events: &mut Vec<Self::Event>) {
-        let mut errors = Vec::new();
-
-        match command {
-            ValidationCommand::ValidateObject { object } => {
-                object.validate_with_config(&self.config, &mut errors);
-
-                for err in errors {
-                    events.push(ValidationFailed {
-                        object: object.clone(),
-                        err,
-                    });
-                }
-            }
-        }
-    }
 }
 
 /// Command for `Layer<Validation>`
@@ -59,7 +42,28 @@ pub enum ValidationCommand {
     },
 }
 
-impl Command<Validation> for ValidationCommand {}
+impl Command<Validation> for ValidationCommand {
+    fn decide(
+        self,
+        state: &Validation,
+        events: &mut Vec<<Validation as State>::Event>,
+    ) {
+        let mut errors = Vec::new();
+
+        match self {
+            ValidationCommand::ValidateObject { object } => {
+                object.validate_with_config(&state.config, &mut errors);
+
+                for err in errors {
+                    events.push(ValidationFailed {
+                        object: object.clone(),
+                        err,
+                    });
+                }
+            }
+        }
+    }
+}
 
 /// Validation of an object failed
 ///


### PR DESCRIPTION
Remove the `State` trait, introducing `Command` and `Event` to replace it, and streamline the command and event used.

In addition to streamlining the `layers` code, the new `Command` trait prepares for commands having a direct return value (in addition to affecting the layer state via events), which wasn't possible under the old structure.

This change is required to make further progress on #2117.