### PR TITLE
Don't use `self.path` in `HalfEdgeGeom`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/edge.rs
+++ b/crates/fj-core/src/algorithms/approx/edge.rs
@@ -30,7 +30,14 @@ impl Approx for (&Handle<HalfEdge>, &Handle<Surface>) {
         let tolerance = tolerance.into();
 
         let start_position_surface =
-            geometry.of_half_edge(half_edge).start_position();
+            geometry.of_half_edge(half_edge).start_position(
+                &geometry
+                    .of_curve(half_edge.curve())
+                    .unwrap()
+                    .local_on(surface)
+                    .unwrap()
+                    .path,
+            );
         let start_position =
             match cache.start_position.get(half_edge.start_vertex()) {
                 Some(position) => position,

--- a/crates/fj-core/src/geometry/half_edge.rs
+++ b/crates/fj-core/src/geometry/half_edge.rs
@@ -47,12 +47,12 @@ impl HalfEdgeGeom {
     }
 
     /// Compute the surface position where the half-edge starts
-    pub fn start_position(&self) -> Point<2> {
+    pub fn start_position(&self, path: &SurfacePath) -> Point<2> {
         // Computing the surface position from the curve position is fine.
         // `HalfEdge` "owns" its start position. There is no competing code that
         // could compute the surface position from slightly different data.
 
         let [start, _] = self.boundary.inner;
-        self.path.point_from_path_coords(start)
+        path.point_from_path_coords(start)
     }
 }

--- a/crates/fj-core/src/operations/split/face.rs
+++ b/crates/fj-core/src/operations/split/face.rs
@@ -105,8 +105,26 @@ impl SplitFace for Shell {
         let dividing_half_edge_a_to_d = {
             let half_edge = HalfEdge::line_segment(
                 [
-                    core.layers.geometry.of_half_edge(&b).start_position(),
-                    core.layers.geometry.of_half_edge(&d).start_position(),
+                    core.layers.geometry.of_half_edge(&b).start_position(
+                        &core
+                            .layers
+                            .geometry
+                            .of_curve(b.curve())
+                            .unwrap()
+                            .local_on(face.surface())
+                            .unwrap()
+                            .path,
+                    ),
+                    core.layers.geometry.of_half_edge(&d).start_position(
+                        &core
+                            .layers
+                            .geometry
+                            .of_curve(d.curve())
+                            .unwrap()
+                            .local_on(face.surface())
+                            .unwrap()
+                            .path,
+                    ),
                 ],
                 None,
                 face.surface().clone(),

--- a/crates/fj-core/src/operations/sweep/sketch.rs
+++ b/crates/fj-core/src/operations/sweep/sketch.rs
@@ -42,7 +42,7 @@ impl SweepSketch for Sketch {
                 // clockwise. Let's check that real quick.
                 assert!(region
                     .exterior()
-                    .winding(&core.layers.geometry)
+                    .winding(&core.layers.geometry, self.surface())
                     .is_ccw());
 
                 let is_negative_sweep = {

--- a/crates/fj-core/src/topology/objects/cycle.rs
+++ b/crates/fj-core/src/topology/objects/cycle.rs
@@ -31,7 +31,11 @@ impl Cycle {
     /// Please note that this is not *the* winding of the cycle, only one of the
     /// two possible windings, depending on the direction you look at the
     /// surface that the cycle is defined on from.
-    pub fn winding(&self, geometry: &Geometry, _: &Handle<Surface>) -> Winding {
+    pub fn winding(
+        &self,
+        geometry: &Geometry,
+        surface: &Handle<Surface>,
+    ) -> Winding {
         // The cycle could be made up of one or two circles. If that is the
         // case, the winding of the cycle is determined by the winding of the
         // first circle.
@@ -70,7 +74,14 @@ impl Cycle {
 
         for (a, b) in self.half_edges().pairs() {
             let [a, b] = [a, b].map(|half_edge| {
-                geometry.of_half_edge(half_edge).start_position()
+                geometry.of_half_edge(half_edge).start_position(
+                    &geometry
+                        .of_curve(half_edge.curve())
+                        .unwrap()
+                        .local_on(surface)
+                        .unwrap()
+                        .path,
+                )
             });
 
             sum += (b.u - a.u) * (b.v + a.v);

--- a/crates/fj-core/src/topology/objects/cycle.rs
+++ b/crates/fj-core/src/topology/objects/cycle.rs
@@ -6,6 +6,8 @@ use crate::{
     topology::{HalfEdge, ObjectSet},
 };
 
+use super::surface::Surface;
+
 /// A cycle of connected edges
 #[derive(Clone, Debug)]
 pub struct Cycle {
@@ -29,7 +31,7 @@ impl Cycle {
     /// Please note that this is not *the* winding of the cycle, only one of the
     /// two possible windings, depending on the direction you look at the
     /// surface that the cycle is defined on from.
-    pub fn winding(&self, geometry: &Geometry) -> Winding {
+    pub fn winding(&self, geometry: &Geometry, _: &Handle<Surface>) -> Winding {
         // The cycle could be made up of one or two circles. If that is the
         // case, the winding of the cycle is determined by the winding of the
         // first circle.

--- a/crates/fj-core/src/topology/objects/face.rs
+++ b/crates/fj-core/src/topology/objects/face.rs
@@ -63,7 +63,7 @@ impl Face {
     /// back sides. The front side is the side, where the face's exterior cycle
     /// is wound counter-clockwise.
     pub fn coord_handedness(&self, geometry: &Geometry) -> Handedness {
-        match self.region.exterior().winding(geometry) {
+        match self.region.exterior().winding(geometry, self.surface()) {
             Winding::Ccw => Handedness::RightHanded,
             Winding::Cw => Handedness::LeftHanded,
         }

--- a/crates/fj-core/src/validate/sketch.rs
+++ b/crates/fj-core/src/validate/sketch.rs
@@ -77,7 +77,7 @@ impl SketchValidationError {
     ) {
         sketch.regions().iter().for_each(|region| {
             let cycle = region.exterior();
-            if cycle.winding(geometry) == Winding::Cw {
+            if cycle.winding(geometry, sketch.surface()) == Winding::Cw {
                 errors.push(ValidationError::Sketch(
                     SketchValidationError::ClockwiseExteriorCycle {
                         cycle: cycle.clone(),
@@ -97,7 +97,9 @@ impl SketchValidationError {
             region
                 .interiors()
                 .iter()
-                .filter(|interior| interior.winding(geometry) == Winding::Ccw)
+                .filter(|interior| {
+                    interior.winding(geometry, sketch.surface()) == Winding::Ccw
+                })
                 .for_each(|cycle| {
                     errors.push(ValidationError::Sketch(
                         SketchValidationError::CounterClockwiseInteriorCycle {

--- a/crates/fj-core/src/validation/checks/curve_geometry_mismatch.rs
+++ b/crates/fj-core/src/validation/checks/curve_geometry_mismatch.rs
@@ -201,6 +201,9 @@ mod tests {
         )
         .is_err());
 
+        // Ignore remaining validation errors.
+        let _ = core.layers.validation.take_errors();
+
         Ok(())
     }
 }

--- a/crates/fj-core/src/validation/checks/face_winding.rs
+++ b/crates/fj-core/src/validation/checks/face_winding.rs
@@ -53,8 +53,8 @@ impl ValidationCheck<Face> for InteriorCycleHasInvalidWinding {
                 return None;
             }
 
-            let exterior_winding = exterior.winding(geometry);
-            let interior_winding = interior.winding(geometry);
+            let exterior_winding = exterior.winding(geometry, object.surface());
+            let interior_winding = interior.winding(geometry, object.surface());
 
             if exterior_winding == interior_winding {
                 return Some(InteriorCycleHasInvalidWinding {

--- a/crates/fj-core/src/validation/checks/half_edge_connection.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_connection.rs
@@ -3,7 +3,7 @@ use fj_math::{Point, Scalar};
 use crate::{
     geometry::Geometry,
     storage::Handle,
-    topology::{Cycle, Face, HalfEdge, Region, Sketch},
+    topology::{Cycle, Face, HalfEdge, Region, Sketch, Surface},
     validation::{validation_check::ValidationCheck, ValidationConfig},
 };
 
@@ -63,7 +63,7 @@ impl ValidationCheck<Face> for AdjacentHalfEdgesNotConnected {
         geometry: &'r Geometry,
         config: &'r ValidationConfig,
     ) -> impl Iterator<Item = Self> + 'r {
-        check_region(object.region(), geometry, config)
+        check_region(object.region(), object.surface(), geometry, config)
     }
 }
 
@@ -73,26 +73,27 @@ impl ValidationCheck<Sketch> for AdjacentHalfEdgesNotConnected {
         geometry: &'r Geometry,
         config: &'r ValidationConfig,
     ) -> impl Iterator<Item = Self> + 'r {
-        object
-            .regions()
-            .iter()
-            .flat_map(|region| check_region(region, geometry, config))
+        object.regions().iter().flat_map(|region| {
+            check_region(region, object.surface(), geometry, config)
+        })
     }
 }
 
 fn check_region<'r>(
     region: &'r Region,
+    surface: &'r Handle<Surface>,
     geometry: &'r Geometry,
     config: &'r ValidationConfig,
 ) -> impl Iterator<Item = AdjacentHalfEdgesNotConnected> + 'r {
     [region.exterior()]
         .into_iter()
         .chain(region.interiors())
-        .flat_map(|cycle| check_cycle(cycle, geometry, config))
+        .flat_map(|cycle| check_cycle(cycle, surface, geometry, config))
 }
 
 fn check_cycle<'r>(
     cycle: &'r Cycle,
+    _: &'r Handle<Surface>,
     geometry: &'r Geometry,
     config: &'r ValidationConfig,
 ) -> impl Iterator<Item = AdjacentHalfEdgesNotConnected> + 'r {


### PR DESCRIPTION
This might seem like a rather small change, but it took a lot to get here. A lot of code had to be updated to correctly define curve geometry, before it could be used here for that.

Hopefully that means that most (or even all) code that needs to set curve geometry now does so. If that is the case, migrating further places to use curve geometry instead of half-edge geometry should be a bit easier from now on.

This is another step towards https://github.com/hannobraun/fornjot/issues/2290.