### PR TITLE
 Return `Option` from `CurveGeom::local_on`

### DIFF
--- a/crates/fj-core/src/geometry/curve.rs
+++ b/crates/fj-core/src/geometry/curve.rs
@@ -33,10 +33,11 @@ impl CurveGeom {
     /// ## Panics
     ///
     /// Panics, if the curve has not been defined on that surface.
-    pub fn local_on(&self, surface: &Handle<Surface>) -> &LocalCurveGeom {
-        self.definitions
-            .get(surface)
-            .expect("Curve not defined on provided surface")
+    pub fn local_on(
+        &self,
+        surface: &Handle<Surface>,
+    ) -> Option<&LocalCurveGeom> {
+        self.definitions.get(surface)
     }
 }
 

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -135,6 +135,7 @@ pub trait BuildHalfEdge {
                     .of_curve(half_edge.curve())
                     .expect("Curve geometry was just defined in same function")
                     .local_on(&surface)
+                    .expect("Curve geometry was just defined in same function")
                     .path,
                 boundary: boundary.unwrap_or_default(),
             },

--- a/crates/fj-core/src/operations/build/shell.rs
+++ b/crates/fj-core/src/operations/build/shell.rs
@@ -112,6 +112,10 @@ pub trait BuildShell {
                                                 defined in same function",
                                             )
                                             .local_on(&surface)
+                                            .expect(
+                                                "Curve geometry was just \
+                                                defined in same function",
+                                            )
                                             .path,
                                         boundary,
                                     },

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -141,8 +141,8 @@ impl SweepHalfEdge for Handle<HalfEdge> {
                                 .geometry
                                 .of_curve(&curve)
                                 .expect(
-                                    "Curve geometry was just \
-                                                defined in same function",
+                                    "Curve geometry was just defined in same \
+                                    function",
                                 )
                                 .local_on(&surface)
                                 .path,

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -145,6 +145,10 @@ impl SweepHalfEdge for Handle<HalfEdge> {
                                     function",
                                 )
                                 .local_on(&surface)
+                                .expect(
+                                    "Curve geometry was just defined in same \
+                                    function",
+                                )
                                 .path,
                             boundary,
                         },


### PR DESCRIPTION
From the message of the main commit:

> This makes the function more flexible, letting the caller decide if it can accept a missing local definition.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.