### PR TITLE
Fix bug where validation errors could overwrite previous validation errors

### DIFF
--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -60,7 +60,7 @@ impl Command<Validation> for TakeErrors {
         state: &Validation,
         events: &mut Vec<Self::Event>,
     ) -> Self::Result {
-        let errors = ValidationErrors(state.errors.values().cloned().collect());
+        let errors = ValidationErrors(state.errors.to_vec());
 
         events.push(self);
 
@@ -92,6 +92,6 @@ pub struct ValidationFailed {
 
 impl Event<Validation> for ValidationFailed {
     fn evolve(&self, state: &mut Validation) {
-        state.errors.insert(self.object.id(), self.err.clone());
+        state.errors.push(self.err.clone());
     }
 }

--- a/crates/fj-core/src/layers/validation.rs
+++ b/crates/fj-core/src/layers/validation.rs
@@ -38,10 +38,7 @@ impl Command<Validation> for ValidateObject<'_> {
                 panic!("{:#?}", err);
             }
 
-            events.push(ValidationFailed {
-                object: self.object.clone(),
-                err,
-            });
+            events.push(ValidationFailed { err });
         }
     }
 }
@@ -83,9 +80,6 @@ impl Event<Validation> for TakeErrors {
 /// Event produced by `Layer<Validation>`.
 #[derive(Clone)]
 pub struct ValidationFailed {
-    /// The object for which validation failed
-    pub object: AnyObject<Stored>,
-
     /// The validation error
     pub err: ValidationError,
 }

--- a/crates/fj-core/src/validation/validation.rs
+++ b/crates/fj-core/src/validation/validation.rs
@@ -1,6 +1,4 @@
-use std::{collections::HashMap, error::Error, thread};
-
-use crate::storage::ObjectId;
+use std::{error::Error, thread};
 
 use super::{ValidationConfig, ValidationError};
 
@@ -8,7 +6,7 @@ use super::{ValidationConfig, ValidationError};
 #[derive(Default)]
 pub struct Validation {
     /// All unhandled validation errors
-    pub errors: HashMap<ObjectId, ValidationError>,
+    pub errors: Vec<ValidationError>,
 
     /// Validation configuration for the validation service
     pub config: ValidationConfig,
@@ -17,7 +15,7 @@ pub struct Validation {
 impl Validation {
     /// Construct an instance of `Validation`, using the provided configuration
     pub fn with_validation_config(config: ValidationConfig) -> Self {
-        let errors = HashMap::new();
+        let errors = Vec::new();
         Self { errors, config }
     }
 }
@@ -31,7 +29,7 @@ impl Drop for Validation {
                 errors:"
             );
 
-            for err in self.errors.values() {
+            for err in self.errors.iter() {
                 println!("{}", err);
 
                 // Once `Report` is stable, we can replace this:


### PR DESCRIPTION
Validation errors were stored in a map, by object ID, which means that only one validation error could be stored per object. This made no sense, and this pull request fixes it. It's also a simplification, so a win all around.

This seems to be a really old bug, but I don't think it had much impact. It could not lead to the presence of validation errors being missed. It could just prevent the user from having a complete picture of what is wrong, if there already are validation errors.