### PR TITLE
Improve query capabilities on `Shell`

### DIFF
--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -43,7 +43,8 @@ impl SplitEdge for Shell {
         let [half_edge_a, half_edge_b] = half_edge.split_half_edge(point, core);
 
         let siblings = {
-            let [sibling_a, sibling_b] = sibling.split_half_edge(point, core);
+            let [sibling_a, sibling_b] =
+                sibling.sibling.split_half_edge(point, core);
             let sibling_b = sibling_b
                 .update_start_vertex(
                     |_, _| half_edge_b.start_vertex().clone(),
@@ -65,7 +66,7 @@ impl SplitEdge for Shell {
                 core,
             )
             .into_inner()
-            .replace_half_edge(&sibling, siblings.clone(), core)
+            .replace_half_edge(&sibling.sibling, siblings.clone(), core)
             .into_inner();
 
         (shell, [[half_edge_a, half_edge_b], siblings])

--- a/crates/fj-core/src/queries/cycle_of_half_edge.rs
+++ b/crates/fj-core/src/queries/cycle_of_half_edge.rs
@@ -1,0 +1,32 @@
+use crate::{
+    storage::Handle,
+    topology::{Cycle, HalfEdge, Shell},
+};
+
+/// Query to find the cycle that a half-edge is part of
+pub trait CycleOfHalfEdge {
+    /// Find the cycle that a half-edge is part of
+    fn find_cycle_of_half_edge(
+        &self,
+        half_edge: &Handle<HalfEdge>,
+    ) -> Option<Handle<Cycle>>;
+}
+
+impl CycleOfHalfEdge for Shell {
+    fn find_cycle_of_half_edge(
+        &self,
+        half_edge: &Handle<HalfEdge>,
+    ) -> Option<Handle<Cycle>> {
+        for face in self.faces() {
+            for cycle in face.region().all_cycles() {
+                for h in cycle.half_edges() {
+                    if h == half_edge {
+                        return Some(cycle.clone());
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/crates/fj-core/src/queries/mod.rs
+++ b/crates/fj-core/src/queries/mod.rs
@@ -11,10 +11,12 @@
 
 mod all_half_edges_with_surface;
 mod bounding_vertices_of_half_edge;
+mod cycle_of_half_edge;
 mod sibling_of_half_edge;
 
 pub use self::{
     all_half_edges_with_surface::AllHalfEdgesWithSurface,
     bounding_vertices_of_half_edge::BoundingVerticesOfHalfEdge,
+    cycle_of_half_edge::CycleOfHalfEdge,
     sibling_of_half_edge::{Sibling, SiblingOfHalfEdge},
 };

--- a/crates/fj-core/src/queries/mod.rs
+++ b/crates/fj-core/src/queries/mod.rs
@@ -16,5 +16,5 @@ mod sibling_of_half_edge;
 pub use self::{
     all_half_edges_with_surface::AllHalfEdgesWithSurface,
     bounding_vertices_of_half_edge::BoundingVerticesOfHalfEdge,
-    sibling_of_half_edge::SiblingOfHalfEdge,
+    sibling_of_half_edge::{Sibling, SiblingOfHalfEdge},
 };

--- a/crates/fj-core/src/queries/sibling_of_half_edge.rs
+++ b/crates/fj-core/src/queries/sibling_of_half_edge.rs
@@ -15,10 +15,7 @@ pub trait SiblingOfHalfEdge {
     /// Returns `None`, if the provided half-edge is not part of the object this
     /// method is called on, or if the provided half-edge has no sibling within
     /// the object.
-    fn get_sibling_of(
-        &self,
-        half_edge: &Handle<HalfEdge>,
-    ) -> Option<Handle<HalfEdge>>;
+    fn get_sibling_of(&self, half_edge: &Handle<HalfEdge>) -> Option<Sibling>;
 }
 
 impl SiblingOfHalfEdge for Shell {
@@ -40,15 +37,12 @@ impl SiblingOfHalfEdge for Shell {
         same_curve && same_vertices
     }
 
-    fn get_sibling_of(
-        &self,
-        half_edge: &Handle<HalfEdge>,
-    ) -> Option<Handle<HalfEdge>> {
+    fn get_sibling_of(&self, half_edge: &Handle<HalfEdge>) -> Option<Sibling> {
         for face in self.faces() {
             for cycle in face.region().all_cycles() {
                 for h in cycle.half_edges() {
                     if self.are_siblings(half_edge, h) {
-                        return Some(h.clone());
+                        return Some(Sibling { sibling: h.clone() });
                     }
                 }
             }
@@ -56,4 +50,10 @@ impl SiblingOfHalfEdge for Shell {
 
         None
     }
+}
+
+/// The sibling of a half-edge, plus some extra information
+pub struct Sibling {
+    /// The sibling
+    pub sibling: Handle<HalfEdge>,
 }

--- a/crates/fj-core/src/queries/sibling_of_half_edge.rs
+++ b/crates/fj-core/src/queries/sibling_of_half_edge.rs
@@ -1,6 +1,6 @@
 use crate::{
     storage::Handle,
-    topology::{HalfEdge, Shell},
+    topology::{Cycle, Face, HalfEdge, Shell},
 };
 
 use super::BoundingVerticesOfHalfEdge;
@@ -42,7 +42,11 @@ impl SiblingOfHalfEdge for Shell {
             for cycle in face.region().all_cycles() {
                 for h in cycle.half_edges() {
                     if self.are_siblings(half_edge, h) {
-                        return Some(Sibling { sibling: h.clone() });
+                        return Some(Sibling {
+                            sibling: h.clone(),
+                            cycle: cycle.clone(),
+                            face: face.clone(),
+                        });
                     }
                 }
             }
@@ -56,4 +60,10 @@ impl SiblingOfHalfEdge for Shell {
 pub struct Sibling {
     /// The sibling
     pub sibling: Handle<HalfEdge>,
+
+    /// The cycle in which the sibling was found
+    pub cycle: Handle<Cycle>,
+
+    /// The face in which the sibling was found
+    pub face: Handle<Face>,
 }


### PR DESCRIPTION
Improve the existing query that returns the sibling of a half-edge, by returning new information. Add a new query, that finds the cycle that a half-edge is in.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290.