### PR TITLE
Update default validation config; compute values from each other, based on the tolerance

### DIFF
--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -44,10 +44,9 @@ impl ValidationConfig {
     pub fn from_tolerance(tolerance: impl Into<Tolerance>) -> Self {
         let tolerance = tolerance.into();
 
-        // This value was chosen pretty arbitrarily. Seems small enough to catch
-        // errors. If it turns out it's too small (because it produces false
-        // positives due to floating-point accuracy issues), we can adjust it.
-        let identical_max_distance = Scalar::from_f64(5e-14);
+        // This value can't be smaller than the tolerance. If it is, we'll get
+        // validation errors everywhere, just from numerical noise.
+        let identical_max_distance = tolerance.inner() * 10.;
 
         // This value can't be smaller than `identical_max_distance`. Otherwise
         // we can have distinct points that satisfy this constraint, but must be

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -44,16 +44,16 @@ impl ValidationConfig {
     pub fn from_tolerance(tolerance: impl Into<Tolerance>) -> Self {
         let tolerance = tolerance.into();
 
+        // This value was chosen pretty arbitrarily. Seems small enough to catch
+        // errors. If it turns out it's too small (because it produces false
+        // positives due to floating-point accuracy issues), we can adjust it.
+        let identical_max_distance = Scalar::from_f64(5e-14);
+
         Self {
             panic_on_error: false,
             tolerance,
             distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
-
-            // This value was chosen pretty arbitrarily. Seems small enough to
-            // catch errors. If it turns out it's too small (because it produces
-            // false positives due to floating-point accuracy issues), we can
-            // adjust it.
-            identical_max_distance: Scalar::from_f64(5e-14),
+            identical_max_distance,
         }
     }
 }

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -49,10 +49,12 @@ impl ValidationConfig {
         // positives due to floating-point accuracy issues), we can adjust it.
         let identical_max_distance = Scalar::from_f64(5e-14);
 
+        let distinct_min_distance = Scalar::from_f64(5e-7); // 0.5 µm
+
         Self {
             panic_on_error: false,
             tolerance,
-            distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
+            distinct_min_distance,
             identical_max_distance,
         }
     }

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -39,12 +39,14 @@ pub struct ValidationConfig {
     pub identical_max_distance: Scalar,
 }
 
-impl Default for ValidationConfig {
-    fn default() -> Self {
+impl ValidationConfig {
+    /// Compute validation config from a tolerance value
+    pub fn from_tolerance(tolerance: impl Into<Tolerance>) -> Self {
+        let tolerance = tolerance.into();
+
         Self {
             panic_on_error: false,
-            tolerance: Tolerance::from_scalar(0.001)
-                .expect("Tolerance provided is larger than zero"),
+            tolerance,
             distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
 
             // This value was chosen pretty arbitrarily. Seems small enough to
@@ -53,5 +55,11 @@ impl Default for ValidationConfig {
             // adjust it.
             identical_max_distance: Scalar::from_f64(5e-14),
         }
+    }
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        Self::from_tolerance(0.001)
     }
 }

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -43,9 +43,9 @@ impl Default for ValidationConfig {
     fn default() -> Self {
         Self {
             panic_on_error: false,
-            distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
             tolerance: Tolerance::from_scalar(0.001)
                 .expect("Tolerance provided is larger than zero"),
+            distinct_min_distance: Scalar::from_f64(5e-7), // 0.5 µm,
 
             // This value was chosen pretty arbitrarily. Seems small enough to
             // catch errors. If it turns out it's too small (because it produces

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -24,12 +24,6 @@ pub struct ValidationConfig {
     /// The tolerance value used for intermediate geometry representation
     pub tolerance: Tolerance,
 
-    /// The minimum distance between distinct objects
-    ///
-    /// Objects whose distance is less than the value defined in this field, are
-    /// considered identical.
-    pub distinct_min_distance: Scalar,
-
     /// The maximum distance between identical objects
     ///
     /// Objects that are considered identical might still have a distance
@@ -37,6 +31,12 @@ pub struct ValidationConfig {
     /// that distance is less than the one defined in this field, can not be
     /// considered identical.
     pub identical_max_distance: Scalar,
+
+    /// The minimum distance between distinct objects
+    ///
+    /// Objects whose distance is less than the value defined in this field, are
+    /// considered identical.
+    pub distinct_min_distance: Scalar,
 }
 
 impl ValidationConfig {
@@ -58,8 +58,8 @@ impl ValidationConfig {
         Self {
             panic_on_error: false,
             tolerance,
-            distinct_min_distance,
             identical_max_distance,
+            distinct_min_distance,
         }
     }
 }

--- a/crates/fj-core/src/validation/config.rs
+++ b/crates/fj-core/src/validation/config.rs
@@ -49,7 +49,12 @@ impl ValidationConfig {
         // positives due to floating-point accuracy issues), we can adjust it.
         let identical_max_distance = Scalar::from_f64(5e-14);
 
-        let distinct_min_distance = Scalar::from_f64(5e-7); // 0.5 µm
+        // This value can't be smaller than `identical_max_distance`. Otherwise
+        // we can have distinct points that satisfy this constraint, but must be
+        // considered identical according to the other.
+        //
+        // This factor was chosen pretty arbitrarily and might need to be tuned.
+        let distinct_min_distance = identical_max_distance * 2.;
 
         Self {
             panic_on_error: false,


### PR DESCRIPTION
These configuration values can't be arbitrary. The tolerance dictates how precise the other ones can be, while the other ones are also required to be in a specific relationship. See the comments in the new code for details.

This is coming out of my work on https://github.com/hannobraun/fornjot/issues/2118.