### PR TITLE
Return `Handle<Surface>` from `BuildSurface` methods

### DIFF
--- a/crates/fj-core/src/objects/stores.rs
+++ b/crates/fj-core/src/objects/stores.rs
@@ -1,8 +1,7 @@
 use fj_math::Vector;
 
 use crate::{
-    geometry::GlobalPath,
-    operations::build::BuildSurface,
+    geometry::{GlobalPath, SurfaceGeometry},
     storage::{Handle, Store},
 };
 
@@ -95,18 +94,27 @@ impl Default for Surfaces {
         let xy_plane = store.reserve();
         store.insert(
             xy_plane.clone(),
-            Surface::surface_from_uv(GlobalPath::x_axis(), Vector::unit_y()),
+            Surface::new(SurfaceGeometry {
+                u: GlobalPath::x_axis(),
+                v: Vector::unit_y(),
+            }),
         );
 
         let xz_plane = store.reserve();
         store.insert(
             xz_plane.clone(),
-            Surface::surface_from_uv(GlobalPath::x_axis(), Vector::unit_z()),
+            Surface::new(SurfaceGeometry {
+                u: GlobalPath::x_axis(),
+                v: Vector::unit_z(),
+            }),
         );
         let yz_plane = store.reserve();
         store.insert(
             yz_plane.clone(),
-            Surface::surface_from_uv(GlobalPath::y_axis(), Vector::unit_z()),
+            Surface::new(SurfaceGeometry {
+                u: GlobalPath::y_axis(),
+                v: Vector::unit_z(),
+            }),
         );
 
         Self {

--- a/crates/fj-core/src/operations/build/face.rs
+++ b/crates/fj-core/src/operations/build/face.rs
@@ -31,8 +31,8 @@ pub trait BuildFace {
         points: [impl Into<Point<3>>; 3],
         core: &mut Core,
     ) -> Polygon<3> {
-        let (surface, points_surface) = Surface::plane_from_points(points);
-        let surface = surface.insert(core);
+        let (surface, points_surface) =
+            Surface::plane_from_points(points, core);
 
         let face = Face::polygon(surface, points_surface, core);
 

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -56,8 +56,8 @@ pub trait BuildShell {
 
                 let (surface, _) = Surface::plane_from_points(
                     [a_pos, b_pos, c_pos].map(Clone::clone),
+                    core,
                 );
-                let surface = surface.insert(core);
 
                 let curves_and_boundaries =
                     [[a, b], [b, c], [c, a]].map(|vertices| {

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -24,7 +24,7 @@ pub trait BuildSurface {
         let (u, u_line) = GlobalPath::line_from_points([a, b]);
         let v = c - a;
 
-        let surface = Surface::surface_from_uv(u, v).insert(core);
+        let surface = Surface::surface_from_uv(u, v, core);
 
         let points_surface = {
             let [a, b] =
@@ -41,12 +41,13 @@ pub trait BuildSurface {
     fn surface_from_uv(
         u: impl Into<GlobalPath>,
         v: impl Into<Vector<3>>,
-    ) -> Surface {
+        core: &mut Core,
+    ) -> Handle<Surface> {
         let geometry = SurfaceGeometry {
             u: u.into(),
             v: v.into(),
         };
-        Surface::new(geometry)
+        Surface::new(geometry).insert(core)
     }
 }
 

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -3,6 +3,9 @@ use fj_math::{Point, Scalar, Vector};
 use crate::{
     geometry::{GlobalPath, SurfaceGeometry},
     objects::Surface,
+    operations::insert::Insert,
+    storage::Handle,
+    Core,
 };
 
 /// Build a [`Surface`]
@@ -14,13 +17,14 @@ pub trait BuildSurface {
     /// Build a plane from the provided points
     fn plane_from_points(
         points: [impl Into<Point<3>>; 3],
-    ) -> (Surface, [Point<2>; 3]) {
+        core: &mut Core,
+    ) -> (Handle<Surface>, [Point<2>; 3]) {
         let [a, b, c] = points.map(Into::into);
 
         let (u, u_line) = GlobalPath::line_from_points([a, b]);
         let v = c - a;
 
-        let surface = Surface::surface_from_uv(u, v);
+        let surface = Surface::surface_from_uv(u, v).insert(core);
 
         let points_surface = {
             let [a, b] =

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -58,8 +58,7 @@ impl SweepHalfEdge for HalfEdge {
     ) -> (Face, Handle<HalfEdge>) {
         let path = path.into();
 
-        let surface =
-            self.path().sweep_surface_path(surface, path).insert(core);
+        let surface = self.path().sweep_surface_path(surface, path, core);
 
         // Next, we need to define the boundaries of the face. Let's start with
         // the global vertices and edges.

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -3,7 +3,7 @@ use fj_math::{Circle, Line, Vector};
 use crate::{
     geometry::{GlobalPath, SurfaceGeometry, SurfacePath},
     objects::Surface,
-    operations::{build::BuildSurface, insert::Insert},
+    operations::build::BuildSurface,
     storage::Handle,
     Core,
 };
@@ -84,6 +84,6 @@ impl SweepSurfacePath for SurfacePath {
             }
         };
 
-        Surface::surface_from_uv(u, path).insert(core)
+        Surface::surface_from_uv(u, path, core)
     }
 }

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -3,7 +3,9 @@ use fj_math::{Circle, Line, Vector};
 use crate::{
     geometry::{GlobalPath, SurfaceGeometry, SurfacePath},
     objects::Surface,
-    operations::build::BuildSurface,
+    operations::{build::BuildSurface, insert::Insert},
+    storage::Handle,
+    Core,
 };
 
 /// # Sweep a [`SurfacePath`]
@@ -26,7 +28,8 @@ pub trait SweepSurfacePath {
         &self,
         surface: &SurfaceGeometry,
         path: impl Into<Vector<3>>,
-    ) -> Surface;
+        core: &mut Core,
+    ) -> Handle<Surface>;
 }
 
 impl SweepSurfacePath for SurfacePath {
@@ -34,7 +37,8 @@ impl SweepSurfacePath for SurfacePath {
         &self,
         surface: &SurfaceGeometry,
         path: impl Into<Vector<3>>,
-    ) -> Surface {
+        core: &mut Core,
+    ) -> Handle<Surface> {
         match surface.u {
             GlobalPath::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
@@ -80,6 +84,6 @@ impl SweepSurfacePath for SurfacePath {
             }
         };
 
-        Surface::surface_from_uv(u, path)
+        Surface::surface_from_uv(u, path).insert(core)
     }
 }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -196,8 +196,8 @@ mod tests {
             Surface::surface_from_uv(
                 GlobalPath::circle_from_radius(1.),
                 [0., 1., 1.],
-            )
-            .insert(&mut core),
+                &mut core,
+            ),
             Region::new(
                 Cycle::new(vec![
                     HalfEdge::circle([0., 0.], 1., &mut core).insert(&mut core)
@@ -258,8 +258,8 @@ mod tests {
                 Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 1., 1.],
-                )
-                .insert(&mut core),
+                    &mut core,
+                ),
                 shared_region.clone(),
             )
             .insert(&mut core),
@@ -267,8 +267,8 @@ mod tests {
                 Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 0., 1.],
-                )
-                .insert(&mut core),
+                    &mut core,
+                ),
                 shared_region.clone(),
             )
             .insert(&mut core),
@@ -307,8 +307,8 @@ mod tests {
                 Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 1., 1.],
-                )
-                .insert(&mut core),
+                    &mut core,
+                ),
                 Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
             )
             .insert(&mut core),
@@ -316,8 +316,8 @@ mod tests {
                 Surface::surface_from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 0., 1.],
-                )
-                .insert(&mut core),
+                    &mut core,
+                ),
                 Region::new(shared_cycle, vec![]).insert(&mut core),
             )
             .insert(&mut core),
@@ -352,8 +352,8 @@ mod tests {
             Surface::surface_from_uv(
                 GlobalPath::circle_from_radius(1.),
                 [0., 0., 1.],
-            )
-            .insert(&mut core),
+                &mut core,
+            ),
             Region::new(
                 Cycle::new(vec![shared_edge.clone()]).insert(&mut core),
                 vec![Cycle::new(vec![shared_edge.clone()]).insert(&mut core)],


### PR DESCRIPTION
This comes out of my work on https://github.com/hannobraun/fornjot/issues/2116, and is another step in preparing for moving surface geometry into a separate geometry layer.