### PR TITLE
Port reference counting validation checks for `Sketch` to new infrastructure

### DIFF
--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -65,7 +65,6 @@ mod curve;
 mod cycle;
 mod face;
 mod half_edge;
-mod references;
 mod region;
 mod shell;
 mod sketch;
@@ -78,10 +77,7 @@ use crate::{
     validation::{ValidationConfig, ValidationError},
 };
 
-pub use self::{
-    references::MultipleReferencesToObject, sketch::SketchValidationError,
-    solid::SolidValidationError,
-};
+pub use self::{sketch::SketchValidationError, solid::SolidValidationError};
 
 /// Assert that some object has a validation error which matches a specific
 /// pattern. This is preferred to matching on [`Validate::validate_and_return_first_error`], since usually we don't care about the order.

--- a/crates/fj-core/src/validate/mod.rs
+++ b/crates/fj-core/src/validate/mod.rs
@@ -79,7 +79,7 @@ use crate::{
 };
 
 pub use self::{
-    references::ObjectNotExclusivelyOwned, sketch::SketchValidationError,
+    references::MultipleReferencesToObject, sketch::SketchValidationError,
     solid::SolidValidationError,
 };
 

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -42,7 +42,9 @@ impl<T, U> ReferenceCounter<T, U> {
         self.0.entry(to).or_default().push(from);
     }
 
-    pub fn find_multiples(&self) -> Vec<MultipleReferencesToObject<T, U>> {
+    pub fn find_multiples(
+        &self,
+    ) -> impl Iterator<Item = MultipleReferencesToObject<T, U>> + '_ {
         self.0
             .iter()
             .filter(|(_, referenced_by)| referenced_by.len() > 1)
@@ -50,7 +52,6 @@ impl<T, U> ReferenceCounter<T, U> {
                 object: object.clone(),
                 referenced_by: referenced_by.to_vec(),
             })
-            .collect()
     }
 }
 
