### PR TITLE
Store surface geometry in new geometry layer

### DIFF
--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -1,0 +1,57 @@
+use std::collections::BTreeMap;
+
+use fj_math::Vector;
+
+use crate::{
+    objects::{Objects, Surface},
+    storage::{Handle, HandleWrapper},
+};
+
+use super::{GlobalPath, SurfaceGeometry};
+
+/// Geometric data that is associated with topological objects
+pub struct Geometry {
+    /// The geometry of surfaces
+    pub surface: BTreeMap<HandleWrapper<Surface>, SurfaceGeometry>,
+}
+
+impl Geometry {
+    /// Create a new instance of `Geometry`
+    pub fn new(objects: &Objects) -> Self {
+        let mut self_ = Self {
+            surface: BTreeMap::new(),
+        };
+
+        self_.define_surface_inner(
+            objects.surfaces.xy_plane(),
+            SurfaceGeometry {
+                u: GlobalPath::x_axis(),
+                v: Vector::unit_y(),
+            },
+        );
+        self_.define_surface_inner(
+            objects.surfaces.xz_plane(),
+            SurfaceGeometry {
+                u: GlobalPath::x_axis(),
+                v: Vector::unit_z(),
+            },
+        );
+        self_.define_surface_inner(
+            objects.surfaces.yz_plane(),
+            SurfaceGeometry {
+                u: GlobalPath::y_axis(),
+                v: Vector::unit_z(),
+            },
+        );
+
+        self_
+    }
+
+    pub(crate) fn define_surface_inner(
+        &mut self,
+        surface: Handle<Surface>,
+        geometry: SurfaceGeometry,
+    ) {
+        self.surface.insert(surface.clone().into(), geometry);
+    }
+}

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -1,11 +1,13 @@
 //! Types that are tied to objects, but aren't objects themselves
 
 mod boundary;
+mod geometry;
 mod path;
 mod surface;
 
 pub use self::{
     boundary::{CurveBoundary, CurveBoundaryElement},
+    geometry::Geometry,
     path::{GlobalPath, SurfacePath},
     surface::SurfaceGeometry,
 };

--- a/crates/fj-core/src/layers/geometry.rs
+++ b/crates/fj-core/src/layers/geometry.rs
@@ -1,0 +1,46 @@
+//! Layer infrastructure for [`Geometry`]
+
+use crate::{
+    geometry::{Geometry, SurfaceGeometry},
+    objects::Surface,
+    storage::Handle,
+};
+
+use super::{Command, Event, Layer};
+
+impl Layer<Geometry> {
+    /// Define the geometry of the provided surface
+    pub fn define_surface(
+        &mut self,
+        surface: Handle<Surface>,
+        geometry: SurfaceGeometry,
+    ) {
+        let mut events = Vec::new();
+        self.process(DefineSurface { surface, geometry }, &mut events);
+    }
+}
+
+/// Define the geometry of a surface
+pub struct DefineSurface {
+    surface: Handle<Surface>,
+    geometry: SurfaceGeometry,
+}
+
+impl Command<Geometry> for DefineSurface {
+    type Result = ();
+    type Event = Self;
+
+    fn decide(
+        self,
+        _: &Geometry,
+        events: &mut Vec<Self::Event>,
+    ) -> Self::Result {
+        events.push(self);
+    }
+}
+
+impl Event<Geometry> for DefineSurface {
+    fn evolve(&self, state: &mut Geometry) {
+        state.define_surface_inner(self.surface.clone(), self.geometry);
+    }
+}

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -20,7 +20,6 @@ use super::Layer;
 ///
 /// For now, there is no need for this, and all layers are just hardcoded here.
 /// That can be changed, once necessary.
-#[derive(Default)]
 pub struct Layers {
     /// The objects layer
     ///
@@ -42,7 +41,11 @@ pub struct Layers {
 impl Layers {
     /// Construct an instance of `Layers`
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            objects: Layer::default(),
+            validation: Layer::default(),
+            presentation: Layer::default(),
+        }
     }
 
     /// Construct an instance of `Layers`, using the provided configuration
@@ -51,5 +54,11 @@ impl Layers {
             validation: Layer::new(Validation::with_validation_config(config)),
             ..Self::new()
         }
+    }
+}
+
+impl Default for Layers {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -41,8 +41,10 @@ pub struct Layers {
 impl Layers {
     /// Construct an instance of `Layers`
     pub fn new() -> Self {
+        let objects = Objects::new();
+
         Self {
-            objects: Layer::default(),
+            objects: Layer::new(objects),
             validation: Layer::default(),
             presentation: Layer::default(),
         }

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -1,4 +1,5 @@
 use crate::{
+    geometry::Geometry,
     objects::Objects,
     presentation::Presentation,
     validation::{Validation, ValidationConfig},
@@ -27,6 +28,11 @@ pub struct Layers {
     /// shapes.
     pub objects: Layer<Objects>,
 
+    /// The geometry layer
+    ///
+    /// Manages geometric information that applies to topological objects.
+    pub geometry: Layer<Geometry>,
+
     /// The validation layer
     ///
     /// Monitors objects and validates them, as they are inserted.
@@ -42,9 +48,11 @@ impl Layers {
     /// Construct an instance of `Layers`
     pub fn new() -> Self {
         let objects = Objects::new();
+        let geometry = Geometry::new(&objects);
 
         Self {
             objects: Layer::new(objects),
+            geometry: Layer::new(geometry),
             validation: Layer::default(),
             presentation: Layer::default(),
         }

--- a/crates/fj-core/src/layers/layers.rs
+++ b/crates/fj-core/src/layers/layers.rs
@@ -49,7 +49,7 @@ impl Layers {
     pub fn with_validation_config(config: ValidationConfig) -> Self {
         Self {
             validation: Layer::new(Validation::with_validation_config(config)),
-            ..Default::default()
+            ..Self::new()
         }
     }
 }

--- a/crates/fj-core/src/layers/mod.rs
+++ b/crates/fj-core/src/layers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! See [`Layers`].
 
+pub mod geometry;
 pub mod objects;
 pub mod presentation;
 pub mod validation;

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -47,7 +47,13 @@ pub trait BuildSurface {
             u: u.into(),
             v: v.into(),
         };
-        Surface::new(geometry).insert(core)
+        let surface = Surface::new(geometry).insert(core);
+
+        core.layers
+            .geometry
+            .define_surface(surface.clone(), geometry);
+
+        surface
     }
 }
 

--- a/crates/fj-core/src/operations/transform/surface.rs
+++ b/crates/fj-core/src/operations/transform/surface.rs
@@ -17,7 +17,13 @@ impl TransformObject for Handle<Surface> {
             .entry(self)
             .or_insert_with(|| {
                 let geometry = self.geometry().transform(transform);
-                Surface::new(geometry).insert(core)
+                let surface = Surface::new(geometry).insert(core);
+
+                core.layers
+                    .geometry
+                    .define_surface(surface.clone(), geometry);
+
+                surface
             })
             .clone()
     }


### PR DESCRIPTION
From a commit message:
> This is just one step towards storing surface geometry in the geometry
> layer. It is not used anywhere yet.

None the less, it is an important step towards moving surface geometry to the geometry layer, which is part of https://github.com/hannobraun/fornjot/issues/2116.