### PR TITLE
Simplify `Surface::surface_from_uv` to `from_uv`

### DIFF
--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -24,7 +24,7 @@ pub trait BuildSurface {
         let (u, u_line) = GlobalPath::line_from_points([a, b]);
         let v = c - a;
 
-        let surface = Surface::surface_from_uv(u, v, core);
+        let surface = Surface::from_uv(u, v, core);
 
         let points_surface = {
             let [a, b] =
@@ -38,7 +38,7 @@ pub trait BuildSurface {
     }
 
     /// Build a plane from the provided `u` and `v`
-    fn surface_from_uv(
+    fn from_uv(
         u: impl Into<GlobalPath>,
         v: impl Into<Vector<3>>,
         core: &mut Core,

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -84,6 +84,6 @@ impl SweepSurfacePath for SurfacePath {
             }
         };
 
-        Surface::surface_from_uv(u, path, core)
+        Surface::from_uv(u, path, core)
     }
 }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -198,7 +198,7 @@ mod tests {
         let mut core = Core::new();
 
         let shared_face = Face::new(
-            Surface::surface_from_uv(
+            Surface::from_uv(
                 GlobalPath::circle_from_radius(1.),
                 [0., 1., 1.],
                 &mut core,
@@ -257,7 +257,7 @@ mod tests {
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![
             Face::new(
-                Surface::surface_from_uv(
+                Surface::from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 1., 1.],
                     &mut core,
@@ -266,7 +266,7 @@ mod tests {
             )
             .insert(&mut core),
             Face::new(
-                Surface::surface_from_uv(
+                Surface::from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 0., 1.],
                     &mut core,
@@ -305,7 +305,7 @@ mod tests {
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![
             Face::new(
-                Surface::surface_from_uv(
+                Surface::from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 1., 1.],
                     &mut core,
@@ -314,7 +314,7 @@ mod tests {
             )
             .insert(&mut core),
             Face::new(
-                Surface::surface_from_uv(
+                Surface::from_uv(
                     GlobalPath::circle_from_radius(1.),
                     [0., 0., 1.],
                     &mut core,
@@ -350,7 +350,7 @@ mod tests {
         let shared_edge = HalfEdge::circle([0., 0.], 1., &mut core);
 
         let invalid_solid = Solid::new(vec![Shell::new(vec![Face::new(
-            Surface::surface_from_uv(
+            Surface::from_uv(
                 GlobalPath::circle_from_radius(1.),
                 [0., 0., 1.],
                 &mut core,


### PR DESCRIPTION
I noticed this while working on https://github.com/hannobraun/fornjot/issues/2290.