### PR TITLE
Add curve geometry to geometry layer

### DIFF
--- a/crates/fj-core/src/geometry/curve.rs
+++ b/crates/fj-core/src/geometry/curve.rs
@@ -1,0 +1,36 @@
+use crate::{storage::Handle, topology::Surface};
+
+use super::SurfacePath;
+
+/// The geometric definition of a curve
+#[derive(Clone)]
+pub struct CurveGeom {
+    /// # The redundant local definitions of the curve geometry
+    ///
+    /// ## Implementation Note
+    ///
+    /// Having multiple redundant definitions is undesirable. However, we can't
+    /// just use one global definition in 3D, as we need the local 2D
+    /// definitions to approximate and triangulate curves, and we currently
+    /// don't have the tools to project a global definition into a local
+    /// context.
+    ///
+    /// Eventually, it should be possible to define the geometry of a curve
+    /// once, either locally or globally, and then convert that single
+    /// definition into (other) local contexts, as needed. There currently is no
+    /// issue to track that specifically, but there is the following issue,
+    /// which is a prerequisite for making the required tooling practical:
+    ///
+    /// <https://github.com/hannobraun/fornjot/issues/2118>
+    pub definitions: Vec<LocalCurveGeom>,
+}
+
+/// The geometric definition of a curve in 2D surface coordinates
+#[derive(Clone)]
+pub struct LocalCurveGeom {
+    /// The path that defines the curve on its surface
+    pub path: SurfacePath,
+
+    /// The surface that the curve is defined on
+    pub surface: Handle<Surface>,
+}

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -62,6 +62,14 @@ impl Geometry {
         self_
     }
 
+    pub(crate) fn define_curve_inner(
+        &mut self,
+        curve: Handle<Curve>,
+        geometry: CurveGeom,
+    ) {
+        self.curve.insert(curve, geometry);
+    }
+
     pub(crate) fn define_half_edge_inner(
         &mut self,
         half_edge: Handle<HalfEdge>,

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -4,13 +4,14 @@ use fj_math::Vector;
 
 use crate::{
     storage::Handle,
-    topology::{HalfEdge, Surface, Topology},
+    topology::{Curve, HalfEdge, Surface, Topology},
 };
 
-use super::{GlobalPath, HalfEdgeGeom, SurfaceGeom};
+use super::{CurveGeom, GlobalPath, HalfEdgeGeom, SurfaceGeom};
 
 /// Geometric data that is associated with topological objects
 pub struct Geometry {
+    curve: BTreeMap<Handle<Curve>, CurveGeom>,
     half_edge: BTreeMap<Handle<HalfEdge>, HalfEdgeGeom>,
     surface: BTreeMap<Handle<Surface>, SurfaceGeom>,
 
@@ -25,6 +26,7 @@ impl Geometry {
     /// Create a new instance of `Geometry`
     pub fn new(topology: &Topology) -> Self {
         let mut self_ = Self {
+            curve: BTreeMap::new(),
             half_edge: BTreeMap::new(),
             surface: BTreeMap::new(),
 
@@ -86,6 +88,17 @@ impl Geometry {
         }
 
         self.surface.insert(surface, geometry);
+    }
+
+    /// # Access the geometry of the provided curve
+    ///
+    /// ## Panics
+    ///
+    /// Panics, if the geometry of the curve is not defined.
+    pub fn of_curve(&self, curve: &Handle<Curve>) -> &CurveGeom {
+        self.curve
+            .get(curve)
+            .expect("Expected geometry of half-edge to be defined")
     }
 
     /// # Access the geometry of the provided half-edge

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -1,6 +1,7 @@
 //! Types that are tied to objects, but aren't objects themselves
 
 mod boundary;
+mod curve;
 mod geometry;
 mod half_edge;
 mod path;
@@ -8,6 +9,7 @@ mod surface;
 
 pub use self::{
     boundary::{CurveBoundary, CurveBoundaryElement},
+    curve::{CurveGeom, LocalCurveGeom},
     geometry::Geometry,
     half_edge::HalfEdgeGeom,
     path::{GlobalPath, SurfacePath},


### PR DESCRIPTION
The new curve geometry is redundant with half-edge geometry, sharing the `SurfacePath`. The intention is to fully migrate the path from `HalfEdgeGeom` to `CurveGeom`, as part of https://github.com/hannobraun/fornjot/issues/2290.

This pull request only adds the basic infrastructure for curve geometry. It is not defined or used anywhere yet.