### PR TITLE
Remove `color` attribute from `Region`

### DIFF
--- a/crates/fj-core/src/objects/kinds/region.rs
+++ b/crates/fj-core/src/objects/kinds/region.rs
@@ -1,7 +1,5 @@
 //! A single, continues 2d region
 
-use fj_interop::Color;
-
 use crate::{
     objects::{Cycle, ObjectSet},
     storage::Handle,
@@ -19,7 +17,6 @@ use crate::{
 pub struct Region {
     exterior: Handle<Cycle>,
     interiors: ObjectSet<Cycle>,
-    color: Option<Color>,
 }
 
 impl Region {
@@ -27,12 +24,10 @@ impl Region {
     pub fn new(
         exterior: Handle<Cycle>,
         interiors: impl IntoIterator<Item = Handle<Cycle>>,
-        color: Option<Color>,
     ) -> Self {
         Self {
             exterior,
             interiors: interiors.into_iter().collect(),
-            color,
         }
     }
 
@@ -53,10 +48,5 @@ impl Region {
         // It would be nice to return `&ObjectSet` here, but I don't see a way
         // for doing that here *and* in `interiors`.
         [self.exterior()].into_iter().chain(self.interiors())
-    }
-
-    /// Access the color of the region
-    pub fn color(&self) -> Option<Color> {
-        self.color
     }
 }

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -22,7 +22,7 @@ pub trait BuildFace {
     /// Build a face with an empty exterior, no interiors, and no color
     fn unbound(surface: Handle<Surface>, core: &mut Core) -> Face {
         let exterior = Cycle::empty().insert(core);
-        let region = Region::new(exterior, [], None).insert(core);
+        let region = Region::new(exterior, []).insert(core);
         Face::new(surface, region)
     }
 

--- a/crates/fj-core/src/operations/build/region.rs
+++ b/crates/fj-core/src/operations/build/region.rs
@@ -16,9 +16,8 @@ pub trait BuildRegion {
     fn empty(core: &mut Core) -> Region {
         let exterior = Cycle::empty().insert(core);
         let interiors = [];
-        let color = None;
 
-        Region::new(exterior, interiors, color)
+        Region::new(exterior, interiors)
     }
 
     /// Build a circle
@@ -28,7 +27,7 @@ pub trait BuildRegion {
         core: &mut Core,
     ) -> Region {
         let exterior = Cycle::circle(center, radius, core).insert(core);
-        Region::new(exterior, [], None)
+        Region::new(exterior, [])
     }
 
     /// Build a polygon
@@ -39,7 +38,7 @@ pub trait BuildRegion {
         Ps::IntoIter: Clone + ExactSizeIterator,
     {
         let exterior = Cycle::polygon(points, core).insert(core);
-        Region::new(exterior, [], None)
+        Region::new(exterior, [])
     }
 }
 

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -53,6 +53,7 @@ impl AddHole for Shell {
             )
             .sweep_region(
                 location.face.surface(),
+                None,
                 path,
                 &mut SweepCache::default(),
                 core,
@@ -118,6 +119,7 @@ impl AddHole for Shell {
             )
             .sweep_region(
                 entry_location.face.surface(),
+                None,
                 path,
                 &mut SweepCache::default(),
                 core,

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -24,8 +24,8 @@ pub trait SetColor {
 
 impl SetColor for Handle<Region> {
     fn set_color(&self, color: impl Into<Color>, core: &mut Core) {
-        let color = color.into();
-
-        core.layers.presentation.set_color(self.clone(), color);
+        core.layers
+            .presentation
+            .set_color(self.clone(), color.into());
     }
 }

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -43,7 +43,6 @@ impl SetColor for Handle<Region> {
         Region::new(
             self.exterior().clone(),
             self.interiors().into_iter().cloned(),
-            Some(color),
         )
     }
 }

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -2,11 +2,7 @@
 
 use fj_interop::Color;
 
-use crate::{
-    objects::{IsObject, Region},
-    storage::Handle,
-    Core,
-};
+use crate::{objects::Region, storage::Handle, Core};
 
 /// Get the color of an object
 pub trait GetColor {
@@ -21,7 +17,7 @@ impl GetColor for Handle<Region> {
 }
 
 /// Set the color of an object
-pub trait SetColor: IsObject {
+pub trait SetColor {
     /// Set the color of the object
     fn set_color(&self, color: impl Into<Color>, core: &mut Core);
 }

--- a/crates/fj-core/src/operations/presentation.rs
+++ b/crates/fj-core/src/operations/presentation.rs
@@ -23,26 +23,13 @@ impl GetColor for Handle<Region> {
 /// Set the color of an object
 pub trait SetColor: IsObject {
     /// Set the color of the object
-    fn set_color(
-        &self,
-        color: impl Into<Color>,
-        core: &mut Core,
-    ) -> Self::BareObject;
+    fn set_color(&self, color: impl Into<Color>, core: &mut Core);
 }
 
 impl SetColor for Handle<Region> {
-    fn set_color(
-        &self,
-        color: impl Into<Color>,
-        core: &mut Core,
-    ) -> Self::BareObject {
+    fn set_color(&self, color: impl Into<Color>, core: &mut Core) {
         let color = color.into();
 
         core.layers.presentation.set_color(self.clone(), color);
-
-        Region::new(
-            self.exterior().clone(),
-            self.interiors().into_iter().cloned(),
-        )
     }
 }

--- a/crates/fj-core/src/operations/replace/curve.rs
+++ b/crates/fj-core/src/operations/replace/curve.rs
@@ -117,7 +117,6 @@ impl ReplaceCurve for Region {
                     })
                     .into_inner(),
                 interiors,
-                self.color(),
             ))
         } else {
             ReplaceOutput::Original(self.clone())

--- a/crates/fj-core/src/operations/replace/half_edge.rs
+++ b/crates/fj-core/src/operations/replace/half_edge.rs
@@ -83,7 +83,6 @@ impl ReplaceHalfEdge for Region {
                     })
                     .into_inner(),
                 interiors,
-                self.color(),
             ))
         } else {
             ReplaceOutput::Original(self.clone())

--- a/crates/fj-core/src/operations/replace/vertex.rs
+++ b/crates/fj-core/src/operations/replace/vertex.rs
@@ -119,7 +119,6 @@ impl ReplaceVertex for Region {
                     })
                     .into_inner(),
                 interiors,
-                self.color(),
             ))
         } else {
             ReplaceOutput::Original(self.clone())

--- a/crates/fj-core/src/operations/reverse/region.rs
+++ b/crates/fj-core/src/operations/reverse/region.rs
@@ -17,7 +17,7 @@ impl Reverse for Region {
             cycle.reverse(core).insert(core).derive_from(cycle, core)
         });
 
-        Region::new(exterior, interiors, self.color())
+        Region::new(exterior, interiors)
     }
 }
 
