### PR TITLE
Don't require dropping validation layer to handle validation errors

### DIFF
--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -8,6 +8,11 @@ use crate::{
 use super::{objects::InsertObject, Command, Event, Layer};
 
 impl Layer<Validation> {
+    /// Take all errors stored in the validation layer
+    pub fn take_errors(&mut self) -> Result<(), ValidationErrors> {
+        self.process(TakeErrors, &mut Vec::new())
+    }
+
     /// Consume the validation layer, returning any validation errors
     pub fn into_result(self) -> Result<(), ValidationErrors> {
         let errors = self.into_state().into_errors();

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -12,17 +12,6 @@ impl Layer<Validation> {
     pub fn take_errors(&mut self) -> Result<(), ValidationErrors> {
         self.process(TakeErrors, &mut Vec::new())
     }
-
-    /// Consume the validation layer, returning any validation errors
-    pub fn into_result(self) -> Result<(), ValidationErrors> {
-        let errors = self.into_state().into_errors();
-
-        if errors.0.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
-    }
 }
 
 impl Command<Validation> for InsertObject {

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -119,11 +119,6 @@ impl Validation {
         let errors = HashMap::new();
         Self { errors, config }
     }
-
-    /// Drop this instance, returning the errors it contained
-    pub fn into_errors(mut self) -> ValidationErrors {
-        ValidationErrors(self.errors.drain().map(|(_, error)| error).collect())
-    }
 }
 
 impl Drop for Validation {

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -236,7 +236,7 @@ mod tests {
         valid_solid.validate_and_return_first_error()?;
 
         // Ignore remaining validation errors.
-        let _ = core.layers.validation.into_result();
+        let _ = core.layers.validation.take_errors();
 
         Ok(())
     }
@@ -289,7 +289,7 @@ mod tests {
         valid_solid.validate_and_return_first_error()?;
 
         // Ignore remaining validation errors.
-        let _ = core.layers.validation.into_result();
+        let _ = core.layers.validation.take_errors();
 
         Ok(())
     }
@@ -339,7 +339,7 @@ mod tests {
         valid_solid.validate_and_return_first_error()?;
 
         // Ignore remaining validation errors.
-        let _ = core.layers.validation.into_result();
+        let _ = core.layers.validation.take_errors();
 
         Ok(())
     }
@@ -379,7 +379,7 @@ mod tests {
         valid_solid.validate_and_return_first_error()?;
 
         // Ignore remaining validation errors.
-        let _ = core.layers.validation.into_result();
+        let _ = core.layers.validation.take_errors();
 
         Ok(())
     }

--- a/crates/fj/src/handle_model.rs
+++ b/crates/fj/src/handle_model.rs
@@ -23,7 +23,7 @@ use crate::Args;
 ///
 /// This function is used by Fornjot's own testing infrastructure, but is useful
 /// beyond that, when using Fornjot directly to define a model.
-pub fn handle_model<M>(model: &M, core: Instance) -> Result
+pub fn handle_model<M>(model: &M, mut core: Instance) -> Result
 where
     for<'r> (&'r M, Tolerance): Triangulate,
     M: BoundingVolume<3>,
@@ -36,7 +36,7 @@ where
     let args = Args::parse();
 
     if !args.ignore_validation {
-        core.layers.validation.into_result()?;
+        core.layers.validation.take_errors()?;
     }
 
     let aabb = model.aabb().unwrap_or(Aabb {


### PR DESCRIPTION
Build on top of https://github.com/hannobraun/fornjot/pull/2215 to implement a command that takes all errors out of the validation layer. Before, you needed to drop the validation layer to handle validation errors, which is no longer necessary. That makes code doing this more flexible (as dropping the validation layer made `fj_core::Instance` unusable), which I need to make progress on https://github.com/hannobraun/fornjot/issues/2117.