### PR TITLE
Update half-edge geometry in geometry layer in more places

### DIFF
--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -8,6 +8,7 @@ use crate::{
     objects::{Curve, Face, HalfEdge, Shell, Surface, Vertex},
     operations::{
         build::{BuildFace, BuildHalfEdge, BuildSurface, Polygon},
+        geometry::UpdateHalfEdgeGeometry,
         insert::{Insert, IsInserted, IsInsertedNo, IsInsertedYes},
         join::JoinCycle,
         reverse::ReverseCurveCoordinateSystems,
@@ -99,6 +100,14 @@ pub trait BuildShell {
                             half_edge
                                 .update_start_vertex(|_, _| vertex, core)
                                 .update_curve(|_, _| curve, core)
+                                .insert(core)
+                                .set_path(
+                                    core.layers
+                                        .geometry
+                                        .of_half_edge(&half_edge)
+                                        .path,
+                                    &mut core.layers.geometry,
+                                )
                         })
                 };
 

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -91,13 +91,14 @@ pub trait BuildShell {
                         .zip_ext([[a, b], [b, c], [c, a]])
                         .zip_ext(curves_and_boundaries)
                         .map(|((vertex, positions), (curve, boundary))| {
-                            HalfEdge::line_segment(
+                            let half_edge = HalfEdge::line_segment(
                                 positions,
                                 Some(boundary.reverse().inner),
                                 core,
-                            )
-                            .update_start_vertex(|_, _| vertex, core)
-                            .update_curve(|_, _| curve, core)
+                            );
+                            half_edge
+                                .update_start_vertex(|_, _| vertex, core)
+                                .update_curve(|_, _| curve, core)
                         })
                 };
 

