### PR TITLE
Make `TransformObject` trait more flexible

### DIFF
--- a/crates/fj-core/src/operations/sweep/region.rs
+++ b/crates/fj-core/src/operations/sweep/region.rs
@@ -52,7 +52,8 @@ impl SweepRegion for Region {
 
         let mut faces = Vec::new();
 
-        let top_surface = bottom_surface.translate(path, core).insert(core);
+        let top_surface =
+            bottom_surface.clone().translate(path, core).insert(core);
 
         let top_exterior = sweep_cycle(
             self.exterior(),

--- a/crates/fj-core/src/operations/transform/curve.rs
+++ b/crates/fj-core/src/operations/transform/curve.rs
@@ -10,12 +10,14 @@ use crate::{
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Handle<Curve> {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         _: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         cache
             .entry(self)
             .or_insert_with(|| {

--- a/crates/fj-core/src/operations/transform/curve.rs
+++ b/crates/fj-core/src/operations/transform/curve.rs
@@ -13,13 +13,13 @@ impl TransformObject for Handle<Curve> {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         _: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
         cache
-            .entry(self)
+            .entry(&self)
             .or_insert_with(|| {
                 // We don't actually need to transform the curve, as its
                 // geometry is locally defined on a surface. We need to set that
@@ -27,7 +27,7 @@ impl TransformObject for Handle<Curve> {
                 // represent the transformed curve.
                 Curve::new()
                     .insert(core)
-                    .copy_geometry_from(self, &mut core.layers.geometry)
+                    .copy_geometry_from(&self, &mut core.layers.geometry)
             })
             .clone()
     }

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -5,12 +5,14 @@ use crate::{topology::Cycle, Core};
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Cycle {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         let half_edges = self.half_edges().iter().map(|half_edge| {
             half_edge
                 .clone()

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -11,10 +11,10 @@ impl TransformObject for Cycle {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self {
-        let edges = self.half_edges().iter().map(|edge| {
+        let half_edges = self.half_edges().iter().map(|edge| {
             edge.clone().transform_with_cache(transform, core, cache)
         });
 
-        Self::new(edges)
+        Self::new(half_edges)
     }
 }

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -8,7 +8,7 @@ impl TransformObject for Cycle {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -11,8 +11,10 @@ impl TransformObject for Cycle {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self {
-        let half_edges = self.half_edges().iter().map(|edge| {
-            edge.clone().transform_with_cache(transform, core, cache)
+        let half_edges = self.half_edges().iter().map(|half_edge| {
+            half_edge
+                .clone()
+                .transform_with_cache(transform, core, cache)
         });
 
         Self::new(half_edges)

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -7,12 +7,14 @@ use crate::{
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Handle<HalfEdge> {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         let curve = self
             .curve()
             .clone()

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -10,7 +10,7 @@ impl TransformObject for Handle<HalfEdge> {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
@@ -28,7 +28,7 @@ impl TransformObject for Handle<HalfEdge> {
 
         core.layers.geometry.define_half_edge(
             half_edge.clone(),
-            *core.layers.geometry.of_half_edge(self),
+            *core.layers.geometry.of_half_edge(&self),
         );
 
         half_edge

--- a/crates/fj-core/src/operations/transform/face.rs
+++ b/crates/fj-core/src/operations/transform/face.rs
@@ -8,7 +8,7 @@ impl TransformObject for Face {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,

--- a/crates/fj-core/src/operations/transform/face.rs
+++ b/crates/fj-core/src/operations/transform/face.rs
@@ -5,12 +5,14 @@ use crate::{topology::Face, Core};
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Face {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         let surface = self
             .surface()
             .clone()

--- a/crates/fj-core/src/operations/transform/mod.rs
+++ b/crates/fj-core/src/operations/transform/mod.rs
@@ -39,7 +39,7 @@ pub trait TransformObject: Sized {
 
     /// Transform the object
     fn transform(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
     ) -> Self::Transformed {
@@ -49,7 +49,7 @@ pub trait TransformObject: Sized {
 
     /// Transform the object using the provided cache
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
@@ -59,7 +59,7 @@ pub trait TransformObject: Sized {
     ///
     /// Convenience wrapper around [`TransformObject::transform`].
     fn translate(
-        &self,
+        self,
         offset: impl Into<Vector<3>>,
         core: &mut Core,
     ) -> Self::Transformed {
@@ -70,7 +70,7 @@ pub trait TransformObject: Sized {
     ///
     /// Convenience wrapper around [`TransformObject::transform`].
     fn rotate(
-        &self,
+        self,
         axis_angle: impl Into<Vector<3>>,
         core: &mut Core,
     ) -> Self::Transformed {
@@ -89,12 +89,12 @@ where
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        if let Some(object) = cache.get(self) {
+        if let Some(object) = cache.get(&self) {
             return object.clone();
         }
 
@@ -102,7 +102,7 @@ where
             .clone_object()
             .transform_with_cache(transform, core, cache)
             .insert(core)
-            .derive_from(self, core);
+            .derive_from(&self, core);
 
         cache.insert(self.clone(), transformed.clone());
 

--- a/crates/fj-core/src/operations/transform/mod.rs
+++ b/crates/fj-core/src/operations/transform/mod.rs
@@ -34,8 +34,15 @@ use super::derive::DeriveFrom;
 /// More convenience methods can be added as required. The only reason this
 /// hasn't been done so far, is that no one has put in the work yet.
 pub trait TransformObject: Sized {
+    /// The result of the transformation
+    type Transformed;
+
     /// Transform the object
-    fn transform(&self, transform: &Transform, core: &mut Core) -> Self {
+    fn transform(
+        &self,
+        transform: &Transform,
+        core: &mut Core,
+    ) -> Self::Transformed {
         let mut cache = TransformCache::default();
         self.transform_with_cache(transform, core, &mut cache)
     }
@@ -46,12 +53,16 @@ pub trait TransformObject: Sized {
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self;
+    ) -> Self::Transformed;
 
     /// Translate the object
     ///
     /// Convenience wrapper around [`TransformObject::transform`].
-    fn translate(&self, offset: impl Into<Vector<3>>, core: &mut Core) -> Self {
+    fn translate(
+        &self,
+        offset: impl Into<Vector<3>>,
+        core: &mut Core,
+    ) -> Self::Transformed {
         self.transform(&Transform::translation(offset), core)
     }
 
@@ -62,22 +73,27 @@ pub trait TransformObject: Sized {
         &self,
         axis_angle: impl Into<Vector<3>>,
         core: &mut Core,
-    ) -> Self {
+    ) -> Self::Transformed {
         self.transform(&Transform::rotation(axis_angle), core)
     }
 }
 
 impl<T> TransformObject for Handle<T>
 where
-    T: Clone + Insert<Inserted = Handle<T>> + TransformObject + 'static,
+    T: Clone
+        + Insert<Inserted = Handle<T>>
+        + TransformObject<Transformed = T>
+        + 'static,
     Handle<T>: Into<AnyObject<Stored>>,
 {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         if let Some(object) = cache.get(self) {
             return object.clone();
         }

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -3,12 +3,14 @@ use crate::{topology::Region, Core};
 use super::TransformObject;
 
 impl TransformObject for Region {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &fj_math::Transform,
         core: &mut Core,
         cache: &mut super::TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         let exterior = self
             .exterior()
             .clone()

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -6,7 +6,7 @@ impl TransformObject for Region {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &fj_math::Transform,
         core: &mut Core,
         cache: &mut super::TransformCache,

--- a/crates/fj-core/src/operations/transform/shell.rs
+++ b/crates/fj-core/src/operations/transform/shell.rs
@@ -8,7 +8,7 @@ impl TransformObject for Shell {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,

--- a/crates/fj-core/src/operations/transform/shell.rs
+++ b/crates/fj-core/src/operations/transform/shell.rs
@@ -5,12 +5,14 @@ use crate::{topology::Shell, Core};
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Shell {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         let faces = self
             .faces()
             .iter()

--- a/crates/fj-core/src/operations/transform/solid.rs
+++ b/crates/fj-core/src/operations/transform/solid.rs
@@ -5,12 +5,14 @@ use crate::{topology::Solid, Core};
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Solid {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         let shells =
             self.shells().iter().cloned().map(|shell| {
                 shell.transform_with_cache(transform, core, cache)

--- a/crates/fj-core/src/operations/transform/solid.rs
+++ b/crates/fj-core/src/operations/transform/solid.rs
@@ -8,7 +8,7 @@ impl TransformObject for Solid {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,

--- a/crates/fj-core/src/operations/transform/surface.rs
+++ b/crates/fj-core/src/operations/transform/surface.rs
@@ -7,12 +7,14 @@ use crate::{
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Handle<Surface> {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         cache
             .entry(self)
             .or_insert_with(|| {

--- a/crates/fj-core/src/operations/transform/surface.rs
+++ b/crates/fj-core/src/operations/transform/surface.rs
@@ -10,18 +10,18 @@ impl TransformObject for Handle<Surface> {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
         cache
-            .entry(self)
+            .entry(&self)
             .or_insert_with(|| {
                 let surface = Surface::new().insert(core);
 
                 let geometry =
-                    core.layers.geometry.of_surface(self).transform(transform);
+                    core.layers.geometry.of_surface(&self).transform(transform);
                 core.layers
                     .geometry
                     .define_surface(surface.clone(), geometry);

--- a/crates/fj-core/src/operations/transform/vertex.rs
+++ b/crates/fj-core/src/operations/transform/vertex.rs
@@ -5,12 +5,14 @@ use crate::{topology::Vertex, Core};
 use super::{TransformCache, TransformObject};
 
 impl TransformObject for Vertex {
+    type Transformed = Self;
+
     fn transform_with_cache(
         &self,
         _: &Transform,
         _: &mut Core,
         _: &mut TransformCache,
-    ) -> Self {
+    ) -> Self::Transformed {
         // There's nothing to actually transform here, as `Vertex` holds no
         // data. We still need this implementation though, as a new `Vertex`
         // object must be created to represent the new and transformed vertex.

--- a/crates/fj-core/src/operations/transform/vertex.rs
+++ b/crates/fj-core/src/operations/transform/vertex.rs
@@ -8,7 +8,7 @@ impl TransformObject for Vertex {
     type Transformed = Self;
 
     fn transform_with_cache(
-        &self,
+        self,
         _: &Transform,
         _: &mut Core,
         _: &mut TransformCache,


### PR DESCRIPTION
This makes some changes to `TransformObject` to allow more flexibility in what can implement it, and what that implementation results in. I need this to implement a fix that currently blocks further progress in https://github.com/hannobraun/fornjot/issues/2290.