### PR TITLE
Return more information from shell-face sweep operation

### DIFF
--- a/crates/fj-core/src/operations/sweep/mod.rs
+++ b/crates/fj-core/src/operations/sweep/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     half_edge::SweepHalfEdge,
     path::SweepSurfacePath,
     region::{SweepRegion, SweptRegion},
-    shell_face::SweepFaceOfShell,
+    shell_face::{ShellExtendedBySweep, SweepFaceOfShell},
     sketch::SweepSketch,
     vertex::SweepVertex,
 };

--- a/crates/fj-core/src/operations/sweep/region.rs
+++ b/crates/fj-core/src/operations/sweep/region.rs
@@ -119,6 +119,7 @@ fn sweep_cycle(
 /// The result of sweeping a [`Region`]
 ///
 /// See [`SweepRegion`].
+#[derive(Clone)]
 pub struct SweptRegion {
     /// The side faces created by the sweep
     pub side_faces: Vec<Face>,

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -73,8 +73,7 @@ impl SweepFaceOfShell for Shell {
                 &mut cache,
                 core,
             )
-            .all_faces()
-            .collect::<Vec<_>>();
+            .all_faces();
 
         let shell = self.remove_face(&face).add_faces(faces, core);
 

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -37,7 +37,7 @@ pub trait SweepFaceOfShell {
         face: Handle<Face>,
         path: impl Into<Vector<3>>,
         core: &mut Core,
-    ) -> Self;
+    ) -> ShellExtendedBySweep;
 }
 
 impl SweepFaceOfShell for Shell {
@@ -46,7 +46,7 @@ impl SweepFaceOfShell for Shell {
         face: Handle<Face>,
         path: impl Into<Vector<3>>,
         core: &mut Core,
-    ) -> Self {
+    ) -> ShellExtendedBySweep {
         let path = path.into();
 
         if !face.region().interiors().is_empty() {
@@ -76,6 +76,16 @@ impl SweepFaceOfShell for Shell {
             .all_faces()
             .collect::<Vec<_>>();
 
-        self.remove_face(&face).add_faces(faces, core)
+        let shell = self.remove_face(&face).add_faces(faces, core);
+
+        ShellExtendedBySweep { shell }
     }
+}
+
+/// The result of sweeping a [`Face`] of a [`Shell`]
+///
+/// See [`SweepFaceOfShell`].
+pub struct ShellExtendedBySweep {
+    /// The resulting shell after the sweep
+    pub shell: Shell,
 }

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -65,17 +65,17 @@ impl SweepFaceOfShell for Shell {
             .insert(core)
             .derive_from(face.region().exterior(), core);
         let region = Region::new(exterior, []);
-        let faces = region
-            .sweep_region(
-                face.surface(),
-                face.region().get_color(core),
-                path,
-                &mut cache,
-                core,
-            )
-            .all_faces();
+        let swept_region = region.sweep_region(
+            face.surface(),
+            face.region().get_color(core),
+            path,
+            &mut cache,
+            core,
+        );
 
-        let shell = self.remove_face(&face).add_faces(faces, core);
+        let shell = self
+            .remove_face(&face)
+            .add_faces(swept_region.all_faces(), core);
 
         ShellExtendedBySweep { shell }
     }

--- a/crates/fj-core/src/operations/sweep/shell_face.rs
+++ b/crates/fj-core/src/operations/sweep/shell_face.rs
@@ -75,9 +75,13 @@ impl SweepFaceOfShell for Shell {
 
         let shell = self
             .remove_face(&face)
-            .add_faces(swept_region.all_faces(), core);
+            .add_faces(swept_region.clone().all_faces(), core);
 
-        ShellExtendedBySweep { shell }
+        ShellExtendedBySweep {
+            shell,
+            side_faces: swept_region.side_faces,
+            top_face: swept_region.top_face,
+        }
     }
 }
 
@@ -87,4 +91,10 @@ impl SweepFaceOfShell for Shell {
 pub struct ShellExtendedBySweep {
     /// The resulting shell after the sweep
     pub shell: Shell,
+
+    /// The side faces created by the sweep
+    pub side_faces: Vec<Face>,
+
+    /// The top face created by the sweep
+    pub top_face: Face,
 }

--- a/models/split/src/lib.rs
+++ b/models/split/src/lib.rs
@@ -21,7 +21,9 @@ pub fn model(size: f64, split_pos: f64, core: &mut fj::core::Core) -> Solid {
 
             let (shell, [face, _]) = shell.split_face(face, line, core);
 
-            [shell.sweep_face_of_shell(face, [0., 0., -size / 2.], core)]
+            [shell
+                .sweep_face_of_shell(face, [0., 0., -size / 2.], core)
+                .shell]
         },
         core,
     )


### PR DESCRIPTION
`SweepFaceOfShell::sweep_face_of_shell` now returns `ShellExtendedBySweep`, which in addition to the resulting shell, also provides the new faces in its `side_faces` and `top_face` fields.