### PR TITLE
Implement `TransformObject` for `Handle<Surface>`

### DIFF
--- a/crates/fj-core/src/operations/sweep/region.rs
+++ b/crates/fj-core/src/operations/sweep/region.rs
@@ -32,7 +32,7 @@ pub trait SweepRegion {
     /// operation's scope.
     fn sweep_region(
         &self,
-        surface: &Surface,
+        surface: &Handle<Surface>,
         color: Option<Color>,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,
@@ -43,7 +43,7 @@ pub trait SweepRegion {
 impl SweepRegion for Region {
     fn sweep_region(
         &self,
-        surface: &Surface,
+        surface: &Handle<Surface>,
         color: Option<Color>,
         path: impl Into<Vector<3>>,
         cache: &mut SweepCache,

--- a/crates/fj-core/src/operations/transform/mod.rs
+++ b/crates/fj-core/src/operations/transform/mod.rs
@@ -102,9 +102,6 @@ pub struct TransformCache(TypeMap);
 
 impl TransformCache {
     fn get<T: 'static>(&mut self, key: &Handle<T>) -> Option<&Handle<T>> {
-        // Silencing Clippy warning due to false positive in Rust 1.73.0. See:
-        // https://github.com/rust-lang/rust-clippy/issues/11390#issuecomment-1750951533
-        #[allow(clippy::unwrap_or_default)]
         let map = self
             .0
             .entry::<BTreeMap<ObjectId, Handle<T>>>()
@@ -114,9 +111,6 @@ impl TransformCache {
     }
 
     fn insert<T: 'static>(&mut self, key: Handle<T>, value: Handle<T>) {
-        // Silencing Clippy warning due to false positive in Rust 1.73.0. See:
-        // https://github.com/rust-lang/rust-clippy/issues/11390#issuecomment-1750951533
-        #[allow(clippy::unwrap_or_default)]
         let map = self
             .0
             .entry::<BTreeMap<ObjectId, Handle<T>>>()

--- a/crates/fj-core/src/operations/transform/mod.rs
+++ b/crates/fj-core/src/operations/transform/mod.rs
@@ -10,7 +10,7 @@ mod solid;
 mod surface;
 mod vertex;
 
-use std::collections::BTreeMap;
+use std::collections::{btree_map, BTreeMap};
 
 use fj_math::{Transform, Vector};
 use type_map::TypeMap;
@@ -101,6 +101,18 @@ where
 pub struct TransformCache(TypeMap);
 
 impl TransformCache {
+    fn entry<T: 'static>(
+        &mut self,
+        key: &Handle<T>,
+    ) -> btree_map::Entry<ObjectId, Handle<T>> {
+        let map = self
+            .0
+            .entry::<BTreeMap<ObjectId, Handle<T>>>()
+            .or_insert_with(BTreeMap::new);
+
+        map.entry(key.id())
+    }
+
     fn get<T: 'static>(&mut self, key: &Handle<T>) -> Option<&Handle<T>> {
         let map = self
             .0

--- a/crates/fj-core/src/operations/transform/surface.rs
+++ b/crates/fj-core/src/operations/transform/surface.rs
@@ -1,17 +1,24 @@
 use fj_math::Transform;
 
-use crate::{objects::Surface, Core};
+use crate::{
+    objects::Surface, operations::insert::Insert, storage::Handle, Core,
+};
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Surface {
+impl TransformObject for Handle<Surface> {
     fn transform_with_cache(
         &self,
         transform: &Transform,
-        _: &mut Core,
-        _: &mut TransformCache,
+        core: &mut Core,
+        cache: &mut TransformCache,
     ) -> Self {
-        let geometry = self.geometry().transform(transform);
-        Self::new(geometry)
+        cache
+            .entry(self)
+            .or_insert_with(|| {
+                let geometry = self.geometry().transform(transform);
+                Surface::new(geometry).insert(core)
+            })
+            .clone()
     }
 }


### PR DESCRIPTION
This comes out of my work on https://github.com/hannobraun/fornjot/issues/2116. It is preparation for taking further steps towards managing surface geometry in a dedicated geometry layer.