### PR TITLE
Allow degenerate triangles

### DIFF
--- a/crates/fj-core/src/algorithms/triangulate/delaunay.rs
+++ b/crates/fj-core/src/algorithms/triangulate/delaunay.rs
@@ -47,13 +47,13 @@ pub fn triangulate(
     let mut triangles = Vec::new();
     for triangle in triangulation.inner_faces() {
         let [v0, v1, v2] = triangle.vertices().map(|vertex| *vertex.data());
-        let triangle_winding = Triangle::<2>::from_points([
+        let triangle = Triangle::<2>::from_points([
             v0.point_surface,
             v1.point_surface,
             v2.point_surface,
         ])
-        .expect("invalid triangle")
-        .winding();
+        .expect("invalid triangle");
+        let triangle_winding = triangle.winding();
 
         let required_winding = match coord_handedness {
             Handedness::LeftHanded => Winding::Cw,

--- a/crates/fj-core/src/algorithms/triangulate/delaunay.rs
+++ b/crates/fj-core/src/algorithms/triangulate/delaunay.rs
@@ -51,8 +51,7 @@ pub fn triangulate(
             v0.point_surface,
             v1.point_surface,
             v2.point_surface,
-        ])
-        .expect("invalid triangle");
+        ]);
         assert!(
             triangle.is_valid(),
             "Expecting triangles created by triangulation to be valid.",

--- a/crates/fj-core/src/algorithms/triangulate/delaunay.rs
+++ b/crates/fj-core/src/algorithms/triangulate/delaunay.rs
@@ -53,14 +53,13 @@ pub fn triangulate(
             v2.point_surface,
         ])
         .expect("invalid triangle");
-        let triangle_winding = triangle.winding();
 
         let required_winding = match coord_handedness {
             Handedness::LeftHanded => Winding::Cw,
             Handedness::RightHanded => Winding::Ccw,
         };
 
-        let triangle = if triangle_winding == required_winding {
+        let triangle = if triangle.winding() == required_winding {
             [v0, v1, v2]
         } else {
             [v0, v2, v1]

--- a/crates/fj-core/src/algorithms/triangulate/delaunay.rs
+++ b/crates/fj-core/src/algorithms/triangulate/delaunay.rs
@@ -53,6 +53,10 @@ pub fn triangulate(
             v2.point_surface,
         ])
         .expect("invalid triangle");
+        assert!(
+            triangle.is_valid(),
+            "Expecting triangles created by triangulation to be valid.",
+        );
 
         let required_winding = match coord_handedness {
             Handedness::LeftHanded => Winding::Cw,

--- a/crates/fj-core/src/algorithms/triangulate/polygon.rs
+++ b/crates/fj-core/src/algorithms/triangulate/polygon.rs
@@ -42,7 +42,7 @@ impl Polygon {
     }
 
     pub fn contains_triangle(&self, triangle: impl Into<Triangle<2>>) -> bool {
-        let [a, b, c] = triangle.into().points();
+        let [a, b, c] = triangle.into().points;
 
         let mut might_be_hole = true;
 

--- a/crates/fj-export/src/lib.rs
+++ b/crates/fj-export/src/lib.rs
@@ -89,7 +89,7 @@ pub fn export_stl(
 ) -> Result<(), Error> {
     let points = mesh
         .triangles()
-        .map(|triangle| triangle.inner.points())
+        .map(|triangle| triangle.inner.points)
         .collect::<Vec<_>>();
 
     let vertices = points.iter().map(|points| {
@@ -136,7 +136,7 @@ pub fn export_obj(
 ) -> Result<(), Error> {
     for (cnt, t) in mesh.triangles().enumerate() {
         // write each point of the triangle
-        for v in t.inner.points() {
+        for v in t.inner.points {
             wavefront_rs::obj::writer::Writer { auto_newline: true }
                 .write(
                     &mut write,

--- a/crates/fj-interop/src/mesh.rs
+++ b/crates/fj-interop/src/mesh.rs
@@ -80,7 +80,7 @@ impl Mesh<Point<3>> {
     ) {
         let triangle = triangle.into();
 
-        for point in triangle.points() {
+        for point in triangle.points {
             self.push_vertex(point);
         }
 

--- a/crates/fj-math/src/line.rs
+++ b/crates/fj-math/src/line.rs
@@ -99,7 +99,7 @@ impl<const D: usize> Line<D> {
 
             // The triangle is valid only, if the three points are not on the
             // same line.
-            Triangle::from_points([a, b, c]).unwrap().is_valid()
+            Triangle::from_points([a, b, c]).is_valid()
         };
 
         if other_origin_is_not_on_self {

--- a/crates/fj-math/src/line.rs
+++ b/crates/fj-math/src/line.rs
@@ -99,7 +99,7 @@ impl<const D: usize> Line<D> {
 
             // The triangle is valid only, if the three points are not on the
             // same line.
-            Triangle::from_points([a, b, c]).is_ok()
+            Triangle::from_points([a, b, c]).unwrap().is_valid()
         };
 
         if other_origin_is_not_on_self {

--- a/crates/fj-math/src/transform.rs
+++ b/crates/fj-math/src/transform.rs
@@ -78,7 +78,7 @@ impl Transform {
 
     /// Transform the given triangle
     pub fn transform_triangle(&self, triangle: &Triangle<3>) -> Triangle<3> {
-        let [a, b, c] = &triangle.points();
+        let [a, b, c] = &triangle.points;
         Triangle::from([
             self.transform_point(a),
             self.transform_point(b),

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -12,7 +12,8 @@ use super::{Point, Scalar};
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 #[repr(C)]
 pub struct Triangle<const D: usize> {
-    points: [Point<D>; 3],
+    /// The points that make up the triangle
+    pub points: [Point<D>; 3],
 }
 
 impl<const D: usize> Triangle<D> {

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -181,7 +181,8 @@ mod tests {
         let a = Point::from([0.0, 0.0]);
         let b = Point::from([1.0, 1.0]);
         let c = Point::from([1.0, 2.0]);
-        let _triangle = Triangle::from([a, b, c]);
+
+        assert!(Triangle::from_points([a, b, c]).is_ok());
     }
 
     #[test]
@@ -189,25 +190,26 @@ mod tests {
         let a = Point::from([0.0, 0.0, 0.0]);
         let b = Point::from([1.0, 1.0, 0.0]);
         let c = Point::from([1.0, 2.0, 0.0]);
-        let _triangle = Triangle::from([a, b, c]);
+
+        assert!(Triangle::from_points([a, b, c]).is_ok());
     }
 
     #[test]
-    #[should_panic]
     fn invalid_triangle_2d() {
         let a = Point::from([0.0, 0.0]);
         let b = Point::from([1.0, 1.0]);
         let c = Point::from([2.0, 2.0]);
-        let _triangle = Triangle::from([a, b, c]);
+
+        assert!(Triangle::from_points([a, b, c]).is_err());
     }
 
     #[test]
-    #[should_panic]
     fn invalid_triangle_3d() {
         let a = Point::from([0.0, 0.0, 0.0]);
         let b = Point::from([1.0, 1.0, 1.0]);
         let c = Point::from([2.0, 2.0, 2.0]);
-        let _triangle = Triangle::from([a, b, c]);
+
+        assert!(Triangle::from_points([a, b, c]).is_err());
     }
 
     #[test]

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -179,8 +179,8 @@ mod tests {
     #[test]
     fn valid_triangle_2d() {
         let a = Point::from([0.0, 0.0]);
-        let b = Point::from([1.0, 1.0]);
-        let c = Point::from([1.0, 2.0]);
+        let b = Point::from([1.0, 0.0]);
+        let c = Point::from([0.0, 1.0]);
 
         assert!(Triangle::from_points([a, b, c]).is_ok());
     }
@@ -188,8 +188,8 @@ mod tests {
     #[test]
     fn valid_triangle_3d() {
         let a = Point::from([0.0, 0.0, 0.0]);
-        let b = Point::from([1.0, 1.0, 0.0]);
-        let c = Point::from([1.0, 2.0, 0.0]);
+        let b = Point::from([0.0, 1.0, 0.0]);
+        let c = Point::from([1.0, 0.0, 0.0]);
 
         assert!(Triangle::from_points([a, b, c]).is_ok());
     }
@@ -197,8 +197,8 @@ mod tests {
     #[test]
     fn invalid_triangle_2d() {
         let a = Point::from([0.0, 0.0]);
-        let b = Point::from([1.0, 1.0]);
-        let c = Point::from([2.0, 2.0]);
+        let b = Point::from([1.0, 0.0]);
+        let c = Point::from([2.0, 0.0]);
 
         assert!(Triangle::from_points([a, b, c]).is_err());
     }
@@ -206,8 +206,8 @@ mod tests {
     #[test]
     fn invalid_triangle_3d() {
         let a = Point::from([0.0, 0.0, 0.0]);
-        let b = Point::from([1.0, 1.0, 1.0]);
-        let c = Point::from([2.0, 2.0, 2.0]);
+        let b = Point::from([1.0, 0.0, 0.0]);
+        let c = Point::from([2.0, 0.0, 0.0]);
 
         assert!(Triangle::from_points([a, b, c]).is_err());
     }

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -23,18 +23,7 @@ impl<const D: usize> Triangle<D> {
         points: [impl Into<Point<D>>; 3],
     ) -> Result<Self, NotATriangle<D>> {
         let points = points.map(Into::into);
-
-        let area = {
-            let [a, b, c] = points.map(Point::to_xyz);
-            (b - a).cross(&(c - a)).magnitude()
-        };
-
-        // A triangle is not valid if it doesn't span any area
-        if area != Scalar::from(0.0) {
-            Ok(Self { points })
-        } else {
-            Err(NotATriangle { points })
-        }
+        Ok(Self { points })
     }
 
     /// Access the triangle's points
@@ -182,7 +171,7 @@ mod tests {
         let b = Point::from([1.0, 0.0]);
         let c = Point::from([0.0, 1.0]);
 
-        assert!(Triangle::from_points([a, b, c]).is_ok());
+        assert!(Triangle::from_points([a, b, c]).unwrap().is_valid());
     }
 
     #[test]
@@ -191,7 +180,7 @@ mod tests {
         let b = Point::from([0.0, 1.0, 0.0]);
         let c = Point::from([1.0, 0.0, 0.0]);
 
-        assert!(Triangle::from_points([a, b, c]).is_ok());
+        assert!(Triangle::from_points([a, b, c]).unwrap().is_valid());
     }
 
     #[test]
@@ -200,7 +189,7 @@ mod tests {
         let b = Point::from([1.0, 0.0]);
         let c = Point::from([2.0, 0.0]);
 
-        assert!(Triangle::from_points([a, b, c]).is_err());
+        assert!(!Triangle::from_points([a, b, c]).unwrap().is_valid());
     }
 
     #[test]
@@ -209,7 +198,7 @@ mod tests {
         let b = Point::from([1.0, 0.0, 0.0]);
         let c = Point::from([2.0, 0.0, 0.0]);
 
-        assert!(Triangle::from_points([a, b, c]).is_err());
+        assert!(!Triangle::from_points([a, b, c]).unwrap().is_valid());
     }
 
     #[test]

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -23,11 +23,6 @@ impl<const D: usize> Triangle<D> {
         Self { points }
     }
 
-    /// Access the triangle's points
-    pub fn points(&self) -> [Point<D>; 3] {
-        self.points
-    }
-
     /// # Determine whether the triangle is valid
     ///
     /// A triangle is valid, if it is not degenerate. In a degenerate triangle,
@@ -88,7 +83,7 @@ impl Triangle<2> {
 impl Triangle<3> {
     /// Convert the triangle to a Parry triangle
     pub fn to_parry(self) -> parry3d_f64::shape::Triangle {
-        self.points().map(|vertex| vertex.to_na()).into()
+        self.points.map(|vertex| vertex.to_na()).into()
     }
 
     /// Cast a ray against the Triangle

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -123,12 +123,6 @@ where
     }
 }
 
-/// Returned by [`Triangle::from_points`], if the points don't form a triangle
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct NotATriangle<const D: usize> {
-    pub points: [Point<D>; 3],
-}
-
 /// Winding direction of a triangle.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Winding {

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -17,8 +17,6 @@ pub struct Triangle<const D: usize> {
 
 impl<const D: usize> Triangle<D> {
     /// Construct a triangle from three points
-    ///
-    /// Returns an error, if the points don't form a triangle.
     pub fn from_points(points: [impl Into<Point<D>>; 3]) -> Self {
         let points = points.map(Into::into);
         Self { points }

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -19,11 +19,9 @@ impl<const D: usize> Triangle<D> {
     /// Construct a triangle from three points
     ///
     /// Returns an error, if the points don't form a triangle.
-    pub fn from_points(
-        points: [impl Into<Point<D>>; 3],
-    ) -> Result<Self, NotATriangle<D>> {
+    pub fn from_points(points: [impl Into<Point<D>>; 3]) -> Self {
         let points = points.map(Into::into);
-        Ok(Self { points })
+        Self { points }
     }
 
     /// Access the triangle's points
@@ -127,7 +125,7 @@ where
     P: Into<Point<D>>,
 {
     fn from(points: [P; 3]) -> Self {
-        Self::from_points(points).expect("invalid triangle")
+        Self::from_points(points)
     }
 }
 
@@ -171,7 +169,7 @@ mod tests {
         let b = Point::from([1.0, 0.0]);
         let c = Point::from([0.0, 1.0]);
 
-        assert!(Triangle::from_points([a, b, c]).unwrap().is_valid());
+        assert!(Triangle::from_points([a, b, c]).is_valid());
     }
 
     #[test]
@@ -180,7 +178,7 @@ mod tests {
         let b = Point::from([0.0, 1.0, 0.0]);
         let c = Point::from([1.0, 0.0, 0.0]);
 
-        assert!(Triangle::from_points([a, b, c]).unwrap().is_valid());
+        assert!(Triangle::from_points([a, b, c]).is_valid());
     }
 
     #[test]
@@ -189,7 +187,7 @@ mod tests {
         let b = Point::from([1.0, 0.0]);
         let c = Point::from([2.0, 0.0]);
 
-        assert!(!Triangle::from_points([a, b, c]).unwrap().is_valid());
+        assert!(!Triangle::from_points([a, b, c]).is_valid());
     }
 
     #[test]
@@ -198,7 +196,7 @@ mod tests {
         let b = Point::from([1.0, 0.0, 0.0]);
         let c = Point::from([2.0, 0.0, 0.0]);
 
-        assert!(!Triangle::from_points([a, b, c]).unwrap().is_valid());
+        assert!(!Triangle::from_points([a, b, c]).is_valid());
     }
 
     #[test]

--- a/crates/fj-math/src/triangle.rs
+++ b/crates/fj-math/src/triangle.rs
@@ -1,3 +1,4 @@
+use approx::AbsDiffEq;
 use parry3d_f64::query::{Ray, RayCast as _};
 
 use crate::Vector;
@@ -39,6 +40,26 @@ impl<const D: usize> Triangle<D> {
     /// Access the triangle's points
     pub fn points(&self) -> [Point<D>; 3] {
         self.points
+    }
+
+    /// # Determine whether the triangle is valid
+    ///
+    /// A triangle is valid, if it is not degenerate. In a degenerate triangle,
+    /// the three points do not form an actual triangle, but a line or even a
+    /// single point.
+    ///
+    /// ## Implementation Note
+    ///
+    /// Right now, this function computes the area of the triangle, and compares
+    /// it against [`Scalar`]'s default epsilon value. This might not be
+    /// flexible enough for all use cases.
+    ///
+    /// Long-term, it might become necessary to add some way to override the
+    /// epsilon value used within this function.
+    pub fn is_valid(&self) -> bool {
+        let [a, b, c] = self.points;
+        let area = (b - a).outer(&(c - a)).magnitude();
+        area > Scalar::default_epsilon()
     }
 
     /// Normalize the triangle

--- a/crates/fj-viewer/src/graphics/vertices.rs
+++ b/crates/fj-viewer/src/graphics/vertices.rs
@@ -29,7 +29,7 @@ impl From<&Mesh<fj_math::Point<3>>> for Vertices {
         let mut m = Mesh::new();
 
         for triangle in mesh.triangles() {
-            let [a, b, c] = triangle.inner.points();
+            let [a, b, c] = triangle.inner.points;
 
             let normal = (b - a).cross(&(c - a)).normalize();
             let color = triangle.color;


### PR DESCRIPTION
Requiring triangles to be valid on construction is too restrictive. In fact, I'm working on some code (for https://github.com/hannobraun/fornjot/issues/2118) that would benefit from degenerate triangles being possible to represent.