### PR TITLE
Start cleanup of validation infrastructure

### DIFF
--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -9,7 +9,7 @@ use fj_interop::Color;
 use crate::{
     objects::{Face, Handedness, ObjectSet},
     operations::presentation::GetColor,
-    validate::ValidationConfig,
+    validation::ValidationConfig,
     Core,
 };
 

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`Core`].
 
-use crate::{layers::Layers, validate::ValidationConfig};
+use crate::{layers::Layers, validation::ValidationConfig};
 
 /// An instance of the Fornjot core
 ///

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -1,7 +1,6 @@
 use crate::{
-    objects::Objects,
-    presentation::Presentation,
-    validate::{Validation, ValidationConfig},
+    objects::Objects, presentation::Presentation, validate::Validation,
+    validation::ValidationConfig,
 };
 
 use super::Layer;

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -1,6 +1,7 @@
 use crate::{
-    objects::Objects, presentation::Presentation, validate::Validation,
-    validation::ValidationConfig,
+    objects::Objects,
+    presentation::Presentation,
+    validation::{Validation, ValidationConfig},
 };
 
 use super::Layer;

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     objects::{AboutToBeStored, AnyObject, Objects},
-    validate::Validation,
+    validation::Validation,
 };
 
 use super::{Command, Event, Layer};

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     objects::{AnyObject, Stored},
-    validate::{Validation, ValidationErrors},
-    validation::ValidationError,
+    validate::Validation,
+    validation::{ValidationError, ValidationErrors},
 };
 
 use super::{objects::InsertObject, Command, Event, Layer};

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -2,8 +2,7 @@
 
 use crate::{
     objects::{AnyObject, Stored},
-    validate::Validation,
-    validation::{ValidationError, ValidationErrors},
+    validation::{Validation, ValidationError, ValidationErrors},
 };
 
 use super::{objects::InsertObject, Command, Event, Layer};

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     objects::{AnyObject, Stored},
-    validate::{Validation, ValidationError, ValidationErrors},
+    validate::{Validation, ValidationErrors},
+    validation::ValidationError,
 };
 
 use super::{objects::InsertObject, Command, Event, Layer};

--- a/crates/fj-core/src/lib.rs
+++ b/crates/fj-core/src/lib.rs
@@ -90,6 +90,7 @@ pub mod presentation;
 pub mod queries;
 pub mod storage;
 pub mod validate;
+pub mod validation;
 
 mod core;
 

--- a/crates/fj-core/src/objects/any_object.rs
+++ b/crates/fj-core/src/objects/any_object.rs
@@ -4,7 +4,8 @@ use crate::{
         Surface, Vertex,
     },
     storage::{Handle, HandleWrapper, ObjectId},
