### PR TITLE
Make tolerance value available in `ValidationConfig`

### DIFF
--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -17,16 +17,13 @@ pub struct Core {
 impl Core {
     /// Construct an instance of `Core`
     pub fn new() -> Self {
-        Self::from_layers(Layers::default())
+        let layers = Layers::default();
+        Self { layers }
     }
 
     /// Construct an instance of `Core`, using the provided configuration
     pub fn with_validation_config(config: ValidationConfig) -> Self {
         let layers = Layers::with_validation_config(config);
-        Self::from_layers(layers)
-    }
-
-    fn from_layers(layers: Layers) -> Self {
         Self { layers }
     }
 

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -12,9 +12,6 @@ use crate::{
 pub struct Core {
     /// The layers of data that make up the state of a core instance
     pub layers: Layers,
-
-    /// Default tolerance used for intermediate geometry representation
-    pub default_tolerance: Tolerance,
 }
 
 impl Core {
@@ -30,13 +27,7 @@ impl Core {
     }
 
     fn from_layers(layers: Layers) -> Self {
-        let default_tolerance = Tolerance::from_scalar(0.001)
-            .expect("Tolerance provided is larger than zero");
-
-        Self {
-            layers,
-            default_tolerance,
-        }
+        Self { layers }
     }
 
     /// Access the tolerance value used for intermediate geometry representation

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -38,6 +38,11 @@ impl Core {
             default_tolerance,
         }
     }
+
+    /// Access the tolerance value used for intermediate geometry representation
+    pub fn tolerance(&self) -> Tolerance {
+        self.default_tolerance
+    }
 }
 
 impl Default for Core {

--- a/crates/fj-core/src/core.rs
+++ b/crates/fj-core/src/core.rs
@@ -41,7 +41,7 @@ impl Core {
 
     /// Access the tolerance value used for intermediate geometry representation
     pub fn tolerance(&self) -> Tolerance {
-        self.default_tolerance
+        self.layers.validation.config.tolerance
     }
 }
 

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -1,5 +1,7 @@
 use fj_math::Scalar;
 
+use crate::algorithms::approx::Tolerance;
+
 /// Configuration required for the validation process
 #[derive(Debug, Clone, Copy)]
 pub struct ValidationConfig {
@@ -18,6 +20,9 @@ pub struct ValidationConfig {
     ///
     /// Defaults to `false`.
     pub panic_on_error: bool,
+
+    /// The tolerance value used for intermediate geometry representation
+    pub tolerance: Tolerance,
 
     /// The minimum distance between distinct objects
     ///
@@ -39,6 +44,8 @@ impl Default for ValidationConfig {
         Self {
             panic_on_error: false,
             distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
+            tolerance: Tolerance::from_scalar(0.001)
+                .expect("Tolerance provided is larger than zero"),
 
             // This value was chosen pretty arbitrarily. Seems small enough to
             // catch errors. If it turns out it's too small (because it produces


### PR DESCRIPTION
From a commit message:

> Validation also needs access to a tolerance value. And since it doesn't have access to `Core`, having it in `ValidationConfig` is the most practical solution.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2118.