### PR TITLE
Implement `Default` for `CurveBoundary<Point<1>>`

### DIFF
--- a/crates/fj-core/src/geometry/boundary.rs
+++ b/crates/fj-core/src/geometry/boundary.rs
@@ -52,6 +52,14 @@ impl<T: CurveBoundaryElement> CurveBoundary<T> {
     }
 }
 
+impl Default for CurveBoundary<Point<1>> {
+    fn default() -> Self {
+        Self {
+            inner: [[0.], [1.]].map(Point::from),
+        }
+    }
+}
+
 impl<S, T: CurveBoundaryElement> From<[S; 2]> for CurveBoundary<T>
 where
     S: Into<T::Repr>,

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -2,7 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::{Arc, Point, Scalar};
 
 use crate::{
-    geometry::{HalfEdgeGeom, LocalCurveGeom, SurfacePath},
+    geometry::{CurveBoundary, HalfEdgeGeom, LocalCurveGeom, SurfacePath},
     operations::{geometry::UpdateHalfEdgeGeometry, insert::Insert},
     storage::Handle,
     topology::{Curve, HalfEdge, Surface, Vertex},
@@ -111,14 +111,15 @@ pub trait BuildHalfEdge {
     /// Create a line segment
     fn line_segment(
         points_surface: [impl Into<Point<2>>; 2],
-        boundary: Option<[Point<1>; 2]>,
+        boundary: Option<CurveBoundary<Point<1>>>,
         surface: Handle<Surface>,
         core: &mut Core,
     ) -> Handle<HalfEdge> {
-        let boundary =
-            boundary.unwrap_or_else(|| [[0.], [1.]].map(Point::from));
+        let boundary = boundary.unwrap_or_else(|| CurveBoundary {
+            inner: [[0.], [1.]].map(Point::from),
+        });
         let path = SurfacePath::line_from_points_with_coords(
-            boundary.zip_ext(points_surface),
+            boundary.inner.zip_ext(points_surface),
         );
 
         let half_edge = HalfEdge::unjoined(core).insert(core);
@@ -130,10 +131,7 @@ pub trait BuildHalfEdge {
         );
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
-            HalfEdgeGeom {
-                path,
-                boundary: boundary.into(),
-            },
+            HalfEdgeGeom { path, boundary },
         );
 
         half_edge

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -115,9 +115,7 @@ pub trait BuildHalfEdge {
         surface: Handle<Surface>,
         core: &mut Core,
     ) -> Handle<HalfEdge> {
-        let boundary = boundary.unwrap_or_else(|| CurveBoundary {
-            inner: [[0.], [1.]].map(Point::from),
-        });
+        let boundary = boundary.unwrap_or_default();
         let path = SurfacePath::line_from_points_with_coords(
             boundary.inner.zip_ext(points_surface),
         );

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -70,11 +70,7 @@ pub trait BuildShell {
                             .cloned()
                             .unwrap_or_else(|| {
                                 let curve = Curve::new().insert(core);
-                                let boundary =
-                                    CurveBoundary::<Point<1>>::from([
-                                        [0.],
-                                        [1.],
-                                    ]);
+                                let boundary = CurveBoundary::default();
 
                                 curves.insert(
                                     vertices,

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -94,7 +94,7 @@ pub trait BuildShell {
                         .map(|((vertex, positions), (curve, boundary))| {
                             let half_edge = HalfEdge::line_segment(
                                 positions,
-                                Some(boundary.reverse().inner),
+                                Some(boundary.reverse()),
                                 surface.clone(),
                                 core,
                             );

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -2,6 +2,7 @@ use fj_interop::{ext::ArrayExt, Color};
 use fj_math::{Point, Scalar, Vector};
 
 use crate::{
+    geometry::CurveBoundary,
     operations::{
         build::{BuildCycle, BuildHalfEdge},
         geometry::UpdateHalfEdgeGeometry,
@@ -121,7 +122,7 @@ impl SweepHalfEdge for Handle<HalfEdge> {
                 let half_edge = {
                     let line_segment = HalfEdge::line_segment(
                         [start, end],
-                        Some(boundary),
+                        Some(CurveBoundary { inner: boundary }),
                         surface.clone(),
                         core,
                     );


### PR DESCRIPTION
Consolidates some redundant code in one central place. This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.