-    validate::{Validate, ValidationConfig, ValidationError},
+    validate::{Validate, ValidationConfig},
+    validation::ValidationError,
 };
 
 macro_rules! any_object {

--- a/crates/fj-core/src/objects/any_object.rs
+++ b/crates/fj-core/src/objects/any_object.rs
@@ -4,8 +4,8 @@ use crate::{
         Surface, Vertex,
     },
     storage::{Handle, HandleWrapper, ObjectId},
-    validate::{Validate, ValidationConfig},
-    validation::ValidationError,
+    validate::Validate,
+    validation::{ValidationConfig, ValidationError},
 };
 
 macro_rules! any_object {

--- a/crates/fj-core/src/validate/curve.rs
+++ b/crates/fj-core/src/validate/curve.rs
@@ -1,6 +1,6 @@
-use crate::objects::Curve;
+use crate::{objects::Curve, validation::ValidationError};
 
-use super::{Validate, ValidationConfig, ValidationError};
+use super::{Validate, ValidationConfig};
 
 impl Validate for Curve {
     fn validate_with_config(

--- a/crates/fj-core/src/validate/curve.rs
+++ b/crates/fj-core/src/validate/curve.rs
@@ -1,6 +1,9 @@
-use crate::{objects::Curve, validation::ValidationError};
+use crate::{
+    objects::Curve,
+    validation::{ValidationConfig, ValidationError},
+};
 
-use super::{Validate, ValidationConfig};
+use super::Validate;
 
 impl Validate for Curve {
     fn validate_with_config(

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -3,9 +3,10 @@ use fj_math::{Point, Scalar};
 use crate::{
     objects::{Cycle, HalfEdge},
     storage::Handle,
+    validation::ValidationError,
 };
 
-use super::{Validate, ValidationConfig, ValidationError};
+use super::{Validate, ValidationConfig};
 
 impl Validate for Cycle {
     fn validate_with_config(
@@ -83,7 +84,8 @@ mod tests {
             build::{BuildCycle, BuildHalfEdge},
             update::UpdateCycle,
         },
-        validate::{cycle::CycleValidationError, Validate, ValidationError},
+        validate::{cycle::CycleValidationError, Validate},
+        validation::ValidationError,
         Core,
     };
 

--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -3,10 +3,10 @@ use fj_math::{Point, Scalar};
 use crate::{
     objects::{Cycle, HalfEdge},
     storage::Handle,
-    validation::ValidationError,
+    validation::{ValidationConfig, ValidationError},
 };
 
-use super::{Validate, ValidationConfig};
+use super::Validate;
 
 impl Validate for Cycle {
     fn validate_with_config(

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -1,8 +1,8 @@
 use fj_math::{Point, Scalar};
 
-use crate::objects::HalfEdge;
+use crate::{objects::HalfEdge, validation::ValidationError};
 
-use super::{Validate, ValidationConfig, ValidationError};
+use super::{Validate, ValidationConfig};
 
 impl Validate for HalfEdge {
     fn validate_with_config(
@@ -70,7 +70,8 @@ mod tests {
         assert_contains_err,
         objects::HalfEdge,
         operations::build::BuildHalfEdge,
-        validate::{EdgeValidationError, Validate, ValidationError},
+        validate::{EdgeValidationError, Validate},
+        validation::ValidationError,
         Core,
     };
 

--- a/crates/fj-core/src/validate/edge.rs
+++ b/crates/fj-core/src/validate/edge.rs
@@ -1,8 +1,11 @@
 use fj_math::{Point, Scalar};
 
-use crate::{objects::HalfEdge, validation::ValidationError};
+use crate::{
+    objects::HalfEdge,
+    validation::{ValidationConfig, ValidationError},
+};
 
-use super::{Validate, ValidationConfig};
+use super::Validate;
 
 impl Validate for HalfEdge {
     fn validate_with_config(

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -1,8 +1,11 @@
 use fj_math::Winding;
 
-use crate::{objects::Face, validation::ValidationError};
+use crate::{
+    objects::Face,
+    validation::{ValidationConfig, ValidationError},
+};
 
-use super::{Validate, ValidationConfig};
+use super::Validate;
 
 impl Validate for Face {
     fn validate_with_config(

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -1,8 +1,8 @@
 use fj_math::Winding;
 
-use crate::objects::Face;
+use crate::{objects::Face, validation::ValidationError};
 
-use super::{Validate, ValidationConfig, ValidationError};
+use super::{Validate, ValidationConfig};
 
 impl Validate for Face {
     fn validate_with_config(
@@ -94,7 +94,8 @@ mod tests {
             reverse::Reverse,
             update::{UpdateCycle, UpdateFace, UpdateRegion},
         },
-        validate::{FaceValidationError, Validate, ValidationError},
+        validate::{FaceValidationError, Validate},
+        validation::ValidationError,
         Core,
     };
 

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -60,6 +60,11 @@
 //! [`Validate::validate_with_config`] and [`ValidationConfig`].
 //!
 //!
+//! ## Implementation Note
+//!
+//! This module is in the process of being replaced. See [`crate::validation`].
+//!
+//!
 //! [`fj-export`]: https://crates.io/crates/fj-export
 //! [issue tracker]: https://github.com/hannobraun/fornjot/issues
 //! [`Layers`]: crate::layers::Layers

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -8,7 +8,7 @@
 //! An object that meets all the requirement for its kind is considered
 //! **valid**. An object that does not meet all of them is considered
 //! **invalid**. This results in a **validation error**, which is represented by
-//! [`ValidationError`].
+//! `ValidationError`.
 //!
 //! Every single requirement is checked by a dedicated function. These functions
 //! are called **validation checks**. Validation checks are currently not
@@ -76,7 +76,7 @@ mod solid;
 mod surface;
 mod vertex;
 
-use crate::storage::ObjectId;
+use crate::{storage::ObjectId, validation::ValidationError};
 
 pub use self::{
     cycle::CycleValidationError, edge::EdgeValidationError,
@@ -84,9 +84,7 @@ pub use self::{
     sketch::SketchValidationError, solid::SolidValidationError,
 };
 
-use std::{
-    collections::HashMap, convert::Infallible, error::Error, fmt, thread,
-};
+use std::{collections::HashMap, error::Error, fmt, thread};
 
 use fj_math::Scalar;
 
@@ -210,40 +208,6 @@ impl Default for ValidationConfig {
             // adjust it.
             identical_max_distance: Scalar::from_f64(5e-14),
         }
-    }
-}
-
-/// An error that can occur during a validation
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum ValidationError {
-    /// `Cycle` validation error
-    #[error("`Cycle` validation error")]
-    Cycle(#[from] CycleValidationError),
-
-    /// `Edge` validation error
-    #[error("`Edge` validation error")]
-    Edge(#[from] EdgeValidationError),
-
-    /// `Face` validation error
-    #[error("`Face` validation error")]
-    Face(#[from] FaceValidationError),
-
-    /// `Shell` validation error
-    #[error("`Shell` validation error")]
-    Shell(#[from] ShellValidationError),
-
-    /// `Solid` validation error
-    #[error("`Solid` validation error")]
-    Solid(#[from] SolidValidationError),
-
-    /// `Sketch` validation error
-    #[error("`Sketch` validation error")]
-    Sketch(#[from] SketchValidationError),
-}
-
-impl From<Infallible> for ValidationError {
-    fn from(infallible: Infallible) -> Self {
-        match infallible {}
     }
 }
 

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -81,7 +81,7 @@ pub use self::{
     sketch::SketchValidationError, solid::SolidValidationError,
 };
 
-use std::{collections::HashMap, error::Error, fmt, thread};
+use std::{collections::HashMap, error::Error, thread};
 
 use fj_math::Scalar;
 
@@ -205,23 +205,5 @@ impl Default for ValidationConfig {
             // adjust it.
             identical_max_distance: Scalar::from_f64(5e-14),
         }
-    }
-}
-
-/// A collection of validation errors
-#[derive(Debug, thiserror::Error)]
-pub struct ValidationErrors(pub Vec<ValidationError>);
-
-impl fmt::Display for ValidationErrors {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let num_errors = self.0.len();
-
-        writeln!(f, "{num_errors} unhandled validation errors:")?;
-
-        for err in &self.0 {
-            writeln!(f, "{err}")?;
-        }
-
-        Ok(())
     }
 }

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -1,14 +1,6 @@
 //! # Infrastructure for validating objects
 //!
-//! ## Structure and Nomenclature
-//!
-//! **Validation** is the process of checking that objects meet specific
-//! requirements. Each kind of object has its own set of requirements.
-//!
-//! An object that meets all the requirement for its kind is considered
-//! **valid**. An object that does not meet all of them is considered
-//! **invalid**. This results in a **validation error**, which is represented by
-//! `ValidationError`.
+//! ## Structure
 //!
 //! Every single requirement is checked by a dedicated function. These functions
 //! are called **validation checks**. Validation checks are currently not

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -73,7 +73,10 @@ mod solid;
 mod surface;
 mod vertex;
 
-use crate::{storage::ObjectId, validation::ValidationError};
+use crate::{
+    storage::ObjectId,
+    validation::{ValidationConfig, ValidationError},
+};
 
 pub use self::{
     cycle::CycleValidationError, edge::EdgeValidationError,
@@ -82,8 +85,6 @@ pub use self::{
 };
 
 use std::{collections::HashMap, error::Error, thread};
-
-use fj_math::Scalar;
 
 /// Assert that some object has a validation error which matches a specific
 /// pattern. This is preferred to matching on [`Validate::validate_and_return_first_error`], since usually we don't care about the order.
@@ -174,36 +175,4 @@ pub trait Validate: Sized {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     );
-}
-
-/// Configuration required for the validation process
-#[derive(Debug, Clone, Copy)]
-pub struct ValidationConfig {
-    /// The minimum distance between distinct objects
-    ///
-    /// Objects whose distance is less than the value defined in this field, are
-    /// considered identical.
-    pub distinct_min_distance: Scalar,
-
-    /// The maximum distance between identical objects
-    ///
-    /// Objects that are considered identical might still have a distance
-    /// between them, due to inaccuracies of the numerical representation. If
-    /// that distance is less than the one defined in this field, can not be
-    /// considered identical.
-    pub identical_max_distance: Scalar,
-}
-
-impl Default for ValidationConfig {
-    fn default() -> Self {
-        Self {
-            distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
-
-            // This value was chosen pretty arbitrarily. Seems small enough to
-            // catch errors. If it turns out it's too small (because it produces
-            // false positives due to floating-point accuracy issues), we can
-            // adjust it.
-            identical_max_distance: Scalar::from_f64(5e-14),
-        }
-    }
 }

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -1,0 +1,33 @@
+use fj_math::Scalar;
+
+/// Configuration required for the validation process
+#[derive(Debug, Clone, Copy)]
+pub struct ValidationConfig {
+    /// The minimum distance between distinct objects
+    ///
+    /// Objects whose distance is less than the value defined in this field, are
+    /// considered identical.
+    pub distinct_min_distance: Scalar,
+
+    /// The maximum distance between identical objects
+    ///
+    /// Objects that are considered identical might still have a distance
+    /// between them, due to inaccuracies of the numerical representation. If
+    /// that distance is less than the one defined in this field, can not be
+    /// considered identical.
+    pub identical_max_distance: Scalar,
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        Self {
+            distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
+
+            // This value was chosen pretty arbitrarily. Seems small enough to
+            // catch errors. If it turns out it's too small (because it produces
+            // false positives due to floating-point accuracy issues), we can
+            // adjust it.
+            identical_max_distance: Scalar::from_f64(5e-14),
+        }
+    }
+}

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -1,4 +1,4 @@
-use std::convert::Infallible;
+use std::{convert::Infallible, fmt};
 
 use crate::validate::{
     CycleValidationError, EdgeValidationError, FaceValidationError,
@@ -36,5 +36,23 @@ pub enum ValidationError {
 impl From<Infallible> for ValidationError {
     fn from(infallible: Infallible) -> Self {
         match infallible {}
+    }
+}
+
+/// A collection of validation errors
+#[derive(Debug, thiserror::Error)]
+pub struct ValidationErrors(pub Vec<ValidationError>);
+
+impl fmt::Display for ValidationErrors {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let num_errors = self.0.len();
+
+        writeln!(f, "{num_errors} unhandled validation errors:")?;
+
+        for err in &self.0 {
+            writeln!(f, "{err}")?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -1,0 +1,40 @@
+use std::convert::Infallible;
+
+use crate::validate::{
+    CycleValidationError, EdgeValidationError, FaceValidationError,
+    ShellValidationError, SketchValidationError, SolidValidationError,
+};
+
+/// An error that can occur during a validation
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ValidationError {
+    /// `Cycle` validation error
+    #[error("`Cycle` validation error")]
+    Cycle(#[from] CycleValidationError),
+
+    /// `Edge` validation error
+    #[error("`Edge` validation error")]
+    Edge(#[from] EdgeValidationError),
+
+    /// `Face` validation error
+    #[error("`Face` validation error")]
+    Face(#[from] FaceValidationError),
+
+    /// `Shell` validation error
+    #[error("`Shell` validation error")]
+    Shell(#[from] ShellValidationError),
+
+    /// `Solid` validation error
+    #[error("`Solid` validation error")]
+    Solid(#[from] SolidValidationError),
+
+    /// `Sketch` validation error
+    #[error("`Sketch` validation error")]
+    Sketch(#[from] SketchValidationError),
+}
+
+impl From<Infallible> for ValidationError {
+    fn from(infallible: Infallible) -> Self {
+        match infallible {}
+    }
+}

--- a/crates/fj-core/src/validation/mod.rs
+++ b/crates/fj-core/src/validation/mod.rs
@@ -9,3 +9,7 @@
 //!
 //! - <https://github.com/hannobraun/fornjot/issues/1713>
 //! - <https://github.com/hannobraun/fornjot/issues/2157>
+
+mod error;
+
+pub use self::error::ValidationError;

--- a/crates/fj-core/src/validation/mod.rs
+++ b/crates/fj-core/src/validation/mod.rs
@@ -1,0 +1,11 @@
+//! # Infrastructure for validating objects
+//!
+//! ## Implementation Note
+//!
+//! This is a new module whose goal is to replace [`crate::validate`]. While
+//! this transition is ongoing, both modules will be incomplete.
+//!
+//! Issues that track the transition:
+//!
+//! - <https://github.com/hannobraun/fornjot/issues/1713>
+//! - <https://github.com/hannobraun/fornjot/issues/2157>

--- a/crates/fj-core/src/validation/mod.rs
+++ b/crates/fj-core/src/validation/mod.rs
@@ -22,4 +22,4 @@
 
 mod error;
 
-pub use self::error::ValidationError;
+pub use self::error::{ValidationError, ValidationErrors};

--- a/crates/fj-core/src/validation/mod.rs
+++ b/crates/fj-core/src/validation/mod.rs
@@ -1,5 +1,15 @@
 //! # Infrastructure for validating objects
 //!
+//! ## Nomenclature
+//!
+//! **Validation** is the process of checking that objects meet specific
+//! requirements. Each kind of object has its own set of requirements.
+//!
+//! An object that meets all the requirement for its kind is considered
+//! **valid**. An object that does not meet all of them is considered
+//! **invalid**. This results in a **validation error**, which is represented by
+//! [`ValidationError`].
+//!
 //! ## Implementation Note
 //!
 //! This is a new module whose goal is to replace [`crate::validate`]. While

--- a/crates/fj-core/src/validation/mod.rs
+++ b/crates/fj-core/src/validation/mod.rs
@@ -20,6 +20,10 @@
 //! - <https://github.com/hannobraun/fornjot/issues/1713>
 //! - <https://github.com/hannobraun/fornjot/issues/2157>
 
+mod config;
 mod error;
 
-pub use self::error::{ValidationError, ValidationErrors};
+pub use self::{
+    config::ValidationConfig,
+    error::{ValidationError, ValidationErrors},
+};

--- a/crates/fj-core/src/validation/mod.rs
+++ b/crates/fj-core/src/validation/mod.rs
@@ -22,8 +22,10 @@
 
 mod config;
 mod error;
+mod validation;
 
 pub use self::{
     config::ValidationConfig,
     error::{ValidationError, ValidationErrors},
+    validation::Validation,
 };

--- a/crates/fj-core/src/validation/validation.rs
+++ b/crates/fj-core/src/validation/validation.rs
@@ -1,0 +1,53 @@
+use std::{collections::HashMap, error::Error, thread};
+
+use crate::storage::ObjectId;
+
+use super::{ValidationConfig, ValidationError};
+
+/// Errors that occurred while validating the objects inserted into the stores
+#[derive(Default)]
+pub struct Validation {
+    /// All unhandled validation errors
+    pub errors: HashMap<ObjectId, ValidationError>,
+
+    /// Validation configuration for the validation service
+    pub config: ValidationConfig,
+}
+
+impl Validation {
+    /// Construct an instance of `Validation`, using the provided configuration
+    pub fn with_validation_config(config: ValidationConfig) -> Self {
+        let errors = HashMap::new();
+        Self { errors, config }
+    }
+}
+
+impl Drop for Validation {
+    fn drop(&mut self) {
+        let num_errors = self.errors.len();
+        if num_errors > 0 {
+            println!(
+                "Dropping `Validation` with {num_errors} unhandled validation \
+                errors:"
+            );
+
+            for err in self.errors.values() {
+                println!("{}", err);
+
+                // Once `Report` is stable, we can replace this:
+                // https://doc.rust-lang.org/std/error/struct.Report.html
+                let mut source = err.source();
+                while let Some(err) = source {
+                    println!("\nCaused by:\n\t{err}");
+                    source = err.source();
+                }
+
+                print!("\n\n");
+            }
+
+            if !thread::panicking() {
+                panic!();
+            }
+        }
+    }
+}

--- a/crates/fj/src/instance.rs
+++ b/crates/fj/src/instance.rs
@@ -6,7 +6,8 @@ use fj_core::{
         bounding_volume::BoundingVolume,
         triangulate::Triangulate,
     },
-    validate::{ValidationConfig, ValidationErrors},
+    validate::ValidationConfig,
+    validation::ValidationErrors,
     Core,
 };
 use fj_interop::Model;

--- a/crates/fj/src/instance.rs
+++ b/crates/fj/src/instance.rs
@@ -6,8 +6,7 @@ use fj_core::{
         bounding_volume::BoundingVolume,
         triangulate::Triangulate,
     },
-    validate::ValidationConfig,
-    validation::ValidationErrors,
+    validation::{ValidationConfig, ValidationErrors},
     Core,
 };
 use fj_interop::Model;


### PR DESCRIPTION
This is the start of a cleanup of the validation infrastructure, to address https://github.com/hannobraun/fornjot/issues/1713 and https://github.com/hannobraun/fornjot/issues/2157.

Create a new module called `validation`, and move over everything from the old `validate` module, which will likely survive the cleanup with little to no changes. The core of the validation infrastructure, validation checks and the `Validate` trait, still live in the old module.