### PR TITLE
Continue cleanup of reference-counting validation code

### DIFF
--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -78,7 +78,10 @@ use crate::{
     validation::{ValidationConfig, ValidationError},
 };
 
-pub use self::{sketch::SketchValidationError, solid::SolidValidationError};
+pub use self::{
+    references::ObjectNotExclusivelyOwned, sketch::SketchValidationError,
+    solid::SolidValidationError,
+};
 
 /// Assert that some object has a validation error which matches a specific
 /// pattern. This is preferred to matching on [`Validate::validate_and_return_first_error`], since usually we don't care about the order.

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -2,6 +2,34 @@ use std::{any::type_name_of_val, collections::HashMap, fmt};
 
 use crate::storage::Handle;
 
+/// Object that should be exclusively owned by another, is not
+///
+/// Some objects are expected to be "owned" by a single other object. This means
+/// that only one reference to these objects must exist within the topological
+/// object graph.
+#[derive(Clone, Debug, thiserror::Error)]
+pub struct ObjectNotExclusivelyOwned<T, U> {
+    object: Handle<T>,
+    referenced_by: Vec<Handle<U>>,
+}
+
+impl<T, U> fmt::Display for ObjectNotExclusivelyOwned<T, U>
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "`{}` ({:?}) referenced by multiple `{}` objects ({:?})",
+            type_name_of_val(&self.object),
+            self.object,
+            type_name_of_val(&self.referenced_by),
+            self.referenced_by
+        )
+    }
+}
+
 #[derive(Default)]
 pub struct ReferenceCounter<T, U>(HashMap<Handle<T>, Vec<Handle<U>>>);
 
@@ -37,32 +65,4 @@ macro_rules! validate_references {
             });
         )*
     };
