### PR TITLE
Add redundant definition of `HalfEdge`'s `CurveBoundary` to geometry layer

### DIFF
--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -31,7 +31,7 @@ impl Approx for (&Handle<HalfEdge>, &SurfaceGeometry) {
             .layers
             .geometry
             .of_half_edge(half_edge)
-            .start_position(half_edge.boundary());
+            .start_position();
         let start_position =
             match cache.start_position.get(half_edge.start_vertex()) {
                 Some(position) => position,

--- a/crates/fj-core/src/geometry/half_edge.rs
+++ b/crates/fj-core/src/geometry/half_edge.rs
@@ -31,6 +31,9 @@ pub struct HalfEdgeGeometry {
     /// really belong here. It exists here for practical reasons that are,
     /// hopefully, temporary.
     pub path: SurfacePath,
+
+    /// # The boundary of the half-edge on its curve
+    pub boundary: CurveBoundary<Point<1>>,
 }
 
 impl HalfEdgeGeometry {

--- a/crates/fj-core/src/geometry/half_edge.rs
+++ b/crates/fj-core/src/geometry/half_edge.rs
@@ -37,6 +37,15 @@ pub struct HalfEdgeGeometry {
 }
 
 impl HalfEdgeGeometry {
+    /// Update the boundary
+    pub fn with_boundary(
+        mut self,
+        boundary: impl Into<CurveBoundary<Point<1>>>,
+    ) -> Self {
+        self.boundary = boundary.into();
+        self
+    }
+
     /// Compute the surface position where the half-edge starts
     pub fn start_position(
         &self,

--- a/crates/fj-core/src/geometry/half_edge.rs
+++ b/crates/fj-core/src/geometry/half_edge.rs
@@ -47,15 +47,12 @@ impl HalfEdgeGeometry {
     }
 
     /// Compute the surface position where the half-edge starts
-    pub fn start_position(
-        &self,
-        boundary: CurveBoundary<Point<1>>,
-    ) -> Point<2> {
+    pub fn start_position(&self) -> Point<2> {
         // Computing the surface position from the curve position is fine.
         // `HalfEdge` "owns" its start position. There is no competing code that
         // could compute the surface position from slightly different data.
 
-        let [start, _] = boundary.inner;
+        let [start, _] = self.boundary.inner;
         self.path.point_from_path_coords(start)
     }
 }

--- a/crates/fj-core/src/objects/kinds/cycle.rs
+++ b/crates/fj-core/src/objects/kinds/cycle.rs
@@ -66,9 +66,7 @@ impl Cycle {
 
         for (a, b) in self.half_edges().pairs() {
             let [a, b] = [a, b].map(|half_edge| {
-                geometry
-                    .of_half_edge(half_edge)
-                    .start_position(half_edge.boundary())
+                geometry.of_half_edge(half_edge).start_position()
             });
 
             sum += (b.u - a.u) * (b.v + a.v);

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -68,9 +68,13 @@ pub trait BuildHalfEdge {
             [arc.start_angle, arc.end_angle].map(|coord| Point::from([coord]));
 
         let half_edge = HalfEdge::unjoined(boundary, core).insert(core);
-        core.layers
-            .geometry
-            .define_half_edge(half_edge.clone(), HalfEdgeGeometry { path });
+        core.layers.geometry.define_half_edge(
+            half_edge.clone(),
+            HalfEdgeGeometry {
+                path,
+                boundary: boundary.into(),
+            },
+        );
 
         half_edge
     }
@@ -86,9 +90,13 @@ pub trait BuildHalfEdge {
             [Scalar::ZERO, Scalar::TAU].map(|coord| Point::from([coord]));
 
         let half_edge = HalfEdge::unjoined(boundary, core).insert(core);
-        core.layers
-            .geometry
-            .define_half_edge(half_edge.clone(), HalfEdgeGeometry { path });
+        core.layers.geometry.define_half_edge(
+            half_edge.clone(),
+            HalfEdgeGeometry {
+                path,
+                boundary: boundary.into(),
+            },
+        );
 
         half_edge
     }
@@ -107,7 +115,13 @@ pub trait BuildHalfEdge {
 
         HalfEdge::unjoined(boundary, core)
             .insert(core)
-            .set_geometry(HalfEdgeGeometry { path }, &mut core.layers.geometry)
+            .set_geometry(
+                HalfEdgeGeometry {
+                    path,
+                    boundary: boundary.into(),
+                },
+                &mut core.layers.geometry,
+            )
     }
 }
 

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -32,16 +32,15 @@ pub trait BuildHalfEdge {
         start_vertex: Handle<Vertex>,
         core: &mut Core,
     ) -> Handle<HalfEdge> {
+        let geometry = core.layers.geometry.of_half_edge(sibling);
+
         HalfEdge::new(
             sibling.boundary().reverse(),
             sibling.curve().clone(),
             start_vertex,
         )
         .insert(core)
-        .set_geometry(
-            core.layers.geometry.of_half_edge(sibling),
-            &mut core.layers.geometry,
-        )
+        .set_geometry(geometry, &mut core.layers.geometry)
     }
 
     /// Create an arc

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -32,7 +32,8 @@ pub trait BuildHalfEdge {
         start_vertex: Handle<Vertex>,
         core: &mut Core,
     ) -> Handle<HalfEdge> {
-        let geometry = core.layers.geometry.of_half_edge(sibling);
+        let mut geometry = core.layers.geometry.of_half_edge(sibling);
+        geometry.boundary = geometry.boundary.reverse();
 
         HalfEdge::new(
             sibling.boundary().reverse(),

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -98,7 +98,7 @@ impl JoinCycle for Cycle {
                     )
                     .insert(core)
                     .set_geometry(
-                        HalfEdgeGeometry { path },
+                        HalfEdgeGeometry { path, boundary },
                         &mut core.layers.geometry,
                     )
             })

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -14,7 +14,8 @@ impl Reverse for Cycle {
             .half_edges()
             .pairs()
             .map(|(current, next)| {
-                let geometry = core.layers.geometry.of_half_edge(current);
+                let mut geometry = core.layers.geometry.of_half_edge(current);
+                geometry.boundary = geometry.boundary.reverse();
 
                 HalfEdge::new(
                     current.boundary().reverse(),

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -14,6 +14,8 @@ impl Reverse for Cycle {
             .half_edges()
             .pairs()
             .map(|(current, next)| {
+                let geometry = core.layers.geometry.of_half_edge(current);
+
                 HalfEdge::new(
                     current.boundary().reverse(),
                     current.curve().clone(),
@@ -21,10 +23,7 @@ impl Reverse for Cycle {
                 )
                 .insert(core)
                 .derive_from(current, core)
-                .set_geometry(
-                    core.layers.geometry.of_half_edge(current),
-                    &mut core.layers.geometry,
-                )
+                .set_geometry(geometry, &mut core.layers.geometry)
             })
             .collect::<Vec<_>>();
 

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -21,9 +21,10 @@ impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
         .insert(core)
         .derive_from(self, core);
 
-        core.layers
-            .geometry
-            .define_half_edge(half_edge.clone(), HalfEdgeGeometry { path });
+        core.layers.geometry.define_half_edge(
+            half_edge.clone(),
+            HalfEdgeGeometry { path, boundary },
+        );
 
         half_edge
     }

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -12,10 +12,10 @@ impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
     fn reverse_curve_coordinate_systems(&self, core: &mut Core) -> Self {
         let mut geometry = core.layers.geometry.of_half_edge(self);
         geometry.path = geometry.path.reverse();
-        let boundary = self.boundary().reverse();
+        geometry.boundary = geometry.boundary.reverse();
 
         let half_edge = HalfEdge::new(
-            boundary,
+            geometry.boundary,
             self.curve().clone(),
             self.start_vertex().clone(),
         )
@@ -26,7 +26,7 @@ impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
             half_edge.clone(),
             HalfEdgeGeometry {
                 path: geometry.path,
-                boundary,
+                boundary: geometry.boundary,
             },
         );
 

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -10,7 +10,8 @@ use super::ReverseCurveCoordinateSystems;
 
 impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
     fn reverse_curve_coordinate_systems(&self, core: &mut Core) -> Self {
-        let path = core.layers.geometry.of_half_edge(self).path.reverse();
+        let mut geometry = core.layers.geometry.of_half_edge(self);
+        geometry.path = geometry.path.reverse();
         let boundary = self.boundary().reverse();
 
         let half_edge = HalfEdge::new(
@@ -23,7 +24,10 @@ impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
 
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
-            HalfEdgeGeometry { path, boundary },
+            HalfEdgeGeometry {
+                path: geometry.path,
+                boundary,
+            },
         );
 
         half_edge

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -1,5 +1,4 @@
 use crate::{
-    geometry::HalfEdgeGeometry,
     objects::HalfEdge,
     operations::{derive::DeriveFrom, insert::Insert},
     storage::Handle,
@@ -22,13 +21,9 @@ impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
         .insert(core)
         .derive_from(self, core);
 
-        core.layers.geometry.define_half_edge(
-            half_edge.clone(),
-            HalfEdgeGeometry {
-                path: geometry.path,
-                boundary: geometry.boundary,
-            },
-        );
+        core.layers
+            .geometry
+            .define_half_edge(half_edge.clone(), geometry);
 
         half_edge
     }

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -105,14 +105,8 @@ impl SplitFace for Shell {
         let dividing_half_edge_a_to_d = {
             let half_edge = HalfEdge::line_segment(
                 [
-                    core.layers
-                        .geometry
-                        .of_half_edge(&b)
-                        .start_position(b.boundary()),
-                    core.layers
-                        .geometry
-                        .of_half_edge(&d)
-                        .start_position(d.boundary()),
+                    core.layers.geometry.of_half_edge(&b).start_position(),
+                    core.layers.geometry.of_half_edge(&d).start_position(),
                 ],
                 None,
                 core,

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -2,7 +2,9 @@ use fj_math::Point;
 
 use crate::{
     objects::{HalfEdge, Vertex},
-    operations::{derive::DeriveFrom, insert::Insert},
+    operations::{
+        derive::DeriveFrom, geometry::UpdateHalfEdgeGeometry, insert::Insert,
+    },
     storage::Handle,
     Core,
 };
@@ -48,22 +50,21 @@ impl SplitHalfEdge for Handle<HalfEdge> {
             self.start_vertex().clone(),
         )
         .insert(core)
-        .derive_from(self, core);
+        .derive_from(self, core)
+        .set_geometry(
+            core.layers.geometry.of_half_edge(self),
+            &mut core.layers.geometry,
+        );
         let b = HalfEdge::new(
             [point, end],
             self.curve().clone(),
             Vertex::new().insert(core),
         )
         .insert(core)
-        .derive_from(self, core);
-
-        core.layers.geometry.define_half_edge(
-            a.clone(),
+        .derive_from(self, core)
+        .set_geometry(
             core.layers.geometry.of_half_edge(self),
-        );
-        core.layers.geometry.define_half_edge(
-            b.clone(),
-            core.layers.geometry.of_half_edge(self),
+            &mut core.layers.geometry,
         );
 
         [a, b]

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -52,7 +52,10 @@ impl SplitHalfEdge for Handle<HalfEdge> {
         .insert(core)
         .derive_from(self, core)
         .set_geometry(
-            core.layers.geometry.of_half_edge(self),
+            core.layers
+                .geometry
+                .of_half_edge(self)
+                .with_boundary([start, point]),
             &mut core.layers.geometry,
         );
         let b = HalfEdge::new(
@@ -63,7 +66,10 @@ impl SplitHalfEdge for Handle<HalfEdge> {
         .insert(core)
         .derive_from(self, core)
         .set_geometry(
-            core.layers.geometry.of_half_edge(self),
+            core.layers
+                .geometry
+                .of_half_edge(self)
+                .with_boundary([point, end]),
             &mut core.layers.geometry,
         );
 

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -450,6 +450,8 @@ mod tests {
                                             .geometry
                                             .of_half_edge(half_edge);
                                         geometry.path = geometry.path.reverse();
+                                        geometry.boundary =
+                                            geometry.boundary.reverse();
 
                                         [HalfEdge::new(
                                             half_edge.boundary().reverse(),

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -93,7 +93,7 @@ impl SolidValidationError {
             .map(|(h, s)| {
                 (
                     s.point_from_surface_coords(
-                        geometry.of_half_edge(&h).start_position(h.boundary()),
+                        geometry.of_half_edge(&h).start_position(),
                     ),
                     h.start_vertex().clone(),
                 )

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -52,9 +52,8 @@ impl ValidationCheck<Cycle> for AdjacentHalfEdgesNotConnected {
                     .path
                     .point_from_path_coords(end)
             };
-            let start_pos_of_second_half_edge = geometry
-                .of_half_edge(second)
-                .start_position(second.boundary());
+            let start_pos_of_second_half_edge =
+                geometry.of_half_edge(second).start_position();
 
             let distance_between_positions = (end_pos_of_first_half_edge
                 - start_pos_of_second_half_edge)


### PR DESCRIPTION
Adds a redundant definition of half-edge boundaries to the geometry layer. The original definition within `HalfEdge` still exists. While I believe that all code that *writes* half-edge boundaries now updates the geometry layer too, lots of code still *reads* that data from `HalfEdge` itself.

This is another step towards addressing https://github.com/hannobraun/fornjot/issues/2116.