### PR TITLE
Add presentation layer

### DIFF
--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -1,5 +1,6 @@
 use crate::{
     objects::Objects,
+    presentation::Presentation,
     validate::{Validation, ValidationConfig},
 };
 
@@ -31,6 +32,11 @@ pub struct Layers {
     ///
     /// Monitors objects and validates them, as they are inserted.
     pub validation: Layer<Validation>,
+
+    /// The presentation layer
+    ///
+    /// Stores data concerning the presentation of objects.
+    pub presentation: Layer<Presentation>,
 }
 
 impl Layers {

--- a/crates/fj-core/src/layers/mod.rs
+++ b/crates/fj-core/src/layers/mod.rs
@@ -3,6 +3,7 @@
 //! See [`Layers`].
 
 pub mod objects;
+pub mod presentation;
 pub mod validation;
 
 mod layer;

--- a/crates/fj-core/src/layers/presentation.rs
+++ b/crates/fj-core/src/layers/presentation.rs
@@ -1,0 +1,104 @@
+//! Layer infrastructure for [`Presentation`]
+
+use fj_interop::Color;
+
+use crate::{
+    objects::{AnyObject, Region, Stored},
+    presentation::Presentation,
+    storage::Handle,
+};
+
+use super::{Command, Event, Layer};
+
+impl Layer<Presentation> {
+    /// Set the color of a region
+    pub fn set_color(&mut self, region: Handle<Region>, color: Color) {
+        let mut events = Vec::new();
+        self.process(SetColor { region, color }, &mut events);
+    }
+
+    /// Mark an object as being derived from another
+    pub fn derive_object(
+        &mut self,
+        original: AnyObject<Stored>,
+        derived: AnyObject<Stored>,
+    ) {
+        let mut events = Vec::new();
+        self.process(DeriveObject { original, derived }, &mut events);
+    }
+}
+
+/// Set the color of a region
+pub struct SetColor {
+    /// The region to set the color for
+    region: Handle<Region>,
+
+    /// The color to set
+    color: Color,
+}
+
+impl Command<Presentation> for SetColor {
+    type Result = ();
+    type Event = Self;
+
+    fn decide(
+        self,
+        _: &Presentation,
+        events: &mut Vec<Self::Event>,
+    ) -> Self::Result {
+        events.push(self);
+    }
+}
+
+impl Event<Presentation> for SetColor {
+    fn evolve(&self, state: &mut Presentation) {
+        state.color.insert(self.region.clone(), self.color);
+    }
+}
+
+/// Handle an object being derived from another
+pub struct DeriveObject {
+    /// The original object
+    original: AnyObject<Stored>,
+
+    /// The derived object
+    derived: AnyObject<Stored>,
+}
+
+impl Command<Presentation> for DeriveObject {
+    type Result = ();
+    type Event = SetColor;
+
+    fn decide(
+        self,
+        state: &Presentation,
+        events: &mut Vec<Self::Event>,
+    ) -> Self::Result {
+        if let (AnyObject::Region(original), AnyObject::Region(derived)) =
+            (self.original, self.derived)
+        {
+            if let Some(color) = state.color.get(&original.0).cloned() {
+                events.push(SetColor {
+                    region: derived.into(),
+                    color,
+                });
+            }
+        }
+    }
+}
+
+/// Command for `Layer<Presentation>`
+pub enum PresentationCommand {}
+
+/// Event produced by `Layer<Presentation>`
+#[derive(Clone)]
+pub enum PresentationEvent {
+    /// The color of a region is being set
+    SetColor {
+        /// The region the color is being set for
+        region: Handle<Region>,
+
+        /// The color being set
+        color: Color,
+    },
+}

--- a/crates/fj-core/src/lib.rs
+++ b/crates/fj-core/src/lib.rs
@@ -86,6 +86,7 @@ pub mod geometry;
 pub mod layers;
 pub mod objects;
 pub mod operations;
+pub mod presentation;
 pub mod queries;
 pub mod storage;
 pub mod validate;

--- a/crates/fj-core/src/operations/derive.rs
+++ b/crates/fj-core/src/operations/derive.rs
@@ -18,9 +18,10 @@ impl<T> DeriveFrom for Handle<T>
 where
     Self: Into<AnyObject<Stored>>,
 {
-    fn derive_from(self, _other: &Self, _core: &mut Core) -> Self {
-        // This is currently a no-op. Eventually, it will trigger a command to
-        // the layers that this information is relevant for.
+    fn derive_from(self, other: &Self, core: &mut Core) -> Self {
+        core.layers
+            .presentation
+            .derive_object(other.clone().into(), self.clone().into());
         self
     }
 }

--- a/crates/fj-core/src/operations/derive.rs
+++ b/crates/fj-core/src/operations/derive.rs
@@ -2,7 +2,11 @@
 //!
 //! See [`DeriveFrom`].
 
-use crate::{storage::Handle, Core};
+use crate::{
+    objects::{AnyObject, Stored},
+    storage::Handle,
+    Core,
+};
 
 /// Mark a store object as derived from another
 pub trait DeriveFrom {
@@ -10,7 +14,10 @@ pub trait DeriveFrom {
     fn derive_from(self, other: &Self, core: &mut Core) -> Self;
 }
 
-impl<T> DeriveFrom for Handle<T> {
+impl<T> DeriveFrom for Handle<T>
+where
+    Self: Into<AnyObject<Stored>>,
+{
     fn derive_from(self, _other: &Self, _core: &mut Core) -> Self {
         // This is currently a no-op. Eventually, it will trigger a command to
         // the layers that this information is relevant for.

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -15,10 +15,12 @@ pub trait SetColor: IsObject {
 
 impl SetColor for Handle<Region> {
     fn set_color(&self, color: impl Into<Color>) -> Self::BareObject {
+        let color = color.into();
+
         Region::new(
             self.exterior().clone(),
             self.interiors().into_iter().cloned(),
-            Some(color.into()),
+            Some(color),
         )
     }
 }

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -22,9 +22,11 @@ impl SetColor for Handle<Region> {
     fn set_color(
         &self,
         color: impl Into<Color>,
-        _core: &mut Core,
+        core: &mut Core,
     ) -> Self::BareObject {
         let color = color.into();
+
+        core.layers.presentation.set_color(self.clone(), color);
 
         Region::new(
             self.exterior().clone(),

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -5,16 +5,25 @@ use fj_interop::Color;
 use crate::{
     objects::{IsObject, Region},
     storage::Handle,
+    Core,
 };
 
 /// Set the color of an object
 pub trait SetColor: IsObject {
     /// Set the color of the object
-    fn set_color(&self, color: impl Into<Color>) -> Self::BareObject;
+    fn set_color(
+        &self,
+        color: impl Into<Color>,
+        core: &mut Core,
+    ) -> Self::BareObject;
 }
 
 impl SetColor for Handle<Region> {
-    fn set_color(&self, color: impl Into<Color>) -> Self::BareObject {
+    fn set_color(
+        &self,
+        color: impl Into<Color>,
+        _core: &mut Core,
+    ) -> Self::BareObject {
         let color = color.into();
 
         Region::new(

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -151,7 +151,7 @@ impl SplitFace for Shell {
 
                 if let Some(color) = face.region().color() {
                     region = region
-                        .set_color(color)
+                        .set_color(color, core)
                         .insert(core)
                         .derive_from(&region, core);
                 }
@@ -194,7 +194,7 @@ impl SplitFace for Shell {
 
                 if let Some(color) = face.region().color() {
                     region = region
-                        .set_color(color)
+                        .set_color(color, core)
                         .insert(core)
                         .derive_from(&region, core);
                 }

--- a/crates/fj-core/src/operations/transform/mod.rs
+++ b/crates/fj-core/src/operations/transform/mod.rs
@@ -16,6 +16,7 @@ use fj_math::{Transform, Vector};
 use type_map::TypeMap;
 
 use crate::{
+    objects::{AnyObject, Stored},
     operations::insert::Insert,
     storage::{Handle, ObjectId},
     Core,
@@ -69,6 +70,7 @@ pub trait TransformObject: Sized {
 impl<T> TransformObject for Handle<T>
 where
     T: Clone + Insert<Inserted = Handle<T>> + TransformObject + 'static,
+    Handle<T>: Into<AnyObject<Stored>>,
 {
     fn transform_with_cache(
         &self,

--- a/crates/fj-core/src/presentation.rs
+++ b/crates/fj-core/src/presentation.rs
@@ -1,0 +1,26 @@
+//! Presentation data for the object graph
+//!
+//! See [`Presentation`].
+
+use std::collections::BTreeMap;
+
+use fj_interop::Color;
+
+use crate::{objects::Region, storage::Handle};
+
+/// Presentation data for the object graph
+///
+/// Assigns attributes relating to the presentation of objects (currently just a
+/// color) to those objects (currently only to regions).
+///
+/// This data is made available through [`Layers`].
+///
+/// [`Layers`]: crate::layers::Layers
+#[derive(Default)]
+pub struct Presentation {
+    /// Color assigned to regions
+    ///
+    /// Having a color is optional, so map does not necessarily contain
+    /// assignments for all existing regions.
+    pub color: BTreeMap<Handle<Region>, Color>,
+}

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -18,7 +18,7 @@ pub fn model(core: &mut fj::core::Core) -> Solid {
                 shell.faces().first(),
                 |face, core| {
                     [face.update_region(
-                        |region, _| region.set_color([0., 1., 0.]),
+                        |region, core| region.set_color([0., 1., 0.], core),
                         core,
                     )]
                 },


### PR DESCRIPTION
This adds a presentation layer to store presentation data for objects, as proposed in https://github.com/hannobraun/fornjot/issues/2117. The presentation layer is being updated with the correct data in the the correct places, but the data in there isn't actually used for anything yet. Doing so is a bit more involved (making sure the presentation layer is available in the right places), and therefore left to a follow-up PR.