### PR TITLE
Move half-edge connection check from `Cycle` to `Face`/`Sketch`

### DIFF
--- a/crates/fj-core/src/validate/cycle.rs
+++ b/crates/fj-core/src/validate/cycle.rs
@@ -1,10 +1,7 @@
 use crate::{
     geometry::Geometry,
     topology::Cycle,
-    validation::{
-        checks::AdjacentHalfEdgesNotConnected, ValidationCheck,
-        ValidationConfig, ValidationError,
-    },
+    validation::{ValidationConfig, ValidationError},
 };
 
 use super::Validate;
@@ -12,13 +9,9 @@ use super::Validate;
 impl Validate for Cycle {
     fn validate(
         &self,
-        config: &ValidationConfig,
-        errors: &mut Vec<ValidationError>,
-        geometry: &Geometry,
+        _: &ValidationConfig,
+        _: &mut Vec<ValidationError>,
+        _: &Geometry,
     ) {
-        errors.extend(
-            AdjacentHalfEdgesNotConnected::check(self, geometry, config)
-                .map(Into::into),
-        );
     }
 }

--- a/crates/fj-core/src/validate/face.rs
+++ b/crates/fj-core/src/validate/face.rs
@@ -2,7 +2,10 @@ use crate::{
     geometry::Geometry,
     topology::Face,
     validation::{
-        checks::{FaceHasNoBoundary, InteriorCycleHasInvalidWinding},
+        checks::{
+            AdjacentHalfEdgesNotConnected, FaceHasNoBoundary,
+            InteriorCycleHasInvalidWinding,
+        },
         ValidationCheck, ValidationConfig, ValidationError,
     },
 };