--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -1,7 +1,8 @@
 use fj_math::Point;
 
 use crate::{
-    geometry::{CurveBoundary, HalfEdgeGeometry, SurfacePath},
+    geometry::{CurveBoundary, Geometry, HalfEdgeGeometry, SurfacePath},
+    layers::Layer,
     objects::HalfEdge,
     operations::insert::Insert,
     storage::Handle,
@@ -10,6 +11,13 @@ use crate::{
 
 /// Update the geometry of a [`HalfEdge`]
 pub trait UpdateHalfEdgeGeometry {
+    /// Set the path of the half-edge
+    fn set_path(
+        self,
+        path: SurfacePath,
+        geometry: &mut Layer<Geometry>,
+    ) -> Self;
+
     /// Update the path of the half-edge
     #[must_use]
     fn update_path(
@@ -28,6 +36,15 @@ pub trait UpdateHalfEdgeGeometry {
 }
 
 impl UpdateHalfEdgeGeometry for Handle<HalfEdge> {
+    fn set_path(
+        self,
+        path: SurfacePath,
+        geometry: &mut Layer<Geometry>,
+    ) -> Self {
+        geometry.define_half_edge(self.clone(), HalfEdgeGeometry { path });
+        self
+    }
+
     fn update_path(
         &self,
         update: impl FnOnce(SurfacePath) -> SurfacePath,

--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Update the geometry of a [`HalfEdge`]
 pub trait UpdateHalfEdgeGeometry {
-    /// Update the path of the edge
+    /// Update the path of the half-edge
     #[must_use]
     fn update_path(
         &self,
@@ -18,7 +18,7 @@ pub trait UpdateHalfEdgeGeometry {
         core: &mut Core,
     ) -> Self;
 
-    /// Update the boundary of the edge
+    /// Update the boundary of the half-edge
     #[must_use]
     fn update_boundary(
         &self,

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -8,6 +8,7 @@ use crate::{
     objects::{Cycle, HalfEdge},
     operations::{
         build::BuildHalfEdge,
+        geometry::UpdateHalfEdgeGeometry,
         insert::Insert,
         update::{UpdateCycle, UpdateHalfEdge},
     },
@@ -144,6 +145,14 @@ impl JoinCycle for Cycle {
                                             .clone()
                                     },
                                     core,
+                                )
+                                .insert(core)
+                                .set_path(
+                                    core.layers
+                                        .geometry
+                                        .of_half_edge(half_edge)
+                                        .path,
+                                    &mut core.layers.geometry,
                                 )]
                         },
                         core,
@@ -151,10 +160,19 @@ impl JoinCycle for Cycle {
                     .update_half_edge(
                         self.half_edges().nth_circular(index + 1),
                         |half_edge, core| {
-                            [half_edge.update_start_vertex(
-                                |_, _| edge_other.start_vertex().clone(),
-                                core,
-                            )]
+                            [half_edge
+                                .update_start_vertex(
+                                    |_, _| edge_other.start_vertex().clone(),
+                                    core,
+                                )
+                                .insert(core)
+                                .set_path(
+                                    core.layers
+                                        .geometry
+                                        .of_half_edge(half_edge)
+                                        .path,
+                                    &mut core.layers.geometry,
+                                )]
                         },
                         core,
                     )

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -129,8 +129,8 @@ impl JoinCycle for Cycle {
                 cycle
                     .update_half_edge(
                         self.half_edges().nth_circular(index),
-                        |edge, core| {
-                            [edge
+                        |half_edge, core| {
+                            [half_edge
                                 .update_curve(
                                     |_, _| edge_other.curve().clone(),
                                     core,
@@ -150,8 +150,8 @@ impl JoinCycle for Cycle {
                     )
                     .update_half_edge(
                         self.half_edges().nth_circular(index + 1),
-                        |edge, core| {
-                            [edge.update_start_vertex(
+                        |half_edge, core| {
+                            [half_edge.update_start_vertex(
                                 |_, _| edge_other.start_vertex().clone(),
                                 core,
                             )]

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -3,8 +3,8 @@ use fj_math::Point;
 use crate::{
     objects::{HalfEdge, Shell},
     operations::{
-        derive::DeriveFrom, insert::Insert, replace::ReplaceHalfEdge,
-        split::SplitHalfEdge, update::UpdateHalfEdge,
+        derive::DeriveFrom, geometry::UpdateHalfEdgeGeometry, insert::Insert,
+        replace::ReplaceHalfEdge, split::SplitHalfEdge, update::UpdateHalfEdge,
     },
     queries::SiblingOfHalfEdge,
     storage::Handle,
@@ -55,9 +55,20 @@ impl SplitEdge for Shell {
                 )
                 .insert(core);
             [sibling_a, sibling_b].map(|half_edge| {
-                half_edge.insert(core).derive_from(&sibling, core)
+                half_edge.insert(core).derive_from(&sibling, core).set_path(
+                    core.layers.geometry.of_half_edge(&sibling).path,
+                    &mut core.layers.geometry,
+                )
             })
         };
+
+        let [half_edge_a, half_edge_b] =
+            [half_edge_a, half_edge_b].map(|half_edge_part| {
+                half_edge_part.set_path(
+                    core.layers.geometry.of_half_edge(half_edge).path,
+                    &mut core.layers.geometry,
+                )
+            });
 
         let shell = self
             .replace_half_edge(

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -7,6 +7,7 @@ use crate::{
     operations::{
         build::{BuildCycle, BuildHalfEdge},
         derive::DeriveFrom,
+        geometry::UpdateHalfEdgeGeometry,
         insert::Insert,
         split::SplitEdge,
         update::{
@@ -110,6 +111,10 @@ impl SplitFace for Shell {
             half_edge
                 .update_start_vertex(|_, _| b.start_vertex().clone(), core)
                 .insert(core)
+                .set_path(
+                    core.layers.geometry.of_half_edge(&half_edge).path,
+                    &mut core.layers.geometry,
+                )
         };
         let dividing_half_edge_c_to_b = HalfEdge::from_sibling(
             &dividing_half_edge_a_to_d,

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -101,13 +101,16 @@ impl SplitFace for Shell {
             .expect("Updated shell must contain updated face");
 
         // Build the edge that's going to divide the new faces.
-        let dividing_half_edge_a_to_d = HalfEdge::line_segment(
-            [b.start_position(), d.start_position()],
-            None,
-            core,
-        )
-        .update_start_vertex(|_, _| b.start_vertex().clone(), core)
-        .insert(core);
+        let dividing_half_edge_a_to_d = {
+            let half_edge = HalfEdge::line_segment(
+                [b.start_position(), d.start_position()],
+                None,
+                core,
+            );
+            half_edge
+                .update_start_vertex(|_, _| b.start_vertex().clone(), core)
+                .insert(core)
+        };
         let dividing_half_edge_c_to_b = HalfEdge::from_sibling(
             &dividing_half_edge_a_to_d,
             d.start_vertex().clone(),

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -6,6 +6,7 @@ use crate::{
     objects::{Cycle, Face, HalfEdge, Region, Vertex},
     operations::{
         build::{BuildCycle, BuildHalfEdge},
+        geometry::UpdateHalfEdgeGeometry,
         insert::Insert,
         presentation::SetColor,
         update::{UpdateCycle, UpdateHalfEdge},
@@ -128,7 +129,10 @@ impl SweepHalfEdge for HalfEdge {
                         half_edge
                     };
 
-                    half_edge.insert(core)
+                    half_edge.insert(core).set_path(
+                        core.layers.geometry.of_half_edge(&line_segment).path,
+                        &mut core.layers.geometry,
+                    )
                 };
 
                 exterior = exterior.add_half_edges([half_edge.clone()], core);

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -114,7 +114,7 @@ impl SweepHalfEdge for HalfEdge {
             .zip_ext(curves)
             .map(|((((boundary, start), end), start_vertex), curve)| {
                 let edge = {
-                    let edge = HalfEdge::line_segment(
+                    let half_edge = HalfEdge::line_segment(
                         [start, end],
                         Some(boundary),
                         core,
@@ -122,9 +122,9 @@ impl SweepHalfEdge for HalfEdge {
                     .update_start_vertex(|_, _| start_vertex, core);
 
                     let edge = if let Some(curve) = curve {
-                        edge.update_curve(|_, _| curve, core)
+                        half_edge.update_curve(|_, _| curve, core)
                     } else {
-                        edge
+                        half_edge
                     };
 
                     edge.insert(core)

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -113,7 +113,7 @@ impl SweepHalfEdge for HalfEdge {
             .zip_ext(vertices)
             .zip_ext(curves)
             .map(|((((boundary, start), end), start_vertex), curve)| {
-                let edge = {
+                let half_edge = {
                     let half_edge = HalfEdge::line_segment(
                         [start, end],
                         Some(boundary),
@@ -130,9 +130,9 @@ impl SweepHalfEdge for HalfEdge {
                     half_edge.insert(core)
                 };
 
-                exterior = exterior.add_half_edges([edge.clone()], core);
+                exterior = exterior.add_half_edges([half_edge.clone()], core);
 
-                edge
+                half_edge
             });
 
         let exterior = exterior.insert(core);

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -114,12 +114,13 @@ impl SweepHalfEdge for HalfEdge {
             .zip_ext(curves)
             .map(|((((boundary, start), end), start_vertex), curve)| {
                 let half_edge = {
-                    let half_edge = HalfEdge::line_segment(
+                    let line_segment = HalfEdge::line_segment(
                         [start, end],
                         Some(boundary),
                         core,
-                    )
-                    .update_start_vertex(|_, _| start_vertex, core);
+                    );
+                    let half_edge = line_segment
+                        .update_start_vertex(|_, _| start_vertex, core);
 
                     let half_edge = if let Some(curve) = curve {
                         half_edge.update_curve(|_, _| curve, core)

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -121,13 +121,13 @@ impl SweepHalfEdge for HalfEdge {
                     )
                     .update_start_vertex(|_, _| start_vertex, core);
 
-                    let edge = if let Some(curve) = curve {
+                    let half_edge = if let Some(curve) = curve {
                         half_edge.update_curve(|_, _| curve, core)
                     } else {
                         half_edge
                     };
 
-                    edge.insert(core)
+                    half_edge.insert(core)
                 };
 
                 exterior = exterior.add_half_edges([edge.clone()], core);

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -404,6 +404,7 @@ mod tests {
         operations::{
             build::BuildShell,
             geometry::UpdateHalfEdgeGeometry,
+            insert::Insert,
             update::{
                 UpdateCycle, UpdateFace, UpdateHalfEdge, UpdateRegion,
                 UpdateShell,
@@ -545,10 +546,19 @@ mod tests {
                                 cycle.update_half_edge(
                                     cycle.half_edges().nth_circular(0),
                                     |half_edge, core| {
-                                        [half_edge.update_curve(
-                                            |_, _| Curve::new(),
-                                            core,
-                                        )]
+                                        [half_edge
+                                            .update_curve(
+                                                |_, _| Curve::new(),
+                                                core,
+                                            )
+                                            .insert(core)
+                                            .set_path(
+                                                core.layers
+                                                    .geometry
+                                                    .of_half_edge(half_edge)
+                                                    .path,
+                                                &mut core.layers.geometry,
+                                            )]
                                     },
                                     core,
                                 )

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -430,8 +430,8 @@ mod tests {
                             |cycle, core| {
                                 cycle.update_half_edge(
                                     cycle.half_edges().nth_circular(0),
-                                    |edge, core| {
-                                        [edge
+                                    |half_edge, core| {
+                                        [half_edge
                                             .update_path(
                                                 |path| path.reverse(),
                                                 core,
@@ -508,8 +508,8 @@ mod tests {
                             |cycle, core| {
                                 cycle.update_half_edge(
                                     cycle.half_edges().nth_circular(0),
-                                    |edge, core| {
-                                        [edge.update_curve(
+                                    |half_edge, core| {
+                                        [half_edge.update_curve(
                                             |_, _| Curve::new(),
                                             core,
                                         )]


### PR DESCRIPTION
I already made sure the geometry layer is updated in all the obvious places in https://github.com/hannobraun/fornjot/pull/2271, but it turns out there were quite a few more that are less obvious.

The problem here is that everywhere a half-edge is updated, by calling `update_curve` or `update_start_vertex`, you create a new half-edge, and the new half-edge does not have any geometry associated with it in the geometry layer. That needs to be added manually, which is exactly what I did in this pull request.

This is a pain, and error-prone, but I think it's only relevant during the current transition. I expect that long-term, only `Surface`, `Curve`, and `Vertex` will have geometry associated with them, and since there's no reason to create new instances of those while wanting to keep the geometry, this problem won't be present then (they contain no topological data, so changing the geometry is literally the only reason you'd want to create a new instance).

This is another step towards https://github.com/hannobraun/fornjot/issues/2116, as now it's possible to actually use the geometry from the geometry layer. This is the next step, and removing that part of the geometry from the object graph can come right after.