### PR TITLE
Add default tolerance to `Core`

### DIFF
--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -15,14 +15,16 @@ pub struct Core {
 impl Core {
     /// Construct an instance of `Core`
     pub fn new() -> Self {
-        Self {
-            layers: Layers::default(),
-        }
+        Self::from_layers(Layers::default())
     }
 
     /// Construct an instance of `Core`, using the provided configuration
     pub fn with_validation_config(config: ValidationConfig) -> Self {
         let layers = Layers::with_validation_config(config);
+        Self::from_layers(layers)
+    }
+
+    fn from_layers(layers: Layers) -> Self {
         Self { layers }
     }
 }

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -2,7 +2,9 @@
 //!
 //! See [`Core`].
 
-use crate::{layers::Layers, validation::ValidationConfig};
+use crate::{
+    algorithms::approx::Tolerance, layers::Layers, validation::ValidationConfig,
+};
 
 /// An instance of the Fornjot core
 ///
@@ -10,6 +12,9 @@ use crate::{layers::Layers, validation::ValidationConfig};
 pub struct Core {
     /// The layers of data that make up the state of a core instance
     pub layers: Layers,
+
+    /// Default tolerance used for intermediate geometry representation
+    pub default_tolerance: Tolerance,
 }
 
 impl Core {
@@ -25,7 +30,13 @@ impl Core {
     }
 
     fn from_layers(layers: Layers) -> Self {
-        Self { layers }
+        let default_tolerance = Tolerance::from_scalar(0.001)
+            .expect("Tolerance provided is larger than zero");
+
+        Self {
+            layers,
+            default_tolerance,
+        }
     }
 }
 

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -7,7 +7,6 @@ use crate::{layers::Layers, validation::ValidationConfig};
 /// An instance of the Fornjot core
 ///
 /// This is the main entry point to `fj-core`'s API.
-#[derive(Default)]
 pub struct Core {
     /// The layers of data that make up the state of a core instance
     pub layers: Layers,
@@ -16,12 +15,20 @@ pub struct Core {
 impl Core {
     /// Construct an instance of `Instance`
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            layers: Layers::default(),
+        }
     }
 
     /// Construct an instance of `Instance`, using the provided configuration
     pub fn with_validation_config(config: ValidationConfig) -> Self {
         let layers = Layers::with_validation_config(config);
         Self { layers }
+    }
+}
+
+impl Default for Core {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -13,14 +13,14 @@ pub struct Core {
 }
 
 impl Core {
-    /// Construct an instance of `Instance`
+    /// Construct an instance of `Core`
     pub fn new() -> Self {
         Self {
             layers: Layers::default(),
         }
     }
 
-    /// Construct an instance of `Instance`, using the provided configuration
+    /// Construct an instance of `Core`, using the provided configuration
     pub fn with_validation_config(config: ValidationConfig) -> Self {
         let layers = Layers::with_validation_config(config);
         Self { layers }


### PR DESCRIPTION
From the description of the main commit:

> As per its documentation, this can be used when computing the new uniform intermediate geometry representation. I'm working on that right now, so it's hopefully going to see some use soon.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2118.