### PR TITLE
Enable layer commands to directly return results

### DIFF
--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -63,6 +63,14 @@ where
 
 /// A command that encodes a request to update a layer's state
 pub trait Command<S> {
+    /// The direct result of processing a command that is returned to the caller
+    ///
+    /// Changes to the state that result from a command are encoded as events
+    /// (see [`Command::Event`]). In addition to that, a command may return
+    /// information to the caller, and `Result` defines the type of that
+    /// information.
+    type Result;
+
     /// An event that encodes a change to the state
     ///
     /// Events are produced by [`Command::decide`] and processed by

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -81,7 +81,7 @@ pub trait Command<S> {
     ///
     /// If the command must result in changes to the state, any number of events
     /// that describe these state changes can be produced.
-    fn decide(self, state: &S, events: &mut Vec<Self::Event>);
+    fn decide(self, state: &S, events: &mut Vec<Self::Event>) -> Self::Result;
 }
 
 /// An event that encodes a change to a layer's state

--- a/crates/fj-core/src/layers/layer.rs
+++ b/crates/fj-core/src/layers/layer.rs
@@ -27,15 +27,21 @@ impl<S> Layer<S> {
     ///
     /// The command is processed synchronously. When this method returns, the
     /// state has been updated.
-    pub fn process<C>(&mut self, command: C, events: &mut Vec<C::Event>)
+    pub fn process<C>(
+        &mut self,
+        command: C,
+        events: &mut Vec<C::Event>,
+    ) -> C::Result
     where
         C: Command<S>,
     {
-        command.decide(&self.state, events);
+        let result = command.decide(&self.state, events);
 
         for event in events {
             event.evolve(&mut self.state);
         }
+
+        result
     }
 
     /// Drop this instance, returning the wrapped state

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -36,6 +36,7 @@ pub struct InsertObject {
 }
 
 impl Command<Objects> for InsertObject {
+    type Result = ();
     type Event = InsertObject;
 
     fn decide(self, _: &Objects, events: &mut Vec<Self::Event>) {

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -21,6 +21,7 @@ impl Layer<Validation> {
 }
 
 impl Command<Validation> for InsertObject {
+    type Result = ();
     type Event = ValidationFailed;
 
     fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {


### PR DESCRIPTION
Build on top of https://github.com/hannobraun/fornjot/pull/2214 to provide the ability for layer commands to directly return results. So far, the only effect a command could have was to generate events to update a layer's state. Now they can additionally return information to the caller directly.

This is a capability I need (and am going to use in a follow-up pull request) to make progress on https://github.com/hannobraun/fornjot/issues/2117.