### PR TITLE
Don't implicitly copy geometry when returning it from geometry layer

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -32,7 +32,7 @@ impl Approx for (&Handle<Curve>, &HalfEdgeGeometry, &Handle<Surface>) {
             None => {
                 let approx = approx_curve(
                     &half_edge.path,
-                    &geometry.of_surface(surface),
+                    geometry.of_surface(surface),
                     half_edge.boundary,
                     tolerance,
                     geometry,

--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -48,16 +48,9 @@ impl Approx for (&Handle<HalfEdge>, &Handle<Surface>) {
         let first = ApproxPoint::new(start_position_surface, start_position);
 
         let rest = {
-            let approx = (
-                half_edge.curve(),
-                &geometry.of_half_edge(half_edge),
-                surface,
-            )
-                .approx_with_cache(
-                    tolerance,
-                    &mut cache.curve,
-                    geometry,
-                );
+            let approx =
+                (half_edge.curve(), geometry.of_half_edge(half_edge), surface)
+                    .approx_with_cache(tolerance, &mut cache.curve, geometry);
 
             approx.points.into_iter().map(|point| {
                 let point_surface = geometry

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -91,25 +91,24 @@ impl Geometry {
     /// ## Panics
     ///
     /// Panics, if the geometry of the surface is not defined.
-    pub fn of_surface(&self, surface: &Handle<Surface>) -> SurfaceGeometry {
+    pub fn of_surface(&self, surface: &Handle<Surface>) -> &SurfaceGeometry {
         self.surface
             .get(surface)
-            .copied()
             .expect("Expected geometry of surface to be defined")
     }
 
     /// Access the geometry of the xy-plane
-    pub fn xy_plane(&self) -> SurfaceGeometry {
+    pub fn xy_plane(&self) -> &SurfaceGeometry {
         self.of_surface(&self.xy_plane)
     }
 
     /// Access the geometry of the xz-plane
-    pub fn xz_plane(&self) -> SurfaceGeometry {
+    pub fn xz_plane(&self) -> &SurfaceGeometry {
         self.of_surface(&self.xz_plane)
     }
 
     /// Access the geometry of the yz-plane
-    pub fn yz_plane(&self) -> SurfaceGeometry {
+    pub fn yz_plane(&self) -> &SurfaceGeometry {
         self.of_surface(&self.yz_plane)
     }
 }

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -80,10 +80,9 @@ impl Geometry {
     pub fn of_half_edge(
         &self,
         half_edge: &Handle<HalfEdge>,
-    ) -> HalfEdgeGeometry {
+    ) -> &HalfEdgeGeometry {
         self.half_edge
             .get(half_edge)
-            .copied()
             .expect("Expected geometry of half-edge to be defined")
     }
 

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -29,7 +29,7 @@ pub trait BuildHalfEdge {
         start_vertex: Handle<Vertex>,
         core: &mut Core,
     ) -> Handle<HalfEdge> {
-        let mut geometry = core.layers.geometry.of_half_edge(sibling);
+        let mut geometry = *core.layers.geometry.of_half_edge(sibling);
         geometry.boundary = geometry.boundary.reverse();
 
         HalfEdge::new(sibling.curve().clone(), start_vertex)

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -102,7 +102,8 @@ pub trait BuildShell {
                                 .update_curve(|_, _| curve, core)
                                 .insert(core)
                                 .set_geometry(
-                                    core.layers
+                                    *core
+                                        .layers
                                         .geometry
                                         .of_half_edge(&half_edge),
                                     &mut core.layers.geometry,

--- a/crates/fj-core/src/operations/holes.rs
+++ b/crates/fj-core/src/operations/holes.rs
@@ -68,7 +68,7 @@ impl AddHole for Shell {
                             [Cycle::empty().add_joined_edges(
                                 [(
                                     entry.clone(),
-                                    core.layers.geometry.of_half_edge(&entry),
+                                    *core.layers.geometry.of_half_edge(&entry),
                                 )],
                                 core,
                             )],
@@ -138,7 +138,7 @@ impl AddHole for Shell {
                             [Cycle::empty().add_joined_edges(
                                 [(
                                     entry.clone(),
-                                    core.layers.geometry.of_half_edge(&entry),
+                                    *core.layers.geometry.of_half_edge(&entry),
                                 )],
                                 core,
                             )],
@@ -159,7 +159,7 @@ impl AddHole for Shell {
                             [Cycle::empty().add_joined_edges(
                                 [(
                                     exit.clone(),
-                                    core.layers.geometry.of_half_edge(exit),
+                                    *core.layers.geometry.of_half_edge(exit),
                                 )],
                                 core,
                             )],

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -137,7 +137,8 @@ impl JoinCycle for Cycle {
                                 )
                                 .insert(core)
                                 .set_geometry(
-                                    core.layers
+                                    *core
+                                        .layers
                                         .geometry
                                         .of_half_edge(half_edge),
                                     &mut core.layers.geometry,
@@ -155,7 +156,8 @@ impl JoinCycle for Cycle {
                                 )
                                 .insert(core)
                                 .set_geometry(
-                                    core.layers
+                                    *core
+                                        .layers
                                         .geometry
                                         .of_half_edge(half_edge),
                                     &mut core.layers.geometry,

--- a/crates/fj-core/src/operations/reverse/cycle.rs
+++ b/crates/fj-core/src/operations/reverse/cycle.rs
@@ -14,7 +14,7 @@ impl Reverse for Cycle {
             .half_edges()
             .pairs()
             .map(|(current, next)| {
-                let mut geometry = core.layers.geometry.of_half_edge(current);
+                let mut geometry = *core.layers.geometry.of_half_edge(current);
                 geometry.boundary = geometry.boundary.reverse();
 
                 HalfEdge::new(

--- a/crates/fj-core/src/operations/reverse/edge.rs
+++ b/crates/fj-core/src/operations/reverse/edge.rs
@@ -9,7 +9,7 @@ use super::ReverseCurveCoordinateSystems;
 
 impl ReverseCurveCoordinateSystems for Handle<HalfEdge> {
     fn reverse_curve_coordinate_systems(&self, core: &mut Core) -> Self {
-        let mut geometry = core.layers.geometry.of_half_edge(self);
+        let mut geometry = *core.layers.geometry.of_half_edge(self);
         geometry.path = geometry.path.reverse();
         geometry.boundary = geometry.boundary.reverse();
 

--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -51,7 +51,7 @@ impl SplitEdge for Shell {
                 )
                 .insert(core)
                 .set_geometry(
-                    core.layers.geometry.of_half_edge(&sibling_b),
+                    *core.layers.geometry.of_half_edge(&sibling_b),
                     &mut core.layers.geometry,
                 );
 

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -115,7 +115,7 @@ impl SplitFace for Shell {
                 .update_start_vertex(|_, _| b.start_vertex().clone(), core)
                 .insert(core)
                 .set_geometry(
-                    core.layers.geometry.of_half_edge(&half_edge),
+                    *core.layers.geometry.of_half_edge(&half_edge),
                     &mut core.layers.geometry,
                 )
         };

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -42,7 +42,7 @@ impl SplitHalfEdge for Handle<HalfEdge> {
     ) -> [Handle<HalfEdge>; 2] {
         let point = point.into();
 
-        let geometry = core.layers.geometry.of_half_edge(self);
+        let geometry = *core.layers.geometry.of_half_edge(self);
         let [start, end] = geometry.boundary.inner;
 
         let a =

--- a/crates/fj-core/src/operations/sweep/cycle.rs
+++ b/crates/fj-core/src/operations/sweep/cycle.rs
@@ -77,7 +77,7 @@ impl SweepCycle for Cycle {
 
             top_edges.push((
                 top_edge,
-                core.layers.geometry.of_half_edge(bottom_half_edge),
+                *core.layers.geometry.of_half_edge(bottom_half_edge),
             ));
         }
 

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -58,7 +58,7 @@ impl SweepHalfEdge for Handle<HalfEdge> {
     ) -> (Face, Handle<HalfEdge>) {
         let path = path.into();
 
-        let geometry = core.layers.geometry.of_half_edge(self);
+        let geometry = *core.layers.geometry.of_half_edge(self);
         let surface = geometry.path.sweep_surface_path(
             &core.layers.geometry.of_surface(&surface),
             path,
@@ -134,7 +134,7 @@ impl SweepHalfEdge for Handle<HalfEdge> {
                     };
 
                     half_edge.insert(core).set_geometry(
-                        core.layers.geometry.of_half_edge(&line_segment),
+                        *core.layers.geometry.of_half_edge(&line_segment),
                         &mut core.layers.geometry,
                     )
                 };

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -59,11 +59,11 @@ impl SweepHalfEdge for Handle<HalfEdge> {
         let path = path.into();
 
         let half_edge_geom = *core.layers.geometry.of_half_edge(self);
-        let surface = half_edge_geom.path.sweep_surface_path(
-            &core.layers.geometry.of_surface(&surface),
-            path,
-            core,
-        );
+        let surface_geom = core.layers.geometry.of_surface(&surface);
+        let surface =
+            half_edge_geom
+                .path
+                .sweep_surface_path(&surface_geom, path, core);
 
         // Next, we need to define the boundaries of the face. Let's start with
         // the global vertices and edges.

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -59,7 +59,7 @@ impl SweepHalfEdge for Handle<HalfEdge> {
         let path = path.into();
 
         let half_edge_geom = *core.layers.geometry.of_half_edge(self);
-        let surface_geom = core.layers.geometry.of_surface(&surface);
+        let surface_geom = *core.layers.geometry.of_surface(&surface);
         let surface =
             half_edge_geom
                 .path

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -58,8 +58,8 @@ impl SweepHalfEdge for Handle<HalfEdge> {
     ) -> (Face, Handle<HalfEdge>) {
         let path = path.into();
 
-        let geometry = *core.layers.geometry.of_half_edge(self);
-        let surface = geometry.path.sweep_surface_path(
+        let half_edge_geom = *core.layers.geometry.of_half_edge(self);
+        let surface = half_edge_geom.path.sweep_surface_path(
             &core.layers.geometry.of_surface(&surface),
             path,
             core,
@@ -85,7 +85,7 @@ impl SweepHalfEdge for Handle<HalfEdge> {
 
         // Let's figure out the surface coordinates of the edge vertices.
         let surface_points = {
-            let [a, b] = geometry.boundary.inner;
+            let [a, b] = half_edge_geom.boundary.inner;
 
             [
                 [a.t, Scalar::ZERO],
@@ -103,7 +103,7 @@ impl SweepHalfEdge for Handle<HalfEdge> {
 
         // Now, the boundaries of each edge.
         let boundaries = {
-            let [a, b] = geometry.boundary.inner;
+            let [a, b] = half_edge_geom.boundary.inner;
             let [c, d] = [0., 1.].map(|coord| Point::from([coord]));
 
             [[a, b], [c, d], [b, a], [d, c]]

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -26,7 +26,7 @@ impl TransformObject for Handle<HalfEdge> {
 
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
-            core.layers.geometry.of_half_edge(self),
+            *core.layers.geometry.of_half_edge(self),
         );
 
         half_edge

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -453,7 +453,7 @@ mod tests {
                                 cycle.update_half_edge(
                                     cycle.half_edges().nth_circular(0),
                                     |half_edge, core| {
-                                        let mut geometry = core
+                                        let mut geometry = *core
                                             .layers
                                             .geometry
                                             .of_half_edge(half_edge);
@@ -546,7 +546,8 @@ mod tests {
                                             )
                                             .insert(core)
                                             .set_geometry(
-                                                core.layers
+                                                *core
+                                                    .layers
                                                     .geometry
                                                     .of_half_edge(half_edge),
                                                 &mut core.layers.geometry,

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -150,18 +150,18 @@ impl ShellValidationError {
 
                 compare_curve_coords(
                     edge_a,
-                    &geometry.of_surface(surface_a),
+                    geometry.of_surface(surface_a),
                     edge_b,
-                    &geometry.of_surface(surface_b),
+                    geometry.of_surface(surface_b),
                     geometry,
                     config,
                     &mut mismatches,
                 );
                 compare_curve_coords(
                     edge_b,
-                    &geometry.of_surface(surface_b),
+                    geometry.of_surface(surface_b),
                     edge_a,
-                    &geometry.of_surface(surface_a),
+                    geometry.of_surface(surface_a),
                     geometry,
                     config,
                     &mut mismatches,
@@ -254,9 +254,9 @@ impl ShellValidationError {
                 // `distinct_min_distance`, that's a problem.
                 if distances(
                     half_edge_a.clone(),
-                    &geometry.of_surface(surface_a),
+                    geometry.of_surface(surface_a),
                     half_edge_b.clone(),
-                    &geometry.of_surface(surface_b),
+                    geometry.of_surface(surface_b),
                     geometry,
                 )
                 .all(|d| d < config.distinct_min_distance)


### PR DESCRIPTION
Not all future geometry definitions will be `Copy`, and cloning implicitly seems wrong to me. For consistency, I think it's better, if all geometry definitions are returned by reference, for the user to do with as required.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.