### PR TITLE
Merge `HandleWrapper` and `Handle`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -7,7 +7,7 @@ use fj_math::Point;
 use crate::{
     geometry::{CurveBoundary, GlobalPath, SurfaceGeometry, SurfacePath},
     objects::Curve,
-    storage::{Handle, HandleWrapper},
+    storage::Handle,
     Core,
 };
 
@@ -146,8 +146,7 @@ impl CurveApprox {
 /// Cache for curve approximations
 #[derive(Default)]
 pub struct CurveApproxCache {
-    inner:
-        BTreeMap<(HandleWrapper<Curve>, CurveBoundary<Point<1>>), CurveApprox>,
+    inner: BTreeMap<(Handle<Curve>, CurveBoundary<Point<1>>), CurveApprox>,
 }
 
 impl CurveApproxCache {
@@ -156,12 +155,12 @@ impl CurveApproxCache {
         handle: &Handle<Curve>,
         boundary: CurveBoundary<Point<1>>,
     ) -> Option<CurveApprox> {
-        let handle = HandleWrapper::from(handle.clone());
-
         if let Some(approx) = self.inner.get(&(handle.clone(), boundary)) {
             return Some(approx.clone());
         }
-        if let Some(approx) = self.inner.get(&(handle, boundary.reverse())) {
+        if let Some(approx) =
+            self.inner.get(&(handle.clone(), boundary.reverse()))
+        {
             return Some(approx.clone().reverse());
         }
 
@@ -174,7 +173,6 @@ impl CurveApproxCache {
         boundary: CurveBoundary<Point<1>>,
         approx: CurveApprox,
     ) -> CurveApprox {
-        let handle = HandleWrapper::from(handle);
         self.inner
             .insert((handle, boundary), approx.clone())
             .unwrap_or(approx)

--- a/crates/fj-core/src/algorithms/approx/vertex.rs
+++ b/crates/fj-core/src/algorithms/approx/vertex.rs
@@ -4,21 +4,18 @@ use std::collections::BTreeMap;
 
 use fj_math::Point;
 
-use crate::{
-    objects::Vertex,
-    storage::{Handle, HandleWrapper},
-};
+use crate::{objects::Vertex, storage::Handle};
 
 /// Cache for vertex approximations
 #[derive(Default)]
 pub struct VertexApproxCache {
-    inner: BTreeMap<HandleWrapper<Vertex>, Point<3>>,
+    inner: BTreeMap<Handle<Vertex>, Point<3>>,
 }
 
 impl VertexApproxCache {
     /// Get an approximated vertex from the cache
     pub fn get(&self, handle: &Handle<Vertex>) -> Option<Point<3>> {
-        self.inner.get(&handle.clone().into()).cloned()
+        self.inner.get(handle).cloned()
     }
 
     /// Insert an approximated vertex into the cache
@@ -27,8 +24,6 @@ impl VertexApproxCache {
         handle: Handle<Vertex>,
         position: Point<3>,
     ) -> Point<3> {
-        self.inner
-            .insert(handle.clone().into(), position)
-            .unwrap_or(position)
+        self.inner.insert(handle, position).unwrap_or(position)
     }
 }

--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -5,7 +5,7 @@ use std::{
 
 use fj_math::Point;
 
-use crate::{objects::Vertex, storage::HandleWrapper};
+use crate::{objects::Vertex, storage::Handle};
 
 /// A boundary on a curve
 ///
@@ -240,7 +240,7 @@ impl CurveBoundaryElement for Point<1> {
 }
 
 impl CurveBoundaryElement for Vertex {
-    type Repr = HandleWrapper<Vertex>;
+    type Repr = Handle<Vertex>;
 }
 
 #[cfg(test)]

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -4,15 +4,15 @@ use fj_math::Vector;
 
 use crate::{
     objects::{HalfEdge, Objects, Surface},
-    storage::{Handle, HandleWrapper},
+    storage::Handle,
 };
 
 use super::{GlobalPath, HalfEdgeGeometry, SurfaceGeometry};
 
 /// Geometric data that is associated with topological objects
 pub struct Geometry {
-    half_edge: BTreeMap<HandleWrapper<HalfEdge>, HalfEdgeGeometry>,
-    surface: BTreeMap<HandleWrapper<Surface>, SurfaceGeometry>,
+    half_edge: BTreeMap<Handle<HalfEdge>, HalfEdgeGeometry>,
+    surface: BTreeMap<Handle<Surface>, SurfaceGeometry>,
 
     xy_plane: Handle<Surface>,
     xz_plane: Handle<Surface>,
@@ -61,7 +61,7 @@ impl Geometry {
         half_edge: Handle<HalfEdge>,
         geometry: HalfEdgeGeometry,
     ) {
-        self.half_edge.insert(half_edge.into(), geometry);
+        self.half_edge.insert(half_edge, geometry);
     }
 
     pub(crate) fn define_surface_inner(
@@ -69,7 +69,7 @@ impl Geometry {
         surface: Handle<Surface>,
         geometry: SurfaceGeometry,
     ) {
-        self.surface.insert(surface.into(), geometry);
+        self.surface.insert(surface, geometry);
     }
 
     /// # Access the geometry of the provided half-edge
@@ -82,7 +82,7 @@ impl Geometry {
         half_edge: &Handle<HalfEdge>,
     ) -> HalfEdgeGeometry {
         self.half_edge
-            .get(&half_edge.clone().into())
+            .get(half_edge)
             .copied()
             .expect("Expected geometry of half-edge to be defined")
     }
@@ -94,7 +94,7 @@ impl Geometry {
     /// Panics, if the geometry of surface is not defined.
     pub fn of_surface(&self, surface: &Handle<Surface>) -> SurfaceGeometry {
         self.surface
-            .get(&surface.clone().into())
+            .get(surface)
             .copied()
             .expect("Expected geometry of surface to be defined")
     }

--- a/crates/fj-core/src/layers/presentation.rs
+++ b/crates/fj-core/src/layers/presentation.rs
@@ -77,9 +77,9 @@ impl Command<Presentation> for DeriveObject {
         if let (AnyObject::Region(original), AnyObject::Region(derived)) =
             (self.original, self.derived)
         {
-            if let Some(color) = state.color.get(&original.0).cloned() {
+            if let Some(color) = state.color.get(&original).cloned() {
                 events.push(SetColor {
-                    region: derived.into(),
+                    region: derived,
                     color,
                 });
             }

--- a/crates/fj-core/src/objects/any_object.rs
+++ b/crates/fj-core/src/objects/any_object.rs
@@ -4,7 +4,7 @@ use crate::{
         Curve, Cycle, Face, HalfEdge, Objects, Region, Shell, Sketch, Solid,
         Surface, Vertex,
     },
-    storage::{Handle, HandleWrapper, ObjectId},
+    storage::{Handle, ObjectId},
     validate::Validate,
     validation::{ValidationConfig, ValidationError},
 };
@@ -62,7 +62,7 @@ macro_rules! any_object {
                             objects.$store.insert(
                                 handle.clone().into(), object
                             );
-                            handle.0.into()
+                            handle.into()
                         }
                     )*
                 }
@@ -138,7 +138,7 @@ impl Form for Bare {
 pub struct Stored;
 
 impl Form for Stored {
-    type Form<T> = HandleWrapper<T>;
+    type Form<T> = Handle<T>;
 }
 
 /// Implementation of [`Form`] for objects that are about to be stored
@@ -152,5 +152,5 @@ impl Form for Stored {
 pub struct AboutToBeStored;
 
 impl Form for AboutToBeStored {
-    type Form<T> = (HandleWrapper<T>, T);
+    type Form<T> = (Handle<T>, T);
 }

--- a/crates/fj-core/src/objects/kinds/curve.rs
+++ b/crates/fj-core/src/objects/kinds/curve.rs
@@ -21,7 +21,7 @@
 /// `Handle::id` to provide those `Eq`/`Ord`/... implementations.
 ///
 /// [`HalfEdge`]: crate::objects::HalfEdge
-#[derive(Clone, Debug, Default, Hash)]
+#[derive(Clone, Debug, Default)]
 pub struct Curve {}
 
 impl Curve {

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A cycle of connected edges
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Cycle {
     half_edges: ObjectSet<HalfEdge>,
 }

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A cycle of connected edges
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Cycle {
     half_edges: ObjectSet<HalfEdge>,
 }

--- a/crates/fj-core/src/objects/kinds/face.rs
+++ b/crates/fj-core/src/objects/kinds/face.rs
@@ -30,7 +30,7 @@ use crate::{
 ///
 /// [`HalfEdge`]: crate::objects::HalfEdge
 /// [`Shell`]: crate::objects::Shell
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Face {
     surface: Handle<Surface>,
     region: Handle<Region>,

--- a/crates/fj-core/src/objects/kinds/face.rs
+++ b/crates/fj-core/src/objects/kinds/face.rs
@@ -30,7 +30,7 @@ use crate::{
 ///
 /// [`HalfEdge`]: crate::objects::HalfEdge
 /// [`Shell`]: crate::objects::Shell
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Face {
     surface: Handle<Surface>,
     region: Handle<Region>,

--- a/crates/fj-core/src/objects/kinds/face.rs
+++ b/crates/fj-core/src/objects/kinds/face.rs
@@ -3,7 +3,7 @@ use fj_math::Winding;
 use crate::{
     geometry::Geometry,
     objects::{Region, Surface},
-    storage::{Handle, HandleWrapper},
+    storage::Handle,
 };
 
 /// A face of a shape
@@ -32,17 +32,14 @@ use crate::{
 /// [`Shell`]: crate::objects::Shell
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Face {
-    surface: HandleWrapper<Surface>,
+    surface: Handle<Surface>,
     region: Handle<Region>,
 }
 
 impl Face {
     /// Construct an instance of `Face`
     pub fn new(surface: Handle<Surface>, region: Handle<Region>) -> Self {
-        Self {
-            surface: surface.into(),
-            region,
-        }
+        Self { surface, region }
     }
 
     /// Access the surface of the face

--- a/crates/fj-core/src/objects/kinds/half_edge.rs
+++ b/crates/fj-core/src/objects/kinds/half_edge.rs
@@ -33,7 +33,7 @@ use crate::{
 ///
 /// [`Cycle`]: crate::objects::Cycle
 /// [`Shell`]: crate::objects::Shell
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct HalfEdge {
     boundary: CurveBoundary<Point<1>>,
     curve: Handle<Curve>,

--- a/crates/fj-core/src/objects/kinds/half_edge.rs
+++ b/crates/fj-core/src/objects/kinds/half_edge.rs
@@ -3,7 +3,7 @@ use fj_math::Point;
 use crate::{
     geometry::CurveBoundary,
     objects::{Curve, Vertex},
-    storage::{Handle, HandleWrapper},
+    storage::Handle,
 };
 
 /// # A directed half-edge, defined in a surface's 2D space
@@ -36,8 +36,8 @@ use crate::{
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct HalfEdge {
     boundary: CurveBoundary<Point<1>>,
-    curve: HandleWrapper<Curve>,
-    start_vertex: HandleWrapper<Vertex>,
+    curve: Handle<Curve>,
+    start_vertex: Handle<Vertex>,
 }
 
 impl HalfEdge {
@@ -49,8 +49,8 @@ impl HalfEdge {
     ) -> Self {
         Self {
             boundary: boundary.into(),
-            curve: curve.into(),
-            start_vertex: start_vertex.into(),
+            curve,
+            start_vertex,
         }
     }
 

--- a/crates/fj-core/src/objects/kinds/half_edge.rs
+++ b/crates/fj-core/src/objects/kinds/half_edge.rs
@@ -33,7 +33,7 @@ use crate::{
 ///
 /// [`Cycle`]: crate::objects::Cycle
 /// [`Shell`]: crate::objects::Shell
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct HalfEdge {
     boundary: CurveBoundary<Point<1>>,
     curve: Handle<Curve>,

--- a/crates/fj-core/src/objects/kinds/region.rs
+++ b/crates/fj-core/src/objects/kinds/region.rs
@@ -13,7 +13,7 @@ use crate::{
 /// region on their left side (on the region's front side).
 ///
 /// [`HalfEdge`]: crate::objects::HalfEdge
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Region {
     exterior: Handle<Cycle>,
     interiors: ObjectSet<Cycle>,

--- a/crates/fj-core/src/objects/kinds/region.rs
+++ b/crates/fj-core/src/objects/kinds/region.rs
@@ -13,7 +13,7 @@ use crate::{
 /// region on their left side (on the region's front side).
 ///
 /// [`HalfEdge`]: crate::objects::HalfEdge
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Region {
     exterior: Handle<Cycle>,
     interiors: ObjectSet<Cycle>,

--- a/crates/fj-core/src/objects/kinds/shell.rs
+++ b/crates/fj-core/src/objects/kinds/shell.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A 3-dimensional closed shell
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Shell {
     faces: ObjectSet<Face>,
 }

--- a/crates/fj-core/src/objects/kinds/shell.rs
+++ b/crates/fj-core/src/objects/kinds/shell.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A 3-dimensional closed shell
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Shell {
     faces: ObjectSet<Face>,
 }

--- a/crates/fj-core/src/objects/kinds/sketch.rs
+++ b/crates/fj-core/src/objects/kinds/sketch.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A 2-dimensional shape
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Sketch {
     regions: ObjectSet<Region>,
 }

--- a/crates/fj-core/src/objects/kinds/sketch.rs
+++ b/crates/fj-core/src/objects/kinds/sketch.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 /// A 2-dimensional shape
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Sketch {
     regions: ObjectSet<Region>,
 }

--- a/crates/fj-core/src/objects/kinds/solid.rs
+++ b/crates/fj-core/src/objects/kinds/solid.rs
@@ -11,7 +11,7 @@ use crate::{
 ///
 /// The shells that form the boundaries of the solid must not intersect. This is
 /// not currently validated.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct Solid {
     shells: ObjectSet<Shell>,
 }

--- a/crates/fj-core/src/objects/kinds/solid.rs
+++ b/crates/fj-core/src/objects/kinds/solid.rs
@@ -11,7 +11,7 @@ use crate::{
 ///
 /// The shells that form the boundaries of the solid must not intersect. This is
 /// not currently validated.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Solid {
     shells: ObjectSet<Shell>,
 }

--- a/crates/fj-core/src/objects/kinds/surface.rs
+++ b/crates/fj-core/src/objects/kinds/surface.rs
@@ -14,7 +14,7 @@
 /// If you need to reference a `Surface` from a struct that needs to derive
 /// `Eq`/`Ord`/..., you can use `HandleWrapper<Vertex>` to do that. It will
 /// use `Handle::id` to provide those `Eq`/`Ord`/... implementations.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Surface {}
 
 impl Surface {

--- a/crates/fj-core/src/objects/kinds/surface.rs
+++ b/crates/fj-core/src/objects/kinds/surface.rs
@@ -14,7 +14,7 @@
 /// If you need to reference a `Surface` from a struct that needs to derive
 /// `Eq`/`Ord`/..., you can use `HandleWrapper<Vertex>` to do that. It will
 /// use `Handle::id` to provide those `Eq`/`Ord`/... implementations.
-#[derive(Clone, Copy, Debug, Default, Hash)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Surface {}
 
 impl Surface {

--- a/crates/fj-core/src/objects/kinds/vertex.rs
+++ b/crates/fj-core/src/objects/kinds/vertex.rs
@@ -83,7 +83,7 @@
 /// [`Sketch`]: crate::objects::Sketch
 /// [`Solid`]: crate::objects::Solid
 /// [`Surface`]: crate::objects::Surface
-#[derive(Clone, Copy, Debug, Default, Hash)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Vertex {}
 
 impl Vertex {

--- a/crates/fj-core/src/objects/kinds/vertex.rs
+++ b/crates/fj-core/src/objects/kinds/vertex.rs
@@ -83,7 +83,7 @@
 /// [`Sketch`]: crate::objects::Sketch
 /// [`Solid`]: crate::objects::Solid
 /// [`Surface`]: crate::objects::Surface
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Vertex {}
 
 impl Vertex {

--- a/crates/fj-core/src/objects/object_set.rs
+++ b/crates/fj-core/src/objects/object_set.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, fmt::Debug, slice, vec};
+use std::{collections::BTreeSet, fmt::Debug, hash::Hash, slice, vec};
 
 use itertools::Itertools;
 
@@ -9,7 +9,7 @@ use crate::storage::Handle;
 /// This is the data structure used by all objects that reference multiple
 /// objects of the same type. It is a set, not containing any duplicate
 /// elements, and it maintains the insertion order of those elements.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ObjectSet<T> {
     // This is supposed to be a set data structure, so what is that `Vec` doing
     // here? Well, it's here because we need it to preserve insertion order, but
@@ -190,6 +190,12 @@ impl<T> ObjectSet<T> {
                 .chain(after)
                 .collect(),
         )
+    }
+}
+
+impl<T> Hash for ObjectSet<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
     }
 }
 

--- a/crates/fj-core/src/objects/object_set.rs
+++ b/crates/fj-core/src/objects/object_set.rs
@@ -30,7 +30,7 @@ impl<T> ObjectSet<T> {
     /// Panics, if the iterator contains duplicate `Handle`s.
     pub fn new(handles: impl IntoIterator<Item = Handle<T>>) -> Self
     where
-        T: Debug + Ord,
+        T: Debug,
     {
         let mut added = BTreeSet::new();
         let mut inner = Vec::new();
@@ -156,7 +156,7 @@ impl<T> ObjectSet<T> {
         replacements: impl IntoIterator<Item = impl Into<Handle<T>>>,
     ) -> Option<Self>
     where
-        T: Debug + Ord,
+        T: Debug,
     {
         let mut iter = self.iter().cloned().peekable();
 
@@ -201,7 +201,7 @@ impl<T> Hash for ObjectSet<T> {
 
 impl<O> FromIterator<Handle<O>> for ObjectSet<O>
 where
-    O: Debug + Ord,
+    O: Debug,
 {
     fn from_iter<T: IntoIterator<Item = Handle<O>>>(handles: T) -> Self {
         Self::new(handles)

--- a/crates/fj-core/src/objects/object_set.rs
+++ b/crates/fj-core/src/objects/object_set.rs
@@ -9,7 +9,7 @@ use crate::storage::Handle;
 /// This is the data structure used by all objects that reference multiple
 /// objects of the same type. It is a set, not containing any duplicate
 /// elements, and it maintains the insertion order of those elements.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug)]
 pub struct ObjectSet<T> {
     // This is supposed to be a set data structure, so what is that `Vec` doing
     // here? Well, it's here because we need it to preserve insertion order, but
@@ -190,6 +190,26 @@ impl<T> ObjectSet<T> {
                 .chain(after)
                 .collect(),
         )
+    }
+}
+
+impl<T> Eq for ObjectSet<T> {}
+
+impl<T> PartialEq for ObjectSet<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl<T> Ord for ObjectSet<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
+impl<T> PartialOrd for ObjectSet<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/fj-core/src/objects/object_set.rs
+++ b/crates/fj-core/src/objects/object_set.rs
@@ -1,8 +1,8 @@
-use std::{collections::BTreeSet, fmt::Debug, iter, slice, vec};
+use std::{collections::BTreeSet, fmt::Debug, slice, vec};
 
 use itertools::Itertools;
 
-use crate::storage::{Handle, HandleWrapper};
+use crate::storage::Handle;
 
 /// An ordered set of objects
 ///
@@ -19,7 +19,7 @@ pub struct ObjectSet<T> {
     // structure (since it is used in objects, and objects themselves are
     // immutable). We need to make sure there are no duplicates when this is
     // constructed (see the constructor below), but after that, we're fine.
-    inner: Vec<HandleWrapper<T>>,
+    inner: Vec<Handle<T>>,
 }
 
 impl<T> ObjectSet<T> {
@@ -28,16 +28,15 @@ impl<T> ObjectSet<T> {
     /// # Panics
     ///
     /// Panics, if the iterator contains duplicate `Handle`s.
-    pub fn new(
-        handles: impl IntoIterator<Item = impl Into<HandleWrapper<T>>>,
-    ) -> Self
+    pub fn new(handles: impl IntoIterator<Item = Handle<T>>) -> Self
     where
         T: Debug + Ord,
     {
         let mut added = BTreeSet::new();
         let mut inner = Vec::new();
 
-        let handles = handles.into_iter().map(|handle| handle.into());
+        // TASK: Inline.
+        let handles = handles.into_iter();
 
         for handle in handles {
             if added.contains(&handle) {
@@ -101,7 +100,7 @@ impl<T> ObjectSet<T> {
 
     /// Return the n-th item
     pub fn nth(&self, index: usize) -> Option<&Handle<T>> {
-        self.inner.get(index).map(|wrapper| &wrapper.0)
+        self.inner.get(index)
     }
 
     /// Return the n-th item, treating the index space as circular
@@ -135,7 +134,7 @@ impl<T> ObjectSet<T> {
 
     /// Access an iterator over the objects
     pub fn iter(&self) -> ObjectSetIter<T> {
-        self.inner.iter().map(HandleWrapper::as_handle)
+        self.inner.iter()
     }
 
     /// Access an iterator over the neighboring pairs of all contained objects
@@ -217,17 +216,14 @@ impl<T> IntoIterator for ObjectSet<T> {
     type IntoIter = ObjectSetIntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter().map(HandleWrapper::into_handle)
+        self.inner.into_iter()
     }
 }
 
 /// An borrowed iterator over an [`ObjectSet`]
 ///
 /// See [`ObjectSet::iter`].
-pub type ObjectSetIter<'r, T> = iter::Map<
-    slice::Iter<'r, HandleWrapper<T>>,
-    fn(&HandleWrapper<T>) -> &Handle<T>,
->;
+pub type ObjectSetIter<'r, T> = slice::Iter<'r, Handle<T>>;
 
 /// An owned iterator over an [`ObjectSet`]
 ///
@@ -239,19 +235,13 @@ pub type ObjectSetIter<'r, T> = iter::Map<
 /// iterator adapters. You can't return a reference to the argument of an
 /// adapter's closure, if you own that argument. You can, if you just reference
 /// the argument.
-pub type ObjectSetIntoIter<T> = iter::Map<
-    vec::IntoIter<HandleWrapper<T>>,
-    fn(HandleWrapper<T>) -> Handle<T>,
->;
+pub type ObjectSetIntoIter<T> = vec::IntoIter<Handle<T>>;
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
 
-    use crate::{
-        objects::Cycle, operations::insert::Insert, storage::HandleWrapper,
-        Core,
-    };
+    use crate::{objects::Cycle, operations::insert::Insert, Core};
 
     use super::ObjectSet;
 
@@ -273,8 +263,8 @@ mod tests {
         let mut core = Core::new();
 
         let bare_cycle = Cycle::new([]);
-        let cycle_a = HandleWrapper::from(bare_cycle.clone().insert(&mut core));
-        let cycle_b = HandleWrapper::from(bare_cycle.insert(&mut core));
+        let cycle_a = bare_cycle.clone().insert(&mut core);
+        let cycle_b = bare_cycle.insert(&mut core);
 
         let _object_set = ObjectSet::new([cycle_a, cycle_b]);
     }
@@ -284,8 +274,8 @@ mod tests {
         let mut core = Core::new();
 
         let bare_cycle = Cycle::new([]);
-        let cycle_a = HandleWrapper::from(bare_cycle.clone().insert(&mut core));
-        let cycle_b = HandleWrapper::from(bare_cycle.insert(&mut core));
+        let cycle_a = bare_cycle.clone().insert(&mut core);
+        let cycle_b = bare_cycle.insert(&mut core);
 
         let _object_set = ObjectSet::new(HashSet::from([cycle_a, cycle_b]));
     }

--- a/crates/fj-core/src/storage/handle.rs
+++ b/crates/fj-core/src/storage/handle.rs
@@ -132,7 +132,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.deref().eq(other.deref())
+        self.id().eq(&other.id())
     }
 }
 
@@ -141,7 +141,7 @@ where
     T: Hash,
 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.deref().hash(state);
+        self.id().hash(state);
     }
 }
 
@@ -150,7 +150,7 @@ where
     T: Ord,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.deref().cmp(other.deref())
+        self.id().cmp(&other.id())
     }
 }
 
@@ -159,7 +159,7 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.deref().partial_cmp(other.deref())
+        self.id().partial_cmp(&other.id())
     }
 }
 

--- a/crates/fj-core/src/storage/handle.rs
+++ b/crates/fj-core/src/storage/handle.rs
@@ -1,6 +1,4 @@
-use std::{
-    any::type_name, borrow::Borrow, cmp::Ordering, fmt, hash::Hash, ops::Deref,
-};
+use std::{any::type_name, borrow::Borrow, fmt, hash::Hash, ops::Deref};
 
 use super::{blocks::Index, store::StoreInner};
 
@@ -176,12 +174,6 @@ where
     }
 }
 
-impl<T> From<HandleWrapper<T>> for Handle<T> {
-    fn from(wrapper: HandleWrapper<T>) -> Self {
-        wrapper.0
-    }
-}
-
 unsafe impl<T> Send for Handle<T> {}
 unsafe impl<T> Sync for Handle<T> {}
 
@@ -204,91 +196,3 @@ impl fmt::Debug for ObjectId {
         write!(f, "object id {id:#x}")
     }
 }
-
-/// A wrapper around [`Handle`] that defines equality based on identity
-///
-/// `HandleWrapper` implements [`Eq`]/[`PartialEq`] and other common traits
-/// that are based on those, based on the identity of a stored object that the
-/// wrapped [`Handle`] references.
-///
-/// This is useful, since some objects are empty (meaning, they don't contain
-/// any data, and don't reference other objects). Such objects only exist to be
-/// distinguished based on their identity. But since a bare object doesn't have
-/// an identity yet, there's no meaningful way to implement [`Eq`]/[`PartialEq`]
-/// for such a bare object type.
-///
-/// However, such objects are referenced by other objects, and if we want to
-/// derive [`Eq`]/[`PartialEq`] for a referencing object, we need something that
-/// can provide [`Eq`]/[`PartialEq`] implementations for the empty objects. That
-/// is the purpose of `HandleWrapper`.
-pub struct HandleWrapper<T>(pub Handle<T>);
-
-impl<T> HandleWrapper<T> {
-    /// Convert `&self` into a `&Handle`
-    pub fn as_handle(&self) -> &Handle<T> {
-        &self.0
-    }
-
-    /// Convert `self` into a `Handle`
-    pub fn into_handle(self) -> Handle<T> {
-        self.0
-    }
-}
-
-impl<T> Deref for HandleWrapper<T> {
-    type Target = Handle<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> Clone for HandleWrapper<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<T> Eq for HandleWrapper<T> {}
-
-impl<T> PartialEq for HandleWrapper<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.id().eq(&other.0.id())
-    }
-}
-
-impl<T> Hash for HandleWrapper<T> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.id().hash(state);
-    }
-}
-
-impl<T> Ord for HandleWrapper<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.id().cmp(&other.0.id())
-    }
-}
-
-impl<T> PartialOrd for HandleWrapper<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T> fmt::Debug for HandleWrapper<T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl<T> From<Handle<T>> for HandleWrapper<T> {
-    fn from(handle: Handle<T>) -> Self {
-        Self(handle)
-    }
-}
-
-unsafe impl<T> Send for HandleWrapper<T> {}
-unsafe impl<T> Sync for HandleWrapper<T> {}

--- a/crates/fj-core/src/storage/handle.rs
+++ b/crates/fj-core/src/storage/handle.rs
@@ -125,41 +125,29 @@ impl<T> Clone for Handle<T> {
     }
 }
 
-impl<T> Eq for Handle<T> where T: Eq {}
+impl<T> Eq for Handle<T> {}
 
-impl<T> PartialEq for Handle<T>
-where
-    T: PartialEq,
-{
+impl<T> PartialEq for Handle<T> {
     fn eq(&self, other: &Self) -> bool {
         self.id().eq(&other.id())
     }
 }
 
-impl<T> Hash for Handle<T>
-where
-    T: Hash,
-{
+impl<T> Hash for Handle<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id().hash(state);
     }
 }
 
-impl<T> Ord for Handle<T>
-where
-    T: Ord,
-{
+impl<T> Ord for Handle<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.id().cmp(&other.id())
     }
 }
 
-impl<T> PartialOrd for Handle<T>
-where
-    T: PartialOrd,
-{
+impl<T> PartialOrd for Handle<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.id().partial_cmp(&other.id())
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/fj-core/src/storage/mod.rs
+++ b/crates/fj-core/src/storage/mod.rs
@@ -5,6 +5,6 @@ mod handle;
 mod store;
 
 pub use self::{
-    handle::{Handle, HandleWrapper, ObjectId},
+    handle::{Handle, ObjectId},
     store::{Iter, Store},
 };

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::hash::Hash;
 
 use crate::objects::{Cycle, Face, HalfEdge, Region, Shell};
 use crate::storage::Handle;
@@ -7,7 +6,7 @@ use crate::storage::Handle;
 #[derive(Default)]
 pub struct ReferenceCounter<T, U>(HashMap<Handle<T>, Vec<Handle<U>>>);
 
-impl<T: Eq + PartialEq + Hash, U> ReferenceCounter<T, U> {
+impl<T, U> ReferenceCounter<T, U> {
     pub fn new() -> Self {
         Self(HashMap::new())
     }

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -8,7 +8,7 @@ use crate::{
     queries::{
         AllHalfEdgesWithSurface, BoundingVerticesOfHalfEdge, SiblingOfHalfEdge,
     },
-    storage::{Handle, HandleWrapper},
+    storage::Handle,
 };
 
 use super::{Validate, ValidationConfig, ValidationError};
@@ -183,7 +183,7 @@ impl ShellValidationError {
         for face in shell.faces() {
             for cycle in face.region().all_cycles() {
                 for half_edge in cycle.half_edges() {
-                    let curve = HandleWrapper::from(half_edge.curve().clone());
+                    let curve = half_edge.curve().clone();
                     let boundary = half_edge.boundary();
                     let vertices =
                         cycle.bounding_vertices_of_half_edge(half_edge).expect(


### PR DESCRIPTION
Only leaves `Handle`, which now displays the behavior of the former `HandleWrapper`. The old behavior of `Handle` made sense, once upon a time, but it was no longer relied on, and has turned into a footgun. Now all comparison and ordering of objects through `Handle` rely on the object ID, instead of any other notions of equality and ordering.

Any redundant trait implementations have been removed from the object types. They were also not relied on in any ways that weren't easily replaced, and this redundancy just seemed like another footgun.

See https://github.com/hannobraun/fornjot/commit/8663d6c2c965a0c175af20d90d09ca2d6aa2350e for an example of why the previous behavior was no longer desirable.