-}
-
-/// Object that should be exclusively owned by another, is not
-///
-/// Some objects are expected to be "owned" by a single other object. This means
-/// that only one reference to these objects must exist within the topological
-/// object graph.
-#[derive(Clone, Debug, thiserror::Error)]
-pub struct ObjectNotExclusivelyOwned<T, U> {
-    object: Handle<T>,
-    referenced_by: Vec<Handle<U>>,
-}
-
-impl<T, U> fmt::Display for ObjectNotExclusivelyOwned<T, U>
-where
-    T: fmt::Debug,
-    U: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "`{}` ({:?}) referenced by multiple `{}` objects ({:?})",
-            type_name_of_val(&self.object),
-            self.object,
-            type_name_of_val(&self.referenced_by),
-            self.referenced_by
-        )
-    }
 }

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -29,7 +29,7 @@ impl<T, U> ReferenceCounter<T, U> {
 /// Find errors and convert to [`crate::validate::ValidationError`]
 #[macro_export]
 macro_rules! validate_references {
-    ($errors:ident, $error_ty:ty;$($counter:ident, $err:ident;)*) => {
+    ($errors:ident;$($counter:ident, $err:ident;)*) => {
         $(
             $counter.find_multiples().iter().for_each(|multiple| {
                 let reference_error = ValidationError::$err(multiple.clone());

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -19,10 +19,8 @@ impl<T, U> ReferenceCounter<T, U> {
             .iter()
             .filter(|(_, referenced_by)| referenced_by.len() > 1)
             .map(|(object, referenced_by)| ObjectNotExclusivelyOwned {
-                references: MultipleReferences {
-                    object: object.clone(),
-                    referenced_by: referenced_by.to_vec(),
-                },
+                object: object.clone(),
+                referenced_by: referenced_by.to_vec(),
             })
             .collect()
     }
@@ -47,19 +45,12 @@ macro_rules! validate_references {
 /// that only one reference to these objects must exist within the topological
 /// object graph.
 #[derive(Clone, Debug, thiserror::Error)]
-#[error(transparent)]
 pub struct ObjectNotExclusivelyOwned<T, U> {
-    /// The invalid references
-    pub references: MultipleReferences<T, U>,
-}
-
-#[derive(Clone, Debug, thiserror::Error)]
-pub struct MultipleReferences<T, U> {
     object: Handle<T>,
     referenced_by: Vec<Handle<U>>,
 }
 
-impl<T, U> fmt::Display for MultipleReferences<T, U>
+impl<T, U> fmt::Display for ObjectNotExclusivelyOwned<T, U>
 where
     T: fmt::Debug,
     U: fmt::Debug,

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -58,7 +58,7 @@ pub enum ObjectNotExclusivelyOwned {
 
     /// [`Face`] referenced by more than one [`Shell`]
     #[error(transparent)]
-    Face {
+    MultipleReferencesToFace {
         /// The invalid references
         references: MultipleReferences<Face, Shell>,
     },

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -49,28 +49,28 @@ macro_rules! validate_references {
 /// object graph.
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum ObjectNotExclusivelyOwned {
-    /// [`Region`] referenced by more than one [`Face`]
+    /// Multiple references to [`Region`]
     #[error(transparent)]
     MultipleReferencesToRegion {
         /// The invalid references
         references: MultipleReferences<Region, Face>,
     },
 
-    /// [`Face`] referenced by more than one [`Shell`]
+    /// Multiple references to [`Face`]
     #[error(transparent)]
     MultipleReferencesToFace {
         /// The invalid references
         references: MultipleReferences<Face, Shell>,
     },
 
-    /// [`HalfEdge`] referenced by more than one [`Cycle`]
+    /// Multiple references to [`HalfEdge`]
     #[error(transparent)]
     MultipleReferencesToHalfEdge {
         /// The invalid references
         references: MultipleReferences<HalfEdge, Cycle>,
     },
 
-    /// [`Cycle`] referenced by more than one [`Region`]
+    /// Multiple references to [`Cycle`]
     #[error(transparent)]
     MultipleReferencesToCycle {
         /// The invalid references

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -72,7 +72,7 @@ pub enum ObjectNotExclusivelyOwned {
 
     /// [`Cycle`] referenced by more than one [`Region`]
     #[error(transparent)]
-    Cycle {
+    MultipleReferencesToCycle {
         /// The invalid references
         references: MultipleReferences<Cycle, Region>,
     },

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -65,7 +65,7 @@ pub enum ObjectNotExclusivelyOwned {
 
     /// [`HalfEdge`] referenced by more than one [`Cycle`]
     #[error(transparent)]
-    HalfEdge {
+    MultipleReferencesToHalfEdge {
         /// The invalid references
         references: MultipleReferences<HalfEdge, Cycle>,
     },

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -36,7 +36,7 @@ macro_rules! validate_references {
         $(
             $counter.find_multiples().iter().for_each(|multiple| {
                 let reference_error = ObjectNotExclusivelyOwned::$err { references: multiple.clone() };
-                $errors.push(Into::<$error_ty>::into(reference_error).into());
+                $errors.push(reference_error.into());
             });
         )*
     };

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -51,7 +51,7 @@ macro_rules! validate_references {
 pub enum ObjectNotExclusivelyOwned {
     /// [`Region`] referenced by more than one [`Face`]
     #[error(transparent)]
-    Region {
+    MultipleReferencesToRegion {
         /// The invalid references
         references: MultipleReferences<Region, Face>,
     },

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -52,21 +52,25 @@ pub enum ObjectNotExclusivelyOwned {
     /// [`Region`] referenced by more than one [`Face`]
     #[error(transparent)]
     Region {
+        /// The invalid references
         references: MultipleReferences<Region, Face>,
     },
     /// [`Face`] referenced by more than one [`Shell`]
     #[error(transparent)]
     Face {
+        /// The invalid references
         references: MultipleReferences<Face, Shell>,
     },
     /// [`HalfEdge`] referenced by more than one [`Cycle`]
     #[error(transparent)]
     HalfEdge {
+        /// The invalid references
         references: MultipleReferences<HalfEdge, Cycle>,
     },
     /// [`Cycle`] referenced by more than one [`Region`]
     #[error(transparent)]
     Cycle {
+        /// The invalid references
         references: MultipleReferences<Cycle, Region>,
     },
 }

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -55,18 +55,21 @@ pub enum ObjectNotExclusivelyOwned {
         /// The invalid references
         references: MultipleReferences<Region, Face>,
     },
+
     /// [`Face`] referenced by more than one [`Shell`]
     #[error(transparent)]
     Face {
         /// The invalid references
         references: MultipleReferences<Face, Shell>,
     },
+
     /// [`HalfEdge`] referenced by more than one [`Cycle`]
     #[error(transparent)]
     HalfEdge {
         /// The invalid references
         references: MultipleReferences<HalfEdge, Cycle>,
     },
+
     /// [`Cycle`] referenced by more than one [`Region`]
     #[error(transparent)]
     Cycle {

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -9,8 +9,7 @@ use crate::{
 };
 
 use super::{
-    references::{ObjectNotExclusivelyOwned, ReferenceCounter},
-    Validate, ValidationConfig, ValidationError,
+    references::ReferenceCounter, Validate, ValidationConfig, ValidationError,
 };
 
 impl Validate for Sketch {

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -131,10 +131,7 @@ mod tests {
             build::BuildHalfEdge, build::BuildRegion, insert::Insert,
         },
         topology::{Cycle, HalfEdge, Region, Sketch, Vertex},
-        validate::{
-            references::ObjectNotExclusivelyOwned, SketchValidationError,
-            Validate, ValidationError,
-        },
+        validate::{SketchValidationError, Validate, ValidationError},
         Core,
     };
 
@@ -166,11 +163,7 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_sketch,
-            ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::MultipleReferencesToCycle {
-                    references: _
-                }
-            )
+            ValidationError::MultipleReferencesToCycle(_)
         );
 
         Ok(())
@@ -206,11 +199,7 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_sketch,
-            ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::MultipleReferencesToHalfEdge {
-                    references: _
-                }
-            )
+            ValidationError::MultipleReferencesToHalfEdge(_)
         );
 
         Ok(())

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -76,7 +76,7 @@ impl SketchValidationError {
         });
 
         validate_references!(
-            errors, SketchValidationError;
+            errors;
             referenced_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, MultipleReferencesToCycle;
         );

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -79,7 +79,7 @@ impl SketchValidationError {
         validate_references!(
             errors, SketchValidationError;
             referenced_edges, MultipleReferencesToHalfEdge;
-            referenced_cycles, Cycle;
+            referenced_cycles, MultipleReferencesToCycle;
         );
     }
 
@@ -167,7 +167,9 @@ mod tests {
             core,
             invalid_sketch,
             ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::Cycle { references: _ }
+                ObjectNotExclusivelyOwned::MultipleReferencesToCycle {
+                    references: _
+                }
             )
         );
 

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -37,10 +37,6 @@ impl Validate for Sketch {
 /// [`Sketch`] validation failed
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum SketchValidationError {
-    /// An object that should be exclusively owned by another, is not
-    #[error(transparent)]
-    ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
-
     /// Region within sketch has exterior cycle with clockwise winding
     #[error(
         "Exterior cycle within sketch region has clockwise winding\n
@@ -170,10 +166,8 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_sketch,
-            ValidationError::Sketch(
-                SketchValidationError::ObjectNotExclusivelyOwned(
-                    ObjectNotExclusivelyOwned::Cycle { references: _ }
-                )
+            ValidationError::ObjectNotExclusivelyOwned(
+                ObjectNotExclusivelyOwned::Cycle { references: _ }
             )
         );
 
@@ -210,10 +204,8 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_sketch,
-            ValidationError::Sketch(
-                SketchValidationError::ObjectNotExclusivelyOwned(
-                    ObjectNotExclusivelyOwned::HalfEdge { references: _ }
-                )
+            ValidationError::ObjectNotExclusivelyOwned(
+                ObjectNotExclusivelyOwned::HalfEdge { references: _ }
             )
         );
 

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -37,7 +37,7 @@ impl Validate for Sketch {
 /// [`Sketch`] validation failed
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum SketchValidationError {
-    /// Object within sketch referenced by more than one other object
+    /// An object that should be exclusively owned by another, is not
     #[error(transparent)]
     ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
 

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -38,7 +38,7 @@ impl Validate for Sketch {
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum SketchValidationError {
     /// Object within sketch referenced by more than one other object
-    #[error("Object within sketch referenced by more than one other Object")]
+    #[error(transparent)]
     ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
 
     /// Region within sketch has exterior cycle with clockwise winding

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -78,7 +78,7 @@ impl SketchValidationError {
 
         validate_references!(
             errors, SketchValidationError;
-            referenced_edges, HalfEdge;
+            referenced_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, Cycle;
         );
     }
@@ -205,7 +205,9 @@ mod tests {
             core,
             invalid_sketch,
             ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::HalfEdge { references: _ }
+                ObjectNotExclusivelyOwned::MultipleReferencesToHalfEdge {
+                    references: _
+                }
             )
         );
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -9,8 +9,7 @@ use crate::{
 use fj_math::Point;
 
 use super::{
-    references::{ObjectNotExclusivelyOwned, ReferenceCounter},
-    Validate, ValidationConfig, ValidationError,
+    references::ReferenceCounter, Validate, ValidationConfig, ValidationError,
 };
 
 impl Validate for Solid {

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -183,9 +183,7 @@ mod tests {
             insert::Insert,
         },
         topology::{Cycle, Face, HalfEdge, Region, Shell, Solid, Surface},
-        validate::{
-            references::ObjectNotExclusivelyOwned, Validate, ValidationError,
-        },
+        validate::{Validate, ValidationError},
         Core,
     };
 
@@ -233,11 +231,7 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::MultipleReferencesToFace {
-                    references: _
-                }
-            )
+            ValidationError::MultipleReferencesToFace(_)
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);
@@ -281,11 +275,7 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::MultipleReferencesToRegion {
-                    references: _
-                }
-            )
+            ValidationError::MultipleReferencesToRegion(_)
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);
@@ -333,11 +323,7 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::MultipleReferencesToCycle {
-                    references: _
-                }
-            )
+            ValidationError::MultipleReferencesToCycle(_)
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);
@@ -377,11 +363,7 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::MultipleReferencesToHalfEdge {
-                    references: _
-                }
-            )
+            ValidationError::MultipleReferencesToHalfEdge(_)
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -163,7 +163,7 @@ impl SolidValidationError {
         });
 
         validate_references!(
-            errors, SolidValidationError;
+            errors;
             referenced_regions, MultipleReferencesToRegion;
             referenced_faces, MultipleReferencesToFace;
             referenced_edges, MultipleReferencesToHalfEdge;

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -167,7 +167,7 @@ impl SolidValidationError {
             errors, SolidValidationError;
             referenced_regions, MultipleReferencesToRegion;
             referenced_faces, MultipleReferencesToFace;
-            referenced_edges, HalfEdge;
+            referenced_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, Cycle;
         );
     }
@@ -376,7 +376,9 @@ mod tests {
             core,
             invalid_solid,
             ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::HalfEdge { references: _ }
+                ObjectNotExclusivelyOwned::MultipleReferencesToHalfEdge {
+                    references: _
+                }
             )
         );
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -168,7 +168,7 @@ impl SolidValidationError {
             referenced_regions, MultipleReferencesToRegion;
             referenced_faces, MultipleReferencesToFace;
             referenced_edges, MultipleReferencesToHalfEdge;
-            referenced_cycles, Cycle;
+            referenced_cycles, MultipleReferencesToCycle;
         );
     }
 }
@@ -334,7 +334,9 @@ mod tests {
             core,
             invalid_solid,
             ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::Cycle { references: _ }
+                ObjectNotExclusivelyOwned::MultipleReferencesToCycle {
+                    references: _
+                }
             )
         );
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -165,7 +165,7 @@ impl SolidValidationError {
 
         validate_references!(
             errors, SolidValidationError;
-            referenced_regions, Region;
+            referenced_regions, MultipleReferencesToRegion;
             referenced_faces, Face;
             referenced_edges, HalfEdge;
             referenced_cycles, Cycle;
@@ -280,7 +280,9 @@ mod tests {
             core,
             invalid_solid,
             ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::Region { references: _ }
+                ObjectNotExclusivelyOwned::MultipleReferencesToRegion {
+                    references: _
+                }
             )
         );
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -67,10 +67,6 @@ pub enum SolidValidationError {
         /// Position of second vertex
         position_b: Point<3>,
     },
-
-    /// Object within solid referenced by more than one other object
-    #[error(transparent)]
-    ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
 }
 
 impl SolidValidationError {
@@ -188,8 +184,7 @@ mod tests {
         },
         topology::{Cycle, Face, HalfEdge, Region, Shell, Solid, Surface},
         validate::{
-            references::ObjectNotExclusivelyOwned, SolidValidationError,
-            Validate, ValidationError,
+            references::ObjectNotExclusivelyOwned, Validate, ValidationError,
         },
         Core,
     };
@@ -238,10 +233,8 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(
-                SolidValidationError::ObjectNotExclusivelyOwned(
-                    ObjectNotExclusivelyOwned::Face { references: _ }
-                )
+            ValidationError::ObjectNotExclusivelyOwned(
+                ObjectNotExclusivelyOwned::Face { references: _ }
             )
         );
 
@@ -286,10 +279,8 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(
-                SolidValidationError::ObjectNotExclusivelyOwned(
-                    ObjectNotExclusivelyOwned::Region { references: _ }
-                )
+            ValidationError::ObjectNotExclusivelyOwned(
+                ObjectNotExclusivelyOwned::Region { references: _ }
             )
         );
 
@@ -338,10 +329,8 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(
-                SolidValidationError::ObjectNotExclusivelyOwned(
-                    ObjectNotExclusivelyOwned::Cycle { references: _ }
-                )
+            ValidationError::ObjectNotExclusivelyOwned(
+                ObjectNotExclusivelyOwned::Cycle { references: _ }
             )
         );
 
@@ -382,10 +371,8 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(
-                SolidValidationError::ObjectNotExclusivelyOwned(
-                    ObjectNotExclusivelyOwned::HalfEdge { references: _ }
-                )
+            ValidationError::ObjectNotExclusivelyOwned(
+                ObjectNotExclusivelyOwned::HalfEdge { references: _ }
             )
         );
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -166,7 +166,7 @@ impl SolidValidationError {
         validate_references!(
             errors, SolidValidationError;
             referenced_regions, MultipleReferencesToRegion;
-            referenced_faces, Face;
+            referenced_faces, MultipleReferencesToFace;
             referenced_edges, HalfEdge;
             referenced_cycles, Cycle;
         );
@@ -234,7 +234,9 @@ mod tests {
             core,
             invalid_solid,
             ValidationError::ObjectNotExclusivelyOwned(
-                ObjectNotExclusivelyOwned::Face { references: _ }
+                ObjectNotExclusivelyOwned::MultipleReferencesToFace {
+                    references: _
+                }
             )
         );
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -69,7 +69,7 @@ pub enum SolidValidationError {
     },
 
     /// Object within solid referenced by more than one other object
-    #[error("Object within solid referenced by more than one other Object")]
+    #[error(transparent)]
     ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
 }
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -70,7 +70,7 @@ pub enum SolidValidationError {
 
     /// Object within solid referenced by more than one other object
     #[error("Object within solid referenced by more than one other Object")]
-    MultipleReferences(#[from] ObjectNotExclusivelyOwned),
+    ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
 }
 
 impl SolidValidationError {
@@ -238,9 +238,11 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(SolidValidationError::MultipleReferences(
-                ObjectNotExclusivelyOwned::Face { references: _ }
-            ))
+            ValidationError::Solid(
+                SolidValidationError::ObjectNotExclusivelyOwned(
+                    ObjectNotExclusivelyOwned::Face { references: _ }
+                )
+            )
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);
@@ -284,9 +286,11 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(SolidValidationError::MultipleReferences(
-                ObjectNotExclusivelyOwned::Region { references: _ }
-            ))
+            ValidationError::Solid(
+                SolidValidationError::ObjectNotExclusivelyOwned(
+                    ObjectNotExclusivelyOwned::Region { references: _ }
+                )
+            )
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);
@@ -334,9 +338,11 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(SolidValidationError::MultipleReferences(
-                ObjectNotExclusivelyOwned::Cycle { references: _ }
-            ))
+            ValidationError::Solid(
+                SolidValidationError::ObjectNotExclusivelyOwned(
+                    ObjectNotExclusivelyOwned::Cycle { references: _ }
+                )
+            )
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);
@@ -376,9 +382,11 @@ mod tests {
         assert_contains_err!(
             core,
             invalid_solid,
-            ValidationError::Solid(SolidValidationError::MultipleReferences(
-                ObjectNotExclusivelyOwned::HalfEdge { references: _ }
-            ))
+            ValidationError::Solid(
+                SolidValidationError::ObjectNotExclusivelyOwned(
+                    ObjectNotExclusivelyOwned::HalfEdge { references: _ }
+                )
+            )
         );
 
         let valid_solid = Solid::new(vec![]).insert(&mut core);

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -1,7 +1,10 @@
 use std::{convert::Infallible, fmt};
 
-use crate::validate::{
-    ObjectNotExclusivelyOwned, SketchValidationError, SolidValidationError,
+use crate::{
+    topology::{Cycle, Face, HalfEdge, Region, Shell},
+    validate::{
+        ObjectNotExclusivelyOwned, SketchValidationError, SolidValidationError,
+    },
 };
 
 use super::checks::{
@@ -39,9 +42,21 @@ pub enum ValidationError {
     #[error(transparent)]
     InteriorCycleHasInvalidWinding(#[from] InteriorCycleHasInvalidWinding),
 
-    /// An object that should be exclusively owned by another, is not
+    /// Multiple references to [`Cycle`]
     #[error(transparent)]
-    ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
+    MultipleReferencesToCycle(ObjectNotExclusivelyOwned<Cycle, Region>),
+
+    /// Multiple references to [`Face`]
+    #[error(transparent)]
+    MultipleReferencesToFace(ObjectNotExclusivelyOwned<Face, Shell>),
+
+    /// Multiple references to [`HalfEdge`]
+    #[error(transparent)]
+    MultipleReferencesToHalfEdge(ObjectNotExclusivelyOwned<HalfEdge, Cycle>),
+
+    /// Multiple references to [`Region`]
+    #[error(transparent)]
+    MultipleReferencesToRegion(ObjectNotExclusivelyOwned<Region, Face>),
 
     /// `Solid` validation error
     #[error("`Solid` validation error")]

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -1,6 +1,8 @@
 use std::{convert::Infallible, fmt};
 
-use crate::validate::{SketchValidationError, SolidValidationError};
+use crate::validate::{
+    ObjectNotExclusivelyOwned, SketchValidationError, SolidValidationError,
+};
 
 use super::checks::{
     AdjacentHalfEdgesNotConnected, CoincidentHalfEdgesAreNotSiblings,
@@ -36,6 +38,10 @@ pub enum ValidationError {
     /// Interior cycle has invalid winding
     #[error(transparent)]
     InteriorCycleHasInvalidWinding(#[from] InteriorCycleHasInvalidWinding),
+
+    /// An object that should be exclusively owned by another, is not
+    #[error(transparent)]
+    ObjectNotExclusivelyOwned(#[from] ObjectNotExclusivelyOwned),
 
     /// `Solid` validation error
     #[error("`Solid` validation error")]


### PR DESCRIPTION
Continues the cleanup started in https://github.com/hannobraun/fornjot/pull/2363. This comes out of my work on https://github.com/hannobraun/fornjot/issues/2157.