@@ -59,7 +60,7 @@ impl<T, U> ReferenceCounter<T, U> {
 macro_rules! validate_references {
     ($errors:ident;$($counter:ident, $err:ident;)*) => {
         $(
-            $counter.find_multiples().iter().for_each(|multiple| {
+            $counter.find_multiples().for_each(|multiple| {
                 let reference_error = ValidationError::$err(multiple.clone());
                 $errors.push(reference_error.into());
             });

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -38,7 +38,7 @@ impl<T, U> ReferenceCounter<T, U> {
         Self(HashMap::new())
     }
 
-    pub fn count_reference(&mut self, to: Handle<T>, from: Handle<U>) {
+    pub fn count(&mut self, to: Handle<T>, from: Handle<U>) {
         self.0.entry(to).or_default().push(from);
     }
 

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -8,12 +8,12 @@ use crate::storage::Handle;
 /// that only one reference to these objects must exist within the topological
 /// object graph.
 #[derive(Clone, Debug, thiserror::Error)]
-pub struct ObjectNotExclusivelyOwned<T, U> {
+pub struct MultipleReferencesToObject<T, U> {
     object: Handle<T>,
     referenced_by: Vec<Handle<U>>,
 }
 
-impl<T, U> fmt::Display for ObjectNotExclusivelyOwned<T, U>
+impl<T, U> fmt::Display for MultipleReferencesToObject<T, U>
 where
     T: fmt::Debug,
     U: fmt::Debug,
@@ -42,11 +42,11 @@ impl<T, U> ReferenceCounter<T, U> {
         self.0.entry(to).or_default().push(from);
     }
 
-    pub fn find_multiples(&self) -> Vec<ObjectNotExclusivelyOwned<T, U>> {
+    pub fn find_multiples(&self) -> Vec<MultipleReferencesToObject<T, U>> {
         self.0
             .iter()
             .filter(|(_, referenced_by)| referenced_by.len() > 1)
-            .map(|(object, referenced_by)| ObjectNotExclusivelyOwned {
+            .map(|(object, referenced_by)| MultipleReferencesToObject {
                 object: object.clone(),
                 referenced_by: referenced_by.to_vec(),
             })

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -42,7 +42,7 @@ impl<T, U> ReferenceCounter<T, U> {
         self.0.entry(to).or_default().push(from);
     }
 
-    pub fn find_multiples(
+    pub fn multiples(
         &self,
     ) -> impl Iterator<Item = MultipleReferencesToObject<T, U>> + '_ {
         self.0
@@ -60,7 +60,7 @@ impl<T, U> ReferenceCounter<T, U> {
 macro_rules! validate_references {
     ($errors:ident;$($counter:ident, $err:ident;)*) => {
         $(
-            $counter.find_multiples().for_each(|multiple| {
+            $counter.multiples().for_each(|multiple| {
                 let reference_error = ValidationError::$err(multiple.clone());
                 $errors.push(reference_error.into());
             });

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -54,16 +54,3 @@ impl<T, U> ReferenceCounter<T, U> {
             })
     }
 }
-
-/// Find errors and convert to [`crate::validate::ValidationError`]
-#[macro_export]
-macro_rules! validate_references {
-    ($errors:ident;$($counter:ident;)*) => {
-        $(
-            $counter.multiples().for_each(|multiple| {
-                let reference_error = multiple.clone();
-                $errors.push(reference_error.into());
-            });
-        )*
-    };
-}

--- a/crates/fj-core/src/validate/references.rs
+++ b/crates/fj-core/src/validate/references.rs
@@ -58,10 +58,10 @@ impl<T, U> ReferenceCounter<T, U> {
 /// Find errors and convert to [`crate::validate::ValidationError`]
 #[macro_export]
 macro_rules! validate_references {
-    ($errors:ident;$($counter:ident, $err:ident;)*) => {
+    ($errors:ident;$($counter:ident;)*) => {
         $(
             $counter.multiples().for_each(|multiple| {
-                let reference_error = ValidationError::$err(multiple.clone());
+                let reference_error = multiple.clone();
                 $errors.push(reference_error.into());
             });
         )*

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -64,20 +64,20 @@ impl SketchValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         let mut cycles = ReferenceCounter::new();
-        let mut referenced_half_edges = ReferenceCounter::new();
+        let mut half_edges = ReferenceCounter::new();
 
         sketch.regions().iter().for_each(|r| {
             r.all_cycles().for_each(|c| {
                 cycles.count(c.clone(), r.clone());
                 c.half_edges().into_iter().for_each(|e| {
-                    referenced_half_edges.count(e.clone(), c.clone());
+                    half_edges.count(e.clone(), c.clone());
                 })
             })
         });
 
         validate_references!(
             errors;
-            referenced_half_edges, MultipleReferencesToHalfEdge;
+            half_edges, MultipleReferencesToHalfEdge;
             cycles, MultipleReferencesToCycle;
         );
     }

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -77,8 +77,8 @@ impl SketchValidationError {
 
         validate_references!(
             errors;
-            half_edges, MultipleReferencesToHalfEdge;
-            cycles, MultipleReferencesToCycle;
+            half_edges;
+            cycles;
         );
     }
 

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -64,20 +64,20 @@ impl SketchValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         let mut referenced_cycles = ReferenceCounter::new();
-        let mut referenced_edges = ReferenceCounter::new();
+        let mut referenced_half_edges = ReferenceCounter::new();
 
         sketch.regions().iter().for_each(|r| {
             r.all_cycles().for_each(|c| {
                 referenced_cycles.count(c.clone(), r.clone());
                 c.half_edges().into_iter().for_each(|e| {
-                    referenced_edges.count(e.clone(), c.clone());
+                    referenced_half_edges.count(e.clone(), c.clone());
                 })
             })
         });
 
         validate_references!(
             errors;
-            referenced_edges, MultipleReferencesToHalfEdge;
+            referenced_half_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, MultipleReferencesToCycle;
         );
     }

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -63,12 +63,12 @@ impl SketchValidationError {
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        let mut referenced_cycles = ReferenceCounter::new();
+        let mut cycles = ReferenceCounter::new();
         let mut referenced_half_edges = ReferenceCounter::new();
 
         sketch.regions().iter().for_each(|r| {
             r.all_cycles().for_each(|c| {
-                referenced_cycles.count(c.clone(), r.clone());
+                cycles.count(c.clone(), r.clone());
                 c.half_edges().into_iter().for_each(|e| {
                     referenced_half_edges.count(e.clone(), c.clone());
                 })
@@ -78,7 +78,7 @@ impl SketchValidationError {
         validate_references!(
             errors;
             referenced_half_edges, MultipleReferencesToHalfEdge;
-            referenced_cycles, MultipleReferencesToCycle;
+            cycles, MultipleReferencesToCycle;
         );
     }
 

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -63,8 +63,8 @@ impl SketchValidationError {
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        let mut referenced_edges = ReferenceCounter::new();
         let mut referenced_cycles = ReferenceCounter::new();
+        let mut referenced_edges = ReferenceCounter::new();
 
         sketch.regions().iter().for_each(|r| {
             r.all_cycles().for_each(|c| {

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -4,7 +4,6 @@ use crate::{
     geometry::Geometry,
     storage::Handle,
     topology::{Cycle, Sketch},
-    validate_references,
     validation::{checks::AdjacentHalfEdgesNotConnected, ValidationCheck},
 };
 
@@ -75,11 +74,8 @@ impl SketchValidationError {
             })
         });
 
-        validate_references!(
-            errors;
-            half_edges;
-            cycles;
-        );
+        errors.extend(cycles.multiples().map(Into::into));
+        errors.extend(half_edges.multiples().map(Into::into));
     }
 
     fn check_exterior_cycles(

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -68,9 +68,9 @@ impl SketchValidationError {
 
         sketch.regions().iter().for_each(|r| {
             r.all_cycles().for_each(|c| {
-                referenced_cycles.count_reference(c.clone(), r.clone());
+                referenced_cycles.count(c.clone(), r.clone());
                 c.half_edges().into_iter().for_each(|e| {
-                    referenced_edges.count_reference(e.clone(), c.clone());
+                    referenced_edges.count(e.clone(), c.clone());
                 })
             })
         });

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -4,12 +4,13 @@ use crate::{
     geometry::Geometry,
     storage::Handle,
     topology::{Cycle, Sketch},
-    validation::{checks::AdjacentHalfEdgesNotConnected, ValidationCheck},
+    validation::{
+        checks::{AdjacentHalfEdgesNotConnected, ReferenceCounter},
+        ValidationCheck,
+    },
 };
 
-use super::{
-    references::ReferenceCounter, Validate, ValidationConfig, ValidationError,
-};
+use super::{Validate, ValidationConfig, ValidationError};
 
 impl Validate for Sketch {
     fn validate(

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -113,83 +113,11 @@ impl SketchValidationError {
 mod tests {
     use crate::{
         assert_contains_err,
-        operations::{
-            build::BuildHalfEdge, build::BuildRegion, insert::Insert,
-        },
+        operations::{build::BuildHalfEdge, insert::Insert},
         topology::{Cycle, HalfEdge, Region, Sketch, Vertex},
         validate::{SketchValidationError, Validate, ValidationError},
         Core,
     };
-
-    #[test]
-    fn should_find_cycle_multiple_references() -> anyhow::Result<()> {
-        let mut core = Core::new();
-
-        let surface = core.layers.topology.surfaces.space_2d();
-
-        let region = <Region as BuildRegion>::circle(
-            [0., 0.],
-            1.,
-            surface.clone(),
-            &mut core,
-        )
-        .insert(&mut core);
-        let valid_sketch = Sketch::new(surface.clone(), vec![region.clone()])
-            .insert(&mut core);
-        valid_sketch.validate_and_return_first_error(&core.layers.geometry)?;
-
-        let shared_cycle = region.exterior();
-        let invalid_sketch = Sketch::new(
-            surface,
-            vec![
-                Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
-                Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
-            ],
-        );
-        assert_contains_err!(
-            core,
-            invalid_sketch,
-            ValidationError::MultipleReferencesToCycle(_)
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn should_find_half_edge_multiple_references() -> anyhow::Result<()> {
-        let mut core = Core::new();
-
-        let surface = core.layers.topology.surfaces.space_2d();
-
-        let region = <Region as BuildRegion>::polygon(
-            [[0., 0.], [1., 1.], [0., 1.]],
-            surface.clone(),
-            &mut core,
-        )
-        .insert(&mut core);
-        let valid_sketch = Sketch::new(surface.clone(), vec![region.clone()])
-            .insert(&mut core);
-        valid_sketch.validate_and_return_first_error(&core.layers.geometry)?;
-
-        let exterior = region.exterior();
-        let cloned_edges: Vec<_> =
-            exterior.half_edges().iter().cloned().collect();
-        let interior = Cycle::new(cloned_edges).insert(&mut core);
-
-        let invalid_sketch = Sketch::new(
-            surface,
-            vec![
-                Region::new(exterior.clone(), vec![interior]).insert(&mut core)
-            ],
-        );
-        assert_contains_err!(
-            core,
-            invalid_sketch,
-            ValidationError::MultipleReferencesToHalfEdge(_)
-        );
-
-        Ok(())
-    }
 
     #[test]
     fn should_find_clockwise_exterior_cycle() -> anyhow::Result<()> {

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -142,10 +142,10 @@ impl SolidValidationError {
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        let mut referenced_regions = ReferenceCounter::new();
         let mut referenced_faces = ReferenceCounter::new();
-        let mut referenced_edges = ReferenceCounter::new();
+        let mut referenced_regions = ReferenceCounter::new();
         let mut referenced_cycles = ReferenceCounter::new();
+        let mut referenced_edges = ReferenceCounter::new();
 
         solid.shells().iter().for_each(|s| {
             s.faces().into_iter().for_each(|f| {

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -145,7 +145,7 @@ impl SolidValidationError {
         let mut faces = ReferenceCounter::new();
         let mut regions = ReferenceCounter::new();
         let mut cycles = ReferenceCounter::new();
-        let mut referenced_half_edges = ReferenceCounter::new();
+        let mut half_edges = ReferenceCounter::new();
 
         solid.shells().iter().for_each(|s| {
             s.faces().into_iter().for_each(|f| {
@@ -154,7 +154,7 @@ impl SolidValidationError {
                 f.region().all_cycles().for_each(|c| {
                     cycles.count(c.clone(), f.region().clone());
                     c.half_edges().into_iter().for_each(|e| {
-                        referenced_half_edges.count(e.clone(), c.clone());
+                        half_edges.count(e.clone(), c.clone());
                     })
                 })
             })
@@ -164,7 +164,7 @@ impl SolidValidationError {
             errors;
             regions, MultipleReferencesToRegion;
             faces, MultipleReferencesToFace;
-            referenced_half_edges, MultipleReferencesToHalfEdge;
+            half_edges, MultipleReferencesToHalfEdge;
             cycles, MultipleReferencesToCycle;
         );
     }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -4,12 +4,11 @@ use crate::{
     geometry::Geometry,
     storage::Handle,
     topology::{Solid, Vertex},
+    validation::checks::ReferenceCounter,
 };
 use fj_math::Point;
 
-use super::{
-    references::ReferenceCounter, Validate, ValidationConfig, ValidationError,
-};
+use super::{Validate, ValidationConfig, ValidationError};
 
 impl Validate for Solid {
     fn validate(

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -142,14 +142,14 @@ impl SolidValidationError {
         _config: &ValidationConfig,
         errors: &mut Vec<ValidationError>,
     ) {
-        let mut referenced_faces = ReferenceCounter::new();
+        let mut faces = ReferenceCounter::new();
         let mut referenced_regions = ReferenceCounter::new();
         let mut referenced_cycles = ReferenceCounter::new();
         let mut referenced_half_edges = ReferenceCounter::new();
 
         solid.shells().iter().for_each(|s| {
             s.faces().into_iter().for_each(|f| {
-                referenced_faces.count(f.clone(), s.clone());
+                faces.count(f.clone(), s.clone());
                 referenced_regions.count(f.region().clone(), f.clone());
                 f.region().all_cycles().for_each(|c| {
                     referenced_cycles.count(c.clone(), f.region().clone());
@@ -163,7 +163,7 @@ impl SolidValidationError {
         validate_references!(
             errors;
             referenced_regions, MultipleReferencesToRegion;
-            referenced_faces, MultipleReferencesToFace;
+            faces, MultipleReferencesToFace;
             referenced_half_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, MultipleReferencesToCycle;
         );

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -144,7 +144,7 @@ impl SolidValidationError {
     ) {
         let mut faces = ReferenceCounter::new();
         let mut regions = ReferenceCounter::new();
-        let mut referenced_cycles = ReferenceCounter::new();
+        let mut cycles = ReferenceCounter::new();
         let mut referenced_half_edges = ReferenceCounter::new();
 
         solid.shells().iter().for_each(|s| {
@@ -152,7 +152,7 @@ impl SolidValidationError {
                 faces.count(f.clone(), s.clone());
                 regions.count(f.region().clone(), f.clone());
                 f.region().all_cycles().for_each(|c| {
-                    referenced_cycles.count(c.clone(), f.region().clone());
+                    cycles.count(c.clone(), f.region().clone());
                     c.half_edges().into_iter().for_each(|e| {
                         referenced_half_edges.count(e.clone(), c.clone());
                     })
@@ -165,7 +165,7 @@ impl SolidValidationError {
             regions, MultipleReferencesToRegion;
             faces, MultipleReferencesToFace;
             referenced_half_edges, MultipleReferencesToHalfEdge;
-            referenced_cycles, MultipleReferencesToCycle;
+            cycles, MultipleReferencesToCycle;
         );
     }
 }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -162,10 +162,10 @@ impl SolidValidationError {
 
         validate_references!(
             errors;
-            regions, MultipleReferencesToRegion;
-            faces, MultipleReferencesToFace;
-            half_edges, MultipleReferencesToHalfEdge;
-            cycles, MultipleReferencesToCycle;
+            regions;
+            faces;
+            half_edges;
+            cycles;
         );
     }
 }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -143,14 +143,14 @@ impl SolidValidationError {
         errors: &mut Vec<ValidationError>,
     ) {
         let mut faces = ReferenceCounter::new();
-        let mut referenced_regions = ReferenceCounter::new();
+        let mut regions = ReferenceCounter::new();
         let mut referenced_cycles = ReferenceCounter::new();
         let mut referenced_half_edges = ReferenceCounter::new();
 
         solid.shells().iter().for_each(|s| {
             s.faces().into_iter().for_each(|f| {
                 faces.count(f.clone(), s.clone());
-                referenced_regions.count(f.region().clone(), f.clone());
+                regions.count(f.region().clone(), f.clone());
                 f.region().all_cycles().for_each(|c| {
                     referenced_cycles.count(c.clone(), f.region().clone());
                     c.half_edges().into_iter().for_each(|e| {
@@ -162,7 +162,7 @@ impl SolidValidationError {
 
         validate_references!(
             errors;
-            referenced_regions, MultipleReferencesToRegion;
+            regions, MultipleReferencesToRegion;
             faces, MultipleReferencesToFace;
             referenced_half_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, MultipleReferencesToCycle;

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -145,7 +145,7 @@ impl SolidValidationError {
         let mut referenced_faces = ReferenceCounter::new();
         let mut referenced_regions = ReferenceCounter::new();
         let mut referenced_cycles = ReferenceCounter::new();
-        let mut referenced_edges = ReferenceCounter::new();
+        let mut referenced_half_edges = ReferenceCounter::new();
 
         solid.shells().iter().for_each(|s| {
             s.faces().into_iter().for_each(|f| {
@@ -154,7 +154,7 @@ impl SolidValidationError {
                 f.region().all_cycles().for_each(|c| {
                     referenced_cycles.count(c.clone(), f.region().clone());
                     c.half_edges().into_iter().for_each(|e| {
-                        referenced_edges.count(e.clone(), c.clone());
+                        referenced_half_edges.count(e.clone(), c.clone());
                     })
                 })
             })
@@ -164,7 +164,7 @@ impl SolidValidationError {
             errors;
             referenced_regions, MultipleReferencesToRegion;
             referenced_faces, MultipleReferencesToFace;
-            referenced_edges, MultipleReferencesToHalfEdge;
+            referenced_half_edges, MultipleReferencesToHalfEdge;
             referenced_cycles, MultipleReferencesToCycle;
         );
     }

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -4,7 +4,6 @@ use crate::{
     geometry::Geometry,
     storage::Handle,
     topology::{Solid, Vertex},
-    validate_references,
 };
 use fj_math::Point;
 
@@ -160,13 +159,10 @@ impl SolidValidationError {
             })
         });
 
-        validate_references!(
-            errors;
-            regions;
-            faces;
-            half_edges;
-            cycles;
-        );
+        errors.extend(faces.multiples().map(Into::into));
+        errors.extend(regions.multiples().map(Into::into));
+        errors.extend(cycles.multiples().map(Into::into));
+        errors.extend(half_edges.multiples().map(Into::into));
     }
 }
 

--- a/crates/fj-core/src/validate/solid.rs
+++ b/crates/fj-core/src/validate/solid.rs
@@ -149,14 +149,12 @@ impl SolidValidationError {
 
         solid.shells().iter().for_each(|s| {
             s.faces().into_iter().for_each(|f| {
-                referenced_faces.count_reference(f.clone(), s.clone());
-                referenced_regions
-                    .count_reference(f.region().clone(), f.clone());
+                referenced_faces.count(f.clone(), s.clone());
+                referenced_regions.count(f.region().clone(), f.clone());
                 f.region().all_cycles().for_each(|c| {
-                    referenced_cycles
-                        .count_reference(c.clone(), f.region().clone());
+                    referenced_cycles.count(c.clone(), f.region().clone());
                     c.half_edges().into_iter().for_each(|e| {
-                        referenced_edges.count_reference(e.clone(), c.clone());
+                        referenced_edges.count(e.clone(), c.clone());
                     })
                 })
             })

--- a/crates/fj-core/src/validation/checks/mod.rs
+++ b/crates/fj-core/src/validation/checks/mod.rs
@@ -8,6 +8,7 @@ mod face_boundary;
 mod face_winding;
 mod half_edge_connection;
 mod half_edge_has_no_sibling;
+mod multiple_references;
 
 pub use self::{
     coincident_half_edges_are_not_siblings::CoincidentHalfEdgesAreNotSiblings,
@@ -16,4 +17,5 @@ pub use self::{
     face_winding::InteriorCycleHasInvalidWinding,
     half_edge_connection::AdjacentHalfEdgesNotConnected,
     half_edge_has_no_sibling::HalfEdgeHasNoSibling,
+    multiple_references::{MultipleReferencesToObject, ReferenceCounter},
 };

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -163,9 +163,9 @@ mod tests {
             &mut core,
         )
         .insert(&mut core);
-        let valid_sketch = Sketch::new(surface.clone(), vec![region.clone()])
+        let valid = Sketch::new(surface.clone(), vec![region.clone()])
             .insert(&mut core);
-        valid_sketch.validate_and_return_first_error(&core.layers.geometry)?;
+        valid.validate_and_return_first_error(&core.layers.geometry)?;
 
         let exterior = region.exterior();
         let cloned_edges: Vec<_> =

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -129,9 +129,9 @@ mod tests {
             &mut core,
         )
         .insert(&mut core);
-        let valid_sketch = Sketch::new(surface.clone(), vec![region.clone()])
+        let valid = Sketch::new(surface.clone(), vec![region.clone()])
             .insert(&mut core);
-        valid_sketch.validate_and_return_first_error(&core.layers.geometry)?;
+        valid.validate_and_return_first_error(&core.layers.geometry)?;
 
         let shared_cycle = region.exterior();
         let invalid_sketch = Sketch::new(

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -110,8 +110,7 @@ mod tests {
     use crate::{
         assert_contains_err,
         operations::{
-            build::{BuildRegion, BuildSketch},
-            insert::Insert,
+            build::BuildSketch,
             update::{UpdateRegion, UpdateSketch},
         },
         topology::{Cycle, Region, Sketch},
@@ -155,16 +154,7 @@ mod tests {
     fn should_find_half_edge_multiple_references() -> anyhow::Result<()> {
         let mut core = Core::new();
 
-        let surface = core.layers.topology.surfaces.space_2d();
-
-        let region = <Region as BuildRegion>::polygon(
-            [[0., 0.], [1., 1.], [0., 1.]],
-            surface.clone(),
-            &mut core,
-        )
-        .insert(&mut core);
-        let valid = Sketch::new(surface.clone(), vec![region.clone()])
-            .insert(&mut core);
+        let valid = Sketch::polygon([[0., 0.], [1., 1.], [0., 1.]], &mut core);
         valid.validate_and_return_first_error(&core.layers.geometry)?;
 
         let invalid = valid.update_region(

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -110,7 +110,9 @@ mod tests {
     use crate::{
         assert_contains_err,
         operations::{
-            build::BuildRegion, insert::Insert, update::UpdateSketch,
+            build::{BuildRegion, BuildSketch},
+            insert::Insert,
+            update::UpdateSketch,
         },
         topology::{Cycle, Region, Sketch},
         validate::Validate,
@@ -122,16 +124,7 @@ mod tests {
     fn should_find_cycle_multiple_references() -> anyhow::Result<()> {
         let mut core = Core::new();
 
-        let surface = core.layers.topology.surfaces.space_2d();
-
-        let region = <Region as BuildRegion>::circle(
-            [0., 0.],
-            1.,
-            surface.clone(),
-            &mut core,
-        )
-        .insert(&mut core);
-        let valid = Sketch::new(surface.clone(), vec![region.clone()]);
+        let valid = Sketch::circle([0., 0.], 1., &mut core);
         valid.validate_and_return_first_error(&core.layers.geometry)?;
 
         let invalid = valid.add_regions(

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -172,7 +172,7 @@ mod tests {
             exterior.half_edges().iter().cloned().collect();
         let interior = Cycle::new(cloned_edges).insert(&mut core);
 
-        let invalid_sketch = Sketch::new(
+        let invalid = Sketch::new(
             surface,
             vec![
                 Region::new(exterior.clone(), vec![interior]).insert(&mut core)
@@ -180,7 +180,7 @@ mod tests {
         );
         assert_contains_err!(
             core,
-            invalid_sketch,
+            invalid,
             ValidationError::MultipleReferencesToHalfEdge(_)
         );
 

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -109,7 +109,9 @@ impl<T, U> ReferenceCounter<T, U> {
 mod tests {
     use crate::{
         assert_contains_err,
-        operations::{build::BuildRegion, insert::Insert},
+        operations::{
+            build::BuildRegion, insert::Insert, update::UpdateSketch,
+        },
         topology::{Cycle, Region, Sketch},
         validate::Validate,
         validation::ValidationError,
@@ -132,13 +134,12 @@ mod tests {
         let valid = Sketch::new(surface.clone(), vec![region.clone()]);
         valid.validate_and_return_first_error(&core.layers.geometry)?;
 
-        let shared_cycle = region.exterior();
-        let invalid = Sketch::new(
-            surface,
-            vec![
-                Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
-                Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
-            ],
+        let invalid = valid.add_regions(
+            [Region::new(
+                valid.regions().first().exterior().clone(),
+                vec![],
+            )],
+            &mut core,
         );
         assert_contains_err!(
             core,

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -118,7 +118,7 @@ mod tests {
     };
 
     #[test]
-    fn should_find_cycle_multiple_references() -> anyhow::Result<()> {
+    fn multiple_references_to_cycle() -> anyhow::Result<()> {
         let mut core = Core::new();
 
         let valid = Sketch::circle([0., 0.], 1., &mut core);
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    fn should_find_half_edge_multiple_references() -> anyhow::Result<()> {
+    fn multiple_references_to_half_edge() -> anyhow::Result<()> {
         let mut core = Core::new();
 
         let valid = Sketch::polygon([[0., 0.], [1., 1.], [0., 1.]], &mut core);

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -2,7 +2,7 @@ use std::{any::type_name_of_val, collections::HashMap, fmt};
 
 use crate::{
     storage::Handle,
-    topology::{Cycle, HalfEdge, Sketch},
+    topology::{Cycle, HalfEdge, Region, Sketch},
     validation::ValidationCheck,
 };
 
@@ -31,6 +31,24 @@ where
             type_name_of_val(&self.referenced_by),
             self.referenced_by
         )
+    }
+}
+
+impl ValidationCheck<Sketch> for MultipleReferencesToObject<Cycle, Region> {
+    fn check<'r>(
+        object: &'r Sketch,
+        _: &'r crate::geometry::Geometry,
+        _: &'r crate::validation::ValidationConfig,
+    ) -> impl Iterator<Item = Self> + 'r {
+        let mut cycles = ReferenceCounter::new();
+
+        for region in object.regions() {
+            for cycle in region.all_cycles() {
+                cycles.count(cycle.clone(), region.clone());
+            }
+        }
+
+        cycles.multiples()
     }
 }
 

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -133,7 +133,7 @@ mod tests {
         valid.validate_and_return_first_error(&core.layers.geometry)?;
 
         let shared_cycle = region.exterior();
-        let invalid_sketch = Sketch::new(
+        let invalid = Sketch::new(
             surface,
             vec![
                 Region::new(shared_cycle.clone(), vec![]).insert(&mut core),
@@ -142,7 +142,7 @@ mod tests {
         );
         assert_contains_err!(
             core,
-            invalid_sketch,
+            invalid,
             ValidationError::MultipleReferencesToCycle(_)
         );
 

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -51,10 +51,10 @@ impl<T, U> ReferenceCounter<T, U> {
     }
 
     pub fn multiples(
-        &self,
-    ) -> impl Iterator<Item = MultipleReferencesToObject<T, U>> + '_ {
+        self,
+    ) -> impl Iterator<Item = MultipleReferencesToObject<T, U>> {
         self.0
-            .iter()
+            .into_iter()
             .filter(|(_, referenced_by)| referenced_by.len() > 1)
             .map(|(object, referenced_by)| MultipleReferencesToObject {
                 object: object.clone(),

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -129,8 +129,7 @@ mod tests {
             &mut core,
         )
         .insert(&mut core);
-        let valid = Sketch::new(surface.clone(), vec![region.clone()])
-            .insert(&mut core);
+        let valid = Sketch::new(surface.clone(), vec![region.clone()]);
         valid.validate_and_return_first_error(&core.layers.geometry)?;
 
         let shared_cycle = region.exterior();

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -30,9 +30,17 @@ where
     }
 }
 
+// Warnings are temporarily silenced, until this struct can be made private.
+// This can happen once this validation check has been fully ported from the old
+// infrastructure.
+#[allow(missing_docs)]
 #[derive(Default)]
 pub struct ReferenceCounter<T, U>(HashMap<Handle<T>, Vec<Handle<U>>>);
 
+// Warnings are temporarily silenced, until this struct can be made private.
+// This can happen once this validation check has been fully ported from the old
+// infrastructure.
+#[allow(missing_docs)]
 impl<T, U> ReferenceCounter<T, U> {
     pub fn new() -> Self {
         Self(HashMap::new())

--- a/crates/fj-core/src/validation/checks/multiple_references.rs
+++ b/crates/fj-core/src/validation/checks/multiple_references.rs
@@ -116,7 +116,10 @@ mod tests {
         },
         topology::{Cycle, Region, Sketch},
         validate::Validate,
-        validation::ValidationError,
+        validation::{
+            checks::MultipleReferencesToObject, ValidationCheck,
+            ValidationError,
+        },
         Core,
     };
 
@@ -125,7 +128,13 @@ mod tests {
         let mut core = Core::new();
 
         let valid = Sketch::circle([0., 0.], 1., &mut core);
-        valid.validate_and_return_first_error(&core.layers.geometry)?;
+        MultipleReferencesToObject::<
+            Cycle,
+            Region
+        >::check_and_return_first_error(
+            &valid,
+            &core.layers.geometry,
+        )?;
 
         let invalid = valid.add_regions(
             [Region::new(
@@ -134,10 +143,9 @@ mod tests {
             )],
             &mut core,
         );
-        assert_contains_err!(
-            core,
-            invalid,
-            ValidationError::MultipleReferencesToCycle(_)
+        MultipleReferencesToObject::<Cycle, Region>::check_and_expect_one_error(
+            &invalid,
+            &core.layers.geometry,
         );
 
         Ok(())

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -2,15 +2,13 @@ use std::{convert::Infallible, fmt};
 
 use crate::{
     topology::{Cycle, Face, HalfEdge, Region, Shell},
-    validate::{
-        MultipleReferencesToObject, SketchValidationError, SolidValidationError,
-    },
+    validate::{SketchValidationError, SolidValidationError},
 };
 
 use super::checks::{
     AdjacentHalfEdgesNotConnected, CoincidentHalfEdgesAreNotSiblings,
     CurveGeometryMismatch, FaceHasNoBoundary, HalfEdgeHasNoSibling,
-    InteriorCycleHasInvalidWinding,
+    InteriorCycleHasInvalidWinding, MultipleReferencesToObject,
 };
 
 /// An error that can occur during a validation

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, fmt};
 use crate::{
     topology::{Cycle, Face, HalfEdge, Region, Shell},
     validate::{
-        ObjectNotExclusivelyOwned, SketchValidationError, SolidValidationError,
+        MultipleReferencesToObject, SketchValidationError, SolidValidationError,
     },
 };
 
@@ -44,19 +44,19 @@ pub enum ValidationError {
 
     /// Multiple references to [`Cycle`]
     #[error(transparent)]
-    MultipleReferencesToCycle(ObjectNotExclusivelyOwned<Cycle, Region>),
+    MultipleReferencesToCycle(MultipleReferencesToObject<Cycle, Region>),
 
     /// Multiple references to [`Face`]
     #[error(transparent)]
-    MultipleReferencesToFace(ObjectNotExclusivelyOwned<Face, Shell>),
+    MultipleReferencesToFace(MultipleReferencesToObject<Face, Shell>),
 
     /// Multiple references to [`HalfEdge`]
     #[error(transparent)]
-    MultipleReferencesToHalfEdge(ObjectNotExclusivelyOwned<HalfEdge, Cycle>),
+    MultipleReferencesToHalfEdge(MultipleReferencesToObject<HalfEdge, Cycle>),
 
     /// Multiple references to [`Region`]
     #[error(transparent)]
-    MultipleReferencesToRegion(ObjectNotExclusivelyOwned<Region, Face>),
+    MultipleReferencesToRegion(MultipleReferencesToObject<Region, Face>),
 
     /// `Solid` validation error
     #[error("`Solid` validation error")]

--- a/crates/fj-core/src/validation/error.rs
+++ b/crates/fj-core/src/validation/error.rs
@@ -44,19 +44,25 @@ pub enum ValidationError {
 
     /// Multiple references to [`Cycle`]
     #[error(transparent)]
-    MultipleReferencesToCycle(MultipleReferencesToObject<Cycle, Region>),
+    MultipleReferencesToCycle(
+        #[from] MultipleReferencesToObject<Cycle, Region>,
+    ),
 
     /// Multiple references to [`Face`]
     #[error(transparent)]
-    MultipleReferencesToFace(MultipleReferencesToObject<Face, Shell>),
+    MultipleReferencesToFace(#[from] MultipleReferencesToObject<Face, Shell>),
 
     /// Multiple references to [`HalfEdge`]
     #[error(transparent)]
-    MultipleReferencesToHalfEdge(MultipleReferencesToObject<HalfEdge, Cycle>),
+    MultipleReferencesToHalfEdge(
+        #[from] MultipleReferencesToObject<HalfEdge, Cycle>,
+    ),
 
     /// Multiple references to [`Region`]
     #[error(transparent)]
-    MultipleReferencesToRegion(MultipleReferencesToObject<Region, Face>),
+    MultipleReferencesToRegion(
+        #[from] MultipleReferencesToObject<Region, Face>,
+    ),
 
     /// `Solid` validation error
     #[error("`Solid` validation error")]


### PR DESCRIPTION
Their counterparts for `Solid` are not fully ported, but that shouldn't be much more work now.

This is another step towards https://github.com/hannobraun/fornjot/issues/2157.