### PR TITLE
Update with arbitrary containers of Handles or HandleWrappers

### DIFF
--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -25,14 +25,15 @@ pub trait UpdateCycle {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_half_edge<T, const N: usize>(
+    fn update_half_edge<T, R>(
         &self,
         handle: &Handle<HalfEdge>,
-        update: impl FnOnce(&Handle<HalfEdge>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<HalfEdge>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
-        T: Insert<Inserted = Handle<HalfEdge>>;
+        T: Insert<Inserted = Handle<HalfEdge>>,
+        R: IntoIterator<Item = T>;
 }
 
 impl UpdateCycle for Cycle {
@@ -51,20 +52,21 @@ impl UpdateCycle for Cycle {
         Cycle::new(half_edges)
     }
 
-    fn update_half_edge<T, const N: usize>(
+    fn update_half_edge<T, R>(
         &self,
         handle: &Handle<HalfEdge>,
-        update: impl FnOnce(&Handle<HalfEdge>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<HalfEdge>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
         T: Insert<Inserted = Handle<HalfEdge>>,
+        R: IntoIterator<Item = T>,
     {
         let edges = self
             .half_edges()
             .replace(
                 handle,
-                update(handle, core).map(|object| {
+                update(handle, core).into_iter().map(|object| {
                     object.insert(core).derive_from(handle, core)
                 }),
             )

--- a/crates/fj-core/src/operations/update/cycle.rs
+++ b/crates/fj-core/src/operations/update/cycle.rs
@@ -23,7 +23,7 @@ pub trait UpdateCycle {
     ///
     /// Panics, if the object can't be found.
     ///
-    /// Panics, if the update results in a duplicate object.
+    /// Panics, if the update results in multiple handles referencing the same object.
     #[must_use]
     fn update_half_edge<T, R>(
         &self,

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -33,7 +33,7 @@ pub trait UpdateRegion {
     ///
     /// Panics, if the object can't be found.
     ///
-    /// Panics, if the update results in a duplicate object.
+    /// Panics, if the update results in multiple handles referencing the same object.
     #[must_use]
     fn update_interior<T, R>(
         &self,

--- a/crates/fj-core/src/operations/update/region.rs
+++ b/crates/fj-core/src/operations/update/region.rs
@@ -35,14 +35,15 @@ pub trait UpdateRegion {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_interior<T, const N: usize>(
+    fn update_interior<T, R>(
         &self,
         handle: &Handle<Cycle>,
-        update: impl FnOnce(&Handle<Cycle>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Cycle>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
-        T: Insert<Inserted = Handle<Cycle>>;
+        T: Insert<Inserted = Handle<Cycle>>,
+        R: IntoIterator<Item = T>;
 }
 
 impl UpdateRegion for Region {
@@ -73,20 +74,21 @@ impl UpdateRegion for Region {
         Region::new(self.exterior().clone(), interiors)
     }
 
-    fn update_interior<T, const N: usize>(
+    fn update_interior<T, R>(
         &self,
         handle: &Handle<Cycle>,
-        update: impl FnOnce(&Handle<Cycle>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Cycle>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
         T: Insert<Inserted = Handle<Cycle>>,
+        R: IntoIterator<Item = T>,
     {
         let interiors = self
             .interiors()
             .replace(
                 handle,
-                update(handle, core).map(|object| {
+                update(handle, core).into_iter().map(|object| {
                     object.insert(core).derive_from(handle, core)
                 }),
             )

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -23,7 +23,7 @@ pub trait UpdateShell {
     ///
     /// Panics, if the object can't be found.
     ///
-    /// Panics, if the update results in a duplicate object.
+    /// Panics, if the update results in multiple handles referencing the same object.
     #[must_use]
     fn update_face<T, R>(
         &self,

--- a/crates/fj-core/src/operations/update/shell.rs
+++ b/crates/fj-core/src/operations/update/shell.rs
@@ -25,14 +25,15 @@ pub trait UpdateShell {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_face<T, const N: usize>(
+    fn update_face<T, R>(
         &self,
         handle: &Handle<Face>,
-        update: impl FnOnce(&Handle<Face>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Face>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
-        T: Insert<Inserted = Handle<Face>>;
+        T: Insert<Inserted = Handle<Face>>,
+        R: IntoIterator<Item = T>;
 
     /// Remove a face from the shell
     #[must_use]
@@ -53,20 +54,21 @@ impl UpdateShell for Shell {
         Shell::new(faces)
     }
 
-    fn update_face<T, const N: usize>(
+    fn update_face<T, R>(
         &self,
         handle: &Handle<Face>,
-        update: impl FnOnce(&Handle<Face>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Face>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
         T: Insert<Inserted = Handle<Face>>,
+        R: IntoIterator<Item = T>,
     {
         let faces = self
             .faces()
             .replace(
                 handle,
-                update(handle, core).map(|object| {
+                update(handle, core).into_iter().map(|object| {
                     object.insert(core).derive_from(handle, core)
                 }),
             )

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -25,14 +25,15 @@ pub trait UpdateSketch {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_region<T, const N: usize>(
+    fn update_region<T, R>(
         &self,
         handle: &Handle<Region>,
-        update: impl FnOnce(&Handle<Region>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Region>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
-        T: Insert<Inserted = Handle<Region>>;
+        T: Insert<Inserted = Handle<Region>>,
+        R: IntoIterator<Item = T>;
 }
 
 impl UpdateSketch for Sketch {
@@ -49,20 +50,21 @@ impl UpdateSketch for Sketch {
         Sketch::new(regions)
     }
 
-    fn update_region<T, const N: usize>(
+    fn update_region<T, R>(
         &self,
         handle: &Handle<Region>,
-        update: impl FnOnce(&Handle<Region>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Region>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
         T: Insert<Inserted = Handle<Region>>,
+        R: IntoIterator<Item = T>,
     {
         let regions = self
             .regions()
             .replace(
                 handle,
-                update(handle, core).map(|object| {
+                update(handle, core).into_iter().map(|object| {
                     object.insert(core).derive_from(handle, core)
                 }),
             )

--- a/crates/fj-core/src/operations/update/sketch.rs
+++ b/crates/fj-core/src/operations/update/sketch.rs
@@ -23,7 +23,7 @@ pub trait UpdateSketch {
     ///
     /// Panics, if the object can't be found.
     ///
-    /// Panics, if the update results in a duplicate object.
+    /// Panics, if the update results in multiple handles referencing the same object.
     #[must_use]
     fn update_region<T, R>(
         &self,

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -23,7 +23,7 @@ pub trait UpdateSolid {
     ///
     /// Panics, if the object can't be found.
     ///
-    /// Panics, if the update results in a duplicate object.
+    /// Panics, if the update results in multiple handles referencing the same object.
     #[must_use]
     fn update_shell<T, R>(
         &self,

--- a/crates/fj-core/src/operations/update/solid.rs
+++ b/crates/fj-core/src/operations/update/solid.rs
@@ -25,14 +25,15 @@ pub trait UpdateSolid {
     ///
     /// Panics, if the update results in a duplicate object.
     #[must_use]
-    fn update_shell<T, const N: usize>(
+    fn update_shell<T, R>(
         &self,
         handle: &Handle<Shell>,
-        update: impl FnOnce(&Handle<Shell>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Shell>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
-        T: Insert<Inserted = Handle<Shell>>;
+        T: Insert<Inserted = Handle<Shell>>,
+        R: IntoIterator<Item = T>;
 }
 
 impl UpdateSolid for Solid {
@@ -49,20 +50,21 @@ impl UpdateSolid for Solid {
         Solid::new(shells)
     }
 
-    fn update_shell<T, const N: usize>(
+    fn update_shell<T, R>(
         &self,
         handle: &Handle<Shell>,
-        update: impl FnOnce(&Handle<Shell>, &mut Core) -> [T; N],
+        update: impl FnOnce(&Handle<Shell>, &mut Core) -> R,
         core: &mut Core,
     ) -> Self
     where
         T: Insert<Inserted = Handle<Shell>>,
+        R: IntoIterator<Item = T>,
     {
         let shells = self
             .shells()
             .replace(
                 handle,
-                update(handle, core).map(|object| {
+                update(handle, core).into_iter().map(|object| {
                     object.insert(core).derive_from(handle, core)
                 }),
             )


### PR DESCRIPTION
The main purpose of this PR was to make it easier to check for duplicate handles referencing the same object, however it comes with a useful side effect.

I personally needed this because my CAD program accepts a scripting language to generate models with. The number of changes a user may make is dynamic, so I need the option to provide a variable number of new faces when updating a shell. I also need to validate that the new list of faces does not contain any duplicate handles so that I can avoid a panic and produce a more meaningful error message for the user.

The key change is that `ObjectSet::new` and `ObjectSet::replace` no longer take just arrays of Handles, but instead they take any iterable object that produces objects that can be turned into HandleWrapper.

This provides two key features:
1. You can pass an array of either Handle or HandleWrapper. Handle Wrapper makes it much easier to check if your handles are duplicates.
2. Any iterable object, such as a vector can be used for the update. I can only know how many shells my user will produce at runtime, so this is useful to me.

With such a workflow, things like this are now easy to implement:
```rust
    let mut result = Ok(());

    solid.update_shell(
        solid.shells().only(),
        |shell, core| {
           let new_faces: Vec<HandleWrapper<Face>> =
              vec![ /* The user does whatever they need to do to generate more faces */ ];
           
           // A HashSet is probably not an ideal way to search for duplicates on this small of a scale,
           // but it's good enough for this demo.
           let new_face_set = HashSet::from(new_faces.iter().map(|face_handle| face_handle.id()));
           
           if new_face_set.len() == new_faces.len() {
               new_faces // Nothing is wrong, we are clear to continue.
           } else {
               // This is an error situation.
               result = Err(Failure::DuplicateFaces);
               
               // Because there currently isn't a way to abort an update, we'll just return a copy of our
               // original shell this results in an unmodified solid.
               [shell.clone()]
           }
        },
        core,
    );

    return result;
```

I think at this point it might be good to rename `HandleWrapper` to `ObjectReference` to imply that we are comparing the references and not the objects, but I'll let you make that call. Coming up with a name that reflects the purpose of that thing is... difficult.