### PR TITLE
Simplify half-edge sibling query

### DIFF
--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -37,7 +37,7 @@ impl SplitEdge for Shell {
         let point = point.into();
 
         let sibling = self
-            .get_sibling_of(half_edge, &core.layers.geometry)
+            .get_sibling_of(half_edge)
             .expect("Expected half-edge and its sibling to be part of shell");
 
         let [half_edge_a, half_edge_b] = half_edge.split_half_edge(point, core);

--- a/crates/fj-core/src/queries/sibling_of_half_edge.rs
+++ b/crates/fj-core/src/queries/sibling_of_half_edge.rs
@@ -1,5 +1,4 @@
 use crate::{
-    geometry::Geometry,
     storage::Handle,
     topology::{HalfEdge, Shell},
 };
@@ -19,7 +18,6 @@ pub trait SiblingOfHalfEdge {
     fn get_sibling_of(
         &self,
         half_edge: &Handle<HalfEdge>,
-        geometry: &Geometry,
     ) -> Option<Handle<HalfEdge>>;
 }
 
@@ -45,7 +43,6 @@ impl SiblingOfHalfEdge for Shell {
     fn get_sibling_of(
         &self,
         half_edge: &Handle<HalfEdge>,
-        _: &Geometry,
     ) -> Option<Handle<HalfEdge>> {
         for face in self.faces() {
             for cycle in face.region().all_cycles() {

--- a/crates/fj-core/src/queries/sibling_of_half_edge.rs
+++ b/crates/fj-core/src/queries/sibling_of_half_edge.rs
@@ -9,12 +9,7 @@ use super::BoundingVerticesOfHalfEdge;
 /// Queries related to the sibling of a [`HalfEdge`]
 pub trait SiblingOfHalfEdge {
     /// Indicate whether the provided half-edges are siblings
-    fn are_siblings(
-        &self,
-        a: &Handle<HalfEdge>,
-        b: &Handle<HalfEdge>,
-        geometry: &Geometry,
-    ) -> bool;
+    fn are_siblings(&self, a: &Handle<HalfEdge>, b: &Handle<HalfEdge>) -> bool;
 
     /// Retrieve the sibling of this half-edge
     ///
@@ -29,12 +24,7 @@ pub trait SiblingOfHalfEdge {
 }
 
 impl SiblingOfHalfEdge for Shell {
-    fn are_siblings(
-        &self,
-        a: &Handle<HalfEdge>,
-        b: &Handle<HalfEdge>,
-        _: &Geometry,
-    ) -> bool {
+    fn are_siblings(&self, a: &Handle<HalfEdge>, b: &Handle<HalfEdge>) -> bool {
         let same_curve = a.curve().id() == b.curve().id();
         let same_vertices = {
             let Some(a_vertices) = self.bounding_vertices_of_half_edge(a)
@@ -55,12 +45,12 @@ impl SiblingOfHalfEdge for Shell {
     fn get_sibling_of(
         &self,
         half_edge: &Handle<HalfEdge>,
-        geometry: &Geometry,
+        _: &Geometry,
     ) -> Option<Handle<HalfEdge>> {
         for face in self.faces() {
             for cycle in face.region().all_cycles() {
                 for h in cycle.half_edges() {
-                    if self.are_siblings(half_edge, h, geometry) {
+                    if self.are_siblings(half_edge, h) {
                         return Some(h.clone());
                     }
                 }

--- a/crates/fj-core/src/queries/sibling_of_half_edge.rs
+++ b/crates/fj-core/src/queries/sibling_of_half_edge.rs
@@ -33,11 +33,9 @@ impl SiblingOfHalfEdge for Shell {
         &self,
         a: &Handle<HalfEdge>,
         b: &Handle<HalfEdge>,
-        geometry: &Geometry,
+        _: &Geometry,
     ) -> bool {
         let same_curve = a.curve().id() == b.curve().id();
-        let same_boundary = geometry.of_half_edge(a).boundary
-            == geometry.of_half_edge(b).boundary.reverse();
         let same_vertices = {
             let Some(a_vertices) = self.bounding_vertices_of_half_edge(a)
             else {
@@ -51,7 +49,7 @@ impl SiblingOfHalfEdge for Shell {
             a_vertices == b_vertices.reverse()
         };
 
-        same_curve && same_boundary && same_vertices
+        same_curve && same_vertices
     }
 
     fn get_sibling_of(

--- a/crates/fj-core/src/validation/checks/coincident_half_edges_are_not_siblings.rs
+++ b/crates/fj-core/src/validation/checks/coincident_half_edges_are_not_siblings.rs
@@ -117,7 +117,7 @@ impl ValidationCheck<Shell> for CoincidentHalfEdgesAreNotSiblings {
                     continue;
                 }
 
-                if object.are_siblings(half_edge_a, half_edge_b, geometry) {
+                if object.are_siblings(half_edge_a, half_edge_b) {
                     // If the half-edges are siblings, they are allowed to be
                     // coincident. Must be, in fact. There's another validation
                     // check that takes care of that.

--- a/crates/fj-core/src/validation/checks/half_edge_has_no_sibling.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_has_no_sibling.rs
@@ -52,8 +52,7 @@ impl ValidationCheck<Shell> for HalfEdgeHasNoSibling {
                             // currently looking at. Let's make sure the logic
                             // we use here to determine that matches the
                             // "official" definition.
-                            assert!(object
-                                .are_siblings(half_edge, sibling, geometry));
+                            assert!(object.are_siblings(half_edge, sibling));
                         }
                         None => {
                             // If this half-edge has a sibling, we haven't seen

--- a/crates/fj-core/src/validation/checks/half_edge_has_no_sibling.rs
+++ b/crates/fj-core/src/validation/checks/half_edge_has_no_sibling.rs
@@ -27,7 +27,7 @@ pub struct HalfEdgeHasNoSibling {
 impl ValidationCheck<Shell> for HalfEdgeHasNoSibling {
     fn check<'r>(
         object: &'r Shell,
-        geometry: &'r Geometry,
+        _: &'r Geometry,
         _: &'r ValidationConfig,
     ) -> impl Iterator<Item = Self> + 'r {
         let mut unmatched_half_edges = BTreeMap::new();
@@ -36,15 +36,13 @@ impl ValidationCheck<Shell> for HalfEdgeHasNoSibling {
             for cycle in face.region().all_cycles() {
                 for half_edge in cycle.half_edges() {
                     let curve = half_edge.curve().clone();
-                    let boundary = geometry.of_half_edge(half_edge).boundary;
                     let vertices =
                         cycle.bounding_vertices_of_half_edge(half_edge).expect(
                             "`half_edge` came from `cycle`, must exist there",
                         );
 
-                    let key = (curve.clone(), boundary, vertices.clone());
-                    let key_reversed =
-                        (curve, boundary.reverse(), vertices.reverse());
+                    let key = (curve.clone(), vertices.clone());
+                    let key_reversed = (curve, vertices.reverse());
 
                     match unmatched_half_edges.remove(&key_reversed) {
                         Some(sibling) => {


### PR DESCRIPTION
From one of the commit messages:

> Two half-edges having the same vertices but different boundaries is invalid, and that should be caught by the half-edge connection validation check.

I came across this opportunity for simplification due to my work on https://github.com/hannobraun/fornjot/issues/2290, which this pull request helps to move along.