### PR TITLE
Simplify `SplitFace::split_face`

### DIFF
--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -8,7 +8,6 @@ use crate::{
         build::{BuildCycle, BuildHalfEdge},
         derive::DeriveFrom,
         insert::Insert,
-        presentation::SetColor,
         split::SplitEdge,
         update::{
             UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion, UpdateShell,
@@ -128,7 +127,7 @@ impl SplitFace for Shell {
         let split_face_a = updated_face_after_split_edges
             .update_region(
                 |region, core| {
-                    let mut region = region
+                    region
                         .update_exterior(
                             |_, core| {
                                 Cycle::empty()
@@ -144,16 +143,7 @@ impl SplitFace for Shell {
                             core,
                         )
                         .insert(core)
-                        .derive_from(region, core);
-
-                    if let Some(color) = face.region().color() {
-                        region = region
-                            .set_color(color, core)
-                            .insert(core)
-                            .derive_from(&region, core);
-                    }
-
-                    region
+                        .derive_from(region, core)
                 },
                 core,
             )
@@ -168,7 +158,7 @@ impl SplitFace for Shell {
         let split_face_b = updated_face_after_split_edges
             .update_region(
                 |region, core| {
-                    let mut region = region
+                    region
                         .update_exterior(
                             |_, core| {
                                 Cycle::empty()
@@ -184,16 +174,7 @@ impl SplitFace for Shell {
                             core,
                         )
                         .insert(core)
-                        .derive_from(region, core);
-
-                    if let Some(color) = face.region().color() {
-                        region = region
-                            .set_color(color, core)
-                            .insert(core)
-                            .derive_from(&region, core);
-                    }
-
-                    region
+                        .derive_from(region, core)
                 },
                 core,
             )

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -127,23 +127,20 @@ impl SplitFace for Shell {
         let split_face_a = updated_face_after_split_edges
             .update_region(
                 |region, core| {
-                    region
-                        .update_exterior(
-                            |_, core| {
-                                Cycle::empty()
-                                    .add_half_edges(
-                                        half_edges_b_to_c_inclusive,
-                                        core,
-                                    )
-                                    .add_half_edges(
-                                        [dividing_half_edge_c_to_b],
-                                        core,
-                                    )
-                            },
-                            core,
-                        )
-                        .insert(core)
-                        .derive_from(region, core)
+                    region.update_exterior(
+                        |_, core| {
+                            Cycle::empty()
+                                .add_half_edges(
+                                    half_edges_b_to_c_inclusive,
+                                    core,
+                                )
+                                .add_half_edges(
+                                    [dividing_half_edge_c_to_b],
+                                    core,
+                                )
+                        },
+                        core,
+                    )
                 },
                 core,
             )
@@ -158,23 +155,20 @@ impl SplitFace for Shell {
         let split_face_b = updated_face_after_split_edges
             .update_region(
                 |region, core| {
-                    region
-                        .update_exterior(
-                            |_, core| {
-                                Cycle::empty()
-                                    .add_half_edges(
-                                        half_edges_d_to_a_inclusive,
-                                        core,
-                                    )
-                                    .add_half_edges(
-                                        [dividing_half_edge_a_to_d],
-                                        core,
-                                    )
-                            },
-                            core,
-                        )
-                        .insert(core)
-                        .derive_from(region, core)
+                    region.update_exterior(
+                        |_, core| {
+                            Cycle::empty()
+                                .add_half_edges(
+                                    half_edges_d_to_a_inclusive,
+                                    core,
+                                )
+                                .add_half_edges(
+                                    [dividing_half_edge_a_to_d],
+                                    core,
+                                )
+                        },
+                        core,
+                    )
                 },
                 core,
             )


### PR DESCRIPTION
There's some complexity there that is no longer necessary. This comes out of my work on https://github.com/hannobraun/fornjot/issues/2117.