### PR TITLE
Disable CI build on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # Windows CI build disabled for the time being. More information:
+          # https://github.com/hannobraun/fornjot/issues/2376
+          # - windows-latest
     runs-on: ${{matrix.os}}
     steps:
       - name: Check out repository


### PR DESCRIPTION
This is a workaround for the problem encountered in https://github.com/hannobraun/fornjot/pull/2375. See https://github.com/hannobraun/fornjot/issues/2376 for more information.