### PR TITLE
Update some code to avoid reading `path` field of `HalfEdgeGeom`

### DIFF
--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -103,7 +103,7 @@ impl JoinCycle for Cycle {
         let half_edges = edges
             .into_iter()
             .circular_tuple_windows()
-            .map(|((prev_half_edge, _), (half_edge, geometry))| {
+            .map(|((prev_half_edge, _), (half_edge, half_edge_geom))| {
                 let half_edge = HalfEdge::unjoined(core)
                     .update_curve(|_, _| half_edge.curve().clone(), core)
                     .update_start_vertex(
@@ -111,13 +111,13 @@ impl JoinCycle for Cycle {
                         core,
                     )
                     .insert(core)
-                    .set_geometry(geometry, &mut core.layers.geometry);
+                    .set_geometry(half_edge_geom, &mut core.layers.geometry);
 
                 core.layers.geometry.define_curve(
                     half_edge.curve().clone(),
                     surface.clone(),
                     LocalCurveGeom {
-                        path: geometry.path,
+                        path: half_edge_geom.path,
                     },
                 );
 

--- a/crates/fj-core/src/operations/join/cycle.rs
+++ b/crates/fj-core/src/operations/join/cycle.rs
@@ -110,7 +110,7 @@ impl JoinCycle for Cycle {
             .map(
                 |(
                     (prev_half_edge, _, _),
-                    (half_edge, half_edge_geom, _curve_geom),
+                    (half_edge, half_edge_geom, curve_geom),
                 )| {
                     let half_edge = HalfEdge::unjoined(core)
                         .update_curve(|_, _| half_edge.curve().clone(), core)
@@ -127,9 +127,7 @@ impl JoinCycle for Cycle {
                     core.layers.geometry.define_curve(
                         half_edge.curve().clone(),
                         surface.clone(),
-                        LocalCurveGeom {
-                            path: half_edge_geom.path,
-                        },
+                        curve_geom,
                     );
 
                     half_edge

--- a/crates/fj-core/src/operations/sweep/cycle.rs
+++ b/crates/fj-core/src/operations/sweep/cycle.rs
@@ -80,6 +80,13 @@ impl SweepCycle for Cycle {
             top_edges.push((
                 top_half_edge,
                 *core.layers.geometry.of_half_edge(bottom_half_edge),
+                core.layers
+                    .geometry
+                    .of_curve(bottom_half_edge.curve())
+                    .unwrap()
+                    .local_on(&bottom_surface)
+                    .unwrap()
+                    .clone(),
             ));
         }
 

--- a/crates/fj-core/src/operations/sweep/half_edge.rs
+++ b/crates/fj-core/src/operations/sweep/half_edge.rs
@@ -60,9 +60,17 @@ impl SweepHalfEdge for Handle<HalfEdge> {
         let path = path.into();
 
         let half_edge_geom = *core.layers.geometry.of_half_edge(self);
+        let curve_geom = core
+            .layers
+            .geometry
+            .of_curve(self.curve())
+            .unwrap()
+            .local_on(&surface)
+            .unwrap()
+            .clone();
         let surface_geom = *core.layers.geometry.of_surface(&surface);
         let surface =
-            half_edge_geom
+            curve_geom
                 .path
                 .sweep_surface_path(&surface_geom, path, core);
 

--- a/crates/fj-core/src/topology/objects/cycle.rs
+++ b/crates/fj-core/src/topology/objects/cycle.rs
@@ -47,11 +47,17 @@ impl Cycle {
                 .expect("Invalid cycle: expected at least one edge");
 
             let half_edge_geom = geometry.of_half_edge(first);
+            let curve_geom = geometry
+                .of_curve(first.curve())
+                .unwrap()
+                .local_on(surface)
+                .unwrap()
+                .clone();
 
             let [a, b] = half_edge_geom.boundary.inner;
             let edge_direction_positive = a < b;
 
-            let circle = match half_edge_geom.path {
+            let circle = match curve_geom.path {
                 SurfacePath::Circle(circle) => circle,
                 SurfacePath::Line(_) => unreachable!(
                     "Invalid cycle: less than 3 edges, but not all are circles"

--- a/crates/fj-core/src/topology/objects/cycle.rs
+++ b/crates/fj-core/src/topology/objects/cycle.rs
@@ -46,12 +46,12 @@ impl Cycle {
                 .next()
                 .expect("Invalid cycle: expected at least one edge");
 
-            let geometry = geometry.of_half_edge(first);
+            let half_edge_geom = geometry.of_half_edge(first);
 
-            let [a, b] = geometry.boundary.inner;
+            let [a, b] = half_edge_geom.boundary.inner;
             let edge_direction_positive = a < b;
 
-            let circle = match geometry.path {
+            let circle = match half_edge_geom.path {
                 SurfacePath::Circle(circle) => circle,
                 SurfacePath::Line(_) => unreachable!(
                     "Invalid cycle: less than 3 edges, but not all are circles"


### PR DESCRIPTION
This prepares for that field being removed eventually, in favor of the same data that's available from `CurveGeom`.

This is another step towards https://github.com/hannobraun/fornjot/issues/2290.