### PR TITLE
Implement `ValidationCheck` for the check

### DIFF
--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -1,6 +1,9 @@
 use crate::{
     objects::Cycle,
-    validation::{ValidationCheck, ValidationConfig, ValidationError},
+    validation::{
+        checks::AdjacentHalfEdgesNotConnected, ValidationCheck,
+        ValidationConfig, ValidationError,
+    },
 };
 
 use super::Validate;
@@ -11,6 +14,8 @@ impl Validate for Cycle {
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        errors.extend(self.check(config).map(Into::into));
+        errors.extend(
+            AdjacentHalfEdgesNotConnected::check(self, config).map(Into::into),
+        );
     }
 }

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -37,12 +37,12 @@ pub struct AdjacentHalfEdgesNotConnected {
     pub unconnected_half_edges: [Handle<HalfEdge>; 2],
 }
 
-impl ValidationCheck<AdjacentHalfEdgesNotConnected> for Cycle {
+impl ValidationCheck<Cycle> for AdjacentHalfEdgesNotConnected {
     fn check(
-        &self,
+        object: &Cycle,
         config: &ValidationConfig,
-    ) -> impl Iterator<Item = AdjacentHalfEdgesNotConnected> {
-        self.half_edges().pairs().filter_map(|(first, second)| {
+    ) -> impl Iterator<Item = Self> {
+        object.half_edges().pairs().filter_map(|(first, second)| {
             let end_pos_of_first_half_edge = {
                 let [_, end] = first.boundary().inner;
                 first.path().point_from_path_coords(end)
@@ -80,12 +80,14 @@ mod tests {
         Core,
     };
 
+    use super::AdjacentHalfEdgesNotConnected;
+
     #[test]
     fn adjacent_half_edges_connected() -> anyhow::Result<()> {
         let mut core = Core::new();
 
         let valid = Cycle::polygon([[0., 0.], [1., 0.], [1., 1.]], &mut core);
-        valid.check_and_return_first_error()?;
+        AdjacentHalfEdgesNotConnected::check_and_return_first_error(&valid)?;
 
         let invalid = valid.update_half_edge(
             valid.half_edges().first(),
@@ -94,7 +96,7 @@ mod tests {
             },
             &mut core,
         );
-        invalid.check_and_expect_one_error();
+        AdjacentHalfEdgesNotConnected::check_and_expect_one_error(&invalid);
 
         Ok(())
     }

--- a/crates/fj-core/src/validation/validation_check.rs
+++ b/crates/fj-core/src/validation/validation_check.rs
@@ -16,9 +16,9 @@ pub trait ValidationCheck<T> {
     /// for use in unit tests), and thus always uses the default configuration.
     fn check_and_return_first_error(&self) -> Result<(), T> {
         let config = ValidationConfig::default();
-        let errors = self.check(&config).collect::<Vec<_>>();
+        let mut errors = self.check(&config);
 
-        if let Some(err) = errors.into_iter().next() {
+        if let Some(err) = errors.next() {
             return Err(err);
         }
 

--- a/crates/fj-core/src/validation/validation_check.rs
+++ b/crates/fj-core/src/validation/validation_check.rs
@@ -6,17 +6,20 @@ use super::ValidationConfig;
 ///
 /// This trait is implemented once per validation check and object it applies
 /// to. `Self` is the object, while `T` identifies the validation check.
-pub trait ValidationCheck<T> {
+pub trait ValidationCheck<T>: Sized {
     /// Run the validation check on the implementing object
-    fn check(&self, config: &ValidationConfig) -> impl Iterator<Item = T>;
+    fn check(
+        object: &T,
+        config: &ValidationConfig,
+    ) -> impl Iterator<Item = Self>;
 
     /// Convenience method to run the check return the first error
     ///
     /// This method is designed for convenience over flexibility (it is intended
     /// for use in unit tests), and thus always uses the default configuration.
-    fn check_and_return_first_error(&self) -> Result<(), T> {
+    fn check_and_return_first_error(object: &T) -> Result<(), Self> {
         let config = ValidationConfig::default();
-        let mut errors = self.check(&config);
+        let mut errors = Self::check(object, &config);
 
         if let Some(err) = errors.next() {
             return Err(err);
@@ -29,12 +32,12 @@ pub trait ValidationCheck<T> {
     ///
     /// This method is designed for convenience over flexibility (it is intended
     /// for use in unit tests), and thus always uses the default configuration.
-    fn check_and_expect_one_error(&self) -> T
+    fn check_and_expect_one_error(object: &T) -> Self
     where
-        T: Display,
+        Self: Display,
     {
         let config = ValidationConfig::default();
-        let mut errors = self.check(&config).peekable();
+        let mut errors = Self::check(object, &config).peekable();
 
         let err = errors
             .next()

--- a/crates/fj-core/src/validation/validation_check.rs
+++ b/crates/fj-core/src/validation/validation_check.rs
@@ -15,8 +15,8 @@ pub trait ValidationCheck<T> {
     /// This method is designed for convenience over flexibility (it is intended
     /// for use in unit tests), and thus always uses the default configuration.
     fn check_and_return_first_error(&self) -> Result<(), T> {
-        let errors =
-            self.check(&ValidationConfig::default()).collect::<Vec<_>>();
+        let config = ValidationConfig::default();
+        let errors = self.check(&config).collect::<Vec<_>>();
 
         if let Some(err) = errors.into_iter().next() {
             return Err(err);

--- a/crates/fj-core/src/validation/validation_check.rs
+++ b/crates/fj-core/src/validation/validation_check.rs
@@ -29,14 +29,14 @@ pub trait ValidationCheck<T> {
     ///
     /// This method is designed for convenience over flexibility (it is intended
     /// for use in unit tests), and thus always uses the default configuration.
-    fn check_and_expect_one_error(&self)
+    fn check_and_expect_one_error(&self) -> T
     where
         T: Display,
     {
         let config = ValidationConfig::default();
         let mut errors = self.check(&config).peekable();
 
-        errors
+        let err = errors
             .next()
             .expect("Expected one validation error; none found");
 
@@ -49,5 +49,7 @@ pub trait ValidationCheck<T> {
 
             panic!("Expected only one validation error")
         }
+
+        err
     }
 }


### PR DESCRIPTION
From the message of the main commit:
> The way it was previously, fully qualified method call syntax would have
> been required to run a validation check. This wasn't visible in the code
> so far, as there only is one validation check currently.
>
> This change makes running validation checks a bit more convenient
> (compared to what it would have needed to be, not what's currently in
> the code). It preserves the discoverability, as the implementations are
> still listed in the documentation of the object type.

This is a further refinement of the infrastructure added for https://github.com/hannobraun/fornjot/issues/2157.