### PR TITLE
Read half-edge geometry from geometry layer in most places

### DIFF
--- a/crates/fj-core/src/algorithms/approx/cycle.rs
+++ b/crates/fj-core/src/algorithms/approx/cycle.rs
@@ -2,8 +2,6 @@
 //!
 //! See [`CycleApprox`].
 
-use std::ops::Deref;
-
 use fj_math::Segment;
 
 use crate::{geometry::SurfaceGeometry, objects::Cycle, Core};
@@ -30,8 +28,7 @@ impl Approx for (&Cycle, &SurfaceGeometry) {
             .half_edges()
             .iter()
             .map(|half_edge| {
-                (half_edge.deref(), surface)
-                    .approx_with_cache(tolerance, cache, core)
+                (half_edge, surface).approx_with_cache(tolerance, cache, core)
             })
             .collect();
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -46,7 +46,7 @@ impl Approx for (&Handle<HalfEdge>, &SurfaceGeometry) {
         let rest = {
             let approx = (
                 half_edge.curve(),
-                half_edge.path(),
+                core.layers.geometry.of_half_edge(half_edge).path,
                 surface,
                 half_edge.boundary(),
             )
@@ -57,8 +57,12 @@ impl Approx for (&Handle<HalfEdge>, &SurfaceGeometry) {
                 );
 
             approx.points.into_iter().map(|point| {
-                let point_surface =
-                    half_edge.path().point_from_path_coords(point.local_form);
+                let point_surface = core
+                    .layers
+                    .geometry
+                    .of_half_edge(half_edge)
+                    .path
+                    .point_from_path_coords(point.local_form);
 
                 ApproxPoint::new(point_surface, point.global_form)
             })

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -5,14 +5,16 @@
 //! approximations are usually used to build cycle approximations, and this way,
 //! the caller doesn't have to deal with duplicate vertices.
 
-use crate::{geometry::SurfaceGeometry, objects::HalfEdge, Core};
+use crate::{
+    geometry::SurfaceGeometry, objects::HalfEdge, storage::Handle, Core,
+};
 
 use super::{
     curve::CurveApproxCache, vertex::VertexApproxCache, Approx, ApproxPoint,
     Tolerance,
 };
 
-impl Approx for (&HalfEdge, &SurfaceGeometry) {
+impl Approx for (&Handle<HalfEdge>, &SurfaceGeometry) {
     type Approximation = HalfEdgeApprox;
     type Cache = HalfEdgeApproxCache;
 

--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -110,7 +110,7 @@ impl Approx for &Face {
             exterior,
             interiors,
             color: self.region().get_color(core),
-            coord_handedness: self.coord_handedness(),
+            coord_handedness: self.coord_handedness(&core.layers.geometry),
         }
     }
 }

--- a/crates/fj-core/src/algorithms/bounding_volume/edge.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/edge.rs
@@ -3,9 +3,10 @@ use fj_math::{Aabb, Vector};
 use crate::{
     geometry::{Geometry, SurfacePath},
     objects::HalfEdge,
+    storage::Handle,
 };
 
-impl super::BoundingVolume<2> for HalfEdge {
+impl super::BoundingVolume<2> for Handle<HalfEdge> {
     fn aabb(&self, _: &Geometry) -> Option<Aabb<2>> {
         match self.path() {
             SurfacePath::Circle(circle) => {

--- a/crates/fj-core/src/algorithms/bounding_volume/edge.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/edge.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 
 impl super::BoundingVolume<2> for Handle<HalfEdge> {
-    fn aabb(&self, _: &Geometry) -> Option<Aabb<2>> {
-        match self.path() {
+    fn aabb(&self, geometry: &Geometry) -> Option<Aabb<2>> {
+        match geometry.of_half_edge(self).path {
             SurfacePath::Circle(circle) => {
                 // Just calculate the AABB of the whole circle. This is not the
                 // most precise, but it should do for now.
@@ -23,7 +23,10 @@ impl super::BoundingVolume<2> for Handle<HalfEdge> {
             }
             SurfacePath::Line(_) => {
                 let points = self.boundary().inner.map(|point_curve| {
-                    self.path().point_from_path_coords(point_curve)
+                    geometry
+                        .of_half_edge(self)
+                        .path
+                        .point_from_path_coords(point_curve)
                 });
 
                 Some(Aabb::<2>::from_points(points))

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -1,7 +1,7 @@
 use fj_math::{Scalar, Winding};
 
 use crate::{
-    geometry::SurfacePath,
+    geometry::{Geometry, SurfacePath},
     objects::{HalfEdge, ObjectSet},
     storage::Handle,
 };
@@ -29,7 +29,7 @@ impl Cycle {
     /// Please note that this is not *the* winding of the cycle, only one of the
     /// two possible windings, depending on the direction you look at the
     /// surface that the cycle is defined on from.
-    pub fn winding(&self) -> Winding {
+    pub fn winding(&self, _: &Geometry) -> Winding {
         // The cycle could be made up of one or two circles. If that is the
         // case, the winding of the cycle is determined by the winding of the
         // first circle.

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -29,7 +29,7 @@ impl Cycle {
     /// Please note that this is not *the* winding of the cycle, only one of the
     /// two possible windings, depending on the direction you look at the
     /// surface that the cycle is defined on from.
-    pub fn winding(&self, _: &Geometry) -> Winding {
+    pub fn winding(&self, geometry: &Geometry) -> Winding {
         // The cycle could be made up of one or two circles. If that is the
         // case, the winding of the cycle is determined by the winding of the
         // first circle.
@@ -43,7 +43,7 @@ impl Cycle {
             let [a, b] = first.boundary().inner;
             let edge_direction_positive = a < b;
 
-            let circle = match first.path() {
+            let circle = match geometry.of_half_edge(first).path {
                 SurfacePath::Circle(circle) => circle,
                 SurfacePath::Line(_) => unreachable!(
                     "Invalid cycle: less than 3 edges, but not all are circles"

--- a/crates/fj-core/src/objects/kinds/face.rs
+++ b/crates/fj-core/src/objects/kinds/face.rs
@@ -65,8 +65,8 @@ impl Face {
     /// Faces *do* have an orientation, meaning they have definite front and
     /// back sides. The front side is the side, where the face's exterior cycle
     /// is wound counter-clockwise.
-    pub fn coord_handedness(&self, _: &Geometry) -> Handedness {
-        match self.region.exterior().winding() {
+    pub fn coord_handedness(&self, geometry: &Geometry) -> Handedness {
+        match self.region.exterior().winding(geometry) {
             Winding::Ccw => Handedness::RightHanded,
             Winding::Cw => Handedness::LeftHanded,
         }

--- a/crates/fj-core/src/objects/kinds/face.rs
+++ b/crates/fj-core/src/objects/kinds/face.rs
@@ -1,6 +1,7 @@
 use fj_math::Winding;
 
 use crate::{
+    geometry::Geometry,
     objects::{Region, Surface},
     storage::{Handle, HandleWrapper},
 };
@@ -64,7 +65,7 @@ impl Face {
     /// Faces *do* have an orientation, meaning they have definite front and
     /// back sides. The front side is the side, where the face's exterior cycle
     /// is wound counter-clockwise.
-    pub fn coord_handedness(&self) -> Handedness {
+    pub fn coord_handedness(&self, _: &Geometry) -> Handedness {
         match self.region.exterior().winding() {
             Winding::Ccw => Handedness::RightHanded,
             Winding::Cw => Handedness::LeftHanded,

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -34,7 +34,7 @@ pub trait BuildHalfEdge {
         core: &mut Core,
     ) -> Handle<HalfEdge> {
         let half_edge = HalfEdge::new(
-            sibling.path(),
+            core.layers.geometry.of_half_edge(sibling).path,
             sibling.boundary().reverse(),
             sibling.curve().clone(),
             start_vertex,
@@ -44,7 +44,7 @@ pub trait BuildHalfEdge {
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
             HalfEdgeGeometry {
-                path: sibling.path(),
+                path: core.layers.geometry.of_half_edge(sibling).path,
             },
         );
 

--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -50,7 +50,7 @@ impl UpdateHalfEdgeGeometry for Handle<HalfEdge> {
         update: impl FnOnce(SurfacePath) -> SurfacePath,
         core: &mut Core,
     ) -> Self {
-        let path = update(self.path());
+        let path = update(core.layers.geometry.of_half_edge(self).path);
 
         let half_edge = HalfEdge::new(
             path,
@@ -73,7 +73,7 @@ impl UpdateHalfEdgeGeometry for Handle<HalfEdge> {
         core: &mut Core,
     ) -> Self {
         HalfEdge::new(
-            self.path(),
+            core.layers.geometry.of_half_edge(self).path,
             update(self.boundary()),
             self.curve().clone(),
             self.start_vertex().clone(),

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -68,7 +68,10 @@ impl AddHole for Shell {
                             [Cycle::empty().add_joined_edges(
                                 [(
                                     entry.clone(),
-                                    entry.path(),
+                                    core.layers
+                                        .geometry
+                                        .of_half_edge(&entry)
+                                        .path,
                                     entry.boundary(),
                                 )],
                                 core,
@@ -139,7 +142,10 @@ impl AddHole for Shell {
                             [Cycle::empty().add_joined_edges(
                                 [(
                                     entry.clone(),
-                                    entry.path(),
+                                    core.layers
+                                        .geometry
+                                        .of_half_edge(&entry)
+                                        .path,
                                     entry.boundary(),
                                 )],
                                 core,
@@ -159,7 +165,14 @@ impl AddHole for Shell {
                     |region, core| {
                         region.add_interiors(
                             [Cycle::empty().add_joined_edges(
-                                [(exit.clone(), exit.path(), exit.boundary())],
+                                [(
+                                    exit.clone(),
+                                    core.layers
+                                        .geometry
+                                        .of_half_edge(exit)
+                                        .path,
+                                    exit.boundary(),
+                                )],
                                 core,
                             )],
                             core,

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -14,7 +14,7 @@ impl Reverse for Cycle {
             .pairs()
             .map(|(current, next)| {
                 let half_edge = HalfEdge::new(
-                    current.path(),
+                    core.layers.geometry.of_half_edge(current).path,
                     current.boundary().reverse(),
                     current.curve().clone(),
                     next.start_vertex().clone(),
@@ -25,7 +25,7 @@ impl Reverse for Cycle {
                 core.layers.geometry.define_half_edge(
                     half_edge.clone(),
                     HalfEdgeGeometry {
-                        path: current.path(),
+                        path: core.layers.geometry.of_half_edge(current).path,
                     },
                 );
 

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -10,7 +10,7 @@ use super::ReverseCurveCoordinateSystems;
 
 impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
     fn reverse_curve_coordinate_systems(&self, core: &mut Core) -> Self {
-        let path = self.path().reverse();
+        let path = core.layers.geometry.of_half_edge(self).path.reverse();
         let boundary = self.boundary().reverse();
 
         let half_edge = HalfEdge::new(

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -44,14 +44,14 @@ impl SplitHalfEdge for Handle<HalfEdge> {
         let [start, end] = self.boundary().inner;
 
         let a = HalfEdge::new(
-            self.path(),
+            core.layers.geometry.of_half_edge(self).path,
             [start, point],
             self.curve().clone(),
             self.start_vertex().clone(),
         )
         .insert(core);
         let b = HalfEdge::new(
-            self.path(),
+            core.layers.geometry.of_half_edge(self).path,
             [point, end],
             self.curve().clone(),
             Vertex::new().insert(core),
@@ -60,11 +60,15 @@ impl SplitHalfEdge for Handle<HalfEdge> {
 
         core.layers.geometry.define_half_edge(
             a.clone(),
-            HalfEdgeGeometry { path: self.path() },
+            HalfEdgeGeometry {
+                path: core.layers.geometry.of_half_edge(self).path,
+            },
         );
         core.layers.geometry.define_half_edge(
             b.clone(),
-            HalfEdgeGeometry { path: self.path() },
+            HalfEdgeGeometry {
+                path: core.layers.geometry.of_half_edge(self).path,
+            },
         );
 
         [a, b]

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -33,7 +33,7 @@ pub trait SplitHalfEdge {
     ) -> [Handle<HalfEdge>; 2];
 }
 
-impl SplitHalfEdge for HalfEdge {
+impl SplitHalfEdge for Handle<HalfEdge> {
     fn split_half_edge(
         &self,
         point: impl Into<Point<1>>,

--- a/crates/fj-core/src/operations/sweep/cycle.rs
+++ b/crates/fj-core/src/operations/sweep/cycle.rs
@@ -77,7 +77,7 @@ impl SweepCycle for Cycle {
 
             top_edges.push((
                 top_edge,
-                bottom_half_edge.path(),
+                core.layers.geometry.of_half_edge(bottom_half_edge).path,
                 bottom_half_edge.boundary(),
             ));
         }

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -59,7 +59,12 @@ impl SweepHalfEdge for Handle<HalfEdge> {
     ) -> (Face, Handle<HalfEdge>) {
         let path = path.into();
 
-        let surface = self.path().sweep_surface_path(surface, path, core);
+        let surface = core
+            .layers
+            .geometry
+            .of_half_edge(self)
+            .path
+            .sweep_surface_path(surface, path, core);
 
         // Next, we need to define the boundaries of the face. Let's start with
         // the global vertices and edges.

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -47,7 +47,7 @@ pub trait SweepHalfEdge {
     ) -> (Face, Handle<HalfEdge>);
 }
 
-impl SweepHalfEdge for HalfEdge {
+impl SweepHalfEdge for Handle<HalfEdge> {
     fn sweep_half_edge(
         &self,
         end_vertex: Handle<Vertex>,

--- a/crates/fj-core/src/operations/sweep/sketch.rs
+++ b/crates/fj-core/src/operations/sweep/sketch.rs
@@ -40,7 +40,10 @@ impl SweepSketch for Sketch {
             let region = {
                 // The following code assumes that the sketch is winded counter-
                 // clockwise. Let's check that real quick.
-                assert!(region.exterior().winding().is_ccw());
+                assert!(region
+                    .exterior()
+                    .winding(&core.layers.geometry)
+                    .is_ccw());
 
                 let is_negative_sweep = {
                     let u = match core.layers.geometry.of_surface(&surface).u {

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -16,7 +16,7 @@ impl TransformObject for Handle<HalfEdge> {
     ) -> Self {
         // Don't need to transform the path, as that's defined in surface
         // coordinates.
-        let path = self.path();
+        let path = core.layers.geometry.of_half_edge(self).path;
         let boundary = self.boundary();
         let curve = self
             .curve()

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -13,10 +13,10 @@ impl Validate for Face {
         &self,
         _: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
-        _: &Geometry,
+        geometry: &Geometry,
     ) {
         FaceValidationError::check_boundary(self, errors);
-        FaceValidationError::check_interior_winding(self, errors);
+        FaceValidationError::check_interior_winding(self, geometry, errors);
     }
 }
 
@@ -56,7 +56,11 @@ impl FaceValidationError {
         // checks for `Cycle` to make sure that the cycle is closed properly.
     }
 
-    fn check_interior_winding(face: &Face, errors: &mut Vec<ValidationError>) {
+    fn check_interior_winding(
+        face: &Face,
+        _: &Geometry,
+        errors: &mut Vec<ValidationError>,
+    ) {
         if face.region().exterior().half_edges().is_empty() {
             // Can't determine winding, if the cycle has no edges. Sounds like a
             // job for a different validation check.

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -58,7 +58,7 @@ impl FaceValidationError {
 
     fn check_interior_winding(
         face: &Face,
-        _: &Geometry,
+        geometry: &Geometry,
         errors: &mut Vec<ValidationError>,
     ) {
         if face.region().exterior().half_edges().is_empty() {
@@ -67,7 +67,7 @@ impl FaceValidationError {
             return;
         }
 
-        let exterior_winding = face.region().exterior().winding();
+        let exterior_winding = face.region().exterior().winding(geometry);
 
         for interior in face.region().interiors() {
             if interior.half_edges().is_empty() {
@@ -75,7 +75,7 @@ impl FaceValidationError {
                 // like a job for a different validation check.
                 continue;
             }
-            let interior_winding = interior.winding();
+            let interior_winding = interior.winding(geometry);
 
             if exterior_winding == interior_winding {
                 errors.push(

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -13,10 +13,12 @@ impl Validate for Sketch {
         &self,
         config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
-        _: &Geometry,
+        geometry: &Geometry,
     ) {
         SketchValidationError::check_object_references(self, config, errors);
-        SketchValidationError::check_exterior_cycles(self, config, errors);
+        SketchValidationError::check_exterior_cycles(
+            self, geometry, config, errors,
+        );
         SketchValidationError::check_interior_cycles(self, config, errors);
     }
 }
@@ -74,6 +76,7 @@ impl SketchValidationError {
 
     fn check_exterior_cycles(
         sketch: &Sketch,
+        _: &Geometry,
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -78,13 +78,13 @@ impl SketchValidationError {
 
     fn check_exterior_cycles(
         sketch: &Sketch,
-        _: &Geometry,
+        geometry: &Geometry,
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
         sketch.regions().iter().for_each(|region| {
             let cycle = region.exterior();
-            if cycle.winding() == Winding::Cw {
+            if cycle.winding(geometry) == Winding::Cw {
                 errors.push(ValidationError::Sketch(
                     SketchValidationError::ClockwiseExteriorCycle {
                         cycle: cycle.clone(),
@@ -96,7 +96,7 @@ impl SketchValidationError {
 
     fn check_interior_cycles(
         sketch: &Sketch,
-        _: &Geometry,
+        geometry: &Geometry,
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
@@ -104,7 +104,7 @@ impl SketchValidationError {
             region
                 .interiors()
                 .iter()
-                .filter(|interior| interior.winding() == Winding::Ccw)
+                .filter(|interior| interior.winding(geometry) == Winding::Ccw)
                 .for_each(|cycle| {
                     errors.push(ValidationError::Sketch(
                         SketchValidationError::CounterClockwiseInteriorCycle {

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -19,7 +19,9 @@ impl Validate for Sketch {
         SketchValidationError::check_exterior_cycles(
             self, geometry, config, errors,
         );
-        SketchValidationError::check_interior_cycles(self, config, errors);
+        SketchValidationError::check_interior_cycles(
+            self, geometry, config, errors,
+        );
     }
 }
 
@@ -94,6 +96,7 @@ impl SketchValidationError {
 
     fn check_interior_cycles(
         sketch: &Sketch,
+        _: &Geometry,
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -41,13 +41,16 @@ pub struct AdjacentHalfEdgesNotConnected {
 impl ValidationCheck<Cycle> for AdjacentHalfEdgesNotConnected {
     fn check(
         object: &Cycle,
-        _: &Geometry,
+        geometry: &Geometry,
         config: &ValidationConfig,
     ) -> impl Iterator<Item = Self> {
         object.half_edges().pairs().filter_map(|(first, second)| {
             let end_pos_of_first_half_edge = {
                 let [_, end] = first.boundary().inner;
-                first.path().point_from_path_coords(end)
+                geometry
+                    .of_half_edge(first)
+                    .path
+                    .point_from_path_coords(end)
             };
             let start_pos_of_second_half_edge = second.start_position();
 


### PR DESCRIPTION
This *almost* makes it possible to remove the `SurfacePath` field from `HalfEdge`, except that `HalfEdge::start_position` is still using it.

This is another step towards https://github.com/hannobraun/fornjot/issues/2116.