### PR TITLE
 Remove the unused `SurfaceGeom::project_global_point` function

### DIFF
--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -1,6 +1,6 @@
 //! The geometry that defines a surface
 
-use fj_math::{Line, Plane, Point, Transform, Vector};
+use fj_math::{Line, Point, Transform, Vector};
 
 use super::GlobalPath;
 
@@ -51,18 +51,6 @@ impl SurfaceGeom {
     fn path_to_line(&self) -> Line<3> {
         let Self::Basic { u, v } = self;
         Line::from_origin_and_direction(u.origin(), *v)
-    }
-
-    /// Project the global point into the surface
-    pub fn project_global_point(&self, point: impl Into<Point<3>>) -> Point<2> {
-        let Self::Basic { u, v } = self;
-
-        let GlobalPath::Line(line) = u else {
-            todo!("Projecting point into non-plane surface is not supported")
-        };
-
-        let plane = Plane::from_parametric(line.origin(), line.direction(), *v);
-        plane.project_point(point)
     }
 
     /// Transform the surface geometry

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -50,7 +50,7 @@ impl SweepSurfacePath for SurfacePath {
                 // What definitely won't work, is computing the bottom edge of
                 // the sweep. The edge sweeping code currently assumes that the
                 // bottom edge is a line (which is true when sweeping from a
-                // flat surface). But is the surface we're sweeping from is
+                // flat surface). But if the surface we're sweeping from is
                 // curved, there's simply no way to represent the curve of the
                 // resulting bottom edge.
                 todo!(


### PR DESCRIPTION
Looks like it's no longer required. I suspect it was used for some of the intersection testing code that I removed a while ago.