### PR TITLE
Add `ValidateObject` command

### DIFF
--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -5,7 +5,7 @@ use crate::{
     validation::Validation,
 };
 
-use super::{Command, Event, Layer};
+use super::{validation::ValidateObject, Command, Event, Layer};
 
 impl Layer<Objects> {
     /// Insert an object into the stores
@@ -20,6 +20,9 @@ impl Layer<Objects> {
         self.process(InsertObject { object }, &mut events);
 
         for event in events {
+            let event = ValidateObject {
+                object: event.object.into(),
+            };
             validation.process(event, &mut Vec::new());
         }
     }

--- a/crates/fj-core/src/layers/objects.rs
+++ b/crates/fj-core/src/layers/objects.rs
@@ -29,9 +29,6 @@ impl Layer<Objects> {
 }
 
 /// Insert an object into the stores
-///
-/// This struct serves as both event and command for `Layer<Objects>`, as well
-/// as a command for `Layer<Validation>`.
 #[derive(Clone, Debug)]
 pub struct InsertObject {
     /// The object to insert

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -26,7 +26,6 @@ impl Command<Validation> for ValidateObject {
 
     fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
-
         self.object.validate(&state.config, &mut errors);
 
         for err in errors {

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -27,12 +27,11 @@ impl Command<Validation> for ValidateObject {
     fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
 
-        let object: AnyObject<Stored> = self.object;
-        object.validate(&state.config, &mut errors);
+        self.object.validate(&state.config, &mut errors);
 
         for err in errors {
             events.push(ValidationFailed {
-                object: object.clone(),
+                object: self.object.clone(),
                 err,
             });
         }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -5,7 +5,7 @@ use crate::{
     validation::{Validation, ValidationError, ValidationErrors},
 };
 
-use super::{objects::InsertObject, Command, Event, Layer};
+use super::{Command, Event, Layer};
 
 impl Layer<Validation> {
     /// Take all errors stored in the validation layer
@@ -14,14 +14,20 @@ impl Layer<Validation> {
     }
 }
 
-impl Command<Validation> for InsertObject {
+/// Validate an object
+pub struct ValidateObject {
+    /// The object to validate
+    pub object: AnyObject<Stored>,
+}
+
+impl Command<Validation> for ValidateObject {
     type Result = ();
     type Event = ValidationFailed;
 
     fn decide(self, state: &Validation, events: &mut Vec<Self::Event>) {
         let mut errors = Vec::new();
 
-        let object: AnyObject<Stored> = self.object.into();
+        let object: AnyObject<Stored> = self.object;
         object.validate(&state.config, &mut errors);
 
         for err in errors {


### PR DESCRIPTION
Add the new `ValidateObject` command for the validation layer, instead of reusing the object layer's `InsertObject` event. This opens the possibility of evolving both structs in different ways.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2116.