### PR TITLE
Correctly define curve geometry when transforming curve

### DIFF
--- a/crates/fj-core/src/operations/transform/curve.rs
+++ b/crates/fj-core/src/operations/transform/curve.rs
@@ -1,7 +1,7 @@
 use fj_math::Transform;
 
 use crate::{
-    operations::{geometry::UpdateCurveGeometry, insert::Insert},
+    operations::insert::Insert,
     storage::Handle,
     topology::{Curve, Surface},
     Core,
@@ -14,23 +14,40 @@ impl TransformObject for (&Handle<Curve>, &Handle<Surface>) {
 
     fn transform_with_cache(
         self,
-        _: &Transform,
+        transform: &Transform,
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let (curve, _) = self;
+        let (curve, surface) = self;
 
-        cache
+        // We don't actually need to transform the curve, as its geometry is
+        // locally defined on a surface. We need to transform that surface
+        // though, or what we do here will have no consequence.
+        //
+        // If this transformation is only one element in the transformation of
+        // a whole object graph, using the cache here ensures that the surface
+        // doesn't get transformed multiple times.
+        let transformed_surface = cache
+            .entry(surface)
+            .or_insert_with(|| surface.transform(transform, core))
+            .clone();
+        let transformed_curve = cache
             .entry(curve)
-            .or_insert_with(|| {
-                // We don't actually need to transform the curve, as its
-                // geometry is locally defined on a surface. We need to set that
-                // geometry for the new object though, that we created here to
-                // represent the transformed curve.
-                Curve::new()
-                    .insert(core)
-                    .copy_geometry_from(curve, &mut core.layers.geometry)
-            })
-            .clone()
+            .or_insert_with(|| Curve::new().insert(core))
+            .clone();
+
+        core.layers.geometry.define_curve(
+            transformed_curve.clone(),
+            transformed_surface,
+            core.layers
+                .geometry
+                .of_curve(curve)
+                .unwrap()
+                .local_on(surface)
+                .unwrap()
+                .clone(),
+        );
+
+        transformed_curve
     }
 }

--- a/crates/fj-core/src/operations/transform/curve.rs
+++ b/crates/fj-core/src/operations/transform/curve.rs
@@ -9,8 +9,8 @@ use crate::{
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Handle<Curve> {
-    type Transformed = Self;
+impl TransformObject for &Handle<Curve> {
+    type Transformed = Handle<Curve>;
 
     fn transform_with_cache(
         self,
@@ -21,7 +21,7 @@ impl TransformObject for Handle<Curve> {
         let curve = self;
 
         cache
-            .entry(&curve)
+            .entry(curve)
             .or_insert_with(|| {
                 // We don't actually need to transform the curve, as its
                 // geometry is locally defined on a surface. We need to set that
@@ -29,7 +29,7 @@ impl TransformObject for Handle<Curve> {
                 // represent the transformed curve.
                 Curve::new()
                     .insert(core)
-                    .copy_geometry_from(&curve, &mut core.layers.geometry)
+                    .copy_geometry_from(curve, &mut core.layers.geometry)
             })
             .clone()
     }

--- a/crates/fj-core/src/operations/transform/curve.rs
+++ b/crates/fj-core/src/operations/transform/curve.rs
@@ -18,8 +18,10 @@ impl TransformObject for Handle<Curve> {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
+        let curve = self;
+
         cache
-            .entry(&self)
+            .entry(&curve)
             .or_insert_with(|| {
                 // We don't actually need to transform the curve, as its
                 // geometry is locally defined on a surface. We need to set that
@@ -27,7 +29,7 @@ impl TransformObject for Handle<Curve> {
                 // represent the transformed curve.
                 Curve::new()
                     .insert(core)
-                    .copy_geometry_from(&self, &mut core.layers.geometry)
+                    .copy_geometry_from(&curve, &mut core.layers.geometry)
             })
             .clone()
     }

--- a/crates/fj-core/src/operations/transform/curve.rs
+++ b/crates/fj-core/src/operations/transform/curve.rs
@@ -3,13 +3,13 @@ use fj_math::Transform;
 use crate::{
     operations::{geometry::UpdateCurveGeometry, insert::Insert},
     storage::Handle,
-    topology::Curve,
+    topology::{Curve, Surface},
     Core,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for &Handle<Curve> {
+impl TransformObject for (&Handle<Curve>, &Handle<Surface>) {
     type Transformed = Handle<Curve>;
 
     fn transform_with_cache(
@@ -18,7 +18,7 @@ impl TransformObject for &Handle<Curve> {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let curve = self;
+        let (curve, _) = self;
 
         cache
             .entry(curve)

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -21,6 +21,6 @@ impl TransformObject for Cycle {
                 .transform_with_cache(transform, core, cache)
         });
 
-        Self::new(half_edges)
+        Cycle::new(half_edges)
     }
 }

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -1,12 +1,15 @@
 use fj_math::Transform;
 
 use crate::{
-    operations::insert::Insert, storage::Handle, topology::Cycle, Core,
+    operations::insert::Insert,
+    storage::Handle,
+    topology::{Cycle, Surface},
+    Core,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for &Handle<Cycle> {
+impl TransformObject for (&Handle<Cycle>, &Handle<Surface>) {
     type Transformed = Handle<Cycle>;
 
     fn transform_with_cache(
@@ -15,7 +18,7 @@ impl TransformObject for &Handle<Cycle> {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let cycle = self;
+        let (cycle, _) = self;
 
         let half_edges = cycle.half_edges().iter().map(|half_edge| {
             half_edge

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -18,10 +18,10 @@ impl TransformObject for (&Handle<Cycle>, &Handle<Surface>) {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let (cycle, _) = self;
+        let (cycle, surface) = self;
 
         let half_edges = cycle.half_edges().iter().map(|half_edge| {
-            half_edge.transform_with_cache(transform, core, cache)
+            (half_edge, surface).transform_with_cache(transform, core, cache)
         });
 
         Cycle::new(half_edges).insert(core)

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -21,9 +21,7 @@ impl TransformObject for (&Handle<Cycle>, &Handle<Surface>) {
         let (cycle, _) = self;
 
         let half_edges = cycle.half_edges().iter().map(|half_edge| {
-            half_edge
-                .clone()
-                .transform_with_cache(transform, core, cache)
+            half_edge.transform_with_cache(transform, core, cache)
         });
 
         Cycle::new(half_edges).insert(core)

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -1,11 +1,13 @@
 use fj_math::Transform;
 
-use crate::{topology::Cycle, Core};
+use crate::{
+    operations::insert::Insert, storage::Handle, topology::Cycle, Core,
+};
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Cycle {
-    type Transformed = Self;
+impl TransformObject for &Handle<Cycle> {
+    type Transformed = Handle<Cycle>;
 
     fn transform_with_cache(
         self,
@@ -21,6 +23,6 @@ impl TransformObject for Cycle {
                 .transform_with_cache(transform, core, cache)
         });
 
-        Cycle::new(half_edges)
+        Cycle::new(half_edges).insert(core)
     }
 }

--- a/crates/fj-core/src/operations/transform/cycle.rs
+++ b/crates/fj-core/src/operations/transform/cycle.rs
@@ -13,7 +13,9 @@ impl TransformObject for Cycle {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let half_edges = self.half_edges().iter().map(|half_edge| {
+        let cycle = self;
+
+        let half_edges = cycle.half_edges().iter().map(|half_edge| {
             half_edge
                 .clone()
                 .transform_with_cache(transform, core, cache)

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -15,11 +15,13 @@ impl TransformObject for Handle<HalfEdge> {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let curve = self
+        let half_edge = self;
+
+        let curve = half_edge
             .curve()
             .clone()
             .transform_with_cache(transform, core, cache);
-        let start_vertex = self
+        let start_vertex = half_edge
             .start_vertex()
             .clone()
             .transform_with_cache(transform, core, cache);
@@ -29,7 +31,7 @@ impl TransformObject for Handle<HalfEdge> {
 
         core.layers.geometry.define_half_edge(
             transformed_half_edge.clone(),
-            *core.layers.geometry.of_half_edge(&self),
+            *core.layers.geometry.of_half_edge(&half_edge),
         );
 
         transformed_half_edge

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -1,12 +1,15 @@
 use fj_math::Transform;
 
 use crate::{
-    operations::insert::Insert, storage::Handle, topology::HalfEdge, Core,
+    operations::insert::Insert,
+    storage::Handle,
+    topology::{HalfEdge, Surface},
+    Core,
 };
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for &Handle<HalfEdge> {
+impl TransformObject for (&Handle<HalfEdge>, &Handle<Surface>) {
     type Transformed = Handle<HalfEdge>;
 
     fn transform_with_cache(
@@ -15,7 +18,7 @@ impl TransformObject for &Handle<HalfEdge> {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let half_edge = self;
+        let (half_edge, _) = self;
 
         let curve = half_edge
             .curve()

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -22,7 +22,6 @@ impl TransformObject for (&Handle<HalfEdge>, &Handle<Surface>) {
 
         let curve = half_edge
             .curve()
-            .clone()
             .transform_with_cache(transform, core, cache);
         let start_vertex = half_edge
             .start_vertex()

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -6,8 +6,8 @@ use crate::{
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Handle<HalfEdge> {
-    type Transformed = Self;
+impl TransformObject for &Handle<HalfEdge> {
+    type Transformed = Handle<HalfEdge>;
 
     fn transform_with_cache(
         self,
@@ -31,7 +31,7 @@ impl TransformObject for Handle<HalfEdge> {
 
         core.layers.geometry.define_half_edge(
             transformed_half_edge.clone(),
-            *core.layers.geometry.of_half_edge(&half_edge),
+            *core.layers.geometry.of_half_edge(half_edge),
         );
 
         transformed_half_edge

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -18,10 +18,9 @@ impl TransformObject for (&Handle<HalfEdge>, &Handle<Surface>) {
         core: &mut Core,
         cache: &mut TransformCache,
     ) -> Self::Transformed {
-        let (half_edge, _) = self;
+        let (half_edge, surface) = self;
 
-        let curve = half_edge
-            .curve()
+        let curve = (half_edge.curve(), surface)
             .transform_with_cache(transform, core, cache);
         let start_vertex = half_edge
             .start_vertex()

--- a/crates/fj-core/src/operations/transform/edge.rs
+++ b/crates/fj-core/src/operations/transform/edge.rs
@@ -24,13 +24,14 @@ impl TransformObject for Handle<HalfEdge> {
             .clone()
             .transform_with_cache(transform, core, cache);
 
-        let half_edge = HalfEdge::new(curve, start_vertex).insert(core);
+        let transformed_half_edge =
+            HalfEdge::new(curve, start_vertex).insert(core);
 
         core.layers.geometry.define_half_edge(
-            half_edge.clone(),
+            transformed_half_edge.clone(),
             *core.layers.geometry.of_half_edge(&self),
         );
 
-        half_edge
+        transformed_half_edge
     }
 }

--- a/crates/fj-core/src/operations/transform/face.rs
+++ b/crates/fj-core/src/operations/transform/face.rs
@@ -17,9 +17,7 @@ impl TransformObject for Face {
             .surface()
             .clone()
             .transform_with_cache(transform, core, cache);
-        let region = self
-            .region()
-            .clone()
+        let region = (self.region(), self.surface())
             .transform_with_cache(transform, core, cache);
 
         Self::new(surface, region)

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -16,13 +16,12 @@ impl TransformObject for (&Handle<Region>, &Handle<Surface>) {
         core: &mut Core,
         cache: &mut super::TransformCache,
     ) -> Self::Transformed {
-        let (region, _) = self;
+        let (region, surface) = self;
 
-        let exterior = region
-            .exterior()
+        let exterior = (region.exterior(), surface)
             .transform_with_cache(transform, core, cache);
         let interiors = region.interiors().iter().map(|interior| {
-            interior.transform_with_cache(transform, core, cache)
+            (interior, surface).transform_with_cache(transform, core, cache)
         });
 
         Region::new(exterior, interiors).insert(core)

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -1,10 +1,13 @@
 use crate::{
-    operations::insert::Insert, storage::Handle, topology::Region, Core,
+    operations::insert::Insert,
+    storage::Handle,
+    topology::{Region, Surface},
+    Core,
 };
 
 use super::TransformObject;
 
-impl TransformObject for &Handle<Region> {
+impl TransformObject for (&Handle<Region>, &Handle<Surface>) {
     type Transformed = Handle<Region>;
 
     fn transform_with_cache(
@@ -13,7 +16,7 @@ impl TransformObject for &Handle<Region> {
         core: &mut Core,
         cache: &mut super::TransformCache,
     ) -> Self::Transformed {
-        let region = self;
+        let (region, _) = self;
 
         let exterior = region
             .exterior()

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -11,11 +11,13 @@ impl TransformObject for Region {
         core: &mut Core,
         cache: &mut super::TransformCache,
     ) -> Self::Transformed {
-        let exterior = self
+        let region = self;
+
+        let exterior = region
             .exterior()
             .clone()
             .transform_with_cache(transform, core, cache);
-        let interiors = self.interiors().iter().cloned().map(|interior| {
+        let interiors = region.interiors().iter().cloned().map(|interior| {
             interior.transform_with_cache(transform, core, cache)
         });
 

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -20,9 +20,8 @@ impl TransformObject for (&Handle<Region>, &Handle<Surface>) {
 
         let exterior = region
             .exterior()
-            .clone()
             .transform_with_cache(transform, core, cache);
-        let interiors = region.interiors().iter().cloned().map(|interior| {
+        let interiors = region.interiors().iter().map(|interior| {
             interior.transform_with_cache(transform, core, cache)
         });
 

--- a/crates/fj-core/src/operations/transform/region.rs
+++ b/crates/fj-core/src/operations/transform/region.rs
@@ -1,9 +1,11 @@
-use crate::{topology::Region, Core};
+use crate::{
+    operations::insert::Insert, storage::Handle, topology::Region, Core,
+};
 
 use super::TransformObject;
 
-impl TransformObject for Region {
-    type Transformed = Self;
+impl TransformObject for &Handle<Region> {
+    type Transformed = Handle<Region>;
 
     fn transform_with_cache(
         self,
@@ -21,6 +23,6 @@ impl TransformObject for Region {
             interior.transform_with_cache(transform, core, cache)
         });
 
-        Region::new(exterior, interiors)
+        Region::new(exterior, interiors).insert(core)
     }
 }

--- a/crates/fj-core/src/operations/transform/surface.rs
+++ b/crates/fj-core/src/operations/transform/surface.rs
@@ -6,8 +6,8 @@ use crate::{
 
 use super::{TransformCache, TransformObject};
 
-impl TransformObject for Handle<Surface> {
-    type Transformed = Self;
+impl TransformObject for &Handle<Surface> {
+    type Transformed = Handle<Surface>;
 
     fn transform_with_cache(
         self,
@@ -16,12 +16,12 @@ impl TransformObject for Handle<Surface> {
         cache: &mut TransformCache,
     ) -> Self::Transformed {
         cache
-            .entry(&self)
+            .entry(self)
             .or_insert_with(|| {
                 let surface = Surface::new().insert(core);
 
                 let geometry =
-                    core.layers.geometry.of_surface(&self).transform(transform);
+                    core.layers.geometry.of_surface(self).transform(transform);
                 core.layers
                     .geometry
                     .define_surface(surface.clone(), geometry);


### PR DESCRIPTION
The code that set the curve geometry until now didn't actually do the right thing. It just copied the geometry from the old curve, but didn't actually create a local definition for the curve on the newly transformed surface.

This is another step towards https://github.com/hannobraun/fornjot/issues/2290.