### PR TITLE
Merge `SurfacePath` and `GlobalPath` into `Path`

### DIFF
--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use fj_math::{Circle, Line, Point};
 
 use crate::{
-    geometry::{CurveBoundary, Geometry, GlobalPath, SurfaceGeom, SurfacePath},
+    geometry::{CurveBoundary, Geometry, GlobalPath, Path, SurfaceGeom},
     storage::Handle,
     topology::{Curve, Surface},
 };
@@ -43,22 +43,22 @@ pub fn approx_curve_with_cache(
 }
 
 fn approx_curve(
-    path: &SurfacePath,
+    path: &Path,
     surface: &SurfaceGeom,
     boundary: CurveBoundary<Point<1>>,
     tolerance: impl Into<Tolerance>,
 ) -> CurveApprox {
     let SurfaceGeom { u, .. } = surface;
     let points = match (path, u) {
-        (SurfacePath::Circle(_), GlobalPath::Circle(_)) => {
+        (Path::Circle(_), GlobalPath::Circle(_)) => {
             approx_circle_on_curved_surface()
         }
-        (SurfacePath::Circle(circle), GlobalPath::Line(_)) => {
+        (Path::Circle(circle), GlobalPath::Line(_)) => {
             approx_circle_on_straight_surface(
                 circle, boundary, surface, tolerance,
             )
         }
-        (SurfacePath::Line(line), _) => {
+        (Path::Line(line), _) => {
             approx_line_on_any_surface(line, boundary, surface, tolerance)
         }
     };
@@ -199,7 +199,7 @@ mod tests {
         algorithms::approx::{
             circle::approx_circle, curve::approx_curve, ApproxPoint,
         },
-        geometry::{CurveBoundary, GlobalPath, SurfaceGeom, SurfacePath},
+        geometry::{CurveBoundary, GlobalPath, Path, SurfaceGeom},
         operations::build::BuildSurface,
         topology::Surface,
         Core,
@@ -210,8 +210,7 @@ mod tests {
         let core = Core::new();
 
         let surface = core.layers.geometry.xz_plane();
-        let (path, boundary) =
-            SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
+        let (path, boundary) = Path::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
 
         let tolerance = 1.;
@@ -226,8 +225,7 @@ mod tests {
             u: GlobalPath::circle_from_radius(1.),
             v: Vector::from([0., 0., 1.]),
         };
-        let (path, boundary) =
-            SurfacePath::line_from_points([[1., 1.], [2., 1.]]);
+        let (path, boundary) = Path::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
 
         let tolerance = 1.;
@@ -247,7 +245,7 @@ mod tests {
             v: Vector::from([0., 0., 1.]),
         };
         let surface = Surface::from_geometry(surface_geom, &mut core);
-        let path = SurfacePath::line_from_points_with_coords([
+        let path = Path::line_from_points_with_coords([
             ([0.], [0., 1.]),
             ([TAU], [TAU, 1.]),
         ]);
@@ -278,7 +276,7 @@ mod tests {
         let surface_geom = *core.layers.geometry.xz_plane();
         let surface = Surface::from_geometry(surface_geom, &mut core);
         let circle = Circle::from_center_and_radius([0., 0.], 1.);
-        let path = SurfacePath::Circle(circle);
+        let path = Path::Circle(circle);
         let boundary = CurveBoundary::from([[0.], [TAU]]);
 
         let tolerance = 1.;

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use fj_math::{Circle, Line, Point};
 
 use crate::{
-    geometry::{CurveBoundary, Geometry, GlobalPath, Path, SurfaceGeom},
+    geometry::{CurveBoundary, Geometry, Path, SurfaceGeom},
     storage::Handle,
     topology::{Curve, Surface},
 };
@@ -50,10 +50,8 @@ fn approx_curve(
 ) -> CurveApprox {
     let SurfaceGeom { u, .. } = surface;
     let points = match (path, u) {
-        (Path::Circle(_), GlobalPath::Circle(_)) => {
-            approx_circle_on_curved_surface()
-        }
-        (Path::Circle(circle), GlobalPath::Line(_)) => {
+        (Path::Circle(_), Path::Circle(_)) => approx_circle_on_curved_surface(),
+        (Path::Circle(circle), Path::Line(_)) => {
             approx_circle_on_straight_surface(
                 circle, boundary, surface, tolerance,
             )
@@ -118,8 +116,8 @@ fn approx_line_on_any_surface(
 
     let SurfaceGeom { u, .. } = surface;
     let approx_u = match u {
-        GlobalPath::Circle(circle) => approx_circle(circle, range_u, tolerance),
-        GlobalPath::Line(line) => approx_line(line),
+        Path::Circle(circle) => approx_circle(circle, range_u, tolerance),
+        Path::Line(line) => approx_line(line),
     };
 
     let mut points = Vec::new();
@@ -199,7 +197,7 @@ mod tests {
         algorithms::approx::{
             circle::approx_circle, curve::approx_curve, ApproxPoint,
         },
-        geometry::{CurveBoundary, GlobalPath, Path, SurfaceGeom},
+        geometry::{CurveBoundary, Path, SurfaceGeom},
         operations::build::BuildSurface,
         topology::Surface,
         Core,
@@ -210,7 +208,8 @@ mod tests {
         let core = Core::new();
 
         let surface = core.layers.geometry.xz_plane();
-        let (path, boundary) = Path::line_from_points([[1., 1.], [2., 1.]]);
+        let (path, boundary) =
+            Path::<2>::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
 
         let tolerance = 1.;
@@ -222,10 +221,11 @@ mod tests {
     #[test]
     fn approx_line_on_curved_surface_but_not_along_curve() {
         let surface = SurfaceGeom {
-            u: GlobalPath::circle_from_radius(1.),
+            u: Path::circle_from_radius(1.),
             v: Vector::from([0., 0., 1.]),
         };
-        let (path, boundary) = Path::line_from_points([[1., 1.], [2., 1.]]);
+        let (path, boundary) =
+            Path::<2>::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
 
         let tolerance = 1.;
@@ -239,7 +239,7 @@ mod tests {
         let mut core = Core::new();
 
         let circle = Circle::from_center_and_radius(Point::origin(), 1.);
-        let global_path = GlobalPath::Circle(circle);
+        let global_path = Path::Circle(circle);
         let surface_geom = SurfaceGeom {
             u: global_path,
             v: Vector::from([0., 0., 1.]),

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -208,8 +208,7 @@ mod tests {
         let core = Core::new();
 
         let surface = core.layers.geometry.xz_plane();
-        let (path, boundary) =
-            Path::<2>::line_from_points([[1., 1.], [2., 1.]]);
+        let (path, boundary) = Path::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
 
         let tolerance = 1.;
@@ -224,8 +223,7 @@ mod tests {
             u: Path::circle_from_radius(1.),
             v: Vector::from([0., 0., 1.]),
         };
-        let (path, boundary) =
-            Path::<2>::line_from_points([[1., 1.], [2., 1.]]);
+        let (path, boundary) = Path::line_from_points([[1., 1.], [2., 1.]]);
         let boundary = CurveBoundary::from(boundary);
 
         let tolerance = 1.;

--- a/crates/fj-core/src/algorithms/approx/curve.rs
+++ b/crates/fj-core/src/algorithms/approx/curve.rs
@@ -43,7 +43,7 @@ pub fn approx_curve_with_cache(
 }
 
 fn approx_curve(
-    path: &Path,
+    path: &Path<2>,
     surface: &SurfaceGeom,
     boundary: CurveBoundary<Point<1>>,
     tolerance: impl Into<Tolerance>,

--- a/crates/fj-core/src/algorithms/bounding_volume/face.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/face.rs
@@ -4,7 +4,7 @@ use fj_math::{Aabb, Vector};
 
 use crate::{
     algorithms::approx::Tolerance,
-    geometry::{Geometry, GlobalPath, SurfaceGeom},
+    geometry::{Geometry, Path, SurfaceGeom},
     topology::Face,
 };
 
@@ -17,7 +17,7 @@ impl super::BoundingVolume<3> for &Face {
 
                 let SurfaceGeom { u, v } = surface;
                 match u {
-                    GlobalPath::Circle(circle) => {
+                    Path::Circle(circle) => {
                         // This is not the most precise way to calculate the
                         // AABB, doing it for the whole circle, but it should
                         // do.
@@ -30,7 +30,7 @@ impl super::BoundingVolume<3> for &Face {
 
                         aabb_bottom.merged(&aabb_top)
                     }
-                    GlobalPath::Line(_) => {
+                    Path::Line(_) => {
                         // A bounding volume must include the body it bounds,
                         // but does not need to match it precisely. So it's
                         // okay, if it's a bit larger.

--- a/crates/fj-core/src/algorithms/bounding_volume/half_edge.rs
+++ b/crates/fj-core/src/algorithms/bounding_volume/half_edge.rs
@@ -1,7 +1,7 @@
 use fj_math::{Aabb, Vector};
 
 use crate::{
-    geometry::{Geometry, SurfacePath},
+    geometry::{Geometry, Path},
     storage::Handle,
     topology::{HalfEdge, Surface, Vertex},
 };
@@ -20,7 +20,7 @@ impl super::BoundingVolume<2>
             .path;
 
         match path {
-            SurfacePath::Circle(circle) => {
+            Path::Circle(circle) => {
                 // Just calculate the AABB of the whole circle. This is not the
                 // most precise, but it should do for now.
 
@@ -32,7 +32,7 @@ impl super::BoundingVolume<2>
                     max: circle.center() + center_to_min_max,
                 })
             }
-            SurfacePath::Line(_) => {
+            Path::Line(_) => {
                 let points =
                     [half_edge.start_vertex(), end_vertex].map(|vertex| {
                         let point_curve = geometry

--- a/crates/fj-core/src/geometry/curve.rs
+++ b/crates/fj-core/src/geometry/curve.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::{storage::Handle, topology::Surface};
 
-use super::SurfacePath;
+use super::Path;
 
 /// The geometric definition of a curve
 #[derive(Clone, Debug, Default)]
@@ -40,5 +40,5 @@ impl CurveGeom {
 #[derive(Clone, Debug)]
 pub struct LocalCurveGeom {
     /// The path that defines the curve on its surface
-    pub path: SurfacePath,
+    pub path: Path,
 }

--- a/crates/fj-core/src/geometry/curve.rs
+++ b/crates/fj-core/src/geometry/curve.rs
@@ -40,5 +40,5 @@ impl CurveGeom {
 #[derive(Clone, Debug)]
 pub struct LocalCurveGeom {
     /// The path that defines the curve on its surface
-    pub path: Path,
+    pub path: Path<2>,
 }

--- a/crates/fj-core/src/geometry/geometry.rs
+++ b/crates/fj-core/src/geometry/geometry.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 
 use super::{
-    vertex::LocalVertexGeom, CurveGeom, GlobalPath, LocalCurveGeom,
-    SurfaceGeom, VertexGeom,
+    vertex::LocalVertexGeom, CurveGeom, LocalCurveGeom, Path, SurfaceGeom,
+    VertexGeom,
 };
 
 /// Geometric data that is associated with topological objects
@@ -43,21 +43,21 @@ impl Geometry {
         self_.define_surface_inner(
             self_.xy_plane.clone(),
             SurfaceGeom {
-                u: GlobalPath::x_axis(),
+                u: Path::x_axis(),
                 v: Vector::unit_y(),
             },
         );
         self_.define_surface_inner(
             self_.xz_plane.clone(),
             SurfaceGeom {
-                u: GlobalPath::x_axis(),
+                u: Path::x_axis(),
                 v: Vector::unit_z(),
             },
         );
         self_.define_surface_inner(
             self_.yz_plane.clone(),
             SurfaceGeom {
-                u: GlobalPath::y_axis(),
+                u: Path::y_axis(),
                 v: Vector::unit_z(),
             },
         );

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     boundary::{CurveBoundary, CurveBoundaryElement},
     curve::{CurveGeom, LocalCurveGeom},
     geometry::Geometry,
-    path::{GlobalPath, SurfacePath},
+    path::{GlobalPath, Path},
     surface::SurfaceGeom,
     vertex::{LocalVertexGeom, VertexGeom},
 };

--- a/crates/fj-core/src/geometry/mod.rs
+++ b/crates/fj-core/src/geometry/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
     boundary::{CurveBoundary, CurveBoundaryElement},
     curve::{CurveGeom, LocalCurveGeom},
     geometry::Geometry,
-    path::{GlobalPath, Path},
+    path::Path,
     surface::SurfaceGeom,
     vertex::{LocalVertexGeom, VertexGeom},
 };

--- a/crates/fj-core/src/geometry/path.rs
+++ b/crates/fj-core/src/geometry/path.rs
@@ -1,12 +1,12 @@
 //! Paths through 2D and 3D space
 //!
-//! See [`SurfacePath`] and [`GlobalPath`].
+//! See [`Path`] and [`GlobalPath`].
 
 use fj_math::{Circle, Line, Point, Scalar, Transform, Vector};
 
 /// A path through surface (2D) space
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum SurfacePath {
+pub enum Path {
     /// A circle
     Circle(Circle<2>),
 
@@ -14,7 +14,7 @@ pub enum SurfacePath {
     Line(Line<2>),
 }
 
-impl SurfacePath {
+impl Path {
     /// Build a circle from the given radius
     pub fn circle_from_center_and_radius(
         center: impl Into<Point<2>>,

--- a/crates/fj-core/src/geometry/path.rs
+++ b/crates/fj-core/src/geometry/path.rs
@@ -80,7 +80,7 @@ impl Path<2> {
 }
 
 impl Path<3> {
-    /// Construct a `GlobalPath` that represents the x-axis
+    /// Construct a `Path` that represents the x-axis
     pub fn x_axis() -> Self {
         Self::Line(Line::from_origin_and_direction(
             Point::origin(),
@@ -88,7 +88,7 @@ impl Path<3> {
         ))
     }
 
-    /// Construct a `GlobalPath` that represents the y-axis
+    /// Construct a `Path` that represents the y-axis
     pub fn y_axis() -> Self {
         Self::Line(Line::from_origin_and_direction(
             Point::origin(),
@@ -96,7 +96,7 @@ impl Path<3> {
         ))
     }
 
-    /// Construct a `GlobalPath` that represents the z-axis
+    /// Construct a `Path` that represents the z-axis
     pub fn z_axis() -> Self {
         Self::Line(Line::from_origin_and_direction(
             Point::origin(),

--- a/crates/fj-core/src/geometry/path.rs
+++ b/crates/fj-core/src/geometry/path.rs
@@ -4,7 +4,7 @@
 
 use fj_math::{Circle, Line, Point, Scalar, Transform, Vector};
 
-/// A path through surface (2D) space
+/// A path through surface (2D) or global (3D) space
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Path<const D: usize> {
     /// A circle

--- a/crates/fj-core/src/geometry/path.rs
+++ b/crates/fj-core/src/geometry/path.rs
@@ -1,6 +1,6 @@
 //! Paths through 2D and 3D space
 //!
-//! See [`Path`] and [`GlobalPath`].
+//! See [`Path`].
 
 use fj_math::{Circle, Line, Point, Scalar, Transform, Vector};
 
@@ -79,17 +79,7 @@ impl Path<2> {
     }
 }
 
-/// A path through global (3D) space
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum GlobalPath {
-    /// A circle
-    Circle(Circle<3>),
-
-    /// A line
-    Line(Line<3>),
-}
-
-impl GlobalPath {
+impl Path<3> {
     /// Construct a `GlobalPath` that represents the x-axis
     pub fn x_axis() -> Self {
         Self::Line(Line::from_origin_and_direction(

--- a/crates/fj-core/src/geometry/path.rs
+++ b/crates/fj-core/src/geometry/path.rs
@@ -6,15 +6,15 @@ use fj_math::{Circle, Line, Point, Scalar, Transform, Vector};
 
 /// A path through surface (2D) space
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub enum Path {
+pub enum Path<const D: usize> {
     /// A circle
-    Circle(Circle<2>),
+    Circle(Circle<D>),
 
     /// A line
-    Line(Line<2>),
+    Line(Line<D>),
 }
 
-impl Path {
+impl Path<2> {
     /// Build a circle from the given radius
     pub fn circle_from_center_and_radius(
         center: impl Into<Point<2>>,

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -4,13 +4,13 @@ use fj_math::{Point, Scalar, Transform, Triangle, Vector};
 
 use crate::algorithms::approx::{PathApproxParams, Tolerance};
 
-use super::GlobalPath;
+use super::Path;
 
 /// The geometry that defines a surface
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct SurfaceGeom {
     /// The u-axis of the surface
-    pub u: GlobalPath,
+    pub u: Path<3>,
 
     /// The v-axis of the surface
     pub v: Vector<3>,
@@ -21,8 +21,8 @@ impl SurfaceGeom {
     pub fn origin(&self) -> Point<3> {
         let Self { u, .. } = self;
         match u {
-            GlobalPath::Circle(circle) => circle.center(),
-            GlobalPath::Line(line) => line.origin(),
+            Path::Circle(circle) => circle.center(),
+            Path::Line(line) => line.origin(),
         }
     }
 
@@ -71,7 +71,7 @@ impl SurfaceGeom {
 
         let Self { u, v } = self;
         match u {
-            GlobalPath::Circle(circle) => {
+            Path::Circle(circle) => {
                 let params = PathApproxParams::for_circle(circle, tolerance);
 
                 let a = point_surface.u - params.increment();
@@ -93,7 +93,7 @@ impl SurfaceGeom {
 
                 (triangle, barycentric_coords)
             }
-            GlobalPath::Line(line) => {
+            Path::Line(line) => {
                 let a = line.direction();
                 let b = *v;
 
@@ -152,13 +152,13 @@ mod tests {
 
     use crate::{
         algorithms::approx::Tolerance,
-        geometry::{GlobalPath, SurfaceGeom},
+        geometry::{Path, SurfaceGeom},
     };
 
     #[test]
     fn point_from_surface_coords() {
         let surface = SurfaceGeom {
-            u: GlobalPath::Line(Line::from_origin_and_direction(
+            u: Path::Line(Line::from_origin_and_direction(
                 Point::from([1., 1., 1.]),
                 Vector::from([0., 2., 0.]),
             )),
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn vector_from_surface_coords() {
         let surface = SurfaceGeom {
-            u: GlobalPath::Line(Line::from_origin_and_direction(
+            u: Path::Line(Line::from_origin_and_direction(
                 Point::from([1., 0., 0.]),
                 Vector::from([0., 2., 0.]),
             )),

--- a/crates/fj-core/src/operations/build/curve.rs
+++ b/crates/fj-core/src/operations/build/curve.rs
@@ -14,7 +14,7 @@ use crate::{
 pub trait BuildCurve {
     /// Build a curve from the provided path and surface
     fn from_path_and_surface(
-        path: Path,
+        path: Path<2>,
         surface: Handle<Surface>,
         core: &mut Core,
     ) -> Handle<Curve> {

--- a/crates/fj-core/src/operations/build/curve.rs
+++ b/crates/fj-core/src/operations/build/curve.rs
@@ -1,5 +1,5 @@
 use crate::{
-    geometry::SurfacePath,
+    geometry::Path,
     operations::{geometry::UpdateCurveGeometry, insert::Insert},
     storage::Handle,
     topology::{Curve, Surface},
@@ -14,7 +14,7 @@ use crate::{
 pub trait BuildCurve {
     /// Build a curve from the provided path and surface
     fn from_path_and_surface(
-        path: SurfacePath,
+        path: Path,
         surface: Handle<Surface>,
         core: &mut Core,
     ) -> Handle<Curve> {

--- a/crates/fj-core/src/operations/build/half_edge.rs
+++ b/crates/fj-core/src/operations/build/half_edge.rs
@@ -1,7 +1,7 @@
 use fj_math::{Arc, Point, Scalar};
 
 use crate::{
-    geometry::{CurveBoundary, LocalCurveGeom, SurfacePath},
+    geometry::{CurveBoundary, LocalCurveGeom, Path},
     operations::{geometry::UpdateCurveGeometry, insert::Insert},
     storage::Handle,
     topology::{Curve, HalfEdge, Surface, Vertex},
@@ -50,8 +50,7 @@ pub trait BuildHalfEdge {
 
         let arc = Arc::from_endpoints_and_angle(start, end, angle_rad);
 
-        let path =
-            SurfacePath::circle_from_center_and_radius(arc.center, arc.radius);
+        let path = Path::circle_from_center_and_radius(arc.center, arc.radius);
         let boundary = CurveBoundary {
             inner: [arc.start_angle, arc.end_angle]
                 .map(|coord| Point::from([coord])),

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -1,7 +1,7 @@
 use fj_math::{Point, Scalar, Vector};
 
 use crate::{
-    geometry::{GlobalPath, SurfaceGeom},
+    geometry::{Path, SurfaceGeom},
     operations::insert::Insert,
     storage::Handle,
     topology::Surface,
@@ -30,7 +30,7 @@ pub trait BuildSurface {
 
     /// Build a surface from the provided `u` and `v`
     fn from_uv(
-        u: impl Into<GlobalPath>,
+        u: impl Into<Path<3>>,
         v: impl Into<Vector<3>>,
         core: &mut Core,
     ) -> Handle<Surface> {
@@ -50,7 +50,7 @@ pub trait BuildSurface {
     ) -> (Handle<Surface>, [Point<2>; 3]) {
         let [a, b, c] = points.map(Into::into);
 
-        let (u, u_line) = GlobalPath::line_from_points([a, b]);
+        let (u, u_line) = Path::<3>::line_from_points([a, b]);
         let v = c - a;
 
         let surface = Surface::from_uv(u, v, core);

--- a/crates/fj-core/src/operations/build/surface.rs
+++ b/crates/fj-core/src/operations/build/surface.rs
@@ -50,7 +50,7 @@ pub trait BuildSurface {
     ) -> (Handle<Surface>, [Point<2>; 3]) {
         let [a, b, c] = points.map(Into::into);
 
-        let (u, u_line) = Path::<3>::line_from_points([a, b]);
+        let (u, u_line) = Path::line_from_points([a, b]);
         let v = c - a;
 
         let surface = Surface::from_uv(u, v, core);

--- a/crates/fj-core/src/operations/geometry/curve.rs
+++ b/crates/fj-core/src/operations/geometry/curve.rs
@@ -2,7 +2,7 @@ use fj_interop::ext::ArrayExt;
 use fj_math::Point;
 
 use crate::{
-    geometry::{CurveBoundary, Geometry, LocalCurveGeom, SurfacePath},
+    geometry::{CurveBoundary, Geometry, LocalCurveGeom, Path},
     layers::Layer,
     storage::Handle,
     topology::{Curve, Surface},
@@ -20,7 +20,7 @@ pub trait UpdateCurveGeometry {
     /// Define the geometry as a path on a surface
     fn make_path_on_surface(
         self,
-        path: SurfacePath,
+        path: Path,
         surface: Handle<Surface>,
         geometry: &mut Layer<Geometry>,
     ) -> Self;
@@ -59,7 +59,7 @@ impl UpdateCurveGeometry for Handle<Curve> {
 
     fn make_path_on_surface(
         self,
-        path: SurfacePath,
+        path: Path,
         surface: Handle<Surface>,
         geometry: &mut Layer<Geometry>,
     ) -> Self {
@@ -75,7 +75,7 @@ impl UpdateCurveGeometry for Handle<Curve> {
         surface: Handle<Surface>,
         geometry: &mut Layer<Geometry>,
     ) -> Self {
-        let path = SurfacePath::line_from_points_with_coords(
+        let path = Path::line_from_points_with_coords(
             points_curve.inner.zip_ext(points_surface),
         );
 

--- a/crates/fj-core/src/operations/geometry/curve.rs
+++ b/crates/fj-core/src/operations/geometry/curve.rs
@@ -20,7 +20,7 @@ pub trait UpdateCurveGeometry {
     /// Define the geometry as a path on a surface
     fn make_path_on_surface(
         self,
-        path: Path,
+        path: Path<2>,
         surface: Handle<Surface>,
         geometry: &mut Layer<Geometry>,
     ) -> Self;
@@ -59,7 +59,7 @@ impl UpdateCurveGeometry for Handle<Curve> {
 
     fn make_path_on_surface(
         self,
-        path: Path,
+        path: Path<2>,
         surface: Handle<Surface>,
         geometry: &mut Layer<Geometry>,
     ) -> Self {

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -1,14 +1,14 @@
 use fj_math::{Circle, Line, Vector};
 
 use crate::{
-    geometry::{GlobalPath, SurfaceGeom, SurfacePath},
+    geometry::{GlobalPath, Path, SurfaceGeom},
     operations::build::BuildSurface,
     storage::Handle,
     topology::Surface,
     Core,
 };
 
-/// # Sweep a [`SurfacePath`]
+/// # Sweep a [`Path`]
 ///
 /// See [module documentation] for more information.
 ///
@@ -32,7 +32,7 @@ pub trait SweepSurfacePath {
     ) -> Handle<Surface>;
 }
 
-impl SweepSurfacePath for SurfacePath {
+impl SweepSurfacePath for Path {
     fn sweep_surface_path(
         &self,
         surface: &SurfaceGeom,
@@ -65,7 +65,7 @@ impl SweepSurfacePath for SurfacePath {
         }
 
         let u = match self {
-            SurfacePath::Circle(circle) => {
+            Path::Circle(circle) => {
                 let center = surface.point_from_surface_coords(
                     circle.center(),
                     core.tolerance(),
@@ -79,7 +79,7 @@ impl SweepSurfacePath for SurfacePath {
 
                 GlobalPath::Circle(circle)
             }
-            SurfacePath::Line(line) => {
+            Path::Line(line) => {
                 let origin = surface
                     .point_from_surface_coords(line.origin(), core.tolerance());
                 let direction = surface.vector_from_surface_coords(

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -43,8 +43,8 @@ impl SweepSurfacePath for Path<2> {
         match u {
             Path::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
-                // `Surface` is a `GlobalPath`, which we are computing below.
-                // That computation might or might not work with an arbitrary
+                // `Surface` is a `Path<3>`, which we are computing below. That
+                // computation might or might not work with an arbitrary
                 // surface. Probably not, but I'm not sure.
                 //
                 // What definitely won't work, is computing the bottom edge of

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -1,7 +1,7 @@
 use fj_math::{Circle, Line, Vector};
 
 use crate::{
-    geometry::{GlobalPath, Path, SurfaceGeom},
+    geometry::{Path, SurfaceGeom},
     operations::build::BuildSurface,
     storage::Handle,
     topology::Surface,
@@ -41,7 +41,7 @@ impl SweepSurfacePath for Path<2> {
     ) -> Handle<Surface> {
         let SurfaceGeom { u, .. } = surface;
         match u {
-            GlobalPath::Circle(_) => {
+            Path::Circle(_) => {
                 // Sweeping a `Curve` creates a `Surface`. The u-axis of that
                 // `Surface` is a `GlobalPath`, which we are computing below.
                 // That computation might or might not work with an arbitrary
@@ -58,7 +58,7 @@ impl SweepSurfacePath for Path<2> {
                     not supported yet."
                 )
             }
-            GlobalPath::Line(_) => {
+            Path::Line(_) => {
                 // We're sweeping from a curve on a flat surface, which is
                 // supported. Carry on.
             }
@@ -77,7 +77,7 @@ impl SweepSurfacePath for Path<2> {
 
                 let circle = Circle::new(center, a, b);
 
-                GlobalPath::Circle(circle)
+                Path::Circle(circle)
             }
             Path::Line(line) => {
                 let origin = surface
@@ -89,7 +89,7 @@ impl SweepSurfacePath for Path<2> {
 
                 let line = Line::from_origin_and_direction(origin, direction);
 
-                GlobalPath::Line(line)
+                Path::Line(line)
             }
         };
 

--- a/crates/fj-core/src/operations/sweep/path.rs
+++ b/crates/fj-core/src/operations/sweep/path.rs
@@ -32,7 +32,7 @@ pub trait SweepSurfacePath {
     ) -> Handle<Surface>;
 }
 
-impl SweepSurfacePath for Path {
+impl SweepSurfacePath for Path<2> {
     fn sweep_surface_path(
         &self,
         surface: &SurfaceGeom,

--- a/crates/fj-core/src/topology/objects/cycle.rs
+++ b/crates/fj-core/src/topology/objects/cycle.rs
@@ -1,7 +1,7 @@
 use fj_math::{Scalar, Winding};
 
 use crate::{
-    geometry::{Geometry, SurfacePath},
+    geometry::{Geometry, Path},
     storage::Handle,
     topology::{HalfEdge, ObjectSet},
 };
@@ -79,8 +79,8 @@ impl Cycle {
             let edge_direction_positive = a < b;
 
             let circle = match curve_geom.path {
-                SurfacePath::Circle(circle) => circle,
-                SurfacePath::Line(_) => unreachable!(
+                Path::Circle(circle) => circle,
+                Path::Line(_) => unreachable!(
                     "Invalid cycle: less than 3 edges, but not all are circles"
                 ),
             };


### PR DESCRIPTION
This was rather easy, so I'm not sure why it wasn't like that in the first place. Anyway, this is a nice simplification that consolidates a bit of redundant code.