### PR TITLE
Update ThreeMF to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,21 +2434,12 @@ checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
 
 [[package]]
 name = "quick-xml"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3199,11 +3190,11 @@ dependencies = [
 
 [[package]]
 name = "threemf"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf108acc769867300099b3c5334f3dd9bf8c420522a7b7a5938ba0142643808e"
+checksum = "542e6ea27d8dc779b54b6325da4a52b97367f7a63a41f9c0ce67a3096e550123"
 dependencies = [
- "quick-xml 0.27.1",
+ "quick-xml",
  "serde",
  "thiserror",
  "zip",
@@ -3787,7 +3778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.31.0",
+ "quick-xml",
  "quote",
 ]
 

--- a/crates/fj-export/Cargo.toml
+++ b/crates/fj-export/Cargo.toml
@@ -17,6 +17,6 @@ workspace = true
 fj-interop.workspace = true
 fj-math.workspace = true
 thiserror = "1.0.57"
-threemf = "0.4.0"
+threemf = "0.5.0"
 stl = "0.2.1"
 wavefront_rs = "=2.0.0-beta.1"

--- a/crates/fj-export/src/lib.rs
+++ b/crates/fj-export/src/lib.rs
@@ -66,7 +66,8 @@ fn export_3mf(mesh: &Mesh<Point<3>>, path: &Path) -> Result<(), Error> {
         },
     };
 
-    threemf::write(path, mesh)?;
+    let mut file = File::create(path)?;
+    threemf::write(&mut file, mesh)?;
 
     Ok(())
 }


### PR DESCRIPTION
Comically minimum effort. Completes #2223 .

I intend to make some bigger changes later but I figured this PR would be an easier starting point.

For my next PR I'd like to adapt the `export_3mf`, `export_stl`, and `export_obj` functions to accept anything implementing `std::io::Write` instead of a file path, add documentation comments, and then make them public.