### PR TITLE
Only expect `&Geometry` in `Approx

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -200,8 +200,8 @@ mod tests {
         let surface = core.layers.topology.surfaces.xz_plane();
 
         let tolerance = 1.;
-        let approx =
-            (&curve, &half_edge, &surface).approx(tolerance, &mut core);
+        let approx = (&curve, &half_edge, &surface)
+            .approx(tolerance, &core.layers.geometry);
 
         assert_eq!(approx.points, vec![]);
     }
@@ -222,8 +222,8 @@ mod tests {
         );
 
         let tolerance = 1.;
-        let approx =
-            (&curve, &half_edge, &surface).approx(tolerance, &mut core);
+        let approx = (&curve, &half_edge, &surface)
+            .approx(tolerance, &core.layers.geometry);
 
         assert_eq!(approx.points, vec![]);
     }
@@ -243,11 +243,11 @@ mod tests {
         let surface = Surface::from_uv(global_path, [0., 0., 1.], &mut core);
 
         let tolerance = 1.;
-        let approx =
-            (&curve, &half_edge, &surface).approx(tolerance, &mut core);
+        let approx = (&curve, &half_edge, &surface)
+            .approx(tolerance, &core.layers.geometry);
 
         let expected_approx = (global_path, boundary)
-            .approx(tolerance, &mut core)
+            .approx(tolerance, &core.layers.geometry)
             .into_iter()
             .map(|(point_local, _)| {
                 let point_surface = path.point_from_path_coords(point_local);
@@ -273,11 +273,11 @@ mod tests {
         let surface = core.layers.topology.surfaces.xz_plane();
 
         let tolerance = 1.;
-        let approx =
-            (&curve, &half_edge, &surface).approx(tolerance, &mut core);
+        let approx = (&curve, &half_edge, &surface)
+            .approx(tolerance, &core.layers.geometry);
 
         let expected_approx = (&path, boundary)
-            .approx(tolerance, &mut core)
+            .approx(tolerance, &core.layers.geometry)
             .into_iter()
             .map(|(point_local, _)| {
                 let point_surface = path.point_from_path_coords(point_local);

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -6,12 +6,11 @@ use fj_math::Point;
 
 use crate::{
     geometry::{
-        CurveBoundary, GlobalPath, HalfEdgeGeometry, SurfaceGeometry,
+        CurveBoundary, Geometry, GlobalPath, HalfEdgeGeometry, SurfaceGeometry,
         SurfacePath,
     },
     storage::Handle,
     topology::{Curve, Surface},
-    Core,
 };
 
 use super::{Approx, ApproxPoint, Tolerance};
@@ -24,7 +23,7 @@ impl Approx for (&Handle<Curve>, &HalfEdgeGeometry, &Handle<Surface>) {
         self,
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation {
         let (curve, half_edge, surface) = self;
 
@@ -33,10 +32,10 @@ impl Approx for (&Handle<Curve>, &HalfEdgeGeometry, &Handle<Surface>) {
             None => {
                 let approx = approx_curve(
                     &half_edge.path,
-                    &core.layers.geometry.of_surface(surface),
+                    &geometry.of_surface(surface),
                     half_edge.boundary,
                     tolerance,
-                    core,
+                    geometry,
                 );
 
                 cache.insert(curve.clone(), half_edge.boundary, approx)
@@ -50,7 +49,7 @@ fn approx_curve(
     surface: &SurfaceGeometry,
     boundary: CurveBoundary<Point<1>>,
     tolerance: impl Into<Tolerance>,
-    core: &mut Core,
+    geometry: &Geometry,
 ) -> CurveApprox {
     // There are different cases of varying complexity. Circles are the hard
     // part here, as they need to be approximated, while lines don't need to be.
@@ -66,7 +65,7 @@ fn approx_curve(
         }
         (SurfacePath::Circle(_), GlobalPath::Line(_)) => {
             (path, boundary)
-                .approx_with_cache(tolerance, &mut (), core)
+                .approx_with_cache(tolerance, &mut (), geometry)
                 .into_iter()
                 .map(|(point_curve, point_surface)| {
                     // We're throwing away `point_surface` here, which is a
@@ -100,7 +99,7 @@ fn approx_curve(
             let approx_u = (surface.u, range_u).approx_with_cache(
                 tolerance,
                 &mut (),
-                core,
+                geometry,
             );
 
             let mut points = Vec::new();

--- a/crates/fj-core/src/algorithms/approx/cycle.rs
+++ b/crates/fj-core/src/algorithms/approx/cycle.rs
@@ -5,9 +5,9 @@
 use fj_math::Segment;
 
 use crate::{
+    geometry::Geometry,
     storage::Handle,
     topology::{Cycle, Surface},
-    Core,
 };
 
 use super::{
@@ -23,7 +23,7 @@ impl Approx for (&Cycle, &Handle<Surface>) {
         self,
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation {
         let (cycle, surface) = self;
         let tolerance = tolerance.into();
@@ -32,7 +32,8 @@ impl Approx for (&Cycle, &Handle<Surface>) {
             .half_edges()
             .iter()
             .map(|half_edge| {
-                (half_edge, surface).approx_with_cache(tolerance, cache, core)
+                (half_edge, surface)
+                    .approx_with_cache(tolerance, cache, geometry)
             })
             .collect();
 

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -6,9 +6,9 @@
 //! the caller doesn't have to deal with duplicate vertices.
 
 use crate::{
+    geometry::Geometry,
     storage::Handle,
     topology::{HalfEdge, Surface},
-    Core,
 };
 
 use super::{
@@ -24,23 +24,18 @@ impl Approx for (&Handle<HalfEdge>, &Handle<Surface>) {
         self,
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation {
         let (half_edge, surface) = self;
         let tolerance = tolerance.into();
 
-        let start_position_surface = core
-            .layers
-            .geometry
-            .of_half_edge(half_edge)
-            .start_position();
+        let start_position_surface =
+            geometry.of_half_edge(half_edge).start_position();
         let start_position =
             match cache.start_position.get(half_edge.start_vertex()) {
                 Some(position) => position,
                 None => {
-                    let position_global = core
-                        .layers
-                        .geometry
+                    let position_global = geometry
                         .of_surface(surface)
                         .point_from_surface_coords(start_position_surface);
                     cache.start_position.insert(
@@ -55,19 +50,17 @@ impl Approx for (&Handle<HalfEdge>, &Handle<Surface>) {
         let rest = {
             let approx = (
                 half_edge.curve(),
-                &core.layers.geometry.of_half_edge(half_edge),
+                &geometry.of_half_edge(half_edge),
                 surface,
             )
                 .approx_with_cache(
                     tolerance,
                     &mut cache.curve,
-                    core,
+                    geometry,
                 );
 
             approx.points.into_iter().map(|point| {
-                let point_surface = core
-                    .layers
-                    .geometry
+                let point_surface = geometry
                     .of_half_edge(half_edge)
                     .path
                     .point_from_path_coords(point.local_form);

--- a/crates/fj-core/src/algorithms/approx/mod.rs
+++ b/crates/fj-core/src/algorithms/approx/mod.rs
@@ -19,7 +19,7 @@ use std::{
 
 use fj_math::Point;
 
-use crate::{geometry::Geometry, Core};
+use crate::geometry::Geometry;
 
 pub use self::tolerance::{InvalidTolerance, Tolerance};
 
@@ -38,10 +38,10 @@ pub trait Approx: Sized {
     fn approx(
         self,
         tolerance: impl Into<Tolerance>,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation {
         let mut cache = Self::Cache::default();
-        self.approx_with_cache(tolerance, &mut cache, &core.layers.geometry)
+        self.approx_with_cache(tolerance, &mut cache, geometry)
     }
 
     /// Approximate the object, using the provided cache

--- a/crates/fj-core/src/algorithms/approx/mod.rs
+++ b/crates/fj-core/src/algorithms/approx/mod.rs
@@ -19,7 +19,7 @@ use std::{
 
 use fj_math::Point;
 
-use crate::Core;
+use crate::{geometry::Geometry, Core};
 
 pub use self::tolerance::{InvalidTolerance, Tolerance};
 
@@ -41,7 +41,7 @@ pub trait Approx: Sized {
         core: &mut Core,
     ) -> Self::Approximation {
         let mut cache = Self::Cache::default();
-        self.approx_with_cache(tolerance, &mut cache, core)
+        self.approx_with_cache(tolerance, &mut cache, &core.layers.geometry)
     }
 
     /// Approximate the object, using the provided cache
@@ -52,7 +52,7 @@ pub trait Approx: Sized {
         self,
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation;
 }
 

--- a/crates/fj-core/src/algorithms/approx/path.rs
+++ b/crates/fj-core/src/algorithms/approx/path.rs
@@ -32,10 +32,7 @@ use std::iter;
 
 use fj_math::{Circle, Point, Scalar, Sign};
 
-use crate::{
-    geometry::{CurveBoundary, GlobalPath, SurfacePath},
-    Core,
-};
+use crate::geometry::{CurveBoundary, Geometry, GlobalPath, SurfacePath};
 
 use super::{Approx, Tolerance};
 
@@ -47,7 +44,7 @@ impl Approx for (&SurfacePath, CurveBoundary<Point<1>>) {
         self,
         tolerance: impl Into<Tolerance>,
         (): &mut Self::Cache,
-        _core: &mut Core,
+        _: &Geometry,
     ) -> Self::Approximation {
         let (path, range) = self;
 
@@ -68,7 +65,7 @@ impl Approx for (GlobalPath, CurveBoundary<Point<1>>) {
         self,
         tolerance: impl Into<Tolerance>,
         (): &mut Self::Cache,
-        _core: &mut Core,
+        _: &Geometry,
     ) -> Self::Approximation {
         let (path, range) = self;
 

--- a/crates/fj-core/src/algorithms/approx/shell.rs
+++ b/crates/fj-core/src/algorithms/approx/shell.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::{topology::Shell, Core};
+use crate::{geometry::Geometry, topology::Shell};
 
 use super::{edge::HalfEdgeApproxCache, face::FaceApprox, Approx, Tolerance};
 
@@ -14,8 +14,8 @@ impl Approx for &Shell {
         self,
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation {
-        self.faces().approx_with_cache(tolerance, cache, core)
+        self.faces().approx_with_cache(tolerance, cache, geometry)
     }
 }

--- a/crates/fj-core/src/algorithms/approx/sketch.rs
+++ b/crates/fj-core/src/algorithms/approx/sketch.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::{topology::Sketch, Core};
+use crate::{geometry::Geometry, topology::Sketch};
 
 use super::{edge::HalfEdgeApproxCache, face::FaceApprox, Approx, Tolerance};
 
@@ -14,7 +14,7 @@ impl Approx for &Sketch {
         self,
         _tolerance: impl Into<Tolerance>,
         _cache: &mut Self::Cache,
-        _core: &mut Core,
+        _: &Geometry,
     ) -> Self::Approximation {
         todo!()
     }

--- a/crates/fj-core/src/algorithms/approx/solid.rs
+++ b/crates/fj-core/src/algorithms/approx/solid.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::{topology::Solid, Core};
+use crate::{geometry::Geometry, topology::Solid};
 
 use super::{edge::HalfEdgeApproxCache, face::FaceApprox, Approx, Tolerance};
 
@@ -14,13 +14,15 @@ impl Approx for &Solid {
         self,
         tolerance: impl Into<Tolerance>,
         cache: &mut Self::Cache,
-        core: &mut Core,
+        geometry: &Geometry,
     ) -> Self::Approximation {
         let tolerance = tolerance.into();
 
         self.shells()
             .iter()
-            .flat_map(|shell| shell.approx_with_cache(tolerance, cache, core))
+            .flat_map(|shell| {
+                shell.approx_with_cache(tolerance, cache, geometry)
+            })
             .collect()
     }
 }

--- a/crates/fj-core/src/algorithms/triangulate/mod.rs
+++ b/crates/fj-core/src/algorithms/triangulate/mod.rs
@@ -36,7 +36,7 @@ where
     fn triangulate_into_mesh(self, mesh: &mut Mesh<Point<3>>, core: &mut Core) {
         let (approx, tolerance) = self;
 
-        let approx = approx.approx(tolerance, core);
+        let approx = approx.approx(tolerance, &core.layers.geometry);
 
         for approx in approx {
             approx.triangulate_into_mesh(mesh, core);
@@ -292,6 +292,8 @@ mod tests {
         core: &mut Core,
     ) -> anyhow::Result<Mesh<Point<3>>> {
         let tolerance = Tolerance::from_scalar(Scalar::ONE)?;
-        Ok(face.approx(tolerance, core).triangulate(core))
+        Ok(face
+            .approx(tolerance, &core.layers.geometry)
+            .triangulate(core))
     }
 }


### PR DESCRIPTION
Previously, it required a full `&mut Core`, which is worse in every way.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.