@@ -16,6 +19,10 @@ impl Validate for Face {
         errors: &mut Vec<ValidationError>,
         geometry: &Geometry,
     ) {
+        errors.extend(
+            AdjacentHalfEdgesNotConnected::check(self, geometry, config)
+                .map(Into::into),
+        );
         errors.extend(
             FaceHasNoBoundary::check(self, geometry, config).map(Into::into),
         );

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -5,6 +5,7 @@ use crate::{
     storage::Handle,
     topology::{Cycle, Sketch},
     validate_references,
+    validation::{checks::AdjacentHalfEdgesNotConnected, ValidationCheck},
 };
 
 use super::{
@@ -19,6 +20,10 @@ impl Validate for Sketch {
         errors: &mut Vec<ValidationError>,
         geometry: &Geometry,
     ) {
+        errors.extend(
+            AdjacentHalfEdgesNotConnected::check(self, geometry, config)
+                .map(Into::into),
+        );
         SketchValidationError::check_object_references(self, config, errors);
         SketchValidationError::check_exterior_cycles(
             self, geometry, config, errors,

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -1,7 +1,11 @@
-use crate::geometry::Geometry;
-use crate::{storage::Handle, topology::Cycle};
-use crate::{topology::Sketch, validate_references};
 use fj_math::Winding;
+
+use crate::{
+    geometry::Geometry,
+    storage::Handle,
+    topology::{Cycle, Sketch},
+    validate_references,
+};
 
 use super::{
     references::{ReferenceCountError, ReferenceCounter},

--- a/crates/fj-core/src/validation/checks/face_boundary.rs
+++ b/crates/fj-core/src/validation/checks/face_boundary.rs
@@ -17,11 +17,11 @@ use crate::{
 pub struct FaceHasNoBoundary {}
 
 impl ValidationCheck<Face> for FaceHasNoBoundary {
-    fn check(
-        object: &Face,
-        _: &Geometry,
-        _: &ValidationConfig,
-    ) -> impl Iterator<Item = Self> {
+    fn check<'r>(
+        object: &'r Face,
+        _: &'r Geometry,
+        _: &'r ValidationConfig,
+    ) -> impl Iterator<Item = Self> + 'r {
         let error = if object.region().exterior().half_edges().is_empty() {
             Some(FaceHasNoBoundary {})
         } else {

--- a/crates/fj-core/src/validation/checks/face_winding.rs
+++ b/crates/fj-core/src/validation/checks/face_winding.rs
@@ -37,11 +37,11 @@ pub struct InteriorCycleHasInvalidWinding {
 }
 
 impl ValidationCheck<Face> for InteriorCycleHasInvalidWinding {
-    fn check(
-        object: &Face,
-        geometry: &Geometry,
-        _: &ValidationConfig,
-    ) -> impl Iterator<Item = Self> {
+    fn check<'r>(
+        object: &'r Face,
+        geometry: &'r Geometry,
+        _: &'r ValidationConfig,
+    ) -> impl Iterator<Item = Self> + 'r {
         object.region().interiors().iter().filter_map(|interior| {
             let exterior = object.region().exterior();
 

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -63,33 +63,41 @@ impl ValidationCheck<Cycle> for AdjacentHalfEdgesNotConnected {
         geometry: &'r Geometry,
         config: &'r ValidationConfig,
     ) -> impl Iterator<Item = Self> + 'r {
-        object.half_edges().pairs().filter_map(|(first, second)| {
-            let end_pos_of_first_half_edge = {
-                let [_, end] = geometry.of_half_edge(first).boundary.inner;
-                geometry
-                    .of_half_edge(first)
-                    .path
-                    .point_from_path_coords(end)
-            };
-            let start_pos_of_second_half_edge =
-                geometry.of_half_edge(second).start_position();
-
-            let distance_between_positions = (end_pos_of_first_half_edge
-                - start_pos_of_second_half_edge)
-                .magnitude();
-
-            if distance_between_positions > config.identical_max_distance {
-                return Some(AdjacentHalfEdgesNotConnected {
-                    end_pos_of_first_half_edge,
-                    start_pos_of_second_half_edge,
-                    distance_between_positions,
-                    unconnected_half_edges: [first.clone(), second.clone()],
-                });
-            }
-
-            None
-        })
+        check_cycle(object, geometry, config)
     }
+}
+
+fn check_cycle<'r>(
+    object: &'r Cycle,
+    geometry: &'r Geometry,
+    config: &'r ValidationConfig,
+) -> impl Iterator<Item = AdjacentHalfEdgesNotConnected> + 'r {
+    object.half_edges().pairs().filter_map(|(first, second)| {
+        let end_pos_of_first_half_edge = {
+            let [_, end] = geometry.of_half_edge(first).boundary.inner;
+            geometry
+                .of_half_edge(first)
+                .path
+                .point_from_path_coords(end)
+        };
+        let start_pos_of_second_half_edge =
+            geometry.of_half_edge(second).start_position();
+
+        let distance_between_positions = (end_pos_of_first_half_edge
+            - start_pos_of_second_half_edge)
+            .magnitude();
+
+        if distance_between_positions > config.identical_max_distance {
+            return Some(AdjacentHalfEdgesNotConnected {
+                end_pos_of_first_half_edge,
+                start_pos_of_second_half_edge,
+                distance_between_positions,
+                unconnected_half_edges: [first.clone(), second.clone()],
+            });
+        }
+
+        None
+    })
 }
 
 #[cfg(test)]

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -68,11 +68,11 @@ impl ValidationCheck<Cycle> for AdjacentHalfEdgesNotConnected {
 }
 
 fn check_cycle<'r>(
-    object: &'r Cycle,
+    cycle: &'r Cycle,
     geometry: &'r Geometry,
     config: &'r ValidationConfig,
 ) -> impl Iterator<Item = AdjacentHalfEdgesNotConnected> + 'r {
-    object.half_edges().pairs().filter_map(|(first, second)| {
+    cycle.half_edges().pairs().filter_map(|(first, second)| {
         let end_pos_of_first_half_edge = {
             let [_, end] = geometry.of_half_edge(first).boundary.inner;
             geometry

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -58,11 +58,11 @@ pub struct AdjacentHalfEdgesNotConnected {
 }
 
 impl ValidationCheck<Cycle> for AdjacentHalfEdgesNotConnected {
-    fn check(
-        object: &Cycle,
-        geometry: &Geometry,
-        config: &ValidationConfig,
-    ) -> impl Iterator<Item = Self> {
+    fn check<'r>(
+        object: &'r Cycle,
+        geometry: &'r Geometry,
+        config: &'r ValidationConfig,
+    ) -> impl Iterator<Item = Self> + 'r {
         object.half_edges().pairs().filter_map(|(first, second)| {
             let end_pos_of_first_half_edge = {
                 let [_, end] = geometry.of_half_edge(first).boundary.inner;

--- a/crates/fj-core/src/validation/validation_check.rs
+++ b/crates/fj-core/src/validation/validation_check.rs
@@ -10,11 +10,11 @@ use super::ValidationConfig;
 /// to. `Self` is the object, while `T` identifies the validation check.
 pub trait ValidationCheck<T>: Sized {
     /// Run the validation check on the implementing object
-    fn check(
-        object: &T,
-        geometry: &Geometry,
-        config: &ValidationConfig,
-    ) -> impl Iterator<Item = Self>;
+    fn check<'r>(
+        object: &'r T,
+        geometry: &'r Geometry,
+        config: &'r ValidationConfig,
+    ) -> impl Iterator<Item = Self> + 'r;
 
     /// Convenience method to run the check return the first error
     ///


### PR DESCRIPTION
From a commit message:

> The code of this check is going to require access to a `Surface` soon, due to changes I'm working on. The reshuffling done in this commit is preparation for having this surface available.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.