### PR TITLE
Made `export_obj` public

### DIFF
--- a/crates/fj-export/src/lib.rs
+++ b/crates/fj-export/src/lib.rs
@@ -130,7 +130,7 @@ pub fn export_stl(
 }
 
 /// Export the provided mesh to the provided writer in the OBJ format.
-fn export_obj(
+pub fn export_obj(
     mesh: &Mesh<Point<3>>,
     mut write: impl Write,
 ) -> Result<(), Error> {


### PR DESCRIPTION
I went to use the new export features in Command CAD and discovered I had made a very small mistake.