@@ -35,6 +35,6 @@ impl ReverseCurveCoordinateSystems for Region {
                 .derive_from(cycle, core)
         });
 
-        Region::new(exterior, interiors, self.color())
+        Region::new(exterior, interiors)
     }
 }

--- a/crates/fj-core/src/operations/sweep/face.rs
+++ b/crates/fj-core/src/operations/sweep/face.rs
@@ -2,7 +2,7 @@ use fj_math::Vector;
 
 use crate::{
     objects::{Face, Shell},
-    operations::insert::Insert,
+    operations::{insert::Insert, presentation::GetColor},
     storage::Handle,
     Core,
 };
@@ -51,7 +51,7 @@ impl SweepFace for Handle<Face> {
             .region()
             .sweep_region(
                 bottom_face.surface(),
-                bottom_face.region().color(),
+                bottom_face.region().get_color(core),
                 path,
                 cache,
                 core,

--- a/crates/fj-core/src/operations/sweep/face.rs
+++ b/crates/fj-core/src/operations/sweep/face.rs
@@ -49,7 +49,13 @@ impl SweepFace for Handle<Face> {
         let bottom_face = self;
         let other_faces = bottom_face
             .region()
-            .sweep_region(bottom_face.surface(), path, cache, core)
+            .sweep_region(
+                bottom_face.surface(),
+                bottom_face.region().color(),
+                path,
+                cache,
+                core,
+            )
             .all_faces()
             .map(|side_face| side_face.insert(core));
 

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -136,7 +136,7 @@ impl SweepHalfEdge for HalfEdge {
             });
 
         let exterior = exterior.insert(core);
-        let region = Region::new(exterior, [], color).insert(core);
+        let region = Region::new(exterior, []).insert(core);
 
         if let Some(color) = color {
             region.set_color(color, core);

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -6,6 +6,7 @@ use crate::{
     operations::{
         build::{BuildCycle, BuildHalfEdge},
         insert::Insert,
+        presentation::SetColor,
         update::{UpdateCycle, UpdateHalfEdge},
     },
     storage::Handle,
@@ -136,6 +137,11 @@ impl SweepHalfEdge for HalfEdge {
 
         let exterior = exterior.insert(core);
         let region = Region::new(exterior, [], color).insert(core);
+
+        if let Some(color) = color {
+            region.set_color(color, core);
+        }
+
         let face = Face::new(surface, region);
 
         (face, edge_top)

--- a/crates/fj-core/src/operations/sweep/region.rs
+++ b/crates/fj-core/src/operations/sweep/region.rs
@@ -32,6 +32,7 @@ pub trait SweepRegion {
     fn sweep_region(
         &self,
         surface: &Surface,
+        color: Option<Color>,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         core: &mut Core,
@@ -42,6 +43,7 @@ impl SweepRegion for Region {
     fn sweep_region(
         &self,
         surface: &Surface,
+        color: Option<Color>,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
         core: &mut Core,
@@ -53,7 +55,7 @@ impl SweepRegion for Region {
         let top_exterior = sweep_cycle(
             self.exterior(),
             surface,
-            self.color(),
+            color,
             &mut faces,
             path,
             cache,
@@ -67,7 +69,7 @@ impl SweepRegion for Region {
                 sweep_cycle(
                     bottom_cycle,
                     surface,
-                    self.color(),
+                    color,
                     &mut faces,
                     path,
                     cache,
@@ -79,8 +81,7 @@ impl SweepRegion for Region {
         let top_face = {
             let top_surface = surface.translate(path, core).insert(core);
             let top_region =
-                Region::new(top_exterior, top_interiors, self.color())
-                    .insert(core);
+                Region::new(top_exterior, top_interiors, color).insert(core);
 
             Face::new(top_surface, top_region)
         };

--- a/crates/fj-core/src/operations/sweep/region.rs
+++ b/crates/fj-core/src/operations/sweep/region.rs
@@ -81,7 +81,7 @@ impl SweepRegion for Region {
         let top_face = {
             let top_surface = surface.translate(path, core).insert(core);
             let top_region =
-                Region::new(top_exterior, top_interiors, color).insert(core);
+                Region::new(top_exterior, top_interiors).insert(core);
 
             Face::new(top_surface, top_region)
         };

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -5,6 +5,7 @@ use crate::{
     operations::{
         derive::DeriveFrom,
         insert::Insert,
+        presentation::GetColor,
         reverse::Reverse,
         sweep::{SweepCache, SweepRegion},
         update::UpdateShell,
@@ -67,7 +68,7 @@ impl SweepFaceOfShell for Shell {
         let faces = region
             .sweep_region(
                 face.surface(),
-                face.region().color(),
+                face.region().get_color(core),
                 path,
                 &mut cache,
                 core,

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -65,7 +65,13 @@ impl SweepFaceOfShell for Shell {
             .derive_from(face.region().exterior(), core);
         let region = Region::new(exterior, [], face.region().color());
         let faces = region
-            .sweep_region(face.surface(), path, &mut cache, core)
+            .sweep_region(
+                face.surface(),
+                region.color(),
+                path,
+                &mut cache,
+                core,
+            )
             .all_faces()
             .collect::<Vec<_>>();
 

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -64,7 +64,7 @@ impl SweepFaceOfShell for Shell {
             .reverse(core)
             .insert(core)
             .derive_from(face.region().exterior(), core);
-        let region = Region::new(exterior, [], face.region().color());
+        let region = Region::new(exterior, []);
         let faces = region
             .sweep_region(
                 face.surface(),

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -67,7 +67,7 @@ impl SweepFaceOfShell for Shell {
         let faces = region
             .sweep_region(
                 face.surface(),
-                region.color(),
+                face.region().color(),
                 path,
                 &mut cache,
                 core,

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -9,9 +9,6 @@ impl TransformObject for Region {
         core: &mut Core,
         cache: &mut super::TransformCache,
     ) -> Self {
-        // Color does not need to be transformed.
-        let color = self.color();
-
         let exterior = self
             .exterior()
             .clone()
@@ -20,6 +17,6 @@ impl TransformObject for Region {
             interior.transform_with_cache(transform, core, cache)
         });
 
-        Region::new(exterior, interiors, color)
+        Region::new(exterior, interiors)
     }
 }

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -57,7 +57,7 @@ impl UpdateRegion for Region {
         let exterior = update(self.exterior(), core)
             .insert(core)
             .derive_from(self.exterior(), core);
-        Region::new(exterior, self.interiors().iter().cloned(), self.color())
+        Region::new(exterior, self.interiors().iter().cloned())
     }
 
     fn add_interiors<T>(
@@ -70,7 +70,7 @@ impl UpdateRegion for Region {
     {
         let interiors = interiors.into_iter().map(|cycle| cycle.insert(core));
         let interiors = self.interiors().iter().cloned().chain(interiors);
-        Region::new(self.exterior().clone(), interiors, self.color())
+        Region::new(self.exterior().clone(), interiors)
     }
 
     fn update_interior<T, const N: usize>(
@@ -91,6 +91,6 @@ impl UpdateRegion for Region {
                 }),
             )
             .expect("Cycle not found");
-        Region::new(self.exterior().clone(), interiors, self.color())
+        Region::new(self.exterior().clone(), interiors)
     }
 }

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -174,12 +174,9 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
 
-            let region = Region::new(
-                valid.region().exterior().clone(),
-                interiors,
-                valid.region().color(),
-            )
-            .insert(&mut core);
+            let region =
+                Region::new(valid.region().exterior().clone(), interiors)
+                    .insert(&mut core);
 
             Face::new(valid.surface().clone(), region)
         };

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -72,10 +72,9 @@ mod tests {
             Region::new(
                 Cycle::new(vec![]).insert(&mut core),
                 vec![shared_cycle.clone()],
-                None,
             )
             .insert(&mut core),
-            Region::new(shared_cycle, vec![], None).insert(&mut core),
+            Region::new(shared_cycle, vec![]).insert(&mut core),
         ]);
         assert_contains_err!(
             invalid_sketch,
@@ -87,7 +86,6 @@ mod tests {
         let valid_sketch = Sketch::new(vec![Region::new(
             Cycle::new(vec![]).insert(&mut core),
             vec![],
-            None,
         )
         .insert(&mut core)]);
         valid_sketch.validate_and_return_first_error()?;
@@ -114,12 +112,10 @@ mod tests {
             Cycle::new(vec![half_edge.clone(), sibling_edge.clone()])
                 .insert(&mut core);
 
-        let invalid_sketch = Sketch::new(vec![Region::new(
-            exterior.clone(),
-            vec![interior],
-            None,
-        )
-        .insert(&mut core)]);
+        let invalid_sketch =
+            Sketch::new(vec![
+                Region::new(exterior.clone(), vec![interior]).insert(&mut core)
+            ]);
         assert_contains_err!(
             invalid_sketch,
             ValidationError::Sketch(SketchValidationError::MultipleReferences(
@@ -128,9 +124,7 @@ mod tests {
         );
 
         let valid_sketch =
-            Sketch::new(vec![
-                Region::new(exterior, vec![], None).insert(&mut core)
-            ]);
+            Sketch::new(vec![Region::new(exterior, vec![]).insert(&mut core)]);
         valid_sketch.validate_and_return_first_error()?;
 
         Ok(())

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -204,7 +204,6 @@ mod tests {
                 ])
                 .insert(&mut core),
                 vec![],
-                None,
             )
             .insert(&mut core),
         )
@@ -251,7 +250,6 @@ mod tests {
             ])
             .insert(&mut core),
             vec![],
-            None,
         )
         .insert(&mut core);
 
@@ -311,8 +309,7 @@ mod tests {
                     v: [0., 1., 1.].into(),
                 })
                 .insert(&mut core),
-                Region::new(shared_cycle.clone(), vec![], None)
-                    .insert(&mut core),
+                Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
             )
             .insert(&mut core),
             Face::new(
@@ -321,7 +318,7 @@ mod tests {
                     v: [0., 0., 1.].into(),
                 })
                 .insert(&mut core),
-                Region::new(shared_cycle, vec![], None).insert(&mut core),
+                Region::new(shared_cycle, vec![]).insert(&mut core),
             )
             .insert(&mut core),
         ])
@@ -360,7 +357,6 @@ mod tests {
             Region::new(
                 Cycle::new(vec![shared_edge.clone()]).insert(&mut core),
                 vec![Cycle::new(vec![shared_edge.clone()]).insert(&mut core)],
-                None,
             )
             .insert(&mut core),
         )

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -1,9 +1,7 @@
 use fj::core::{
     objects::Solid,
     operations::{
-        presentation::SetColor,
-        split::SplitFace,
-        update::{UpdateFace, UpdateShell, UpdateSolid},
+        presentation::SetColor, split::SplitFace, update::UpdateSolid,
     },
 };
 
@@ -14,19 +12,7 @@ pub fn model(core: &mut fj::core::Core) -> Solid {
     cuboid.update_shell(
         cuboid.shells().only(),
         |shell, core| {
-            let shell = shell.update_face(
-                shell.faces().first(),
-                |face, core| {
-                    [face.update_region(
-                        |region, core| {
-                            region.set_color([0., 1., 0.], core);
-                            region.clone()
-                        },
-                        core,
-                    )]
-                },
-                core,
-            );
+            shell.faces().first().region().set_color([0., 1., 0.], core);
 
             // Split colored face, to make sure the same color is applied to the
             // two derived faces.

--- a/models/color/src/lib.rs
+++ b/models/color/src/lib.rs
@@ -18,7 +18,10 @@ pub fn model(core: &mut fj::core::Core) -> Solid {
                 shell.faces().first(),
                 |face, core| {
                     [face.update_region(
-                        |region, core| region.set_color([0., 1., 0.], core),
+                        |region, core| {
+                            region.set_color([0., 1., 0.], core);
+                            region.clone()
+                        },
                         core,
                     )]
                 },


### PR DESCRIPTION
Remove the redundant `color` attribute from `Region`, thereby making the presentation layer the only place where color is set.

Close https://github.com/hannobraun/fornjot/issues/2117