### PR TITLE
Implement `SplitHalfEdge` for `Cycle`

### DIFF
--- a/crates/fj-core/src/operations/split/edge.rs
+++ b/crates/fj-core/src/operations/split/edge.rs
@@ -5,7 +5,7 @@ use crate::{
         geometry::UpdateHalfEdgeGeometry, insert::Insert,
         replace::ReplaceHalfEdge, split::SplitHalfEdge, update::UpdateHalfEdge,
     },
-    queries::SiblingOfHalfEdge,
+    queries::{CycleOfHalfEdge, SiblingOfHalfEdge},
     storage::Handle,
     topology::{HalfEdge, Shell},
     Core,
@@ -40,11 +40,14 @@ impl SplitEdge for Shell {
             .get_sibling_of(half_edge)
             .expect("Expected half-edge and its sibling to be part of shell");
 
-        let [half_edge_a, half_edge_b] = half_edge.split_half_edge(point, core);
+        let [half_edge_a, half_edge_b] = self
+            .find_cycle_of_half_edge(half_edge)
+            .expect("Expected half-edge to be part of shell")
+            .split_half_edge(half_edge, point, core);
 
         let siblings = {
             let [sibling_a, sibling_b] =
-                sibling.sibling.split_half_edge(point, core);
+                sibling.cycle.split_half_edge(&sibling.sibling, point, core);
             let sibling_b = sibling_b
                 .update_start_vertex(
                     |_, _| half_edge_b.start_vertex().clone(),

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -41,26 +41,32 @@ impl SplitHalfEdge for Handle<HalfEdge> {
         point: impl Into<Point<1>>,
         core: &mut Core,
     ) -> [Handle<HalfEdge>; 2] {
+        let half_edge = self;
         let point = point.into();
 
-        let geometry = *core.layers.geometry.of_half_edge(self);
+        let geometry = *core.layers.geometry.of_half_edge(half_edge);
         let [start, end] = geometry.boundary.inner;
 
-        let a =
-            HalfEdge::new(self.curve().clone(), self.start_vertex().clone())
-                .insert(core)
-                .derive_from(self, core)
-                .set_geometry(
-                    geometry.with_boundary([start, point]),
-                    &mut core.layers.geometry,
-                );
-        let b = HalfEdge::new(self.curve().clone(), Vertex::new().insert(core))
-            .insert(core)
-            .derive_from(self, core)
-            .set_geometry(
-                geometry.with_boundary([point, end]),
-                &mut core.layers.geometry,
-            );
+        let a = HalfEdge::new(
+            half_edge.curve().clone(),
+            half_edge.start_vertex().clone(),
+        )
+        .insert(core)
+        .derive_from(half_edge, core)
+        .set_geometry(
+            geometry.with_boundary([start, point]),
+            &mut core.layers.geometry,
+        );
+        let b = HalfEdge::new(
+            half_edge.curve().clone(),
+            Vertex::new().insert(core),
+        )
+        .insert(core)
+        .derive_from(half_edge, core)
+        .set_geometry(
+            geometry.with_boundary([point, end]),
+            &mut core.layers.geometry,
+        );
 
         core.layers.geometry.define_vertex(
             b.start_vertex().clone(),

--- a/crates/fj-core/src/operations/split/half_edge.rs
+++ b/crates/fj-core/src/operations/split/half_edge.rs
@@ -6,7 +6,7 @@ use crate::{
         derive::DeriveFrom, geometry::UpdateHalfEdgeGeometry, insert::Insert,
     },
     storage::Handle,
-    topology::{HalfEdge, Vertex},
+    topology::{Cycle, HalfEdge, Vertex},
     Core,
 };
 
@@ -30,18 +30,19 @@ pub trait SplitHalfEdge {
     #[must_use]
     fn split_half_edge(
         &self,
+        half_edge: &Handle<HalfEdge>,
         point: impl Into<Point<1>>,
         core: &mut Core,
     ) -> [Handle<HalfEdge>; 2];
 }
 
-impl SplitHalfEdge for Handle<HalfEdge> {
+impl SplitHalfEdge for Cycle {
     fn split_half_edge(
         &self,
+        half_edge: &Handle<HalfEdge>,
         point: impl Into<Point<1>>,
         core: &mut Core,
     ) -> [Handle<HalfEdge>; 2] {
-        let half_edge = self;
         let point = point.into();
 
         let geometry = *core.layers.geometry.of_half_edge(half_edge);


### PR DESCRIPTION
From the message of the main commit:

> This provides more flexibility, specifically regarding the ongoing changes to the geometry representation.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2290, and I have a pull request of the way that makes use of the flexibility that this one provides.