### PR TITLE
Rename `plane_from_uv` to `surface_from_uv`

### DIFF
--- a/crates/fj-core/src/objects/stores.rs
+++ b/crates/fj-core/src/objects/stores.rs
@@ -95,18 +95,18 @@ impl Default for Surfaces {
         let xy_plane = store.reserve();
         store.insert(
             xy_plane.clone(),
-            Surface::plane_from_uv(GlobalPath::x_axis(), Vector::unit_y()),
+            Surface::surface_from_uv(GlobalPath::x_axis(), Vector::unit_y()),
         );
 
         let xz_plane = store.reserve();
         store.insert(
             xz_plane.clone(),
-            Surface::plane_from_uv(GlobalPath::x_axis(), Vector::unit_z()),
+            Surface::surface_from_uv(GlobalPath::x_axis(), Vector::unit_z()),
         );
         let yz_plane = store.reserve();
         store.insert(
             yz_plane.clone(),
-            Surface::plane_from_uv(GlobalPath::y_axis(), Vector::unit_z()),
+            Surface::surface_from_uv(GlobalPath::y_axis(), Vector::unit_z()),
         );
 
         Self {

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -20,7 +20,7 @@ pub trait BuildSurface {
         let (u, u_line) = GlobalPath::line_from_points([a, b]);
         let v = c - a;
 
-        let surface = Surface::plane_from_uv(u, v);
+        let surface = Surface::surface_from_uv(u, v);
 
         let points_surface = {
             let [a, b] =
@@ -34,7 +34,7 @@ pub trait BuildSurface {
     }
 
     /// Build a plane from the provided `u` and `v`
-    fn plane_from_uv(
+    fn surface_from_uv(
         u: impl Into<GlobalPath>,
         v: impl Into<Vector<3>>,
     ) -> Surface {

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -80,6 +80,6 @@ impl SweepSurfacePath for SurfacePath {
             }
         };
 
-        Surface::plane_from_uv(u, path)
+        Surface::surface_from_uv(u, path)
     }
 }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -193,7 +193,7 @@ mod tests {
         let mut core = Core::new();
 
         let shared_face = Face::new(
-            Surface::plane_from_uv(
+            Surface::surface_from_uv(
                 GlobalPath::circle_from_radius(1.),
                 [0., 1., 1.],
             )
@@ -255,7 +255,7 @@ mod tests {
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![
             Face::new(
-                Surface::plane_from_uv(
+                Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 1., 1.],
                 )
@@ -264,7 +264,7 @@ mod tests {
             )
             .insert(&mut core),
             Face::new(
-                Surface::plane_from_uv(
+                Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 0., 1.],
                 )
@@ -304,7 +304,7 @@ mod tests {
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![
             Face::new(
-                Surface::plane_from_uv(
+                Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 1., 1.],
                 )
@@ -313,7 +313,7 @@ mod tests {
             )
             .insert(&mut core),
             Face::new(
-                Surface::plane_from_uv(
+                Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 0., 1.],
                 )
@@ -349,7 +349,7 @@ mod tests {
             HalfEdge::circle([0., 0.], 1., &mut core).insert(&mut core);
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![Face::new(
-            Surface::plane_from_uv(
+            Surface::surface_from_uv(
                 GlobalPath::circle_from_radius(1.),
                 [0., 0., 1.],
             )


### PR DESCRIPTION
The previous name was plain wrong.

This fixes the mistake introduced in https://github.com/hannobraun/fornjot/pull/2239, and just as that pull request, comes out of my work on https://github.com/hannobraun/fornjot/issues/2116.