### PR TITLE
Add operation for updating half-edge geometry

### DIFF
--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -1,0 +1,2 @@
+/// Update the geometry of a [`HalfEdge`]
+pub trait UpdateHalfEdgeGeometry {}

--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -1,2 +1,33 @@
+use crate::{
+    geometry::SurfacePath, objects::HalfEdge, operations::insert::Insert,
+    storage::Handle, Core,
+};
+
 /// Update the geometry of a [`HalfEdge`]
-pub trait UpdateHalfEdgeGeometry {}
+pub trait UpdateHalfEdgeGeometry {
+    /// Update the path of the edge
+    #[must_use]
+    fn update_path(
+        &self,
+        update: impl FnOnce(SurfacePath) -> SurfacePath,
+        core: &mut Core,
+    ) -> Self;
+}
+
+impl UpdateHalfEdgeGeometry for Handle<HalfEdge> {
+    fn update_path(
+        &self,
+        update: impl FnOnce(SurfacePath) -> SurfacePath,
+        core: &mut Core,
+    ) -> Self {
+        let path = update(self.path());
+
+        HalfEdge::new(
+            path,
+            self.boundary(),
+            self.curve().clone(),
+            self.start_vertex().clone(),
+        )
+        .insert(core)
+    }
+}

--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -1,6 +1,11 @@
+use fj_math::Point;
+
 use crate::{
-    geometry::SurfacePath, objects::HalfEdge, operations::insert::Insert,
-    storage::Handle, Core,
+    geometry::{CurveBoundary, SurfacePath},
+    objects::HalfEdge,
+    operations::insert::Insert,
+    storage::Handle,
+    Core,
 };
 
 /// Update the geometry of a [`HalfEdge`]
@@ -10,6 +15,14 @@ pub trait UpdateHalfEdgeGeometry {
     fn update_path(
         &self,
         update: impl FnOnce(SurfacePath) -> SurfacePath,
+        core: &mut Core,
+    ) -> Self;
+
+    /// Update the boundary of the edge
+    #[must_use]
+    fn update_boundary(
+        &self,
+        update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
         core: &mut Core,
     ) -> Self;
 }
@@ -25,6 +38,20 @@ impl UpdateHalfEdgeGeometry for Handle<HalfEdge> {
         HalfEdge::new(
             path,
             self.boundary(),
+            self.curve().clone(),
+            self.start_vertex().clone(),
+        )
+        .insert(core)
+    }
+
+    fn update_boundary(
+        &self,
+        update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
+        core: &mut Core,
+    ) -> Self {
+        HalfEdge::new(
+            self.path(),
+            update(self.boundary()),
             self.curve().clone(),
             self.start_vertex().clone(),
         )

--- a/crates/fj-core/src/operations/geometry/mod.rs
+++ b/crates/fj-core/src/operations/geometry/mod.rs
@@ -1,0 +1,5 @@
+//! Operations to update the geometry of objects
+
+mod half_edge;
+
+pub use self::half_edge::UpdateHalfEdgeGeometry;

--- a/crates/fj-core/src/operations/mod.rs
+++ b/crates/fj-core/src/operations/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod build;
 pub mod derive;
+pub mod geometry;
 pub mod holes;
 pub mod insert;
 pub mod join;

--- a/crates/fj-core/src/operations/update/half_edge.rs
+++ b/crates/fj-core/src/operations/update/half_edge.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 /// Update a [`HalfEdge`]
-pub trait UpdateHalfEdge: Sized {
+pub trait UpdateHalfEdge {
     /// Update the boundary of the edge
     #[must_use]
     fn update_boundary(

--- a/crates/fj-core/src/operations/update/half_edge.rs
+++ b/crates/fj-core/src/operations/update/half_edge.rs
@@ -1,7 +1,4 @@
-use fj_math::Point;
-
 use crate::{
-    geometry::CurveBoundary,
     objects::{Curve, HalfEdge, Vertex},
     operations::{derive::DeriveFrom, insert::Insert},
     storage::Handle,
@@ -10,13 +7,6 @@ use crate::{
 
 /// Update a [`HalfEdge`]
 pub trait UpdateHalfEdge {
-    /// Update the boundary of the edge
-    #[must_use]
-    fn update_boundary(
-        &self,
-        update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
-    ) -> Self;
-
     /// Update the curve of the edge
     #[must_use]
     fn update_curve<T>(
@@ -39,18 +29,6 @@ pub trait UpdateHalfEdge {
 }
 
 impl UpdateHalfEdge for HalfEdge {
-    fn update_boundary(
-        &self,
-        update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,
-    ) -> Self {
-        HalfEdge::new(
-            self.path(),
-            update(self.boundary()),
-            self.curve().clone(),
-            self.start_vertex().clone(),
-        )
-    }
-
     fn update_curve<T>(
         &self,
         update: impl FnOnce(&Handle<Curve>, &mut Core) -> T,

--- a/crates/fj-core/src/operations/update/half_edge.rs
+++ b/crates/fj-core/src/operations/update/half_edge.rs
@@ -1,7 +1,7 @@
 use fj_math::Point;
 
 use crate::{
-    geometry::{CurveBoundary, SurfacePath},
+    geometry::CurveBoundary,
     objects::{Curve, HalfEdge, Vertex},
     operations::{derive::DeriveFrom, insert::Insert},
     storage::Handle,
@@ -10,14 +10,6 @@ use crate::{
 
 /// Update a [`HalfEdge`]
 pub trait UpdateHalfEdge: Sized {
-    /// Update the path of the edge
-    #[must_use]
-    fn update_path(
-        &self,
-        update: impl FnOnce(SurfacePath) -> SurfacePath,
-        core: &mut Core,
-    ) -> Handle<Self>;
-
     /// Update the boundary of the edge
     #[must_use]
     fn update_boundary(
@@ -47,22 +39,6 @@ pub trait UpdateHalfEdge: Sized {
 }
 
 impl UpdateHalfEdge for HalfEdge {
-    fn update_path(
-        &self,
-        update: impl FnOnce(SurfacePath) -> SurfacePath,
-        core: &mut Core,
-    ) -> Handle<Self> {
-        let path = update(self.path());
-
-        HalfEdge::new(
-            path,
-            self.boundary(),
-            self.curve().clone(),
-            self.start_vertex().clone(),
-        )
-        .insert(core)
-    }
-
     fn update_boundary(
         &self,
         update: impl FnOnce(CurveBoundary<Point<1>>) -> CurveBoundary<Point<1>>,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -403,6 +403,7 @@ mod tests {
         objects::{Curve, Shell},
         operations::{
             build::BuildShell,
+            geometry::UpdateHalfEdgeGeometry,
             update::{
                 UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion,
                 UpdateShell,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -436,9 +436,10 @@ mod tests {
                                                 |path| path.reverse(),
                                                 core,
                                             )
-                                            .update_boundary(|boundary| {
-                                                boundary.reverse()
-                                            })]
+                                            .update_boundary(
+                                                |boundary| boundary.reverse(),
+                                                core,
+                                            )]
                                     },
                                     core,
                                 )


### PR DESCRIPTION
Add the trait `UpdateHalfEdgeGeometry` and migrate the applicable method from `UpdateHalfEdge`. As part of my work on https://github.com/hannobraun/fornjot/issues/2116, these methods are about to diverge from the others in the trait significantly, which would cause issues that are avoided by splitting the trait.