### PR TITLE
Shorten names of geometry struct

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -6,7 +6,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::{
-        CurveBoundary, Geometry, GlobalPath, HalfEdgeGeom, SurfaceGeometry,
+        CurveBoundary, Geometry, GlobalPath, HalfEdgeGeom, SurfaceGeom,
         SurfacePath,
     },
     storage::Handle,
@@ -46,7 +46,7 @@ impl Approx for (&Handle<Curve>, &HalfEdgeGeom, &Handle<Surface>) {
 
 fn approx_curve(
     path: &SurfacePath,
-    surface: &SurfaceGeometry,
+    surface: &SurfaceGeom,
     boundary: CurveBoundary<Point<1>>,
     tolerance: impl Into<Tolerance>,
     geometry: &Geometry,

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -6,7 +6,7 @@ use fj_math::Point;
 
 use crate::{
     geometry::{
-        CurveBoundary, Geometry, GlobalPath, HalfEdgeGeometry, SurfaceGeometry,
+        CurveBoundary, Geometry, GlobalPath, HalfEdgeGeom, SurfaceGeometry,
         SurfacePath,
     },
     storage::Handle,
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{Approx, ApproxPoint, Tolerance};
 
-impl Approx for (&Handle<Curve>, &HalfEdgeGeometry, &Handle<Surface>) {
+impl Approx for (&Handle<Curve>, &HalfEdgeGeom, &Handle<Surface>) {
     type Approximation = CurveApprox;
     type Cache = CurveApproxCache;
 
@@ -182,7 +182,7 @@ mod tests {
 
     use crate::{
         algorithms::approx::{Approx, ApproxPoint},
-        geometry::{CurveBoundary, GlobalPath, HalfEdgeGeometry, SurfacePath},
+        geometry::{CurveBoundary, GlobalPath, HalfEdgeGeom, SurfacePath},
         operations::{build::BuildSurface, insert::Insert},
         topology::{Curve, Surface},
         Core,
@@ -196,7 +196,7 @@ mod tests {
         let (path, boundary) =
             SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
-        let half_edge = HalfEdgeGeometry { path, boundary };
+        let half_edge = HalfEdgeGeom { path, boundary };
         let surface = core.layers.topology.surfaces.xz_plane();
 
         let tolerance = 1.;
@@ -214,7 +214,7 @@ mod tests {
         let (path, boundary) =
             SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
-        let half_edge = HalfEdgeGeometry { path, boundary };
+        let half_edge = HalfEdgeGeom { path, boundary };
         let surface = Surface::from_uv(
             GlobalPath::circle_from_radius(1.),
             [0., 0., 1.],
@@ -239,7 +239,7 @@ mod tests {
             ([TAU], [TAU, 1.]),
         ]);
         let boundary = CurveBoundary::from([[0.], [TAU]]);
-        let half_edge = HalfEdgeGeometry { path, boundary };
+        let half_edge = HalfEdgeGeom { path, boundary };
         let surface = Surface::from_uv(global_path, [0., 0., 1.], &mut core);
 
         let tolerance = 1.;
@@ -269,7 +269,7 @@ mod tests {
         let curve = Curve::new().insert(&mut core);
         let path = SurfacePath::circle_from_center_and_radius([0., 0.], 1.);
         let boundary = CurveBoundary::from([[0.], [TAU]]);
-        let half_edge = HalfEdgeGeometry { path, boundary };
+        let half_edge = HalfEdgeGeom { path, boundary };
         let surface = core.layers.topology.surfaces.xz_plane();
 
         let tolerance = 1.;

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -7,12 +7,12 @@ use crate::{
     topology::{HalfEdge, Surface, Topology},
 };
 
-use super::{GlobalPath, HalfEdgeGeom, SurfaceGeometry};
+use super::{GlobalPath, HalfEdgeGeom, SurfaceGeom};
 
 /// Geometric data that is associated with topological objects
 pub struct Geometry {
     half_edge: BTreeMap<Handle<HalfEdge>, HalfEdgeGeom>,
-    surface: BTreeMap<Handle<Surface>, SurfaceGeometry>,
+    surface: BTreeMap<Handle<Surface>, SurfaceGeom>,
 
     xy_plane: Handle<Surface>,
     xz_plane: Handle<Surface>,
@@ -33,21 +33,21 @@ impl Geometry {
 
         self_.define_surface_inner(
             self_.xy_plane.clone(),
-            SurfaceGeometry {
+            SurfaceGeom {
                 u: GlobalPath::x_axis(),
                 v: Vector::unit_y(),
             },
         );
         self_.define_surface_inner(
             self_.xz_plane.clone(),
-            SurfaceGeometry {
+            SurfaceGeom {
                 u: GlobalPath::x_axis(),
                 v: Vector::unit_z(),
             },
         );
         self_.define_surface_inner(
             self_.yz_plane.clone(),
-            SurfaceGeometry {
+            SurfaceGeom {
                 u: GlobalPath::y_axis(),
                 v: Vector::unit_z(),
             },
@@ -67,7 +67,7 @@ impl Geometry {
     pub(crate) fn define_surface_inner(
         &mut self,
         surface: Handle<Surface>,
-        geometry: SurfaceGeometry,
+        geometry: SurfaceGeom,
     ) {
         self.surface.insert(surface, geometry);
     }
@@ -88,24 +88,24 @@ impl Geometry {
     /// ## Panics
     ///
     /// Panics, if the geometry of the surface is not defined.
-    pub fn of_surface(&self, surface: &Handle<Surface>) -> &SurfaceGeometry {
+    pub fn of_surface(&self, surface: &Handle<Surface>) -> &SurfaceGeom {
         self.surface
             .get(surface)
             .expect("Expected geometry of surface to be defined")
     }
 
     /// Access the geometry of the xy-plane
-    pub fn xy_plane(&self) -> &SurfaceGeometry {
+    pub fn xy_plane(&self) -> &SurfaceGeom {
         self.of_surface(&self.xy_plane)
     }
 
     /// Access the geometry of the xz-plane
-    pub fn xz_plane(&self) -> &SurfaceGeometry {
+    pub fn xz_plane(&self) -> &SurfaceGeom {
         self.of_surface(&self.xz_plane)
     }
 
     /// Access the geometry of the yz-plane
-    pub fn yz_plane(&self) -> &SurfaceGeometry {
+    pub fn yz_plane(&self) -> &SurfaceGeom {
         self.of_surface(&self.yz_plane)
     }
 }

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -7,11 +7,11 @@ use crate::{
     topology::{HalfEdge, Surface, Topology},
 };
 
-use super::{GlobalPath, HalfEdgeGeometry, SurfaceGeometry};
+use super::{GlobalPath, HalfEdgeGeom, SurfaceGeometry};
 
 /// Geometric data that is associated with topological objects
 pub struct Geometry {
-    half_edge: BTreeMap<Handle<HalfEdge>, HalfEdgeGeometry>,
+    half_edge: BTreeMap<Handle<HalfEdge>, HalfEdgeGeom>,
     surface: BTreeMap<Handle<Surface>, SurfaceGeometry>,
 
     xy_plane: Handle<Surface>,
@@ -59,7 +59,7 @@ impl Geometry {
     pub(crate) fn define_half_edge_inner(
         &mut self,
         half_edge: Handle<HalfEdge>,
-        geometry: HalfEdgeGeometry,
+        geometry: HalfEdgeGeom,
     ) {
         self.half_edge.insert(half_edge, geometry);
     }
@@ -77,10 +77,7 @@ impl Geometry {
     /// ## Panics
     ///
     /// Panics, if the geometry of the half-edge is not defined.
-    pub fn of_half_edge(
-        &self,
-        half_edge: &Handle<HalfEdge>,
-    ) -> &HalfEdgeGeometry {
+    pub fn of_half_edge(&self, half_edge: &Handle<HalfEdge>) -> &HalfEdgeGeom {
         self.half_edge
             .get(half_edge)
             .expect("Expected geometry of half-edge to be defined")

--- a/crates/fj-core/src/geometry/half_edge.rs
+++ b/crates/fj-core/src/geometry/half_edge.rs
@@ -4,7 +4,7 @@ use super::{CurveBoundary, SurfacePath};
 
 /// The geometry of a half-edge
 #[derive(Copy, Clone)]
-pub struct HalfEdgeGeometry {
+pub struct HalfEdgeGeom {
     /// # The path of the half-edge
     ///
     /// ## Implementation Note
@@ -36,7 +36,7 @@ pub struct HalfEdgeGeometry {
     pub boundary: CurveBoundary<Point<1>>,
 }
 
-impl HalfEdgeGeometry {
+impl HalfEdgeGeom {
     /// Update the boundary
     pub fn with_boundary(
         mut self,

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -9,7 +9,7 @@ mod surface;
 pub use self::{
     boundary::{CurveBoundary, CurveBoundaryElement},
     geometry::Geometry,
-    half_edge::HalfEdgeGeometry,
+    half_edge::HalfEdgeGeom,
     path::{GlobalPath, SurfacePath},
     surface::SurfaceGeometry,
 };

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -11,5 +11,5 @@ pub use self::{
     geometry::Geometry,
     half_edge::HalfEdgeGeom,
     path::{GlobalPath, SurfacePath},
-    surface::SurfaceGeometry,
+    surface::SurfaceGeom,
 };

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -6,7 +6,7 @@ use super::GlobalPath;
 
 /// The geometry that defines a surface
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct SurfaceGeometry {
+pub struct SurfaceGeom {
     /// The u-axis of the surface
     pub u: GlobalPath,
 
@@ -14,7 +14,7 @@ pub struct SurfaceGeometry {
     pub v: Vector<3>,
 }
 
-impl SurfaceGeometry {
+impl SurfaceGeom {
     /// Convert a point in surface coordinates to model coordinates
     pub fn point_from_surface_coords(
         &self,
@@ -64,11 +64,11 @@ mod tests {
     use fj_math::{Line, Point, Vector};
     use pretty_assertions::assert_eq;
 
-    use crate::geometry::{GlobalPath, SurfaceGeometry};
+    use crate::geometry::{GlobalPath, SurfaceGeom};
 
     #[test]
     fn point_from_surface_coords() {
-        let surface = SurfaceGeometry {
+        let surface = SurfaceGeom {
             u: GlobalPath::Line(Line::from_origin_and_direction(
                 Point::from([1., 1., 1.]),
                 Vector::from([0., 2., 0.]),
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn vector_from_surface_coords() {
-        let surface = SurfaceGeometry {
+        let surface = SurfaceGeom {
             u: GlobalPath::Line(Line::from_origin_and_direction(
                 Point::from([1., 0., 0.]),
                 Vector::from([0., 2., 0.]),

--- a/crates/fj-core/src/layers/geometry.rs
+++ b/crates/fj-core/src/layers/geometry.rs
@@ -1,7 +1,7 @@
 //! Layer infrastructure for [`Geometry`]
 
 use crate::{
-    geometry::{Geometry, HalfEdgeGeometry, SurfaceGeometry},
+    geometry::{Geometry, HalfEdgeGeom, SurfaceGeometry},
     storage::Handle,
     topology::{HalfEdge, Surface},
 };
@@ -13,7 +13,7 @@ impl Layer<Geometry> {
     pub fn define_half_edge(
         &mut self,
         half_edge: Handle<HalfEdge>,
-        geometry: HalfEdgeGeometry,
+        geometry: HalfEdgeGeom,
     ) {
         let mut events = Vec::new();
         self.process(
@@ -39,7 +39,7 @@ impl Layer<Geometry> {
 /// Define the geometry of a half-edge
 pub struct DefineHalfEdge {
     half_edge: Handle<HalfEdge>,
-    geometry: HalfEdgeGeometry,
+    geometry: HalfEdgeGeom,
 }
 
 impl Command<Geometry> for DefineHalfEdge {

--- a/crates/fj-core/src/layers/geometry.rs
+++ b/crates/fj-core/src/layers/geometry.rs
@@ -1,7 +1,7 @@
 //! Layer infrastructure for [`Geometry`]
 
 use crate::{
-    geometry::{Geometry, HalfEdgeGeom, SurfaceGeometry},
+    geometry::{Geometry, HalfEdgeGeom, SurfaceGeom},
     storage::Handle,
     topology::{HalfEdge, Surface},
 };
@@ -29,7 +29,7 @@ impl Layer<Geometry> {
     pub fn define_surface(
         &mut self,
         surface: Handle<Surface>,
-        geometry: SurfaceGeometry,
+        geometry: SurfaceGeom,
     ) {
         let mut events = Vec::new();
         self.process(DefineSurface { surface, geometry }, &mut events);
@@ -64,7 +64,7 @@ impl Event<Geometry> for DefineHalfEdge {
 /// Define the geometry of a surface
 pub struct DefineSurface {
     surface: Handle<Surface>,
-    geometry: SurfaceGeometry,
+    geometry: SurfaceGeom,
 }
 
 impl Command<Geometry> for DefineSurface {

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -2,7 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::{Arc, Point, Scalar};
 
 use crate::{
-    geometry::{HalfEdgeGeometry, SurfacePath},
+    geometry::{HalfEdgeGeom, SurfacePath},
     operations::{geometry::UpdateHalfEdgeGeometry, insert::Insert},
     storage::Handle,
     topology::{Curve, HalfEdge, Vertex},
@@ -63,7 +63,7 @@ pub trait BuildHalfEdge {
         let half_edge = HalfEdge::unjoined(core).insert(core);
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
-            HalfEdgeGeometry {
+            HalfEdgeGeom {
                 path,
                 boundary: boundary.into(),
             },
@@ -85,7 +85,7 @@ pub trait BuildHalfEdge {
         let half_edge = HalfEdge::unjoined(core).insert(core);
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
-            HalfEdgeGeometry {
+            HalfEdgeGeom {
                 path,
                 boundary: boundary.into(),
             },
@@ -107,7 +107,7 @@ pub trait BuildHalfEdge {
         );
 
         HalfEdge::unjoined(core).insert(core).set_geometry(
-            HalfEdgeGeometry {
+            HalfEdgeGeom {
                 path,
                 boundary: boundary.into(),
             },

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -1,7 +1,7 @@
 use fj_math::{Point, Scalar, Vector};
 
 use crate::{
-    geometry::{GlobalPath, SurfaceGeometry},
+    geometry::{GlobalPath, SurfaceGeom},
     operations::insert::Insert,
     storage::Handle,
     topology::Surface,
@@ -47,7 +47,7 @@ pub trait BuildSurface {
 
         core.layers.geometry.define_surface(
             surface.clone(),
-            SurfaceGeometry {
+            SurfaceGeom {
                 u: u.into(),
                 v: v.into(),
             },

--- a/crates/fj-core/src/operations/geometry/half_edge.rs
+++ b/crates/fj-core/src/operations/geometry/half_edge.rs
@@ -1,5 +1,5 @@
 use crate::{
-    geometry::{Geometry, HalfEdgeGeometry},
+    geometry::{Geometry, HalfEdgeGeom},
     layers::Layer,
     storage::Handle,
     topology::HalfEdge,
@@ -10,7 +10,7 @@ pub trait UpdateHalfEdgeGeometry {
     /// Set the path of the half-edge
     fn set_geometry(
         self,
-        geometry: HalfEdgeGeometry,
+        geometry: HalfEdgeGeom,
         layer: &mut Layer<Geometry>,
     ) -> Self;
 }
@@ -18,7 +18,7 @@ pub trait UpdateHalfEdgeGeometry {
 impl UpdateHalfEdgeGeometry for Handle<HalfEdge> {
     fn set_geometry(
         self,
-        geometry: HalfEdgeGeometry,
+        geometry: HalfEdgeGeom,
         layer: &mut Layer<Geometry>,
     ) -> Self {
         layer.define_half_edge(self.clone(), geometry);

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use itertools::Itertools;
 
 use crate::{
-    geometry::HalfEdgeGeometry,
+    geometry::HalfEdgeGeom,
     operations::{
         build::BuildHalfEdge,
         geometry::UpdateHalfEdgeGeometry,
@@ -21,7 +21,7 @@ pub trait JoinCycle {
     #[must_use]
     fn add_joined_edges<Es>(&self, edges: Es, core: &mut Core) -> Self
     where
-        Es: IntoIterator<Item = (Handle<HalfEdge>, HalfEdgeGeometry)>,
+        Es: IntoIterator<Item = (Handle<HalfEdge>, HalfEdgeGeom)>,
         Es::IntoIter: Clone + ExactSizeIterator;
 
     /// Join the cycle to another
@@ -78,7 +78,7 @@ pub trait JoinCycle {
 impl JoinCycle for Cycle {
     fn add_joined_edges<Es>(&self, edges: Es, core: &mut Core) -> Self
     where
-        Es: IntoIterator<Item = (Handle<HalfEdge>, HalfEdgeGeometry)>,
+        Es: IntoIterator<Item = (Handle<HalfEdge>, HalfEdgeGeom)>,
         Es::IntoIter: Clone + ExactSizeIterator,
     {
         let half_edges = edges

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -1,7 +1,7 @@
 use fj_math::{Circle, Line, Vector};
 
 use crate::{
-    geometry::{GlobalPath, SurfaceGeometry, SurfacePath},
+    geometry::{GlobalPath, SurfaceGeom, SurfacePath},
     operations::build::BuildSurface,
     storage::Handle,
     topology::Surface,
@@ -26,7 +26,7 @@ pub trait SweepSurfacePath {
     /// <https://github.com/hannobraun/fornjot/issues/1112>
     fn sweep_surface_path(
         &self,
-        surface: &SurfaceGeometry,
+        surface: &SurfaceGeom,
         path: impl Into<Vector<3>>,
         core: &mut Core,
     ) -> Handle<Surface>;
@@ -35,7 +35,7 @@ pub trait SweepSurfacePath {
 impl SweepSurfacePath for SurfacePath {
     fn sweep_surface_path(
         &self,
-        surface: &SurfaceGeometry,
+        surface: &SurfaceGeom,
         path: impl Into<Vector<3>>,
         core: &mut Core,
     ) -> Handle<Surface> {

--- a/crates/fj-core/src/validate/shell.rs
+++ b/crates/fj-core/src/validate/shell.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fmt};
 use fj_math::{Point, Scalar};
 
 use crate::{
-    geometry::{CurveBoundary, Geometry, SurfaceGeometry},
+    geometry::{CurveBoundary, Geometry, SurfaceGeom},
     queries::{
         AllHalfEdgesWithSurface, BoundingVerticesOfHalfEdge, SiblingOfHalfEdge,
     },
@@ -101,9 +101,9 @@ impl ShellValidationError {
 
                 fn compare_curve_coords(
                     edge_a: &Handle<HalfEdge>,
-                    surface_a: &SurfaceGeometry,
+                    surface_a: &SurfaceGeom,
                     edge_b: &Handle<HalfEdge>,
-                    surface_b: &SurfaceGeometry,
+                    surface_b: &SurfaceGeom,
                     geometry: &Geometry,
                     config: &ValidationConfig,
                     mismatches: &mut Vec<CurveCoordinateSystemMismatch>,
@@ -382,14 +382,14 @@ impl fmt::Display for CoincidentHalfEdgeVertices {
 /// Returns an [`Iterator`] of the distance at each sample.
 fn distances(
     edge_a: Handle<HalfEdge>,
-    surface_a: &SurfaceGeometry,
+    surface_a: &SurfaceGeom,
     edge_b: Handle<HalfEdge>,
-    surface_b: &SurfaceGeometry,
+    surface_b: &SurfaceGeom,
     geometry: &Geometry,
 ) -> impl Iterator<Item = Scalar> {
     fn sample(
         percent: f64,
-        (edge, surface): (&Handle<HalfEdge>, &SurfaceGeometry),
+        (edge, surface): (&Handle<HalfEdge>, &SurfaceGeom),
         geometry: &Geometry,
     ) -> Point<3> {
         let [start, end] = geometry.of_half_edge(edge).boundary.inner;


### PR DESCRIPTION
Geometry is a very common concept within `fj-core`, and those structs are widely used. A shorthand seems justified.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.