### PR TITLE
Consolidate redundancies in `SurfaceGeom::triangle_at`

### DIFF
--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -86,11 +86,9 @@ impl SurfaceGeom {
                 Triangle::from(triangle_points_in_global_space)
             }
             Path::Line(line) => {
-                let b = self.v;
-
                 let point_global = line.origin()
                     + line.direction() * point_surface.u
-                    + b * point_surface.v;
+                    + self.v * point_surface.v;
 
                 // We don't need to approximate a plane, so our triangle can be
                 // arbitrarily large or small. Here we choose the smallest

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -65,23 +65,18 @@ impl SurfaceGeom {
     ) -> (Triangle<3>, [Scalar; 3]) {
         let point_surface = point_surface.into();
 
-        let triangle = match &self.u {
+        let [a, b] = match &self.u {
             Path::Circle(circle) => {
                 let params = PathApproxParams::for_circle(circle, tolerance);
 
                 let a = point_surface.u - params.increment();
                 let b = point_surface.u + params.increment();
 
-                let [a, b] = [a, b]
+                [a, b]
                     .map(|point_circle| {
                         circle.point_from_circle_coords([point_circle])
                     })
-                    .map(|point_global| {
-                        point_global + self.v * point_surface.v
-                    });
-
-                let c = a + (b - a) / 2.;
-                Triangle::from([a, b, c])
+                    .map(|point_global| point_global + self.v * point_surface.v)
             }
             Path::Line(line) => {
                 // We don't need to approximate a line. So instead of creating a
@@ -91,9 +86,12 @@ impl SurfaceGeom {
                     + line.direction() * point_surface.u
                     + self.v * point_surface.v;
 
-                Triangle::from([point; 3])
+                [point, point]
             }
         };
+
+        let c = a + (b - a) / 2.;
+        let triangle = Triangle::from([a, b, c]);
 
         let barycentric_coords = [1. / 3.; 3].map(Into::into);
         (triangle, barycentric_coords)

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -65,7 +65,7 @@ impl SurfaceGeom {
     ) -> (Triangle<3>, [Scalar; 3]) {
         let point_surface = point_surface.into();
 
-        match &self.u {
+        let triangle = match &self.u {
             Path::Circle(circle) => {
                 let params = PathApproxParams::for_circle(circle, tolerance);
 
@@ -83,10 +83,7 @@ impl SurfaceGeom {
                             point_global + self.v * point_surface.v
                         });
 
-                let triangle = Triangle::from(triangle_points_in_global_space);
-                let barycentric_coords = [1. / 3.; 3].map(Into::into);
-
-                (triangle, barycentric_coords)
+                Triangle::from(triangle_points_in_global_space)
             }
             Path::Line(line) => {
                 let a = line.direction();
@@ -99,12 +96,12 @@ impl SurfaceGeom {
                 // arbitrarily large or small. Here we choose the smallest
                 // possible size (it is collapsed to a point), as per the
                 // documentation of this function.
-                let triangle = Triangle::from([point_global; 3]);
-                let barycentric_coords = [1. / 3.; 3].map(Into::into);
-
-                (triangle, barycentric_coords)
+                Triangle::from([point_global; 3])
             }
-        }
+        };
+
+        let barycentric_coords = [1. / 3.; 3].map(Into::into);
+        (triangle, barycentric_coords)
     }
 
     /// Convert a point in surface coordinates to model coordinates

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -69,14 +69,14 @@ impl SurfaceGeom {
             Path::Circle(circle) => {
                 let params = PathApproxParams::for_circle(circle, tolerance);
 
-                let a = point_surface.u - params.increment();
-                let b = point_surface.u + params.increment();
-
-                [a, b]
-                    .map(|point_circle| {
-                        circle.point_from_circle_coords([point_circle])
-                    })
-                    .map(|point_global| point_global + self.v * point_surface.v)
+                [
+                    point_surface.u - params.increment(),
+                    point_surface.u + params.increment(),
+                ]
+                .map(|point_circle| {
+                    circle.point_from_circle_coords([point_circle])
+                })
+                .map(|point_global| point_global + self.v * point_surface.v)
             }
             Path::Line(line) => {
                 // We don't need to approximate a line. So instead of creating a

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -86,11 +86,11 @@ impl SurfaceGeom {
                 Triangle::from(triangle_points_in_global_space)
             }
             Path::Line(line) => {
-                let a = line.direction();
                 let b = self.v;
 
-                let point_global =
-                    line.origin() + a * point_surface.u + b * point_surface.v;
+                let point_global = line.origin()
+                    + line.direction() * point_surface.u
+                    + b * point_surface.v;
 
                 // We don't need to approximate a plane, so our triangle can be
                 // arbitrarily large or small. Here we choose the smallest

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -71,19 +71,18 @@ impl SurfaceGeom {
 
                 let a = point_surface.u - params.increment();
                 let b = point_surface.u + params.increment();
-                let c = point_surface.u; // triangle is degenerate, as per docs
 
-                let triangle_points_in_circle_space = [a, b, c];
-                let triangle_points_in_global_space =
-                    triangle_points_in_circle_space
-                        .map(|point_circle| {
-                            circle.point_from_circle_coords([point_circle])
-                        })
-                        .map(|point_global| {
-                            point_global + self.v * point_surface.v
-                        });
+                let triangle_points_in_circle_space = [a, b];
+                let [a, b] = triangle_points_in_circle_space
+                    .map(|point_circle| {
+                        circle.point_from_circle_coords([point_circle])
+                    })
+                    .map(|point_global| {
+                        point_global + self.v * point_surface.v
+                    });
 
-                Triangle::from(triangle_points_in_global_space)
+                let c = a + (b - a) / 2.;
+                Triangle::from([a, b, c])
             }
             Path::Line(line) => {
                 // We don't need to approximate a line. So instead of creating a

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -86,14 +86,13 @@ impl SurfaceGeom {
                 Triangle::from(triangle_points_in_global_space)
             }
             Path::Line(line) => {
+                // We don't need to approximate a line. So instead of creating a
+                // line segment to represent the line at this point, we just
+                // need this single point.
                 let point_global = line.origin()
                     + line.direction() * point_surface.u
                     + self.v * point_surface.v;
 
-                // We don't need to approximate a plane, so our triangle can be
-                // arbitrarily large or small. Here we choose the smallest
-                // possible size (it is collapsed to a point), as per the
-                // documentation of this function.
                 Triangle::from([point_global; 3])
             }
         };

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -89,11 +89,11 @@ impl SurfaceGeom {
                 // We don't need to approximate a line. So instead of creating a
                 // line segment to represent the line at this point, we just
                 // need this single point.
-                let point_global = line.origin()
+                let point = line.origin()
                     + line.direction() * point_surface.u
                     + self.v * point_surface.v;
 
-                Triangle::from([point_global; 3])
+                Triangle::from([point; 3])
             }
         };
 

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -65,8 +65,7 @@ impl SurfaceGeom {
     ) -> (Triangle<3>, [Scalar; 3]) {
         let point_surface = point_surface.into();
 
-        let Self { u, v } = self;
-        match u {
+        match &self.u {
             Path::Circle(circle) => {
                 let params = PathApproxParams::for_circle(circle, tolerance);
 
@@ -81,7 +80,7 @@ impl SurfaceGeom {
                             circle.point_from_circle_coords([point_circle])
                         })
                         .map(|point_global| {
-                            point_global + *v * point_surface.v
+                            point_global + self.v * point_surface.v
                         });
 
                 let triangle = Triangle::from(triangle_points_in_global_space);
@@ -91,7 +90,7 @@ impl SurfaceGeom {
             }
             Path::Line(line) => {
                 let a = line.direction();
-                let b = *v;
+                let b = self.v;
 
                 let point_global =
                     line.origin() + a * point_surface.u + b * point_surface.v;

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -72,8 +72,7 @@ impl SurfaceGeom {
                 let a = point_surface.u - params.increment();
                 let b = point_surface.u + params.increment();
 
-                let triangle_points_in_circle_space = [a, b];
-                let [a, b] = triangle_points_in_circle_space
+                let [a, b] = [a, b]
                     .map(|point_circle| {
                         circle.point_from_circle_coords([point_circle])
                     })

--- a/crates/fj-core/src/geometry/surface.rs
+++ b/crates/fj-core/src/geometry/surface.rs
@@ -71,7 +71,7 @@ impl SurfaceGeom {
 
                 let a = point_surface.u - params.increment();
                 let b = point_surface.u + params.increment();
-                let c = a; // triangle is degenerate, as per function docs
+                let c = point_surface.u; // triangle is degenerate, as per docs
 
                 let triangle_points_in_circle_space = [a, b, c];
                 let triangle_points_in_global_space =
@@ -84,7 +84,7 @@ impl SurfaceGeom {
                         });
 
                 let triangle = Triangle::from(triangle_points_in_global_space);
-                let barycentric_coords = [0.5, 0.5, 0.0].map(Into::into);
+                let barycentric_coords = [1. / 3.; 3].map(Into::into);
 
                 (triangle, barycentric_coords)
             }


### PR DESCRIPTION
Consolidate the redundant parts of the two code paths into shared code. This is preparation for extracting the curve-specific parts of those methods into a curve geometry trait, or something along those lines.

This comes out of my work on https://github.com/hannobraun/fornjot/issues/2118.