### PR TITLE
Remove color from `FaceApprox`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -102,11 +102,12 @@ impl Approx for Handle<Face> {
         }
 
         let color = self.region().get_color(core);
+        let coord_handedness = self.coord_handedness(&core.layers.geometry);
         FaceApprox {
             exterior,
             interiors,
             color,
-            coord_handedness: self.coord_handedness(&core.layers.geometry),
+            coord_handedness,
         }
     }
 }

--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -4,10 +4,7 @@
 
 use std::{collections::BTreeSet, ops::Deref};
 
-use fj_interop::Color;
-
 use crate::{
-    operations::presentation::GetColor,
     storage::Handle,
     topology::{Face, Handedness, ObjectSet},
     validation::ValidationConfig,
@@ -101,13 +98,11 @@ impl Approx for Handle<Face> {
             interiors.insert(cycle);
         }
 
-        let color = self.region().get_color(core);
         let coord_handedness = self.coord_handedness(&core.layers.geometry);
         FaceApprox {
             face: self,
             exterior,
             interiors,
-            color,
             coord_handedness,
         }
     }
@@ -124,9 +119,6 @@ pub struct FaceApprox {
 
     /// Approximations of the interior cycles
     pub interiors: BTreeSet<CycleApprox>,
-
-    /// The color of the approximated face
-    pub color: Option<Color>,
 
     /// The handedness of the approximated face's front-side coordinate system
     pub coord_handedness: Handedness,

--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -104,6 +104,7 @@ impl Approx for Handle<Face> {
         let color = self.region().get_color(core);
         let coord_handedness = self.coord_handedness(&core.layers.geometry);
         FaceApprox {
+            face: self,
             exterior,
             interiors,
             color,
@@ -115,6 +116,9 @@ impl Approx for Handle<Face> {
 /// An approximation of a [`Face`]
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FaceApprox {
+    /// The [`Face`], that this approximates
+    pub face: Handle<Face>,
+
     /// Approximation of the exterior cycle
     pub exterior: CycleApprox,
 

--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -101,10 +101,11 @@ impl Approx for Handle<Face> {
             interiors.insert(cycle);
         }
 
+        let color = self.region().get_color(core);
         FaceApprox {
             exterior,
             interiors,
-            color: self.region().get_color(core),
+            color,
             coord_handedness: self.coord_handedness(&core.layers.geometry),
         }
     }

--- a/crates/fj-core/src/algorithms/approx/face.rs
+++ b/crates/fj-core/src/algorithms/approx/face.rs
@@ -8,6 +8,7 @@ use fj_interop::Color;
 
 use crate::{
     operations::presentation::GetColor,
+    storage::Handle,
     topology::{Face, Handedness, ObjectSet},
     validation::ValidationConfig,
     Core,
@@ -32,7 +33,7 @@ impl Approx for &ObjectSet<Face> {
 
         let approx = self
             .into_iter()
-            .map(|face| face.approx_with_cache(tolerance, cache, core))
+            .map(|face| face.clone().approx_with_cache(tolerance, cache, core))
             .collect();
 
         let min_distance = ValidationConfig::default().distinct_min_distance;
@@ -65,7 +66,7 @@ impl Approx for &ObjectSet<Face> {
     }
 }
 
-impl Approx for &Face {
+impl Approx for Handle<Face> {
     type Approximation = FaceApprox;
     type Cache = HalfEdgeApproxCache;
 

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -45,11 +45,7 @@ where
 }
 
 impl Triangulate for FaceApprox {
-    fn triangulate_into_mesh(
-        self,
-        mesh: &mut Mesh<Point<3>>,
-        _core: &mut Core,
-    ) {
+    fn triangulate_into_mesh(self, mesh: &mut Mesh<Point<3>>, core: &mut Core) {
         let face_as_polygon = Polygon::new()
             .with_exterior(
                 self.exterior
@@ -69,7 +65,7 @@ impl Triangulate for FaceApprox {
                 .contains_triangle(triangle.map(|point| point.point_surface))
         });
 
-        let color = self.face.region().get_color(_core).unwrap_or_default();
+        let color = self.face.region().get_color(core).unwrap_or_default();
 
         for triangle in triangles {
             let points = triangle.map(|point| point.point_global);

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -87,8 +87,10 @@ mod tests {
         algorithms::approx::{Approx, Tolerance},
         operations::{
             build::{BuildCycle, BuildFace},
+            insert::Insert,
             update::{UpdateFace, UpdateRegion},
         },
+        storage::Handle,
         topology::{Cycle, Face},
         Core,
     };
@@ -114,7 +116,8 @@ mod tests {
                         )
                     },
                     &mut core,
-                );
+                )
+                .insert(&mut core);
 
         let a = Point::from(a).to_xyz();
         let b = Point::from(b).to_xyz();
@@ -147,17 +150,22 @@ mod tests {
 
         let surface = core.layers.topology.surfaces.xy_plane();
 
-        let face = Face::unbound(surface.clone(), &mut core).update_region(
-            |region, core| {
-                region
-                    .update_exterior(
-                        |_, core| Cycle::polygon([a, b, c, d], core),
-                        core,
-                    )
-                    .add_interiors([Cycle::polygon([e, f, g, h], core)], core)
-            },
-            &mut core,
-        );
+        let face = Face::unbound(surface.clone(), &mut core)
+            .update_region(
+                |region, core| {
+                    region
+                        .update_exterior(
+                            |_, core| Cycle::polygon([a, b, c, d], core),
+                            core,
+                        )
+                        .add_interiors(
+                            [Cycle::polygon([e, f, g, h], core)],
+                            core,
+                        )
+                },
+                &mut core,
+            )
+            .insert(&mut core);
 
         let triangles = triangulate(face, &mut core)?;
 
@@ -236,15 +244,17 @@ mod tests {
 
         let surface = core.layers.topology.surfaces.xy_plane();
 
-        let face = Face::unbound(surface.clone(), &mut core).update_region(
-            |region, core| {
-                region.update_exterior(
-                    |_, core| Cycle::polygon([a, b, c, d, e], core),
-                    core,
-                )
-            },
-            &mut core,
-        );
+        let face = Face::unbound(surface.clone(), &mut core)
+            .update_region(
+                |region, core| {
+                    region.update_exterior(
+                        |_, core| Cycle::polygon([a, b, c, d, e], core),
+                        core,
+                    )
+                },
+                &mut core,
+            )
+            .insert(&mut core);
 
         let triangles = triangulate(face, &mut core)?;
 
@@ -282,7 +292,7 @@ mod tests {
     }
 
     fn triangulate(
-        face: Face,
+        face: Handle<Face>,
         core: &mut Core,
     ) -> anyhow::Result<Mesh<Point<3>>> {
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -6,7 +6,7 @@ mod polygon;
 use fj_interop::Mesh;
 use fj_math::Point;
 
-use crate::Core;
+use crate::{operations::presentation::GetColor, Core};
 
 use self::polygon::Polygon;
 
@@ -69,7 +69,7 @@ impl Triangulate for FaceApprox {
                 .contains_triangle(triangle.map(|point| point.point_surface))
         });
 
-        let color = self.color.unwrap_or_default();
+        let color = self.face.region().get_color(_core).unwrap_or_default();
 
         for triangle in triangles {
             let points = triangle.map(|point| point.point_global);


### PR DESCRIPTION
This means, the approximation code no longer has to know about color, or any other presentation data in the future.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.